### PR TITLE
Disable PDF auto-downloading

### DIFF
--- a/api/tasks/browser_agent_tasks.py
+++ b/api/tasks/browser_agent_tasks.py
@@ -621,7 +621,7 @@ async def _run_agent(
                 timeout=30_000,
                 no_viewport=True,
                 accept_downloads=accept_downloads,
-                auto_download_pdfs=True,
+                auto_download_pdfs=False,
                 proxy=proxy_settings,
                 custom_context={'available_file_paths': available_file_paths},
             )


### PR DESCRIPTION
This pull request makes a minor configuration change to the browser agent task by disabling automatic PDF downloads.

This was causing issues with some agents that were trying to read PDFs.