### PR TITLE
Improve docs search indexing

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
     "prestart": "npm run gen-api-docs",
     "start": "docusaurus start --host 0.0.0.0",
     "prebuild": "npm run gen-api-docs",
-    "build": "docusaurus build && pagefind --site build && node scripts/postbuild.mjs",
+    "build": "docusaurus build && node scripts/prepare-pagefind.mjs && pagefind --site build && node scripts/postbuild.mjs",
     "serve": "docusaurus serve --host 0.0.0.0",
     "clear": "docusaurus clear",
     "gen-api-docs": "node scripts/prepare-openapi.mjs && docusaurus gen-api-docs all && node scripts/polish-api-sidebar.mjs"

--- a/docs/scripts/prepare-pagefind.mjs
+++ b/docs/scripts/prepare-pagefind.mjs
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const buildDir = path.resolve('build');
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(entryPath);
+    }
+    return entry.isFile() && entry.name.endsWith('.html') ? [entryPath] : [];
+  });
+}
+
+function prepareHtml(source) {
+  let html = source;
+
+  // Keep Pagefind excerpts focused on the documentation itself, not Docusaurus
+  // navigation chrome. Pagefind falls back to indexing the whole body otherwise.
+  html = html.replace('<article>', '<article data-pagefind-body>');
+  html = html.replace(
+    /<nav([^>]*class="[^"]*theme-doc-breadcrumbs[^"]*"[^>]*)>/g,
+    '<nav$1 data-pagefind-ignore>'
+  );
+
+  return html;
+}
+
+if (!fs.existsSync(buildDir)) {
+  throw new Error(`Build directory not found: ${buildDir}`);
+}
+
+let prepared = 0;
+for (const filePath of walk(buildDir)) {
+  const html = fs.readFileSync(filePath, 'utf8');
+  const nextHtml = prepareHtml(html);
+  if (nextHtml !== html) {
+    fs.writeFileSync(filePath, nextHtml);
+    prepared += 1;
+  }
+}
+
+console.log(`Prepared ${prepared} HTML files for Pagefind indexing.`);

--- a/docs/src/theme/SearchBar/index.js
+++ b/docs/src/theme/SearchBar/index.js
@@ -3,6 +3,19 @@ import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 import './styles.css';
 
+function stripHtmlExtension(url) {
+  return url?.replace(/\.html(?=$|#|\?)/, '') ?? url;
+}
+
+function normalizeResultUrls(result) {
+  result.url = stripHtmlExtension(result.url);
+  result.sub_results = result.sub_results?.map((subResult) => ({
+    ...subResult,
+    url: stripHtmlExtension(subResult.url),
+  }));
+  return result;
+}
+
 export default function SearchBar() {
   const ref = useRef(null);
 
@@ -29,6 +42,7 @@ export default function SearchBar() {
         element: ref.current,
         showSubResults: true,
         showImages: false,
+        processResult: normalizeResultUrls,
         resetStyles: false,
       });
     };


### PR DESCRIPTION
## Summary
- mark generated doc articles as Pagefind bodies before indexing
- ignore breadcrumb chrome in the Pagefind index
- normalize Pagefind result links to clean Docusaurus routes

## Verification
- npm run build
- docker build -t gobii-docs-search .
- tested production nginx image search in the in-app browser for "get agents"