### PR TITLE
Extract shared slugify utility

### DIFF
--- a/frontend/src/components/agentChat/ToolClusterCard.tsx
+++ b/frontend/src/components/agentChat/ToolClusterCard.tsx
@@ -6,6 +6,7 @@ import { ToolClusterTimelineOverlay } from './ToolClusterTimelineOverlay'
 import type { ToolClusterEvent } from './types'
 import type { ToolEntryDisplay } from './tooling/types'
 import { formatRelativeTimestamp } from '../../util/time'
+import { slugify } from '../../util/slugify'
 import { scrollIntoViewIfNeeded } from './scrollIntoView'
 
 type ToolClusterCardProps = {
@@ -16,13 +17,6 @@ type ToolClusterCardProps = {
 function ToolIcon({ icon, className }: { icon: ToolEntryDisplay['icon'] | undefined; className?: string }) {
   const IconComponent = icon ?? Workflow
   return <IconComponent className={className} aria-hidden="true" />
-}
-
-function slugify(value: string) {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
 }
 
 export function ToolClusterCard({ cluster, suppressedThinkingCursor }: ToolClusterCardProps) {

--- a/frontend/src/components/agentChat/ToolClusterTimelineOverlay.tsx
+++ b/frontend/src/components/agentChat/ToolClusterTimelineOverlay.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Workflow, X } from 'lucide-react'
 
 import { formatRelativeTimestamp } from '../../util/time'
+import { slugify } from '../../util/slugify'
 import { MarkdownViewer } from '../common/MarkdownViewer'
 import type { ToolClusterTransform, ToolEntryDisplay } from './tooling/types'
 
@@ -15,13 +16,6 @@ type ToolClusterTimelineOverlayProps = {
 function ToolIcon({ icon, className }: { icon: ToolEntryDisplay['icon'] | undefined; className?: string }) {
   const IconComponent = icon ?? Workflow
   return <IconComponent className={className} aria-hidden="true" />
-}
-
-function slugify(value: string) {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
 }
 
 function deriveCaption(entry: ToolEntryDisplay): string | null {

--- a/frontend/src/util/slugify.ts
+++ b/frontend/src/util/slugify.ts
@@ -1,0 +1,6 @@
+export function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}


### PR DESCRIPTION
### Motivation
- Deduplicate the `slugify` implementation used by tool cluster components to improve maintainability and avoid drift.

### Description
- Add `frontend/src/util/slugify.ts` which exports `slugify(value: string)` as a shared helper.
- Update `frontend/src/components/agentChat/ToolClusterCard.tsx` and `frontend/src/components/agentChat/ToolClusterTimelineOverlay.tsx` to import and use the shared `slugify` instead of defining local copies.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e825dfa408330b717134a6b009719)