### PR TITLE
feat: add Avian as LLM provider

### DIFF
--- a/api/migrations/0334_add_avian_provider.py
+++ b/api/migrations/0334_add_avian_provider.py
@@ -1,0 +1,31 @@
+"""Seed LLMProvider record for Avian (OpenAI-compatible inference API)."""
+
+from django.db import migrations
+
+
+def seed_avian_provider(apps, schema_editor):
+    LLMProvider = apps.get_model("api", "LLMProvider")
+    LLMProvider.objects.get_or_create(
+        key="avian",
+        defaults={
+            "display_name": "Avian",
+            "enabled": True,
+            "env_var_name": "AVIAN_API_KEY",
+            "browser_backend": "OPENAI_COMPAT",
+            "supports_safety_identifier": False,
+            "model_prefix": "openai/",
+            "vertex_project": "",
+            "vertex_location": "",
+        },
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0333_globalagentskill_and_agentskill_source"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_avian_provider, reverse_code=migrations.RunPython.noop),
+    ]

--- a/api/migrations/0334_add_avian_provider.py
+++ b/api/migrations/0334_add_avian_provider.py
@@ -20,6 +20,11 @@ def seed_avian_provider(apps, schema_editor):
     )
 
 
+def remove_avian_provider(apps, schema_editor):
+    LLMProvider = apps.get_model("api", "LLMProvider")
+    LLMProvider.objects.filter(key="avian").delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -27,5 +32,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(seed_avian_provider, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(seed_avian_provider, reverse_code=remove_avian_provider),
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gobii-platform"
-version = "2.10.0"
+version = "2.10.1"
 description = "Platform for browser agents"
 requires-python = ">=3.12"
 

--- a/setup/forms.py
+++ b/setup/forms.py
@@ -74,6 +74,7 @@ class LLMConfigForm(forms.Form):
     PROVIDER_OPENROUTER = "openrouter"
     PROVIDER_ANTHROPIC = "anthropic"
     PROVIDER_FIREWORKS = "fireworks"
+    PROVIDER_AVIAN = "avian"
     PROVIDER_CUSTOM = "custom"
 
     PROVIDER_CHOICES = (
@@ -81,6 +82,7 @@ class LLMConfigForm(forms.Form):
         (PROVIDER_OPENROUTER, _("OpenRouter")),
         (PROVIDER_ANTHROPIC, _("Anthropic")),
         (PROVIDER_FIREWORKS, _("Fireworks.ai")),
+        (PROVIDER_AVIAN, _("Avian")),
         (PROVIDER_CUSTOM, _("Custom OpenAI-compatible endpoint")),
     )
 

--- a/setup/views.py
+++ b/setup/views.py
@@ -47,6 +47,7 @@ DEFAULT_ORCHESTRATOR_MODELS = {
     LLMConfigForm.PROVIDER_OPENROUTER: "deepseek/deepseek-v3.2",
     LLMConfigForm.PROVIDER_ANTHROPIC: "claude-sonnet-4-20250514",
     LLMConfigForm.PROVIDER_FIREWORKS: "accounts/fireworks/models/gpt-oss-120b",
+    LLMConfigForm.PROVIDER_AVIAN: "deepseek-v3.2",
 }
 
 DEFAULT_BROWSER_MODELS = {
@@ -54,16 +55,19 @@ DEFAULT_BROWSER_MODELS = {
     LLMConfigForm.PROVIDER_OPENROUTER: "deepseek/deepseek-v3.2",
     LLMConfigForm.PROVIDER_ANTHROPIC: "claude-sonnet-4-20250514",
     LLMConfigForm.PROVIDER_FIREWORKS: "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507",
+    LLMConfigForm.PROVIDER_AVIAN: "deepseek-v3.2",
 }
 
 DEFAULT_BROWSER_BASE_URLS = {
     LLMConfigForm.PROVIDER_OPENROUTER: "https://openrouter.ai/api/v1",
     LLMConfigForm.PROVIDER_FIREWORKS: "https://api.fireworks.ai/inference/v1",
+    LLMConfigForm.PROVIDER_AVIAN: "https://api.avian.io/v1",
 }
 DEFAULT_PROVIDER_API_BASES = {
     LLMConfigForm.PROVIDER_OPENAI: "https://api.openai.com/v1",
     LLMConfigForm.PROVIDER_OPENROUTER: DEFAULT_BROWSER_BASE_URLS.get(LLMConfigForm.PROVIDER_OPENROUTER, ""),
     LLMConfigForm.PROVIDER_FIREWORKS: DEFAULT_BROWSER_BASE_URLS.get(LLMConfigForm.PROVIDER_FIREWORKS, ""),
+    LLMConfigForm.PROVIDER_AVIAN: DEFAULT_BROWSER_BASE_URLS.get(LLMConfigForm.PROVIDER_AVIAN, ""),
 }
 
 ORCHESTRATOR_ENDPOINT_KEYS = {
@@ -71,6 +75,7 @@ ORCHESTRATOR_ENDPOINT_KEYS = {
     LLMConfigForm.PROVIDER_OPENROUTER: "openrouter_deepseek_32",
     LLMConfigForm.PROVIDER_ANTHROPIC: "anthropic_sonnet4",
     LLMConfigForm.PROVIDER_FIREWORKS: "fireworks_gpt_oss_120b",
+    LLMConfigForm.PROVIDER_AVIAN: "avian_deepseek_v32",
 }
 
 BROWSER_ENDPOINT_KEYS = {
@@ -78,6 +83,7 @@ BROWSER_ENDPOINT_KEYS = {
     LLMConfigForm.PROVIDER_OPENROUTER: "openrouter_deepseek_32",
     LLMConfigForm.PROVIDER_ANTHROPIC: "anthropic_sonnet4",
     LLMConfigForm.PROVIDER_FIREWORKS: "fireworks_qwen3_235b",
+    LLMConfigForm.PROVIDER_AVIAN: "avian_deepseek_v32",
 }
 
 PROVIDER_KEY_MAP = {
@@ -85,6 +91,7 @@ PROVIDER_KEY_MAP = {
     LLMConfigForm.PROVIDER_OPENROUTER: "openrouter",
     LLMConfigForm.PROVIDER_ANTHROPIC: "anthropic",
     LLMConfigForm.PROVIDER_FIREWORKS: "fireworks",
+    LLMConfigForm.PROVIDER_AVIAN: "avian",
 }
 
 MODEL_PREFIXES = {
@@ -92,6 +99,7 @@ MODEL_PREFIXES = {
     LLMConfigForm.PROVIDER_OPENROUTER: "openrouter/",
     LLMConfigForm.PROVIDER_ANTHROPIC: "anthropic/",
     LLMConfigForm.PROVIDER_FIREWORKS: "fireworks_ai/",
+    LLMConfigForm.PROVIDER_AVIAN: "openai/",
 }
 
 

--- a/setup/views.py
+++ b/setup/views.py
@@ -347,15 +347,16 @@ class SetupWizardView(View):
             provider.save()
 
             endpoint_key = ORCHESTRATOR_ENDPOINT_KEYS[provider_choice]
+            effective_api_base = api_base or DEFAULT_PROVIDER_API_BASES.get(provider_choice, "")
             endpoint = self._create_or_update_persistent_endpoint(
                 key_slug=endpoint_key,
                 provider=provider,
                 litellm_model=model,
-                api_base=api_base,
+                api_base=effective_api_base,
                 supports_tool_choice=supports_tool_choice,
                 use_parallel_tools=use_parallel_tools,
                 supports_vision=supports_vision,
-                update_api_base=bool(api_base),
+                update_api_base=bool(effective_api_base),
             )
 
         self._reset_persistent_tiers(endpoint)


### PR DESCRIPTION
## Summary

- Adds [Avian](https://avian.io) as a first-class OpenAI-compatible LLM provider in the setup wizard and provider configuration system
- Avian serves inference at `https://api.avian.io/v1` with the following models:
  - **DeepSeek V3.2** (164K context) — $0.14 / $0.28 per M tokens
  - **Kimi K2.5** (128K context) — $0.14 / $0.28 per M tokens
  - **GLM-5** (128K context) — $0.25 / $0.50 per M tokens
  - **MiniMax M2.5** (1M context) — $0.15 / $0.30 per M tokens
- Default model for both orchestrator and browser agents: `deepseek-v3.2`

## Changes

- **`setup/forms.py`** — Add `PROVIDER_AVIAN` constant and choice to `LLMConfigForm`
- **`setup/views.py`** — Register Avian in all provider lookup maps: default orchestrator/browser models, base URLs, endpoint keys, provider key map, and model prefixes
- **`api/migrations/0334_add_avian_provider.py`** — Data migration to seed the `LLMProvider` record (key=`avian`, env var=`AVIAN_API_KEY`, backend=`OPENAI_COMPAT`)

## Test plan

- [ ] Verify the setup wizard displays "Avian" in the provider dropdown
- [ ] Select Avian as orchestrator provider, confirm default model populates as `deepseek-v3.2`
- [ ] Test LLM connectivity with a valid Avian API key
- [ ] Confirm migration applies cleanly on a fresh database
- [ ] Verify existing provider configurations are unaffected