### PR TITLE
Build docs image with production URL

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ permissions:
   packages: write
 
 env:
-  DOCS_SITE_URL: https://docs-staging.ship.gobii.ai
+  DOCS_SITE_URL: https://docs.gobii.ai
   DOCS_IMAGE: ghcr.io/gobii-ai/gobii-docs
 
 jobs:


### PR DESCRIPTION
## Summary
- Build the docs image with https://docs.gobii.ai as the baked Docusaurus site URL
- Keeps production canonical links, sitemap, robots.txt, OpenGraph URLs, and llms files pointed at the future production docs host

## Verification
- npm run build
- docker build --build-arg DOCS_SITE_URL=https://docs.gobii.ai -t gobii-docs-prod-prep:local docs
- Local container smoke test for /healthz, docs pages, API pages, OpenAPI assets, llms.txt, and Pagefind
- In-app browser check for API reference, language tabs, and search result URLs