### PR TITLE
Validate phone region

### DIFF
--- a/console/templates/partials/_sms_form.html
+++ b/console/templates/partials/_sms_form.html
@@ -77,6 +77,19 @@
                 Resend code
               {% endif %}
             </button>
+
+            {# Allow user to cancel verification and change number #}
+            <button
+                type="button"
+                class="px-4 py-2 bg-red-50 text-red-700 border border-red-200 rounded-md hover:bg-red-100"
+                hx-post="{{ post_url }}"
+                hx-target="#sms-verification-form"
+                hx-swap="outerHTML"
+                hx-include="#sms-verification-form"
+                hx-vals='{"delete_phone": "1"}'
+            >
+              Cancel
+            </button>
           </div>
       {% endif %}
     </div>

--- a/constants/phone_countries.py
+++ b/constants/phone_countries.py
@@ -1,0 +1,26 @@
+"""
+Supported phone regions for user SMS numbers.
+
+Use ISO 3166-1 alpha-2 region codes as returned by libphonenumber's
+region_code_for_number(). Keep this list in sync with product support.
+"""
+
+# North America
+SUPPORTED_REGION_CODES = {
+    # Canada, Puerto Rico, USA, Virgin Islands (British/U.S.)
+    "CA", "PR", "US", "VG", "VI",
+
+    # Asia
+    "IN", "JP",
+
+    # Europe
+    "AT", "BE", "DK", "FR", "DE", "IS", "IE", "IM", "IT", "NL", "NO",
+    "PT", "ES", "SE", "CH", "UA", "GB",
+
+    # South America
+    "AR", "BR", "CL", "EC", "PE",
+
+    # Oceania (Australia, Cocos, Christmas), New Zealand
+    "AU", "CC", "CX", "NZ",
+}
+

--- a/pages/mixins.py
+++ b/pages/mixins.py
@@ -134,6 +134,24 @@ class PhoneNumberMixin:
                     form.save()
                 except IntegrityError as e:
                     return self._render_phone_partial(error="This phone number is already in use.") if req.headers.get("HX-Request") else redirect(req.path)
+            else:
+                # Provide a minimal error message without listing supported countries
+                # Detect specific unsupported-country error from the form, otherwise fall back
+                unsupported_msg = "Phone numbers from this country are not yet supported."
+                error_msg = unsupported_msg
+                try:
+                    errs = []
+                    for field, messages in form.errors.items():
+                        if isinstance(messages, (list, tuple)):
+                            errs.extend([str(m) for m in messages])
+                        else:
+                            errs.append(str(messages))
+                    if not any(unsupported_msg in m for m in errs):
+                        error_msg = "Enter a valid phone number."
+                except Exception:
+                    error_msg = unsupported_msg
+
+                return self._render_phone_partial(error=error_msg) if req.headers.get("HX-Request") else redirect(req.path)
 
             return self._render_phone_partial() if req.headers.get("HX-Request") else redirect(req.path)
             # fall through: invalid


### PR DESCRIPTION
This pull request improves phone number validation and user experience in the console forms by introducing country-based support checks and more informative error handling. It adds a centralized list of supported regions, ensures consistent validation across forms, and provides users with clearer feedback and the ability to cancel phone verification.

**Phone number validation and region support:**

* Added `SUPPORTED_REGION_CODES` in `constants/phone_countries.py` to define supported countries for user SMS numbers, using ISO 3166-1 alpha-2 codes.
* Updated validation logic in `console/forms.py` to check both E.164 format and whether the phone number's country is supported, using the `phonenumbers` library in multiple form clean methods. [[1]](diffhunk://#diff-79792cb9c8cc9ad6d54919ddf29978862e9e711fbdfd10b531878fd8d9737990L93-R112) [[2]](diffhunk://#diff-79792cb9c8cc9ad6d54919ddf29978862e9e711fbdfd10b531878fd8d9737990R306-R317) [[3]](diffhunk://#diff-79792cb9c8cc9ad6d54919ddf29978862e9e711fbdfd10b531878fd8d9737990R654-R676)

**User experience improvements:**

* Added a "Cancel" button to the SMS verification form (`_sms_form.html`), allowing users to cancel verification and change their phone number.

**Error handling enhancements:**

* Improved error messaging in `pages/mixins.py` to provide specific feedback when a phone number's country is unsupported, and fallback to a generic message for other validation errors.