### PR TITLE
Fix peer message labels

### DIFF
--- a/frontend/src/components/agentAudit/EventRows.tsx
+++ b/frontend/src/components/agentAudit/EventRows.tsx
@@ -136,9 +136,10 @@ export function MessageRow({
   const attachments = message.attachments || []
   const selfAgentName = message.self_agent_name?.trim() || 'Agent'
   const peerAgentName = message.peer_agent?.name?.trim() || 'Linked agent'
-  const directionLabel = message.peer_agent
-    ? (message.is_outbound ? `${selfAgentName} → ${peerAgentName}` : `${peerAgentName} → ${selfAgentName}`)
-    : (message.is_outbound ? 'Agent → User' : 'User → Agent')
+  const [from, to] = message.peer_agent
+    ? [selfAgentName, peerAgentName]
+    : ['Agent', 'User']
+  const directionLabel = message.is_outbound ? `${from} → ${to}` : `${to} → ${from}`
 
   return (
     <div className="rounded-lg border border-slate-200/80 bg-white px-3 py-2 shadow-[0_1px_2px_rgba(15,23,42,0.06)]">


### PR DESCRIPTION
## Summary
- update agent auditor message row labels to use peer agent metadata when present
- render agent-to-agent messages as `<self agent> → <peer agent>` (or reverse for inbound)
- keep existing `Agent → User` / `User → Agent` labels for non-peer messages

## Testing
- `npm run lint -- src/components/agentAudit/EventRows.tsx` *(fails due to existing ESLint flat-config migration issue in repo config, not due to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83ac1f13883308847d8c28f3a3850)