### PR TITLE
Add per-user `max_intelligence_tier` quota and enforce cap in LLM tier resolution

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -125,7 +125,7 @@ class ApiKeyAdmin(admin.ModelAdmin):
 
 @admin.register(UserQuota)
 class UserQuotaAdmin(admin.ModelAdmin):
-    list_display = ("user", "agent_limit")
+    list_display = ("user", "agent_limit", "max_intelligence_tier")
     search_fields = ("user__email", "user__id")
 
 

--- a/api/agent/core/llm_config.py
+++ b/api/agent/core/llm_config.py
@@ -195,6 +195,7 @@ def resolve_preferred_tier_for_owner(owner: Any | None, tier_key: str | None) ->
         plan = None
 
     allowed = max_allowed_tier_for_plan(plan, is_organization=_is_org_owner(owner))
+    allowed = apply_user_quota_tier_cap(owner, allowed)
     return _clamp_tier(resolved, allowed)
 
 
@@ -256,6 +257,36 @@ def max_allowed_tier_for_plan(
     return AgentLLMTier.STANDARD
 
 
+def apply_user_quota_tier_cap(owner: Any | None, max_allowed: AgentLLMTier) -> AgentLLMTier:
+    """Apply a per-user quota override to intelligence tier limits when configured."""
+
+    if owner is None or _is_org_owner(owner):
+        return max_allowed
+
+    quota = getattr(owner, "quota", None)
+    tier_key = getattr(quota, "max_intelligence_tier", None) if quota is not None else None
+    if not tier_key and getattr(owner, "pk", None):
+        try:
+            UserQuota = apps.get_model("api", "UserQuota")
+            tier_key = (
+                UserQuota.objects.filter(user_id=owner.pk)
+                .values_list("max_intelligence_tier", flat=True)
+                .first()
+            )
+        except (AppRegistryNotReady, DatabaseError, LookupError):
+            tier_key = None
+
+    if not tier_key:
+        return max_allowed
+
+    try:
+        cap_tier = AgentLLMTier(str(tier_key).strip().lower())
+    except ValueError:
+        return max_allowed
+
+    return cap_tier
+
+
 def _clamp_tier(target: AgentLLMTier, max_allowed: AgentLLMTier) -> AgentLLMTier:
     if TIER_ORDER[target] <= TIER_ORDER[max_allowed]:
         return target
@@ -277,6 +308,7 @@ def default_preferred_tier_for_owner(owner: Any | None) -> AgentLLMTier:
         plan = None
 
     allowed = max_allowed_tier_for_plan(plan, is_organization=_is_org_owner(owner))
+    allowed = apply_user_quota_tier_cap(owner, allowed)
     if allowed != AgentLLMTier.STANDARD and resolved == AgentLLMTier.STANDARD:
         resolved = AgentLLMTier.PREMIUM
 
@@ -511,6 +543,7 @@ def get_agent_llm_tier(agent: Any, *, is_first_loop: bool | None = None) -> Agen
     is_org_owned = bool(getattr(agent, "organization_id", None))
     trial_eligible = bool(not is_org_owned and _within_new_account_premium_window(owner))
     allowed_tier = max_allowed_tier_for_plan(plan, is_organization=is_org_owned)
+    allowed_tier = apply_user_quota_tier_cap(owner, allowed_tier)
     trial_boost_active = trial_eligible and allowed_tier == AgentLLMTier.STANDARD
     if trial_boost_active:
         allowed_tier = AgentLLMTier.PREMIUM

--- a/api/migrations/0300_userquota_max_intelligence_tier.py
+++ b/api/migrations/0300_userquota_max_intelligence_tier.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0299_promptconfig_browser_task_unified_history_limit"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userquota",
+            name="max_intelligence_tier",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("standard", "Standard"),
+                    ("premium", "Premium"),
+                    ("max", "Max"),
+                    ("ultra", "Ultra"),
+                    ("ultra_max", "Ultra Max"),
+                ],
+                default=None,
+                help_text="If set, overrides the plan max and caps the highest intelligence tier this user can select for persistent agents.",
+                max_length=16,
+                null=True,
+            ),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -506,6 +506,14 @@ class ApiKey(models.Model):
 
 
 class UserQuota(models.Model):
+    INTELLIGENCE_TIER_CHOICES = (
+        ("standard", "Standard"),
+        ("premium", "Premium"),
+        ("max", "Max"),
+        ("ultra", "Ultra"),
+        ("ultra_max", "Ultra Max"),
+    )
+
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="quota"
     )
@@ -513,6 +521,14 @@ class UserQuota(models.Model):
     # Optional per-user override for max contacts per agent; when null or <= 0, plan default applies
     max_agent_contacts = models.PositiveIntegerField(null=True, blank=True, default=None,
                                                     help_text="If set (>0), overrides plan max contacts per agent for this user")
+    max_intelligence_tier = models.CharField(
+        max_length=16,
+        null=True,
+        blank=True,
+        choices=INTELLIGENCE_TIER_CHOICES,
+        default=None,
+        help_text="If set, overrides the plan max and caps the highest intelligence tier this user can select for persistent agents.",
+    )
 
     def __str__(self):
         return f"Quota for {self.user.email}"

--- a/console/views.py
+++ b/console/views.py
@@ -62,6 +62,7 @@ from api.agent.core.llm_config import (
     get_llm_tier_label,
     get_llm_tier_multipliers,
     get_llm_tier_ranks,
+    apply_user_quota_tier_cap,
     max_allowed_tier_for_plan,
 )
 from api.agent.avatar import maybe_schedule_agent_avatar
@@ -326,6 +327,7 @@ def build_llm_intelligence_props(
             plan = get_user_plan(owner)
 
     allowed_tier = max_allowed_tier_for_plan(plan, is_organization=(owner_type == 'organization'))
+    allowed_tier = apply_user_quota_tier_cap(owner, allowed_tier)
     system_default_tier = get_system_default_tier().value
     tier_ranks = get_llm_tier_ranks()
     allowed_rank = tier_ranks.get(allowed_tier.value)
@@ -4870,6 +4872,7 @@ class AgentDetailView(ConsoleViewMixin, DetailView):
                 plan = None
 
         allowed_llm_tier = max_allowed_tier_for_plan(plan, is_organization=(owner_type == 'organization'))
+        allowed_llm_tier = apply_user_quota_tier_cap(owner, allowed_llm_tier)
         if settings.GOBII_PROPRIETARY_MODE:
             can_edit_intelligence = bool(
                 owner is not None

--- a/tests/unit/test_llm_tier_preferences.py
+++ b/tests/unit/test_llm_tier_preferences.py
@@ -20,6 +20,7 @@ from api.models import (
     PersistentAgent,
     TaskCredit,
     TaskCreditConfig,
+    UserQuota,
 )
 from constants.plans import PlanNames
 from tests.utils.llm_seed import get_intelligence_tier
@@ -85,6 +86,17 @@ class SystemDefaultTierTests(TestCase):
         # Free plan users are limited to STANDARD; preferences/defaults should be clamped.
         self.assertEqual(resolve_preferred_tier_for_owner(self.user, None), AgentLLMTier.STANDARD)
         self.assertEqual(resolve_preferred_tier_for_owner(self.user, "max"), AgentLLMTier.STANDARD)
+
+    def test_user_quota_can_cap_paid_plan_tier(self):
+        UserQuota.objects.filter(user=self.user).update(max_intelligence_tier=AgentLLMTier.PREMIUM.value)
+        with patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}):
+            resolved = resolve_preferred_tier_for_owner(self.user, AgentLLMTier.ULTRA_MAX.value)
+        self.assertEqual(resolved, AgentLLMTier.PREMIUM)
+
+    def test_user_quota_can_override_free_plan_limit(self):
+        UserQuota.objects.filter(user=self.user).update(max_intelligence_tier=AgentLLMTier.MAX.value)
+        resolved = resolve_preferred_tier_for_owner(self.user, AgentLLMTier.ULTRA_MAX.value)
+        self.assertEqual(resolved, AgentLLMTier.MAX)
 
 
 @tag("batch_llm_intelligence")


### PR DESCRIPTION
### Motivation
- Allow a per-user override to cap the highest intelligence tier a user can select for persistent agents independent of plan limits.
- Surface the setting in admin so operators can view and edit per-user intelligence caps.
- Ensure UI and server-side tier resolution respect the per-user cap when calculating allowed and default tiers.

### Description
- Add `max_intelligence_tier` `CharField` to `UserQuota` with choices and help text and include a new migration `0300_userquota_max_intelligence_tier.py` to persist the column.
- Add `max_intelligence_tier` to the `UserQuotaAdmin` `list_display` for visibility in the admin UI.
- Implement `apply_user_quota_tier_cap(owner, max_allowed)` in `api.agent.core.llm_config` and wire it into `resolve_preferred_tier_for_owner`, `default_preferred_tier_for_owner`, and `get_agent_llm_tier` to enforce per-user caps, including DB fallback lookup when `owner.quota` is not populated.
- Apply the same cap in console logic by importing and calling `apply_user_quota_tier_cap` in `console.views` where allowed tiers are computed, and update the unit tests to cover the new capping behavior in `tests/unit/test_llm_tier_preferences.py`.

### Testing
- Added unit tests in `tests/unit/test_llm_tier_preferences.py` covering that `UserQuota.max_intelligence_tier` can cap paid-plan tiers and can override free-plan limits; these tests passed.
- Existing tier preference and system-default tests were run as part of the unit test file and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a576e4dbf083308693d22f5ad34f17)