### PR TITLE
Skip sandbox discovery pods for non-stdio MCP servers

### DIFF
--- a/api/services/sandbox_kubernetes.py
+++ b/api/services/sandbox_kubernetes.py
@@ -334,9 +334,14 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
         if not server_payload:
             return {"status": "error", "message": "Missing MCP server payload for discovery."}
         if not _requires_discovery_pod(server_payload):
+            from api.agent.tools.mcp_manager import get_mcp_manager
+
+            manager = get_mcp_manager()
+            ok = manager.discover_tools_for_server(server_config_id)
             return {
-                "status": "skipped",
-                "message": "Discovery pod only applies to user-scoped stdio MCP servers.",
+                "status": "ok" if ok else "error",
+                "reason": reason,
+                "message": "Discovery pod skipped for non-stdio user server.",
             }
 
         proxy_url: Optional[str] = None

--- a/tests/unit/test_sandbox_kubernetes.py
+++ b/tests/unit/test_sandbox_kubernetes.py
@@ -100,10 +100,13 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
         self.assertIsNone(create_args.kwargs.get("no_proxy"))
         mock_delete_pod.assert_called_once_with(_discovery_pod_name("cfg-3"))
 
-    def test_discovery_skips_for_user_scope_http_server(self):
+    def test_discovery_uses_local_discovery_for_user_scope_http_server(self):
         backend = self._backend()
 
-        with patch.object(backend, "_create_discovery_pod") as mock_create_pod:
+        with patch.object(backend, "_create_discovery_pod") as mock_create_pod, patch(
+            "api.agent.tools.mcp_manager.get_mcp_manager"
+        ) as mock_get_manager:
+            mock_get_manager.return_value.discover_tools_for_server.return_value = True
             result = backend.discover_mcp_tools(
                 "cfg-4",
                 reason="unit-test",
@@ -115,5 +118,6 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
                 },
             )
 
-        self.assertEqual(result.get("status"), "skipped")
+        self.assertEqual(result.get("status"), "ok")
+        mock_get_manager.return_value.discover_tools_for_server.assert_called_once_with("cfg-4")
         mock_create_pod.assert_not_called()


### PR DESCRIPTION
### Motivation
- Discovery pods were being created for HTTP-based MCP servers even when no stdio/command-based runtime was present, leading to unnecessary pod provisioning; the intent is to only spawn discovery pods for user-scoped stdio MCP servers.

### Description
- Add `_requires_discovery_pod(server_payload)` in `api/services/sandbox_kubernetes.py` to detect `scope == MCPServerConfig.Scope.USER`, presence of `command`, and absence of `url` and import `MCPServerConfig` for the check.
- Short-circuit `KubernetesSandboxBackend.discover_mcp_tools` to return a `{status: "skipped"}` response when the payload does not require a discovery pod instead of attempting proxy/pod setup.
- Add `test_discovery_skips_for_user_scope_http_server` to `tests/unit/test_sandbox_kubernetes.py` and update existing discovery fixtures to include `scope: "user"` so they continue to exercise the stdio discovery path.

### Testing
- Ran the targeted test module with environment overrides using `DJANGO_SECRET_KEY=test POSTGRES_DB=test POSTGRES_USER=test POSTGRES_PASSWORD=test POSTGRES_HOST=localhost POSTGRES_PORT=5432 REDIS_URL=redis://localhost:6379/0 GOBII_ENCRYPTION_KEY=dummy ANTHROPIC_API_KEY=dummy uv run python manage.py test tests.unit.test_sandbox_kubernetes --settings=config.test_settings`, and the suite completed `OK` (4 tests).
- An initial run without required environment variables failed due to missing env vars (e.g., `DJANGO_SECRET_KEY`), which was resolved by providing the test env overrides.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57b5ea40c8330a7bf218f5e7a681d)