### PR TITLE
feat: add SKIP_FRONTEND_BUILD arg and optimize runtime COPY in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,7 +120,8 @@ ENV STATIC_ROOT=/app/staticfiles \
 # ── Granular COPY from builder ──────────────────
 # Copy only what's needed at runtime. Excludes: frontend/, node_modules/,
 # .npm, tests/, __pycache__/, gobii_platform.egg-info/, static/ (source),
-# docs/, scripts/, reports/, assets/, mediafiles/, .github/, .venv/
+# docs/, scripts/, reports/, assets/, mediafiles/, .github/, .venv/,
+# prompts/, sandbox_compute_server/, src/ (empty / not tracked in git)
 
 # Python application directories
 COPY --from=builder /app/api ./api
@@ -133,11 +134,8 @@ COPY --from=builder /app/marketing_events ./marketing_events
 COPY --from=builder /app/middleware ./middleware
 COPY --from=builder /app/misc ./misc
 COPY --from=builder /app/pages ./pages
-COPY --from=builder /app/prompts ./prompts
 COPY --from=builder /app/proprietary ./proprietary
-COPY --from=builder /app/sandbox_compute_server ./sandbox_compute_server
 COPY --from=builder /app/setup ./setup
-COPY --from=builder /app/src ./src
 COPY --from=builder /app/tasks ./tasks
 COPY --from=builder /app/templates ./templates
 COPY --from=builder /app/templatetags ./templatetags


### PR DESCRIPTION
## Summary

Optimize the Docker image build for CI deployments by making the frontend build optional and reducing the runtime image size.

## Changes

### 1. `SKIP_FRONTEND_BUILD` build arg (default: `false`)

When `SKIP_FRONTEND_BUILD=true` is passed, the Dockerfile skips `npm ci` and `npm run build` in the builder stage. This saves ~3-5 minutes on CI builds where frontend assets are already published to CDN separately.

- `collectstatic` still runs unconditionally (handles non-frontend static files)
- Node.js and MCP tools (`@brightdata/mcp`, `exa-mcp-server`) remain unconditionally installed
- Default behavior (`false`) is identical to before — local `docker compose` works unchanged

### 2. Granular runtime COPY

Replaced `COPY --from=builder /app /app` with targeted COPY commands that exclude:
- `frontend/node_modules/` (~300MB)
- Frontend source files
- `.npm` cache
- Build-only artifacts (`docs/`, `scripts/`, `reports/`, `assets/`, etc.)

This reduces the final image size significantly.

## Testing

Both build paths verified locally:
- `docker build -f docker/Dockerfile --platform linux/amd64 .` (default, full frontend build) ✓
- `docker build -f docker/Dockerfile --platform linux/amd64 --build-arg SKIP_FRONTEND_BUILD=true .` (skip frontend) ✓

## Related

Deploy workflow PR (passes `SKIP_FRONTEND_BUILD=true` to Docker builds): https://github.com/gobii-ai/gobii/pull/278