### PR TITLE
CRUD operations for org billing in stripe endpoints

### DIFF
--- a/pages/signals.py
+++ b/pages/signals.py
@@ -223,11 +223,6 @@ def handle_subscription_event(event, **kwargs):
                 logger.exception("Failed to track subscription cancellation for user %s", owner.id)
         else:
             billing = organization_billing
-            if billing is None:
-                try:
-                    billing = owner.billing
-                except OrganizationBilling.DoesNotExist:
-                    billing = None
             if billing:
                 updates: list[str] = []
                 if getattr(billing, "stripe_subscription_id", None):
@@ -308,13 +303,7 @@ def handle_subscription_event(event, **kwargs):
                 }
             )
         else:
-            mark_owner_billing_with_plan(owner, plan_value, update_anchor=False)
-            billing = organization_billing
-            if billing is None:
-                try:
-                    billing = owner.billing
-                except OrganizationBilling.DoesNotExist:
-                    billing = None
+            billing = mark_owner_billing_with_plan(owner, plan_value, update_anchor=False)
             if billing:
                 updates: list[str] = []
                 if getattr(sub, 'current_period_start', None):

--- a/pages/signals.py
+++ b/pages/signals.py
@@ -16,9 +16,13 @@ from util.analytics import Analytics, AnalyticsEvent, AnalyticsSource
 import logging
 import stripe
 
-from api.models import UserBilling
+from api.models import UserBilling, OrganizationBilling
 from util.payments_helper import PaymentsHelper
-from util.subscription_helper import get_user_task_credit_limit, mark_user_billing_with_plan, downgrade_user_to_free_plan
+from util.subscription_helper import (
+    mark_owner_billing_with_plan,
+    mark_user_billing_with_plan,
+    downgrade_owner_to_free_plan,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -171,11 +175,30 @@ def handle_subscription_event(event, **kwargs):
             raise
 
     customer: Customer | None = sub.customer
-    if not customer or not customer.subscriber:
-        logger.debug("Subscription %s has no linked user; nothing to do.", sub.id)
+    if not customer:
+        logger.debug("Subscription %s has no linked customer; nothing to do.", sub.id)
         return
 
-    user = customer.subscriber
+    owner = None
+    owner_type = ""
+    organization_billing: OrganizationBilling | None = None
+
+    if customer.subscriber:
+        owner = customer.subscriber
+        owner_type = "user"
+    else:
+        organization_billing = (
+            OrganizationBilling.objects.select_related("organization")
+            .filter(stripe_customer_id=customer.id)
+            .first()
+        )
+        if organization_billing and organization_billing.organization:
+            owner = organization_billing.organization
+            owner_type = "organization"
+
+    if not owner:
+        logger.debug("Subscription %s has no linked billing owner; nothing to do.", sub.id)
+        return
 
     # Handle explicit deletions (downgrade to free immediately)
     try:
@@ -184,18 +207,40 @@ def handle_subscription_event(event, **kwargs):
         event_type = ""
 
     if event_type == "customer.subscription.deleted" or getattr(sub, "status", "") == "canceled":
-        downgrade_user_to_free_plan(user)
-        try:
-            Analytics.track_event(
-                user_id=user.id,
-                event=AnalyticsEvent.SUBSCRIPTION_CANCELLED,
-                source=AnalyticsSource.WEB,
-                properties={
-                    'stripe.subscription_id': getattr(sub, 'id', None),
-                },
-            )
-        except Exception:
-            logger.exception("Failed to track subscription cancellation for user %s", user.id)
+        downgrade_owner_to_free_plan(owner)
+
+        if owner_type == "user":
+            try:
+                Analytics.track_event(
+                    user_id=owner.id,
+                    event=AnalyticsEvent.SUBSCRIPTION_CANCELLED,
+                    source=AnalyticsSource.WEB,
+                    properties={
+                        'stripe.subscription_id': getattr(sub, 'id', None),
+                    },
+                )
+            except Exception:
+                logger.exception("Failed to track subscription cancellation for user %s", owner.id)
+        else:
+            billing = organization_billing
+            if billing is None:
+                try:
+                    billing = owner.billing
+                except OrganizationBilling.DoesNotExist:
+                    billing = None
+            if billing:
+                updates: list[str] = []
+                if getattr(billing, "stripe_subscription_id", None):
+                    billing.stripe_subscription_id = None
+                    updates.append("stripe_subscription_id")
+                if getattr(billing, "cancel_at", None):
+                    billing.cancel_at = None
+                    updates.append("cancel_at")
+                if getattr(billing, "cancel_at_period_end", False):
+                    billing.cancel_at_period_end = False
+                    updates.append("cancel_at_period_end")
+                if updates:
+                    billing.save(update_fields=updates)
         return
 
     # Prefer explicit Stripe retrieve when present; otherwise use dj-stripe's cached payload
@@ -221,47 +266,79 @@ def handle_subscription_event(event, **kwargs):
 
         plan = get_plan_by_product_id(plan_id)
 
-        # Grant plan credits (idempotent via invoice_id when present)
         invoice_id = source_data.get("latest_invoice")
-        TaskCreditService.grant_subscription_credits(
-            user,
-            plan=plan,
-            invoice_id=invoice_id or ""
-        )
 
         try:
             plan_choice = PlanNamesChoices(plan["id"]) if plan else PlanNamesChoices.FREE
-            plan_value = plan_choice.value  # explicit string value
+            plan_value = plan_choice.value
         except Exception:
             plan_value = PlanNamesChoices.FREE.value
 
-        # Update the user's billing plan, preserving anchor until we set it from Stripe below
-        mark_user_billing_with_plan(user, plan_value, update_anchor=False)
+        if owner_type == "user":
+            mark_user_billing_with_plan(owner, plan_value, update_anchor=False)
+            TaskCreditService.grant_subscription_credits(
+                owner,
+                plan=plan,
+                invoice_id=invoice_id or ""
+            )
 
-        # Align local anchor day with the Stripe subscription period start for Pro
-        try:
-            ub = user.billing
-            if getattr(sub, 'current_period_start', None):
-                new_day = sub.current_period_start.day
-                if ub.billing_cycle_anchor != new_day:
-                    ub.billing_cycle_anchor = new_day
-                    ub.save(update_fields=["billing_cycle_anchor"])
-        except UserBilling.DoesNotExist as ue:
-            logger.exception("UserBilling record not found for user %s during anchor alignment: %s", user.id, ue)
-        except Exception as e:
-            logger.exception("Failed to align billing anchor with Stripe period for user %s: %s", user.id, e)
+            try:
+                ub = owner.billing
+                if getattr(sub, 'current_period_start', None):
+                    new_day = sub.current_period_start.day
+                    if ub.billing_cycle_anchor != new_day:
+                        ub.billing_cycle_anchor = new_day
+                        ub.save(update_fields=["billing_cycle_anchor"])
+            except UserBilling.DoesNotExist as ue:
+                logger.exception("UserBilling record not found for user %s during anchor alignment: %s", owner.id, ue)
+            except Exception as e:
+                logger.exception("Failed to align billing anchor with Stripe period for user %s: %s", owner.id, e)
 
-        # Analytics/identify for visibility
-        Analytics.identify(user.id, {
-            'plan': plan_value,
-        })
-
-        Analytics.track_event(
-            user_id=user.id,
-            event=AnalyticsEvent.SUBSCRIPTION_CREATED,
-            source=AnalyticsSource.WEB,
-            properties={
+            Analytics.identify(owner.id, {
                 'plan': plan_value,
-                'stripe.invoice_id': invoice_id,
-            }
-        )
+            })
+
+            Analytics.track_event(
+                user_id=owner.id,
+                event=AnalyticsEvent.SUBSCRIPTION_CREATED,
+                source=AnalyticsSource.WEB,
+                properties={
+                    'plan': plan_value,
+                    'stripe.invoice_id': invoice_id,
+                }
+            )
+        else:
+            mark_owner_billing_with_plan(owner, plan_value, update_anchor=False)
+            billing = organization_billing
+            if billing is None:
+                try:
+                    billing = owner.billing
+                except OrganizationBilling.DoesNotExist:
+                    billing = None
+            if billing:
+                updates: list[str] = []
+                if getattr(sub, 'current_period_start', None):
+                    new_day = sub.current_period_start.day
+                    if billing.billing_cycle_anchor != new_day:
+                        billing.billing_cycle_anchor = new_day
+                        updates.append("billing_cycle_anchor")
+
+                new_subscription_id = getattr(sub, 'id', None)
+                if getattr(billing, 'stripe_subscription_id', None) != new_subscription_id:
+                    billing.stripe_subscription_id = new_subscription_id
+                    updates.append("stripe_subscription_id")
+
+                if hasattr(billing, 'cancel_at'):
+                    cancel_at = getattr(sub, 'cancel_at', None)
+                    if billing.cancel_at != cancel_at:
+                        billing.cancel_at = cancel_at
+                        updates.append("cancel_at")
+
+                if hasattr(billing, 'cancel_at_period_end'):
+                    cancel_end = getattr(sub, 'cancel_at_period_end', None)
+                    if cancel_end is not None and billing.cancel_at_period_end != cancel_end:
+                        billing.cancel_at_period_end = cancel_end
+                        updates.append("cancel_at_period_end")
+
+                if updates:
+                    billing.save(update_fields=updates)

--- a/tests/unit/test_subscription_helper.py
+++ b/tests/unit/test_subscription_helper.py
@@ -100,24 +100,24 @@ class MarkOrganizationBillingWithPlanTests(TestCase):
 
         with patch("util.subscription_helper.timezone.now") as mock_now:
             mock_now.return_value = datetime(2025, 3, 15, tzinfo=datetime_timezone.utc)
-            mark_organization_billing_with_plan(self.organization, PlanNames.STARTUP)
+            mark_organization_billing_with_plan(self.organization, PlanNames.ORG_TEAM)
 
         billing = OrganizationBilling.objects.get(organization=self.organization)
-        self.assertEqual(billing.subscription, PlanNames.STARTUP)
+        self.assertEqual(billing.subscription, PlanNames.ORG_TEAM)
         self.assertEqual(billing.billing_cycle_anchor, 15)
 
         with patch("util.subscription_helper.timezone.now") as mock_now:
             mock_now.return_value = datetime(2025, 4, 2, tzinfo=datetime_timezone.utc)
-            mark_organization_billing_with_plan(self.organization, PlanNames.STARTUP, update_anchor=False)
+            mark_organization_billing_with_plan(self.organization, PlanNames.ORG_TEAM, update_anchor=False)
 
         billing.refresh_from_db()
-        self.assertEqual(billing.subscription, PlanNames.STARTUP)
+        self.assertEqual(billing.subscription, PlanNames.ORG_TEAM)
         self.assertEqual(billing.billing_cycle_anchor, 15)
 
     def test_downgrade_sets_timestamp(self):
         with patch("util.subscription_helper.timezone.now") as mock_now:
             mock_now.return_value = datetime(2025, 5, 5, tzinfo=datetime_timezone.utc)
-            mark_organization_billing_with_plan(self.organization, PlanNames.STARTUP)
+            mark_organization_billing_with_plan(self.organization, PlanNames.ORG_TEAM)
 
         with patch("util.subscription_helper.timezone.now") as mock_now:
             mock_now.return_value = datetime(2025, 6, 1, tzinfo=datetime_timezone.utc)

--- a/util/subscription_helper.py
+++ b/util/subscription_helper.py
@@ -554,9 +554,6 @@ def mark_owner_billing_with_plan(owner, plan_name: str, update_anchor: bool = Tr
 
         updates: list[str] = []
         if created:
-            if plan_name == PlanNames.FREE:
-                billing_record.downgraded_at = timezone.now()
-                billing_record.save(update_fields=["downgraded_at"])
             return billing_record
 
         for key, value in defaults.items():


### PR DESCRIPTION
This pull request introduces comprehensive support for organization-level billing and subscription management, extending existing user-based logic to handle organizations as first-class billing entities. It refactors core subscription helper functions to work generically with both users and organizations, updates event handling to distinguish between owner types, and adds targeted tests for organization billing workflows.

Key changes include:

**Generalization of Subscription Logic for Organizations and Users:**

- Refactored core helper functions (such as `get_stripe_customer`, `get_active_subscription`, `get_owner_plan`, and `get_or_create_stripe_customer`) in `util/subscription_helper.py` to accept either a user or an organization as the owner, with internal logic to resolve the owner type and fetch or create the appropriate billing records. This enables seamless support for both user and organization billing. [[1]](diffhunk://#diff-44308b093217fe3a6335cc1fcd223b53a1523b71c6103b601ba6b89137f37a37L34-R131) [[2]](diffhunk://#diff-44308b093217fe3a6335cc1fcd223b53a1523b71c6103b601ba6b89137f37a37L109-R187) [[3]](diffhunk://#diff-44308b093217fe3a6335cc1fcd223b53a1523b71c6103b601ba6b89137f37a37L181-R262)

- Added utility functions like `_resolve_owner_type`, `_get_billing_model_and_filters`, `_get_billing_record`, and `_get_or_create_billing_record` to abstract owner-type-specific behavior and reduce code duplication.

**Subscription Event Handling Improvements:**

- Updated `handle_subscription_event` in `pages/signals.py` to determine whether a subscription event is associated with a user or organization, and to route downgrade, plan update, and analytics logic accordingly. This ensures correct handling of cancellation, plan changes, and billing anchor alignment for both owner types. [[1]](diffhunk://#diff-1f4b2d782b1c12c27e8fec48e7995341d84458f49ee0c6d921f0615a1e812c7cL174-R201) [[2]](diffhunk://#diff-1f4b2d782b1c12c27e8fec48e7995341d84458f49ee0c6d921f0615a1e812c7cL187-R243) [[3]](diffhunk://#diff-1f4b2d782b1c12c27e8fec48e7995341d84458f49ee0c6d921f0615a1e812c7cL224-R344)

**Organization Billing Plan Management:**

- Introduced `mark_organization_billing_with_plan` and `downgrade_organization_to_free_plan` functions, and ensured that organization billing records are created, updated, and downgraded in sync with plan changes and Stripe events. [[1]](diffhunk://#diff-df561205c10ae968546e6f09e2dc7c8329be3dd54047873950f97d6259c3aa62L1-R13) [[2]](diffhunk://#diff-df561205c10ae968546e6f09e2dc7c8329be3dd54047873950f97d6259c3aa62R80-R129)

**Testing Enhancements:**

- Added a new test class `MarkOrganizationBillingWithPlanTests` to `tests/unit/test_subscription_helper.py` to verify that organization billing records are correctly created, updated, and downgraded, including handling of billing cycle anchors and downgrade timestamps.

**Imports and Typing:**

- Updated imports in `pages/signals.py` and `util/subscription_helper.py` to include organization billing models and typing improvements, ensuring all new logic is correctly referenced and type-safe. [[1]](diffhunk://#diff-1f4b2d782b1c12c27e8fec48e7995341d84458f49ee0c6d921f0615a1e812c7cL19-R25) [[2]](diffhunk://#diff-44308b093217fe3a6335cc1fcd223b53a1523b71c6103b601ba6b89137f37a37R14)

These changes lay the groundwork for robust organization-level billing and subscription management, aligning the codebase for future scalability and multi-tenant support.