### PR TITLE
Fix agent creation race condition

### DIFF
--- a/console/views.py
+++ b/console/views.py
@@ -975,8 +975,8 @@ class AgentCreateContactView(LoginRequiredMixin, PhoneNumberMixin, TemplateView)
                         owner_agent=persistent_agent,
                     )
 
-                    # Trigger the first event processing run
-                    process_agent_events_task.delay(str(persistent_agent.id))
+                    # Trigger the first event processing run after commit
+                    transaction.on_commit(lambda: process_agent_events_task.delay(str(persistent_agent.id)))
                     
                     # Clear session data
                     if 'agent_charter' in request.session:
@@ -1163,8 +1163,8 @@ class AgentEnableSmsView(LoginRequiredMixin, PhoneNumberMixin, TemplateView):
                     owner_agent=self.agent,
                 )
 
-                # Trigger the first event processing run
-                process_agent_events_task.delay(str(self.agent.id))
+                # Trigger the first event processing run after commit
+                transaction.on_commit(lambda: process_agent_events_task.delay(str(self.agent.id)))
 
         except Exception as e:
             messages.error(
@@ -1334,7 +1334,7 @@ class AgentDetailView(LoginRequiredMixin, DetailView):
                         )
 
                     from api.agent.tasks.process_events import process_agent_events_task
-                    process_agent_events_task.delay(str(agent.id))
+                    transaction.on_commit(lambda: process_agent_events_task.delay(str(agent.id)))
                     
                     # Switch agent to manual allowlist mode if not already
                     # (though it should already be manual with our new changes)
@@ -2258,7 +2258,7 @@ class AgentSecretsRequestView(LoginRequiredMixin, TemplateView):
 
                         # Trigger agent event processing to resume agent with new credentials
                         from api.agent.tasks.process_events import process_agent_events_task
-                        process_agent_events_task.delay(str(agent.pk))
+                        transaction.on_commit(lambda: process_agent_events_task.delay(str(agent.pk)))
 
                         Analytics.track_event(
                             user_id=self.request.user.id,
@@ -2544,7 +2544,7 @@ class AgentContactRequestsView(LoginRequiredMixin, TemplateView):
                         
                         # Trigger agent event processing
                         from api.agent.tasks.process_events import process_agent_events_task
-                        process_agent_events_task.delay(str(agent.pk))
+                        transaction.on_commit(lambda: process_agent_events_task.delay(str(agent.pk)))
                         
                         Analytics.track_event(
                             user_id=self.request.user.id,


### PR DESCRIPTION
This pull request updates several places in `console/views.py` to ensure that agent event processing tasks are only triggered after the related database transactions have been successfully committed. This change helps prevent race conditions and ensures data consistency, especially when agent creation or updates are involved.

**Improvements to agent event processing task triggering:**

* Replaced direct calls to `process_agent_events_task.delay()` with `transaction.on_commit(...)` in multiple `post` methods, so the event processing is triggered only after the database transaction is committed. [[1]](diffhunk://#diff-4cef7994e7a77d4cb967d1a70fd1d8a39c7146d02356078884390882cee8d33bL978-R979) [[2]](diffhunk://#diff-4cef7994e7a77d4cb967d1a70fd1d8a39c7146d02356078884390882cee8d33bL1337-R1337) [[3]](diffhunk://#diff-4cef7994e7a77d4cb967d1a70fd1d8a39c7146d02356078884390882cee8d33bL2261-R2261) [[4]](diffhunk://#diff-4cef7994e7a77d4cb967d1a70fd1d8a39c7146d02356078884390882cee8d33bL2547-R2547)
* Updated `_enable_sms_and_redirect` method to trigger agent event processing after commit using `transaction.on_commit(...)` instead of immediately.