### PR TITLE
Tune docs caching for Cloudflare

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,6 +105,35 @@ jobs:
           test "$(redirect_for /getting-started/introduction.html)" = "301 http://127.0.0.1:8080/getting-started/introduction"
           test "$(redirect_for /getting-started/introduction/)" = "301 http://127.0.0.1:8080/getting-started/introduction"
 
+          header_for() {
+            local path="$1"
+            local header="$2"
+            curl -sSI "http://127.0.0.1:8080${path}" \
+              | awk -v header="${header}" 'BEGIN { IGNORECASE = 1 } index($0, header ":") == 1 { sub("\r$", ""); sub("^[^:]+: *", ""); print; exit }'
+          }
+
+          asset_js="$(node - <<'NODE'
+          (async () => {
+            const html = await (await fetch('http://127.0.0.1:8080/')).text();
+            const match = html.match(/\/assets\/js\/[^"]+\.js/);
+            if (!match) process.exit(1);
+            console.log(match[0]);
+          })();
+          NODE
+          )"
+          pagefind_fragment="/$(find build/pagefind/fragment -name '*.pf_fragment' -print -quit | sed 's#^build/##')"
+
+          test "$(header_for /healthz Cache-Control)" = "no-store"
+          test "$(header_for / Cache-Control)" = "public, max-age=0, must-revalidate"
+          test "$(header_for / CDN-Cache-Control)" = "public, max-age=300, stale-while-revalidate=86400"
+          test "$(header_for / Cloudflare-CDN-Cache-Control)" = "public, max-age=300, stale-while-revalidate=86400"
+          test "$(header_for "$asset_js" Cache-Control)" = "public, max-age=31536000, immutable"
+          test "$(header_for /assets/js/not-real.js Cache-Control)" = ""
+          test "$(header_for /pagefind/pagefind-ui.js Cache-Control)" = "public, max-age=300, must-revalidate"
+          test "$(header_for "$pagefind_fragment" Cache-Control)" = "public, max-age=31536000, immutable"
+          test "$(header_for /api-reference/openapi.json Cloudflare-CDN-Cache-Control)" = "public, max-age=300, stale-while-revalidate=86400"
+          test "$(header_for /api-reference/agents-api/get-agents Cache-Control)" = "public, max-age=300"
+
   publish:
     name: Publish Docs Image
     runs-on: ubuntu-latest

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -3,48 +3,105 @@ server {
   server_name _;
   absolute_redirect off;
   port_in_redirect off;
+  etag on;
+  gzip on;
+  gzip_vary on;
+  gzip_types
+    application/javascript
+    application/json
+    application/wasm
+    image/svg+xml
+    text/css
+    text/plain;
   root /usr/share/nginx/html;
   index index.html;
 
   location = /healthz {
     access_log off;
-    add_header Content-Type text/plain;
+    default_type text/plain;
+    add_header Cache-Control "no-store" always;
     return 200 "ok\n";
   }
 
   location = / {
+    add_header Cache-Control "public, max-age=0, must-revalidate";
+    add_header CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
+    add_header Cloudflare-CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
     try_files /index.html =404;
   }
 
   location = /index.html {
+    add_header Cache-Control "public, max-age=300" always;
     return 301 /$is_args$args;
   }
 
   location = /api-reference {
+    add_header Cache-Control "public, max-age=300" always;
     return 301 /api-reference/list-persistent-agents$is_args$args;
   }
 
   location = /GobiiAPI.yaml {
-    add_header Cache-Control "public, max-age=300";
+    add_header Cache-Control "public, max-age=300, must-revalidate";
+    add_header CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
+    add_header Cloudflare-CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
     try_files /GobiiAPI.yaml =404;
   }
 
   include /usr/share/nginx/html/legacy-redirects.conf;
 
   location ~ ^/(.+)\.html$ {
+    add_header Cache-Control "public, max-age=300" always;
     return 301 /$1$is_args$args;
   }
 
   location ~ ^/(.+)/$ {
+    add_header Cache-Control "public, max-age=300" always;
     return 301 /$1$is_args$args;
   }
 
-  location ~* \.(?:js|css|woff2?|png|jpg|jpeg|gif|webp|svg|ico)$ {
+  location ^~ /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    try_files $uri =404;
+  }
+
+  location ~ ^/pagefind/(?:fragment|index)/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    try_files $uri =404;
+  }
+
+  location ~ ^/pagefind/pagefind\.[a-z0-9_]+\.pf_meta$ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    try_files $uri =404;
+  }
+
+  location /pagefind/ {
+    add_header Cache-Control "public, max-age=300, must-revalidate";
+    add_header CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
+    add_header Cloudflare-CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
+    try_files $uri =404;
+  }
+
+  location ~ ^/api-reference/openapi\.json$ {
+    add_header Cache-Control "public, max-age=300, must-revalidate";
+    add_header CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
+    add_header Cloudflare-CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
+    try_files $uri =404;
+  }
+
+  location ~* ^/images/.*\.(?:png|jpg|jpeg|gif|webp|svg|ico)$ {
+    add_header Cache-Control "public, max-age=86400, stale-while-revalidate=604800";
+    try_files $uri =404;
+  }
+
+  location ~* \.(?:woff2?)$ {
     add_header Cache-Control "public, max-age=31536000, immutable";
     try_files $uri =404;
   }
 
   location / {
+    add_header Cache-Control "public, max-age=0, must-revalidate";
+    add_header CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
+    add_header Cloudflare-CDN-Cache-Control "public, max-age=300, stale-while-revalidate=86400";
     try_files $uri $uri.html $uri/ /index.html;
   }
 }

--- a/docs/scripts/postbuild.mjs
+++ b/docs/scripts/postbuild.mjs
@@ -165,8 +165,8 @@ function writeNginxRedirects() {
   ];
 
   for (const [from, to] of Object.entries(legacyApiRedirects)) {
-    lines.push(`location = /${from} { return 301 /${to}$is_args$args; }`);
-    lines.push(`location = /${from}.html { return 301 /${to}$is_args$args; }`);
+    lines.push(`location = /${from} { add_header Cache-Control "public, max-age=300" always; return 301 /${to}$is_args$args; }`);
+    lines.push(`location = /${from}.html { add_header Cache-Control "public, max-age=300" always; return 301 /${to}$is_args$args; }`);
   }
 
   writeText('legacy-redirects.conf', `${lines.join('\n')}\n`);


### PR DESCRIPTION
## Summary\n- make docs nginx responses explicit for Cloudflare: immutable hashed assets, short edge TTL HTML/OpenAPI/Pagefind shell files, and no-store health checks\n- avoid year-long browser caching for unversioned Pagefind/search and image paths\n- add CI header checks so cache regressions are caught alongside route smoke tests\n\n## Verification\n- npm --prefix docs run build\n- docker build -t gobii-docs-cf ./docs\n- local nginx route and cache header smoke checks via Node fetch\n\n## Notes\nCloudflare does not cache HTML/JSON by default. These origin headers are ready for a Cache Rule that caches eligible HTML at the edge while keeping browsers revalidating HTML on navigation.