### PR TITLE
Keep docs root healthy for Gateway checks

### DIFF
--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -13,7 +13,11 @@ server {
   }
 
   location = / {
-    return 301 /getting-started/introduction$is_args$args;
+    try_files /index.html =404;
+  }
+
+  location = /index.html {
+    return 301 /$is_args$args;
   }
 
   location = /api-reference {


### PR DESCRIPTION
## Summary
- serve the docs root as a 200 response for GKE Gateway/NEG health checks
- keep /index.html canonicalizing to /
- preserve the SEO redirect behavior added in #932

## Verification
- npm run build
- docker build --build-arg DOCS_SITE_URL=https://docs.gobii.ai -t gobii-docs-redirects-fix:local .
- local nginx checks for /, /healthz, /api-reference, legacy Mintlify API URLs, .html URLs, trailing slash URLs, and query-string preservation