### PR TITLE
Update provider weights

### DIFF
--- a/api/agent/core/llm_config.py
+++ b/api/agent/core/llm_config.py
@@ -77,20 +77,20 @@ TOKEN_BASED_TIER_CONFIGS = {
             [("anthropic", 0.5), ("openrouter_glm", 0.5)],  # Tier 3: 50/50 Anthropic/GLM-4.5 split
         ]
     },
-    # 7500-20000 tokens: 62.5% GLM-4.5, 27.5% GPT-5, 10% GPT-OSS-120B primary tier
+    # 7500-20000 tokens: 70% GLM-4.5, 10% Google Gemini 2.5 Pro, 10% GPT-5, 10% GPT-OSS-120B
     "medium": {
         "range": (7500, 20000),
         "tiers": [
-            [("openrouter_glm", 0.625), ("openai_gpt5", 0.275), ("fireworks_gpt_oss_120b", 0.10)],  # Tier 1: 62.5% GLM-4.5, 27.5% GPT-5, 10% GPT-OSS-120B
+            [("openrouter_glm", 0.70), ("google", 0.10), ("openai_gpt5", 0.10), ("fireworks_gpt_oss_120b", 0.10)],  # Tier 1: 65% GLM-4.5, 15% Google, 10% GPT-OSS-120B, 10% GPT-5
             [("openrouter_glm", 0.34), ("openai_gpt5", 0.33), ("anthropic", 0.33)],  # Tier 2: Even split between GLM-4.5, GPT-5, and Anthropic
             [("openai_gpt5", 1.0)],  # Tier 3: 100% GPT-5 (last resort)
         ]
     },
-    # 20000+ tokens: 62.5% GLM-4.5, 27.5% GPT-5, 10% GPT-OSS-120B primary tier
+    # 20000+ tokens: 70% GLM-4.5, 10% Google Gemini 2.5 Pro, 10% GPT-5, 10% GPT-OSS-120B
     "large": {
         "range": (20000, float('inf')),
         "tiers": [
-            [("openrouter_glm", 0.625), ("openai_gpt5", 0.275), ("fireworks_gpt_oss_120b", 0.10)],  # Tier 1: 62.5% GLM-4.5, 27.5% GPT-5, 10% GPT-OSS-120B
+            [("openrouter_glm", 0.70), ("google", 0.10), ("openai_gpt5", 0.10), ("fireworks_gpt_oss_120b", 0.10)],  # Tier 1: 65% GLM-4.5, 15% Google, 10% GPT-OSS-120B, 10% GPT-5
             [("openai_gpt5", 1.0)],  # Tier 2: 100% GPT-5
             [("anthropic", 1.0)],  # Tier 3: 100% Anthropic (Sonnet 4)
             [("fireworks_qwen3_235b_a22b", 1.0)],  # Tier 4: 100% Fireworks Qwen3-235B (last resort)


### PR DESCRIPTION
This pull request updates the LLM provider selection logic for medium and large token ranges to include Google Gemini 2.5 Pro as an option, and adjusts the provider weighting accordingly. It also updates related unit tests to reflect these new provider options and expected behaviors.

LLM provider configuration updates:

* Updated the `medium` (7500-20000 tokens) and `large` (20000+ tokens) tiers in `llm_config.py` to include Google Gemini 2.5 Pro as a provider in tier 1, with new weightings: 70% GLM-4.5, 10% Google, 10% GPT-5, 10% GPT-OSS-120B.

Test updates for new provider logic:

* Modified `test_token_based_failover_medium_range` to expect Google as a possible tier 1 provider, updating assertions to check for either `openrouter_glm` or `google` as the first provider, and to include Google in the set of expected providers/models.
* Modified `test_token_based_failover_large_range` to expect Google as the first provider when available, updating assertions accordingly and ensuring the failover list includes at least Google and Anthropic.