### PR TITLE
Update preview cleanup dispatch action

### DIFF
--- a/.github/workflows/preview-cleanup-dispatch.yml
+++ b/.github/workflows/preview-cleanup-dispatch.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_retrieval_mode: repository
-          installation_retrieval_payload: gobii-ai/gobii
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: gobii-ai
+          repositories: gobii
 
       - name: Notify infra repo for cleanup
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
## Summary
- move preview cleanup dispatch token generation to actions/create-github-app-token@v3
- keep same-repo PR close dispatch behavior unchanged

## Validation
- YAML parse for preview-cleanup-dispatch.yml
- actionlint for preview-cleanup-dispatch.yml