### PR TITLE
Polish docs visual details

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -13,6 +13,8 @@
   --gobii-doc-panel-border: #dfe3ea;
   --gobii-doc-muted-border: #e8ebf0;
   --gobii-doc-subtle-active: rgba(47, 124, 239, 0.09);
+  --gobii-doc-focus-ring: rgba(47, 124, 239, 0.24);
+  --gobii-doc-soft-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
 }
 
 [data-theme='dark'] {
@@ -24,6 +26,22 @@
   --gobii-doc-panel-border: #303846;
   --gobii-doc-muted-border: #242b36;
   --gobii-doc-subtle-active: rgba(47, 124, 239, 0.16);
+  --gobii-doc-focus-ring: rgba(82, 146, 255, 0.28);
+  --gobii-doc-soft-shadow: 0 1px 2px rgba(0, 0, 0, 0.28);
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  background: rgba(47, 124, 239, 0.2);
+}
+
+.navbar {
+  border-bottom: 1px solid var(--gobii-doc-muted-border);
+  box-shadow: none;
 }
 
 .navbar__logo {
@@ -32,6 +50,39 @@
 
 .navbar__logo img {
   object-fit: contain;
+}
+
+.navbar__item,
+.navbar__link {
+  transition: color 140ms ease, opacity 140ms ease;
+}
+
+.navbar__link:hover,
+.navbar__link--active {
+  color: var(--ifm-color-primary);
+}
+
+.navbar__items--right .navbar__link {
+  opacity: 0.88;
+}
+
+.navbar__items--right .navbar__link:hover {
+  opacity: 1;
+}
+
+.theme-doc-markdown a:not(.button):not(.card) {
+  text-underline-offset: 0.18em;
+  text-decoration-thickness: 1px;
+}
+
+.theme-doc-markdown a:not(.button):not(.card):hover {
+  text-decoration-thickness: 2px;
+}
+
+.theme-doc-markdown :where(code):not(pre code) {
+  border: 1px solid var(--gobii-doc-muted-border);
+  border-radius: 6px;
+  padding: 0.08rem 0.3rem;
 }
 
 .theme-doc-markdown {
@@ -59,6 +110,7 @@
   padding: 1rem;
   margin: 1rem 0;
   background: var(--ifm-background-surface-color);
+  box-shadow: var(--gobii-doc-soft-shadow);
 }
 
 .gobii-doc-card img {
@@ -77,6 +129,13 @@
   color: var(--ifm-color-emphasis-800);
 }
 
+.theme-api-markdown :focus-visible,
+.theme-doc-sidebar-container :focus-visible,
+.navbar :focus-visible {
+  outline: 2px solid var(--gobii-doc-focus-ring);
+  outline-offset: 2px;
+}
+
 .theme-api-markdown .openapi__heading {
   font-size: 2rem;
   letter-spacing: 0;
@@ -88,10 +147,16 @@
   background: var(--gobii-doc-panel-background);
   border: 1px solid var(--gobii-doc-panel-border);
   border-radius: 8px;
+  box-shadow: var(--gobii-doc-soft-shadow);
   display: inline-flex;
   gap: 0.65rem;
   max-width: 100%;
   padding: 0.62rem 0.72rem;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.openapi__method-endpoint:hover {
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 42%, var(--gobii-doc-panel-border));
 }
 
 .openapi__method-endpoint .badge {
@@ -114,6 +179,10 @@
   border-color: var(--gobii-doc-muted-border);
 }
 
+.openapi-left-panel__container details summary {
+  cursor: pointer;
+}
+
 .openapi-left-panel__container .openapi-tabs__heading {
   font-size: 1.45rem;
 }
@@ -134,7 +203,7 @@
   background: var(--gobii-doc-panel-background) !important;
   border: 1px solid var(--gobii-doc-panel-border) !important;
   border-radius: 8px !important;
-  box-shadow: none !important;
+  box-shadow: var(--gobii-doc-soft-shadow) !important;
 }
 
 .openapi-security__details {
@@ -149,10 +218,16 @@
   flex-wrap: nowrap !important;
   gap: 0.35rem;
   padding: 0.72rem 0.72rem 0.45rem !important;
+  scroll-padding-inline: 0.75rem;
 }
 
 .openapi-tabs__code-list-container::-webkit-scrollbar {
   height: 6px;
+}
+
+.openapi-tabs__code-list-container::-webkit-scrollbar-thumb {
+  background: var(--ifm-color-emphasis-300);
+  border-radius: 999px;
 }
 
 .openapi-tabs__code-item {
@@ -161,7 +236,12 @@
   height: 2.25rem !important;
   min-width: auto !important;
   padding: 0 0.72rem !important;
+  transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease;
   width: auto !important;
+}
+
+.openapi-tabs__code-item:hover {
+  background: var(--gobii-doc-subtle-active) !important;
 }
 
 .openapi-tabs__code-item svg,
@@ -184,6 +264,18 @@
   max-height: 22rem;
 }
 
+.openapi-tabs__code-container pre::-webkit-scrollbar,
+.openapi-schema__container::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+}
+
+.openapi-tabs__code-container pre::-webkit-scrollbar-thumb,
+.openapi-schema__container::-webkit-scrollbar-thumb {
+  background: var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+}
+
 .openapi-explorer__request-form,
 .openapi-explorer__response-container {
   font-size: 0.9rem;
@@ -200,6 +292,12 @@
 .theme-doc-sidebar-container .menu__link {
   border-radius: 6px;
   line-height: 1.25;
+  transition: background-color 140ms ease, color 140ms ease, transform 140ms ease;
+}
+
+.theme-doc-sidebar-container .menu__link:hover {
+  background: var(--gobii-doc-subtle-active);
+  transform: translateX(1px);
 }
 
 .theme-doc-sidebar-container .menu__link--active {
@@ -207,11 +305,39 @@
   font-weight: 600;
 }
 
+.theme-doc-sidebar-container .menu__link--sublist-caret::after {
+  opacity: 0.72;
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+
+.theme-doc-sidebar-container .menu__link--sublist-caret:hover::after {
+  opacity: 1;
+}
+
 .theme-doc-sidebar-container .menu__list .menu__list {
   padding-left: 0.75rem;
 }
 
+.pagination-nav__link {
+  border-radius: 8px;
+  transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: var(--gobii-doc-soft-shadow);
+  transform: translateY(-1px);
+}
+
 @media (max-width: 996px) {
+  .navbar__brand {
+    min-width: 0;
+  }
+
+  .navbar__logo {
+    height: 1.6rem;
+  }
+
   .theme-api-markdown .openapi__heading {
     font-size: 2.35rem;
   }

--- a/docs/src/theme/SearchBar/styles.css
+++ b/docs/src/theme/SearchBar/styles.css
@@ -19,9 +19,47 @@
 }
 
 .gobii-pagefind-search .pagefind-ui__search-input {
-  height: 38px;
-  padding-left: 0.75rem;
-  font-size: 0.875rem;
+  border-color: var(--ifm-color-emphasis-300);
+  height: 38px !important;
+  padding-left: 2.45rem !important;
+  padding-right: 0.9rem !important;
+  font-size: 0.875rem !important;
+  transition: border-color 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
+}
+
+.gobii-pagefind-search .pagefind-ui__search-input:hover {
+  border-color: var(--ifm-color-emphasis-400);
+}
+
+.gobii-pagefind-search .pagefind-ui__search-input:focus {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 3px var(--gobii-doc-focus-ring);
+}
+
+.gobii-pagefind-search .pagefind-ui__search-clear {
+  align-items: center;
+  border: 0 !important;
+  border-radius: 6px !important;
+  color: var(--ifm-color-emphasis-700) !important;
+  display: flex;
+  font-size: 0 !important;
+  height: 1.7rem !important;
+  justify-content: center;
+  padding: 0 !important;
+  right: 0.45rem !important;
+  transition: background-color 140ms ease, color 140ms ease;
+  width: 1.7rem !important;
+}
+
+.gobii-pagefind-search .pagefind-ui__search-clear::before {
+  content: '×';
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.gobii-pagefind-search .pagefind-ui__search-clear:hover {
+  background: var(--gobii-doc-subtle-active) !important;
+  color: var(--ifm-font-color-base) !important;
 }
 
 .gobii-pagefind-search .pagefind-ui__drawer {
@@ -36,5 +74,35 @@
   border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
   background: var(--ifm-background-surface-color);
-  box-shadow: var(--ifm-global-shadow-lw);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.16);
+}
+
+.gobii-pagefind-search .pagefind-ui__result {
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+}
+
+.gobii-pagefind-search .pagefind-ui__result:hover {
+  background: var(--gobii-doc-subtle-active);
+}
+
+.gobii-pagefind-search mark {
+  background: color-mix(in srgb, var(--ifm-color-primary) 22%, transparent);
+  border-radius: 4px;
+  color: inherit;
+  padding: 0 0.1rem;
+}
+
+@media (max-width: 600px) {
+  .gobii-pagefind-search {
+    min-width: 0;
+    width: min(46vw, 180px);
+  }
+
+  .gobii-pagefind-search .pagefind-ui__search-input {
+    height: 36px !important;
+    font-size: 0.84rem !important;
+    padding-left: 2.15rem !important;
+    padding-right: 0.75rem !important;
+  }
 }


### PR DESCRIPTION
## Summary\n- add subtle tactile polish to docs navbar, sidebar, API panels, code tabs, and pagination\n- improve Pagefind search focus, clear button, result hover, and match highlight styling\n- tighten mobile navbar search sizing so the Gobii wordmark has room\n\n## Verification\n- npm --prefix docs run build\n- docker build -t gobii-docs-charm ./docs\n- local nginx route smoke checks for /, /healthz, API page, and legacy redirects\n- visual checks in dark, light, and mobile viewports