### PR TITLE
Fix occasional exception when attaching safety identifier

### DIFF
--- a/api/agent/core/step_compaction.py
+++ b/api/agent/core/step_compaction.py
@@ -426,7 +426,7 @@ def llm_summarise_steps(previous: str, steps: Sequence[StepData], safety_identif
 
         if model.startswith("openai"):
             if safety_identifier:
-                params["safety_identifier"] = safety_identifier
+                params["safety_identifier"] = str(safety_identifier)
 
         resp = run_completion(model=model, messages=prompt, params=params)
         return resp.choices[0].message.content.strip()


### PR DESCRIPTION
This pull request makes a minor adjustment to how the `safety_identifier` parameter is handled when summarizing steps with an OpenAI model. The change ensures that `safety_identifier` is always passed as a string, which can help prevent type-related issues in downstream processing.

* Always convert `safety_identifier` to a string before passing it to the `params` dictionary in the `llm_summarise_steps` function in `step_compaction.py`.