### PR TITLE
Prompt Cache Optimization

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -1762,6 +1762,7 @@ def _get_system_instruction(
     *,
     is_first_run: bool = False,
 ) -> str:
+    """Return the static system instruction prompt for the agent."""
 
     base_prompt = (
         f"You are a persistent AI agent named '{agent.name}'. Use this name as your self identity when talking to the user. "


### PR DESCRIPTION
Moved budget information and reasoning streak information from the system prompt to the user prompt.
The iteration count is incremented all the time, and since it was at the beginning of the system prompt, it was causing cache misses.