### PR TITLE
Guard preview cleanup dispatches

### DIFF
--- a/.github/workflows/preview-cleanup-dispatch.yml
+++ b/.github/workflows/preview-cleanup-dispatch.yml
@@ -11,6 +11,7 @@ jobs:
   dispatch:
     name: Dispatch Preview Cleanup
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary
- skip preview cleanup dispatch from fork-originated PR close events
- keep same-repo PR close cleanup dispatches unchanged

## Validation
- YAML parse for preview-cleanup-dispatch.yml
- actionlint for preview-cleanup-dispatch.yml