### PR TITLE
Harden CI/CD workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -39,10 +39,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -64,15 +64,15 @@ jobs:
       TEST_OUTPUT_DIR: test-results
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Set up uv (with cache)
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           ignore-nothing-to-cache: true
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload test results artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-sandbox-server
           path: test-results/**
@@ -386,22 +386,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up uv (with cache)
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           ignore-nothing-to-cache: true
 
       - name: Restore venv cache
         id: restore-venv
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock') }}
@@ -426,7 +426,7 @@ jobs:
 
       - name: Save venv cache
         if: steps.restore-venv.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock') }}
@@ -450,7 +450,7 @@ jobs:
 
       - name: Upload test results artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.batch }}
           path: test-results/**
@@ -466,7 +466,7 @@ jobs:
     needs: [tests, sandbox-server-tests]
     steps:
       - name: Download all test result artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: test-results-*
           merge-multiple: true
@@ -496,10 +496,10 @@ jobs:
       R2_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -567,15 +567,15 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_retrieval_mode: repository
-          installation_retrieval_payload: gobii-ai/gobii
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: gobii-ai
+          repositories: gobii
 
       - name: Notify infra repo
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: gobii-ai/gobii
@@ -601,15 +601,15 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          installation_retrieval_mode: repository
-          installation_retrieval_payload: gobii-ai/gobii
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: gobii-ai
+          repositories: gobii
 
       - name: Notify infra repo
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: gobii-ai/gobii

--- a/.github/workflows/droid-implement.yml
+++ b/.github/workflows/droid-implement.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Acknowledge on issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.createComment({
@@ -30,7 +30,7 @@ jobs:
             });
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Extract prompt
         id: prompt
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             let prompt = '';
@@ -59,18 +59,21 @@ jobs:
         env:
           FACTORY_API_KEY: ${{ secrets.DROID_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          DROID_PROMPT: ${{ steps.prompt.outputs.text }}
         run: |
-          BRANCH="droid/issue-${{ github.event.issue.number }}"
+          BRANCH="droid/issue-${ISSUE_NUMBER}"
           git checkout -b "$BRANCH"
 
           droid exec --auto high -m claude-opus-4-6 "
             You are working in a GitHub Actions CI environment.
-            Implement the following request from issue #${{ github.event.issue.number }} (${{ github.event.issue.title }}):
+            Implement the following request from issue #${ISSUE_NUMBER} (${ISSUE_TITLE}):
 
-            ${{ steps.prompt.outputs.text }}
+            ${DROID_PROMPT}
 
             After implementing:
-            1. Commit your changes with a descriptive message referencing issue #${{ github.event.issue.number }}
+            1. Commit your changes with a descriptive message referencing issue #${ISSUE_NUMBER}
             2. Push the branch to origin
-            3. Create a pull request linking back to issue #${{ github.event.issue.number }} using 'Closes #${{ github.event.issue.number }}' in the PR body
+            3. Create a pull request linking back to issue #${ISSUE_NUMBER} using 'Closes #${ISSUE_NUMBER}' in the PR body
           "

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/preview-cleanup-dispatch.yml
+++ b/.github/workflows/preview-cleanup-dispatch.yml
@@ -23,7 +23,7 @@ jobs:
           repositories: gobii
 
       - name: Notify infra repo for cleanup
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: gobii-ai/gobii

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,18 +33,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Bump version
         env:


### PR DESCRIPTION
## Summary
- update CI/CD workflow actions to current maintained major versions
- replace legacy tibdex GitHub App token dispatches with actions/create-github-app-token
- route Droid issue prompt data through env vars instead of direct inline script interpolation

## Validation
- ruby YAML parse for all workflows
- actionlint over all workflows
- git diff --check