### PR TITLE
Restore docs API language tabs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -79,7 +79,6 @@ const config = {
         defaultMode: 'dark',
         respectPrefersColorScheme: true,
       },
-      languageTabs: [{ language: 'curl' }],
       image: 'images/gobii-fish-with-text-dark-purple.png',
       navbar: {
         logo: {


### PR DESCRIPTION
## Summary
- remove the cURL-only Pagefind/API language tab override
- restore the generated multi-language API examples

## Verification
- npm run build
- docker build -t gobii-docs-lang-tabs .
- verified the production nginx image shows the full API language tab set