### PR TITLE
Fix Agent Web Task Follow-up

### DIFF
--- a/tests/unit/test_redis_budget_leaks.py
+++ b/tests/unit/test_redis_budget_leaks.py
@@ -152,10 +152,9 @@ class RedisBudgetLeakTests(TestCase):
         # Get the source code of _process_browser_use_task_core
         source = inspect.getsource(tasks_module._process_browser_use_task_core)
         
-        # Check that it includes branch cleanup on failure
+        # Check that it includes decrement of outstanding-children on completion/failure
         has_cleanup = (
-            'remove_branch' in source or
-            'Clean up branch' in source
+            'bump_branch_depth' in source and '-1' in source
         )
         
         self.assertTrue(


### PR DESCRIPTION
### The Issue
The agent loop closes the budget cycle on sleep because it believes there are no outstanding child tasks. The tracking for "outstanding children" is not actually updated when a web task is spawned, so it always reads zero and closes the cycle prematurely.

### The Fix
The agent loop uses AgentBudgetManager.get_branch_depth(...) to decide whether to close the cycle when sleeping. Before, nothing incremented this, so it looked like "0 children" and closed the budget prematurely. Now, the parent branch counter increments on spawn and decrements on completion; the loop will leave the cycle active when > 0, and allow follow-up processing after the last child completes.