### PR TITLE
Add Data Deletion Policy page and link in footer

### DIFF
--- a/pages/templates/data-deletion.html
+++ b/pages/templates/data-deletion.html
@@ -37,7 +37,7 @@
 
   <h2>3. How to Request Deletion</h2>
   <p>To request deletion of your personal data, email us at:</p>
-  <p><a href="mailto:privacy@gobii.com"><strong>privacy@gobii.com</strong></a></p>
+  <p><a href="mailto:{{ settings.PUBLIC_SUPPORT_EMAIL }}"><strong>{{ settings.PUBLIC_SUPPORT_EMAIL }}</strong></a></p>
   <p>Please include the email address associated with your Gobii account so we can locate your data. We may need to verify your identity before processing your request.</p>
 
   <h2>4. What Happens After You Request Deletion</h2>
@@ -60,6 +60,6 @@
   <p><strong>Gobii Inc.</strong><br>
   455 Market St, Ste 1940, PMB 790239<br>
   San Francisco, California 94105, USA<br>
-  Email: <a href="mailto:privacy@gobii.com">privacy@gobii.com</a></p>
+  Email: <a href="mailto:{{ settings.PUBLIC_SUPPORT_EMAIL }}">{{ settings.PUBLIC_SUPPORT_EMAIL }}</a></p>
 </article>
 {% endblock %}

--- a/pages/templates/data-deletion.html
+++ b/pages/templates/data-deletion.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+{% block title %}Data Deletion Policy · Gobii{% endblock %}
+{% block head_extras %}
+  {{ block.super }}
+  <meta name="description" content="Learn how to request deletion of your personal data from Gobii.">
+{% endblock %}
+
+{% block content %}
+<style>
+  .prose h1,
+  .prose h2 {
+    @apply font-semibold;
+  }
+</style>
+<article class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16 prose prose-slate">
+  <h1>Data Deletion Policy</h1>
+  <p><em>Last updated: April 14, 2026</em></p>
+
+  <p><strong>Gobii Inc.</strong><br>
+  455 Market St, Ste 1940<br>
+  PMB 790239<br>
+  San Francisco, California 94105, USA</p>
+
+  <h2>1. Overview</h2>
+  <p>Under the EU General Data Protection Regulation (GDPR), the California Consumer Privacy Rights Act (CPRA), and other applicable privacy laws, you have the right to request deletion of your personal data. This page explains how to exercise that right with Gobii.</p>
+  <p>For full details on the data we collect and how we use it, please see our <a href="{% url 'proprietary:privacy' %}">Privacy Policy</a>.</p>
+
+  <h2>2. What Data We Store</h2>
+  <p>When you use Gobii, we may store the following categories of personal data:</p>
+  <ul>
+    <li><strong>Account Data</strong> — name, email address, password hash, billing address, payment-method tokens.</li>
+    <li><strong>Content &amp; Instructions</strong> — scripts, prompts, URLs, or other material you submit to the Service.</li>
+    <li><strong>Usage &amp; Log Data</strong> — IP address, timestamps, API call parameters, error traces.</li>
+    <li><strong>Device / Analytics Data</strong> — cookies, page views, referrers, click-streams.</li>
+    <li><strong>Support Data</strong> — messages and attachments from support interactions.</li>
+  </ul>
+
+  <h2>3. How to Request Deletion</h2>
+  <p>To request deletion of your personal data, email us at:</p>
+  <p><a href="mailto:privacy@gobii.com"><strong>privacy@gobii.com</strong></a></p>
+  <p>Please include the email address associated with your Gobii account so we can locate your data. We may need to verify your identity before processing your request.</p>
+
+  <h2>4. What Happens After You Request Deletion</h2>
+  <ul>
+    <li>We will acknowledge your request within <strong>5 business days</strong>.</li>
+    <li>Your data will be deleted within <strong>30 days</strong> of verification, as required by the GDPR.</li>
+    <li>Once deletion is complete, we will send you a confirmation email.</li>
+  </ul>
+
+  <h2>5. What Gets Deleted vs. Retained</h2>
+  <p>Upon a valid deletion request, we will delete your account data, content, usage logs, and support data. However, we may retain certain information where required by law:</p>
+  <ul>
+    <li><strong>Billing &amp; tax records</strong> — retained for up to 7 years to comply with financial and tax regulations.</li>
+    <li><strong>Legal holds</strong> — data subject to active legal proceedings or government requests will be preserved until the matter is resolved.</li>
+  </ul>
+  <p>Retained data is kept in a restricted state and is not used for any other purpose.</p>
+
+  <h2>6. Contact Us</h2>
+  <p>If you have questions about this policy or your data rights, contact us at:</p>
+  <p><strong>Gobii Inc.</strong><br>
+  455 Market St, Ste 1940, PMB 790239<br>
+  San Francisco, California 94105, USA<br>
+  Email: <a href="mailto:privacy@gobii.com">privacy@gobii.com</a></p>
+</article>
+{% endblock %}

--- a/pages/views.py
+++ b/pages/views.py
@@ -1692,6 +1692,12 @@ class PrivacyPolicyView(TemplateView):
     template_name = "privacy.html"
 
 
+class DataDeletionPolicyView(TemplateView):
+    """Static Data Deletion Policy page."""
+
+    template_name = "data-deletion.html"
+
+
 class AboutView(TemplateView):
     """Simple static About page."""
 

--- a/proprietary/urls.py
+++ b/proprietary/urls.py
@@ -1,6 +1,15 @@
 from django.urls import path
 
-from pages.views import AboutView, CareersView, DataDeletionPolicyView, TeamView, TermsOfServiceView, PrivacyPolicyView, StartupCheckoutView, ScaleCheckoutView
+from pages.views import (
+    AboutView,
+    CareersView,
+    DataDeletionPolicyView,
+    PrivacyPolicyView,
+    ScaleCheckoutView,
+    StartupCheckoutView,
+    TeamView,
+    TermsOfServiceView,
+)
 from .views import PricingView, SupportView, ContactView, BlogIndexView, BlogPostView, PrequalifyView
 
 # Keep names consistent with pages app so existing {% url 'proprietary:...'%} still work

--- a/proprietary/urls.py
+++ b/proprietary/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from pages.views import AboutView, CareersView, TeamView, TermsOfServiceView, PrivacyPolicyView, StartupCheckoutView, ScaleCheckoutView
+from pages.views import AboutView, CareersView, DataDeletionPolicyView, TeamView, TermsOfServiceView, PrivacyPolicyView, StartupCheckoutView, ScaleCheckoutView
 from .views import PricingView, SupportView, ContactView, BlogIndexView, BlogPostView, PrequalifyView
 
 # Keep names consistent with pages app so existing {% url 'proprietary:...'%} still work
@@ -16,6 +16,7 @@ urlpatterns = [
     path("careers/", CareersView.as_view(), name="careers"),
     path("tos/", TermsOfServiceView.as_view(), name="tos"),
     path("privacy/", PrivacyPolicyView.as_view(), name="privacy"),
+    path("data-deletion/", DataDeletionPolicyView.as_view(), name="data_deletion"),
     path("subscribe/startup/", StartupCheckoutView.as_view(), name="startup_checkout"),
     path("subscribe/pro/", StartupCheckoutView.as_view(), name="pro_checkout"),
     path("subscribe/scale/", ScaleCheckoutView.as_view(), name="scale_checkout"),

--- a/templates/includes/_footer.html
+++ b/templates/includes/_footer.html
@@ -80,7 +80,7 @@
     <span>&bull;</span>
     <a href="{% url 'proprietary:privacy' %}" class="hover:text-blue-600 underline">Privacy&nbsp;Policy</a>
     <span>&bull;</span>
-    <a href="{% url 'proprietary:data_deletion' %}" class="hover:text-blue-600 underline">Data&nbsp;Deletion</a>
+    <a href="{% url 'proprietary:data_deletion' %}" class="hover:text-blue-600 underline">Data&nbsp;Deletion&nbsp;Policy</a>
     {%  endif %}
   </div>
 </footer> 

--- a/templates/includes/_footer.html
+++ b/templates/includes/_footer.html
@@ -79,6 +79,8 @@
     <a href="{% url 'proprietary:tos' %}" class="hover:text-blue-600 underline">Terms&nbsp;of&nbsp;Service</a>
     <span>&bull;</span>
     <a href="{% url 'proprietary:privacy' %}" class="hover:text-blue-600 underline">Privacy&nbsp;Policy</a>
+    <span>&bull;</span>
+    <a href="{% url 'proprietary:data_deletion' %}" class="hover:text-blue-600 underline">Data&nbsp;Deletion</a>
     {%  endif %}
   </div>
 </footer> 


### PR DESCRIPTION
## Summary
This PR adds a new Data Deletion Policy page to comply with GDPR, CPRA, and other privacy regulations, making it easy for users to understand their data deletion rights and request procedures.

## Key Changes
- **New template**: `pages/templates/data-deletion.html` — Comprehensive Data Deletion Policy page covering:
  - Overview of deletion rights under GDPR and CPRA
  - Categories of personal data stored by Gobii
  - Instructions for requesting data deletion via privacy@gobii.com
  - Timeline for processing requests (5 business days acknowledgment, 30 days deletion)
  - Details on what data gets deleted vs. retained (billing/tax records, legal holds)
  - Contact information for privacy inquiries

- **New view**: `DataDeletionPolicyView` in `pages/views.py` — Simple TemplateView to render the policy page

- **New route**: `/data-deletion/` in `proprietary/urls.py` with name `data_deletion` for consistent URL naming

- **Footer update**: Added "Data Deletion" link in `templates/includes/_footer.html` alongside existing Terms of Service and Privacy Policy links

## Implementation Details
- The policy page uses the same styling and structure as existing policy pages (extends base.html, uses prose classes)
- Includes a link back to the Privacy Policy for users wanting more details on data collection
- Follows the established URL naming convention in the proprietary app
- Footer link is properly separated with bullet points for consistency

https://claude.ai/code/session_012zYr11fe3TR6UmPUWg6dhL