### PR TITLE
[Droid] Auto-swap bar to horizontal_bar for long labels

### DIFF
--- a/api/agent/tools/create_chart.py
+++ b/api/agent/tools/create_chart.py
@@ -39,6 +39,12 @@ CHART_TYPES = {
     "scatter",
 }
 
+# Thresholds for auto-swapping bar → horizontal_bar.  Horizontal bars handle
+# long category labels better because labels sit on the y-axis where there is
+# ample horizontal room.
+_LONG_LABEL_CHAR_THRESHOLD = 15
+_MANY_CATEGORIES_THRESHOLD = 5
+
 
 def _execute_query_for_data(query: str) -> tuple[List[Dict], Optional[List[str]], Optional[str]]:
     """Execute a SQL query and return results as a list of dicts."""
@@ -50,6 +56,35 @@ def _execute_query_for_data(query: str) -> tuple[List[Dict], Optional[List[str]]
 def _extract_values(data: List[Dict], key: str) -> List[Any]:
     """Extract values for a given key from list of dicts."""
     return [row.get(key) for row in data]
+
+
+def _max_label_len(labels: list) -> int:
+    """Return the maximum string length among label values."""
+    return max((len(str(v)) for v in labels if v is not None), default=0)
+
+
+def _should_swap_to_horizontal(chart_type: str, x_vals: list) -> bool:
+    """Return True when a bar chart should automatically swap to horizontal_bar.
+
+    Triggers when any label exceeds the character threshold *or* there are more
+    categories than comfortably fit on a vertical x-axis.
+    """
+    if chart_type != "bar":
+        return False
+    has_long_label = _max_label_len(x_vals) > _LONG_LABEL_CHAR_THRESHOLD
+    has_many_categories = len([v for v in x_vals if v is not None]) > _MANY_CATEGORIES_THRESHOLD
+    return has_long_label or has_many_categories
+
+
+def _compute_horizontal_bar_left_margin(labels: list) -> float:
+    """Return a left subplot margin (0–1 fraction of figure width) sized for y-axis labels.
+
+    tight_layout alone can still clip long category labels in some rendering
+    paths; an explicit margin based on the longest label prevents that.
+    """
+    max_len = _max_label_len(labels)
+    # ~0.01 figure-fraction per character, clamped to a safe range.
+    return max(0.15, min(0.45, max_len * 0.01))
 
 
 def _setup_style():
@@ -233,12 +268,21 @@ def _generate_chart(
     fig, ax = plt.subplots(figsize=figsize)
 
     # Extract data based on chart type
+    swapped = False
     if chart_type in ("pie", "donut"):
         val_data = _extract_values(data, values) if values else []
         label_data = _extract_values(data, labels) if labels else []
         _create_pie_chart(ax, val_data, label_data, chart_colors, donut=(chart_type == "donut"))
     else:
         x_vals = _extract_values(data, x) if x else list(range(len(data)))
+
+        # Auto-swap bar → horizontal_bar when category labels are too long or
+        # too numerous.  Swap the explicit axis labels and remember the swap so
+        # we can also correct the *default* axis labels below.
+        swapped = _should_swap_to_horizontal(chart_type, x_vals)
+        if swapped:
+            chart_type = "horizontal_bar"
+            xlabel, ylabel = ylabel, xlabel
 
         # Handle single or multiple y series
         if isinstance(y, list):
@@ -271,20 +315,30 @@ def _generate_chart(
             elif chart_type == "scatter":
                 _create_scatter_chart(ax, x_vals, y_vals, chart_colors)
 
+        # Reserve enough left margin for horizontal bar y-axis labels so they
+        # are not clipped in the final SVG.
+        if chart_type == "horizontal_bar":
+            fig.subplots_adjust(left=_compute_horizontal_bar_left_margin(x_vals))
+
     # Set labels and title
     if title:
         ax.set_title(title, pad=15, fontweight='bold')
 
     if chart_type not in ("pie", "donut"):
+        # When auto-swapped the categories (x) moved to the y-axis and values
+        # (y) moved to the x-axis, so default labels need the same swap.
+        default_xlabel = y if swapped else x
+        default_ylabel = x if swapped else y
+
         if xlabel:
             ax.set_xlabel(xlabel)
-        elif x:
-            ax.set_xlabel(x.replace("_", " ").title())
+        elif default_xlabel and isinstance(default_xlabel, str):
+            ax.set_xlabel(default_xlabel.replace("_", " ").title())
 
         if ylabel:
             ax.set_ylabel(ylabel)
-        elif y and isinstance(y, str):
-            ax.set_ylabel(y.replace("_", " ").title())
+        elif default_ylabel and isinstance(default_ylabel, str):
+            ax.set_ylabel(default_ylabel.replace("_", " ").title())
 
     # Rotate x-axis labels if they're long
     if chart_type not in ("pie", "donut", "horizontal_bar"):

--- a/tests/unit/test_create_chart.py
+++ b/tests/unit/test_create_chart.py
@@ -5,7 +5,17 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 
-from api.agent.tools.create_chart import _build_chart_save_path, execute_create_chart, get_create_chart_tool
+from api.agent.tools.create_chart import (
+    _LONG_LABEL_CHAR_THRESHOLD,
+    _MANY_CATEGORIES_THRESHOLD,
+    _build_chart_save_path,
+    _compute_horizontal_bar_left_margin,
+    _generate_chart,
+    _max_label_len,
+    _should_swap_to_horizontal,
+    execute_create_chart,
+    get_create_chart_tool,
+)
 from api.models import BrowserUseAgent, PersistentAgent
 
 
@@ -556,3 +566,198 @@ class CreateChartToolTests(TestCase):
         self.assertTrue(first_path.startswith("/charts/bar_20260208_175356_"))
         self.assertTrue(second_path.startswith("/charts/bar_20260208_175356_"))
         self.assertNotEqual(first_path, second_path)
+
+
+@tag("batch_agent_tools")
+class MaxLabelLenTests(TestCase):
+    """Unit tests for _max_label_len helper."""
+
+    def test_empty_list(self):
+        self.assertEqual(_max_label_len([]), 0)
+
+    def test_all_none(self):
+        self.assertEqual(_max_label_len([None, None]), 0)
+
+    def test_short_strings(self):
+        self.assertEqual(_max_label_len(["Jan", "Feb", "Mar"]), 3)
+
+    def test_mixed_types_converted_to_str(self):
+        self.assertEqual(_max_label_len([1, 10, 100]), 3)
+
+    def test_long_label_dominates(self):
+        labels = ["A", "B", "Very Long Label Name Here"]
+        self.assertEqual(_max_label_len(labels), len("Very Long Label Name Here"))
+
+    def test_none_values_skipped(self):
+        labels = [None, "Short", "A Longer Label"]
+        self.assertEqual(_max_label_len(labels), len("A Longer Label"))
+
+
+@tag("batch_agent_tools")
+class ShouldSwapToHorizontalTests(TestCase):
+    """Unit tests for _should_swap_to_horizontal."""
+
+    def test_non_bar_type_never_swaps(self):
+        long_labels = ["A Very Long Label Name Here"] * 3
+        for chart_type in ("horizontal_bar", "line", "area", "scatter", "pie", "donut"):
+            self.assertFalse(
+                _should_swap_to_horizontal(chart_type, long_labels),
+                f"Expected no swap for chart_type={chart_type!r}",
+            )
+
+    def test_bar_with_short_labels_does_not_swap(self):
+        short_labels = ["Jan", "Feb", "Mar"]
+        self.assertFalse(_should_swap_to_horizontal("bar", short_labels))
+
+    def test_bar_with_labels_exactly_at_char_threshold_does_not_swap(self):
+        labels = ["x" * _LONG_LABEL_CHAR_THRESHOLD]
+        self.assertFalse(_should_swap_to_horizontal("bar", labels))
+
+    def test_bar_with_labels_one_over_char_threshold_swaps(self):
+        labels = ["x" * (_LONG_LABEL_CHAR_THRESHOLD + 1)]
+        self.assertTrue(_should_swap_to_horizontal("bar", labels))
+
+    def test_bar_with_many_categories_swaps(self):
+        labels = [f"c{i}" for i in range(_MANY_CATEGORIES_THRESHOLD + 1)]
+        self.assertTrue(_should_swap_to_horizontal("bar", labels))
+
+    def test_bar_at_category_threshold_does_not_swap(self):
+        labels = [f"c{i}" for i in range(_MANY_CATEGORIES_THRESHOLD)]
+        self.assertFalse(_should_swap_to_horizontal("bar", labels))
+
+    def test_bar_with_long_labels_swaps(self):
+        labels = ["Very Long Category Name", "Another Long Name", "Short"]
+        self.assertTrue(_should_swap_to_horizontal("bar", labels))
+
+    def test_bar_with_empty_labels_does_not_swap(self):
+        self.assertFalse(_should_swap_to_horizontal("bar", []))
+
+    def test_bar_with_all_none_labels_does_not_swap(self):
+        self.assertFalse(_should_swap_to_horizontal("bar", [None, None]))
+
+    def test_bar_with_numeric_labels_below_threshold(self):
+        self.assertFalse(_should_swap_to_horizontal("bar", [1, 2, 3]))
+
+
+@tag("batch_agent_tools")
+class ComputeHorizontalBarLeftMarginTests(TestCase):
+    """Unit tests for _compute_horizontal_bar_left_margin."""
+
+    def test_empty_labels_returns_minimum(self):
+        self.assertAlmostEqual(_compute_horizontal_bar_left_margin([]), 0.15)
+
+    def test_short_labels_clamp_to_minimum(self):
+        self.assertAlmostEqual(_compute_horizontal_bar_left_margin(["Jan", "Feb"]), 0.15)
+
+    def test_moderate_labels(self):
+        labels = ["x" * 20]
+        self.assertAlmostEqual(_compute_horizontal_bar_left_margin(labels), 0.20)
+
+    def test_long_labels_clamp_to_maximum(self):
+        labels = ["x" * 100]
+        self.assertAlmostEqual(_compute_horizontal_bar_left_margin(labels), 0.45)
+
+    def test_margin_increases_with_label_length(self):
+        short_margin = _compute_horizontal_bar_left_margin(["Short"])
+        long_margin = _compute_horizontal_bar_left_margin(["A Much Longer Label That Needs Space"])
+        self.assertGreaterEqual(long_margin, short_margin)
+
+    def test_result_within_valid_bounds(self):
+        for length in range(0, 60, 5):
+            labels = ["x" * length]
+            margin = _compute_horizontal_bar_left_margin(labels)
+            self.assertGreaterEqual(margin, 0.15)
+            self.assertLessEqual(margin, 0.45)
+
+
+@tag("batch_agent_tools")
+class AxisSwapIntegrationTests(TestCase):
+    """Integration tests: verify auto-swap and margin behaviour inside _generate_chart."""
+
+    SHORT_DATA = [
+        {"cat": "Jan", "val": 10},
+        {"cat": "Feb", "val": 20},
+        {"cat": "Mar", "val": 30},
+    ]
+
+    LONG_LABEL_DATA = [
+        {"cat": "North America Operations", "val": 100},
+        {"cat": "European Union Markets", "val": 200},
+        {"cat": "Asia Pacific Region", "val": 150},
+    ]
+
+    MANY_CATEGORIES_DATA = [
+        {"cat": f"Cat {i}", "val": i * 10}
+        for i in range(_MANY_CATEGORIES_THRESHOLD + 1)
+    ]
+
+    def _make_svg(self, chart_type, data, x="cat", y="val", **kwargs):
+        svg_bytes = _generate_chart(chart_type=chart_type, data=data, x=x, y=y, **kwargs)
+        return svg_bytes.decode("utf-8")
+
+    def test_bar_with_short_labels_renders_vertical_bars(self):
+        svg = self._make_svg("bar", self.SHORT_DATA)
+        self.assertIn("<svg", svg)
+
+    def test_bar_with_long_labels_renders_horizontal_bars(self):
+        svg = self._make_svg("bar", self.LONG_LABEL_DATA)
+        self.assertIn("<svg", svg)
+        self.assertIn("rect", svg)
+
+    def test_bar_with_long_labels_svg_contains_label_text(self):
+        """Long labels must appear in the SVG (not truncated)."""
+        svg = self._make_svg("bar", self.LONG_LABEL_DATA)
+        self.assertIn("North America", svg)
+
+    def test_bar_with_many_categories_auto_swaps(self):
+        svg = self._make_svg("bar", self.MANY_CATEGORIES_DATA)
+        self.assertIn("<svg", svg)
+        self.assertIn("rect", svg)
+
+    def test_explicit_horizontal_bar_with_long_labels_preserves_labels(self):
+        svg = self._make_svg("horizontal_bar", self.LONG_LABEL_DATA)
+        self.assertIn("North America", svg)
+
+    def test_horizontal_bar_with_short_labels_succeeds(self):
+        svg = self._make_svg("horizontal_bar", self.SHORT_DATA)
+        self.assertIn("<svg", svg)
+
+    def test_line_chart_with_long_labels_is_not_swapped(self):
+        """Non-bar chart types must not be affected by auto-swap logic."""
+        svg = self._make_svg("line", self.LONG_LABEL_DATA)
+        self.assertIn("<svg", svg)
+
+    def test_generate_chart_returns_bytes(self):
+        svg_bytes = _generate_chart(
+            chart_type="bar", data=self.SHORT_DATA, x="cat", y="val",
+        )
+        self.assertIsInstance(svg_bytes, bytes)
+        self.assertTrue(svg_bytes.startswith(b"<?xml") or svg_bytes.startswith(b"<svg"))
+
+    @patch("api.agent.files.filespace_service.write_bytes_to_dir")
+    @patch("api.agent.files.attachment_helpers.build_signed_filespace_download_url")
+    def test_execute_create_chart_succeeds_with_long_labels(self, mock_signed_url, mock_write):
+        """execute_create_chart with a bar chart and long labels succeeds via auto-swap."""
+        mock_write.return_value = {"status": "ok", "path": "/charts/hbar.svg", "node_id": "id1"}
+        mock_signed_url.return_value = "https://example.com/hbar.svg"
+
+        User = get_user_model()
+        user = User.objects.create_user(
+            username="swap@example.com", email="swap@example.com", password="secret",
+        )
+        browser_agent = BrowserUseAgent.objects.create(user=user, name="Swap Browser")
+        agent = PersistentAgent.objects.create(
+            user=user, name="Swap Agent", charter="test", browser_use_agent=browser_agent,
+        )
+
+        with mock_query_data(self.LONG_LABEL_DATA):
+            result = execute_create_chart(agent, {
+                "type": "bar",
+                "query": "SELECT cat, val FROM t",
+                "x": "cat",
+                "y": "val",
+                "title": "Long Label Bar",
+            })
+
+        self.assertEqual(result["status"], "ok")
+        self.assertIn("inline", result)


### PR DESCRIPTION
Resolves #772

This PR was generated by Factory.ai Droid. It implements the requested fix in `create_chart.py` to:
1. Auto-swap `bar` charts to `horizontal_bar` when category labels are long or numerous.
2. Explicitly compute and set the left margin to prevent clipping in the final SVG.