### PR TITLE
Format task counter to whole number

### DIFF
--- a/console/templates/index.html
+++ b/console/templates/index.html
@@ -47,7 +47,7 @@
         <p class="text-sm font-medium text-slate-500">Available Tasks</p>
       </div>
       <div class="flex-grow flex items-center justify-center mt-auto">
-        <h3 class="text-3xl font-semibold text-slate-900">{% if account.usage.tasks_available >= 0 %}{{ account.usage.tasks_available }}{% else %}∞{% endif %}</h3>
+        <h3 class="text-3xl font-semibold text-slate-900">{% if account.usage.tasks_available >= 0 %}{{ account.usage.tasks_available|floatformat:0 }}{% else %}∞{% endif %}</h3>
       </div>
       <!-- additional task quota information -->
       <div>


### PR DESCRIPTION
This pull request makes a small change to the display of the available tasks count in the `console/templates/index.html` file. The change ensures that the number of available tasks is always shown as an integer without any decimal places.

* Updated the template to use the `floatformat:0` filter when displaying `account.usage.tasks_available`, so the number is always rendered as an integer.