### PR TITLE
Add Factory Droid GitHub Actions workflow

### DIFF
--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,41 @@
+name: Droid
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  droid:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Droid
+        uses: Factory-AI/droid-action@v3
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}


### PR DESCRIPTION
## What

Adds the **@Droid** GitHub Actions workflow so that Droid responds to `@droid` mentions in:

- Issue comments
- Pull request comments
- Pull request reviews
- Issue descriptions and titles

## Setup required after merging

1. **Create a Factory API key** at https://app.factory.ai/settings/api-keys
2. **Add the secret** to this repo: go to **Settings > Secrets and variables > Actions** and add:
   - **Name:** `FACTORY_API_KEY`
   - **Value:** Your generated API key

Once the secret is configured and this PR is merged, tagging `@droid` in any issue or PR comment will trigger the workflow.