### PR TITLE
Exclude send_email and send_sms tool calls from the agent context

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -1699,6 +1699,12 @@ def _get_unified_history_prompt(agent: PersistentAgent, history_group) -> None:
     for s in steps:
         try:
             tc = s.tool_call
+
+            # Exclude send_email and send_sms tool calls entirely from prompt history,
+            # since they are listed in the agent comms part of the context
+            if tc.tool_name in ("send_email", "send_sms"):
+                continue
+
             components = {
                 "meta": f"[{s.created_at.isoformat()}] Tool {tc.tool_name} called.",
                 "params": json.dumps(tc.tool_params)


### PR DESCRIPTION
This pull request makes a targeted change to the way prompt history is constructed for agents. Specifically, it improves the context provided to the agent by excluding certain communication tool calls that are already represented elsewhere.

Prompt history filtering:

* In the `_get_unified_history_prompt` function in `api/agent/core/event_processing.py`, tool calls to `send_email` and `send_sms` are now excluded from the prompt history, since these are already included in the agent communications section of the context.