### PR TITLE
Let API docs use full width

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -30,6 +30,21 @@
   max-width: 860px;
 }
 
+@media (min-width: 997px) {
+  .container:has(.theme-api-markdown) {
+    max-width: none;
+  }
+
+  .theme-doc-markdown:has(.theme-api-markdown) {
+    max-width: none;
+  }
+
+  div[class*='docItemCol']:has(.theme-api-markdown) {
+    flex: 0 0 100%;
+    max-width: 100% !important;
+  }
+}
+
 .gobii-doc-card {
   border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- keep prose docs constrained to readable width
- remove the prose max-width and OpenAPI doc-column cap only on API reference pages
- lets the API reference consume the available desktop viewport instead of leaving a large blank right side

## Verification
- npm run build
- Docker/nginx served locally on :3022
- Headless Chrome measurement at 2048px viewport: API row spans 1748px from sidebar to viewport edge
- Visual screenshot reviewed