### PR TITLE
Harden docs SEO

### DIFF
--- a/docs/content/advanced-usage/custom-email-settings.mdx
+++ b/docs/content/advanced-usage/custom-email-settings.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Custom Email Settings"
 sidebarTitle: "Email Settings"
-description: "Use your own SMTP and IMAP for agent email"
+description: "Configure custom SMTP and IMAP mailboxes so Gobii agents can send and receive email through your own domain."
 ---
 
 Gobii can send and receive email using the default delivery provider. If you want an agent to use your own mailbox, configure SMTP (outbound) and IMAP (inbound) on the agent's Email Settings page.

--- a/docs/content/advanced-usage/mcp-servers.mdx
+++ b/docs/content/advanced-usage/mcp-servers.mdx
@@ -1,6 +1,7 @@
 ---
 title: "MCP Servers"
 sidebarTitle: "MCP Servers"
+description: "Connect Model Context Protocol servers to Gobii agents so automations can use external tools, services, and data sources."
 ---
 
 Model Context Protocol (MCP) servers let your agents access external tools and services beyond the default browser automation stack. Use MCP servers to connect data sources, SaaS tools, or custom services and then enable those tools per agent.

--- a/docs/content/core-concepts.mdx
+++ b/docs/content/core-concepts.mdx
@@ -1,4 +1,4 @@
 ---
 title: "Core Concepts"
-description: "Core Concepts"
+description: "Understand the core Gobii concepts behind AI agents, browser tasks, contacts, files, organizations, and task credits."
 sidebarTitle: "Core Concepts"

--- a/docs/content/core-concepts/agent-contacts.mdx
+++ b/docs/content/core-concepts/agent-contacts.mdx
@@ -1,6 +1,7 @@
 ---
 title: Contacts
 sidebarTitle: Contacts
+description: "Manage the email, SMS, and chat contact points that let users and systems communicate with Gobii agents."
 ---
 
 Every agent may communicate with the owner via their approved method. Additionally, each _may_ have additional contacts if desired. Additional contacts may be added by messaging your agent ("Loop my teammate Will (will@example.com) in to our thread"), or via the agent configuration page.

--- a/docs/content/core-concepts/agents.mdx
+++ b/docs/content/core-concepts/agents.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Core Concept - Agents"
 sidebarTitle: "Agents"
+description: "Learn how Gobii agents run continuously, use browser automation tools, maintain state, and communicate over chat, email, SMS, and API."
 ---
 
 An **agent** is an AI worker that runs continuously, and uses tools such as web browsers

--- a/docs/content/core-concepts/dedicated-ips.mdx
+++ b/docs/content/core-concepts/dedicated-ips.mdx
@@ -1,6 +1,7 @@
 ---
 title: Dedicated IPs
 sidebarTitle: Dedicated IPs
+description: "Use dedicated IPs to give Gobii agents stable network identity for browser automation and allowlisted workflows."
 ---
 
 By default, the IP address an agent uses for accessing the internet may change. Users who would like to have a consistent IP address for their agent may add one or more dedicated IP address to their account, and assign them to their agent.

--- a/docs/content/core-concepts/files.mdx
+++ b/docs/content/core-concepts/files.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Files"
 sidebarTitle: "Files"
-description: "Upload, download, and manage agent files"
+description: "Upload, download, reuse, and manage files that Gobii agents can access across web chat, email, SMS, and browser tasks."
 ---
 
 Agents can work with files across web chat, email, and SMS. Files are stored in the agent's file space so you can reuse them later or share them back to your team.

--- a/docs/content/core-concepts/intelligence-selector.mdx
+++ b/docs/content/core-concepts/intelligence-selector.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Intelligence Selector"
 sidebarTitle: "Intelligence Selector"
-description: "Balance reasoning capabilities and cost"
+description: "Tune Gobii agent intelligence settings to balance model reasoning quality, task credit usage, cost, and automation reliability."
 ---
 
 On an agent's configuration screen, Pro, Scale, and Team plan members may adjust the intelligence of the LLM used for processing their agent's tasks. Higher intelligence selections will boost the agent's ability to perform complex tasks, at the cost of higher task credit usage. We recommend you experiment with the setting on agents and use the lowest intelligence model that provides satisfactory results.

--- a/docs/content/core-concepts/organizations.mdx
+++ b/docs/content/core-concepts/organizations.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Organizations"
 sidebarTitle: "Organizations"
+description: "Organize Gobii agents, seats, billing, permissions, and shared automation workflows across a team."
 ---
 
 ## Organizations & Seats

--- a/docs/content/core-concepts/task-credits.mdx
+++ b/docs/content/core-concepts/task-credits.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Task Credits"
 sidebarTitle: "Task Credits"
+description: "Understand how Gobii task credits map to browser automation work, agent activity, and model intelligence settings."
 ---
 
 Every account has a pool of _Task Credits_ per billing cycle. Agents consume these credits as they perform tasks, at a granular level. For example, an agent may use 0.04 task credits to send an email. These are deducted from the users task credit allowance upon execution.

--- a/docs/content/core-concepts/tasks.mdx
+++ b/docs/content/core-concepts/tasks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tasks"
 sidebarTitle: "Tasks"
-description: "The smallest unit of work"
+description: "Understand Gobii tasks, the small units of browser automation work that agents complete behind the scenes."
 ---
 
 Tasks are the smallest unit of work on Gobii, and happen behind the scenes. When your Gobii is taking action on your behalf, multiple smaller units are generally required to meet to fulfill your request. For example:

--- a/docs/content/developers/async-vs-sync.mdx
+++ b/docs/content/developers/async-vs-sync.mdx
@@ -1,0 +1,27 @@
+---
+title: "Async vs Sync"
+sidebarTitle: "Async vs Sync"
+description: "Choose between asynchronous webhooks, polling, and synchronous waits when running Gobii browser automation tasks."
+---
+
+Gobii tasks are asynchronous by default. For production integrations, submit the task, store the returned task ID,
+and receive results through a webhook when the browser automation finishes.
+
+Use synchronous requests only when the caller can safely wait for a bounded response. Synchronous calls are useful
+for quick demos, local tools, and short tasks, but long-running browser work should use webhooks or polling.
+
+## Recommended flow
+
+1. Submit a task without `wait`.
+2. Store the returned task ID.
+3. Receive completion through a webhook.
+4. Fetch the task result from the API if your system needs to reconcile state.
+
+If webhooks are not available, poll task status conservatively. For Gobii Cloud, avoid polling more than once every
+30 seconds.
+
+## When to use `wait`
+
+Use `wait` when you expect the task to finish quickly and the client can tolerate holding the HTTP connection open.
+The maximum wait time is 900 seconds. If the task does not complete before the timeout, continue with the asynchronous
+task ID and fetch the result later.

--- a/docs/content/developers/developer-agents.mdx
+++ b/docs/content/developers/developer-agents.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Agent API"
 sidebarTitle: "Agent API"
+description: "Create, schedule, activate, message, inspect, update, and delete persistent Gobii agents through the REST API."
 ---
 
 Agents are always-on workers you configure once and reuse for multistep automations. Each agent keeps its own

--- a/docs/content/developers/developer-basics.mdx
+++ b/docs/content/developers/developer-basics.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Developer Basics"
 sidebarTitle: "Basics"
+description: "Learn Gobii API fundamentals: authentication, base URLs, agents, browser-use tasks, pagination, sync requests, and webhooks."
 ---
 
 ## What the API does

--- a/docs/content/developers/developer-tasks.mdx
+++ b/docs/content/developers/developer-tasks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tasks (for Developers)"
 sidebarTitle: "browser-use Tasks"
-description: "Create and manage tasks for browser-use"
+description: "Create, monitor, cancel, and retrieve results from browser-use tasks through the Gobii API."
 ---
 
 Developers can create single, ad-hoc tasks that do _not_ run continuously. These are useful for a singular action to be performed by an agent, without the overhead of creating and destructing an agent.

--- a/docs/content/developers/structured-data.mdx
+++ b/docs/content/developers/structured-data.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Structured Data"
 sidebarTitle: "Structured Data"
+description: "Request structured JSON outputs from Gobii agents so browser automation results are easier to validate, store, and integrate."
 ---
 
 API requests can return data in a structured JSON format, if requested. To use this feature, in your API request, specify the `output_schema` like so:

--- a/docs/content/developers/webhooks.mdx
+++ b/docs/content/developers/webhooks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Webhooks"
 sidebarTitle: "Webhooks"
-description: "The preferred way for receiving agent results"
+description: "Use Gobii webhooks to receive asynchronous browser-use task results, completion events, and cancellation events."
 ---
 
 ### Task webhooks

--- a/docs/content/getting-started/introduction.mdx
+++ b/docs/content/getting-started/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Welcome to Gobii 🤙"
-description: ""
+description: "Learn what Gobii AI browser agents are, who they help, and how to start using Gobii Cloud or the open source platform."
 sidebarTitle: "Welcome to Gobii 🤙"
 keywords: ["introduction", "getting started"]
 ---

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,12 +1,15 @@
 const lightCodeTheme = require('prism-react-renderer').themes.github;
 const darkCodeTheme = require('prism-react-renderer').themes.dracula;
 
+const siteUrl = process.env.DOCS_SITE_URL || 'https://docs.gobii.ai';
+const socialImage = `${siteUrl}/images/gobii-fish-with-text-dark-purple.png`;
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Gobii',
   tagline: 'Documentation for Gobii AI browser agents',
   favicon: 'images/favicon.png',
-  url: process.env.DOCS_SITE_URL || 'https://docs.gobii.ai',
+  url: siteUrl,
   baseUrl: '/',
   organizationName: 'gobii-ai',
   projectName: 'gobii-platform',
@@ -71,15 +74,64 @@ const config = {
   ],
 
   themes: ['docusaurus-theme-openapi-docs'],
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'theme-color',
+        content: '#090b0f',
+      },
+    },
+    {
+      tagName: 'script',
+      attributes: {
+        type: 'application/ld+json',
+      },
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Organization',
+        name: 'Gobii',
+        url: 'https://gobii.ai',
+        logo: `${siteUrl}/images/favicon.png`,
+        sameAs: ['https://github.com/gobii-ai/gobii-platform'],
+      }),
+    },
+    {
+      tagName: 'script',
+      attributes: {
+        type: 'application/ld+json',
+      },
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: 'Gobii Docs',
+        url: siteUrl,
+        publisher: {
+          '@type': 'Organization',
+          name: 'Gobii',
+        },
+      }),
+    },
+  ],
 
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      metadata: [
+        {
+          name: 'description',
+          content:
+            'Gobii documentation for AI browser agents, browser-use task automation, API integrations, webhooks, MCP servers, and self-hosted deployments.',
+        },
+        {name: 'keywords', content: 'Gobii, AI browser agents, browser-use, browser automation API, AI agents, web automation'},
+        {property: 'og:site_name', content: 'Gobii Docs'},
+        {property: 'og:type', content: 'website'},
+      ],
       colorMode: {
         defaultMode: 'dark',
         respectPrefersColorScheme: true,
       },
-      image: 'images/gobii-fish-with-text-dark-purple.png',
+      image: socialImage,
       navbar: {
         logo: {
           alt: 'Gobii',

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,10 +6,11 @@
     "prestart": "npm run gen-api-docs",
     "start": "docusaurus start --host 0.0.0.0",
     "prebuild": "npm run gen-api-docs",
-    "build": "docusaurus build && node scripts/prepare-pagefind.mjs && pagefind --site build && node scripts/postbuild.mjs",
+    "build": "docusaurus build && node scripts/prepare-pagefind.mjs && pagefind --site build && node scripts/postbuild.mjs && npm run verify-seo",
     "serve": "docusaurus serve --host 0.0.0.0",
     "clear": "docusaurus clear",
-    "gen-api-docs": "node scripts/prepare-openapi.mjs && docusaurus gen-api-docs all && node scripts/polish-api-sidebar.mjs"
+    "gen-api-docs": "node scripts/prepare-openapi.mjs && docusaurus gen-api-docs all && node scripts/polish-api-sidebar.mjs",
+    "verify-seo": "node scripts/verify-seo.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.0",

--- a/docs/scripts/polish-api-sidebar.mjs
+++ b/docs/scripts/polish-api-sidebar.mjs
@@ -36,6 +36,9 @@ function removeDuplicateSummary(source) {
 const spec = YAML.parse(fs.readFileSync(specPath, 'utf8'));
 const groups = new Map();
 const labelsById = new Map();
+const descriptionsById = new Map();
+const tagDescriptionsBySlug = new Map((spec.tags ?? []).map((tag) => [slugify(tag.name), tag.description]));
+const apiInfoDescription = spec.info?.description;
 
 for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
   for (const [method, operation] of Object.entries(pathItem ?? {})) {
@@ -48,6 +51,7 @@ for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
     const label = sidebarTitle ?? operation.summary ?? operation.operationId;
     const id = kebabOperationId(operation.operationId);
     labelsById.set(id, label);
+    descriptionsById.set(id, operation.description);
     const item = {
       type: 'doc',
       id: `api-reference/${id}`,
@@ -100,6 +104,34 @@ for (const [id, label] of labelsById) {
 
   let doc = fs.readFileSync(docPath, 'utf8');
   doc = doc.replace(/^sidebar_label: ".*"$/m, `sidebar_label: "${label.replace(/"/g, '\\"')}"`);
+  const description = descriptionsById.get(id);
+  if (description) {
+    doc = doc.replace(/^description: ".*"$/m, `description: "${description.replace(/"/g, '\\"')}"`);
+  }
   doc = removeDuplicateSummary(doc);
+  fs.writeFileSync(docPath, doc);
+}
+
+if (apiInfoDescription) {
+  const docPath = new URL('gobii-api.info.mdx', apiDocsDir);
+  if (fs.existsSync(docPath)) {
+    let doc = fs.readFileSync(docPath, 'utf8');
+    doc = doc.replace(/^description: ".*"$/m, `description: "${apiInfoDescription.replace(/"/g, '\\"')}"`);
+    fs.writeFileSync(docPath, doc);
+  }
+}
+
+for (const [slug, description] of tagDescriptionsBySlug) {
+  const docPath = new URL(`${slug}.tag.mdx`, apiDocsDir);
+  if (!fs.existsSync(docPath) || !description) {
+    continue;
+  }
+
+  let doc = fs.readFileSync(docPath, 'utf8');
+  if (/^description: /m.test(doc)) {
+    doc = doc.replace(/^description: ".*"$/m, `description: "${description.replace(/"/g, '\\"')}"`);
+  } else {
+    doc = doc.replace(/^title: .*\n/m, (match) => `${match}description: "${description.replace(/"/g, '\\"')}"\n`);
+  }
   fs.writeFileSync(docPath, doc);
 }

--- a/docs/scripts/prepare-openapi.mjs
+++ b/docs/scripts/prepare-openapi.mjs
@@ -46,14 +46,20 @@ const text = fs.readFileSync(specPath, 'utf8');
 const doc = YAML.parseDocument(text);
 const root = doc.toJS();
 
+root.info = {
+  ...root.info,
+  description:
+    'REST API reference for Gobii AI browser agents, browser-use automation tasks, webhooks, authentication, request parameters, and response schemas.',
+};
+
 root.tags = [
-  { name: 'Agents API' },
-  { name: 'browser-use Tasks API' },
-  { name: 'Utilities' },
+  { name: 'Agents API', description: 'Persistent Gobii agent endpoints for creating, scheduling, messaging, and managing AI browser agents.' },
+  { name: 'browser-use Tasks API', description: 'browser-use profile and task endpoints for submitting browser automation jobs, polling status, and retrieving results.' },
+  { name: 'Utilities', description: 'Utility endpoints for health checks and simple Gobii API integration verification.' },
 ];
 
-for (const pathItem of Object.values(root.paths ?? {})) {
-  for (const operation of Object.values(pathItem ?? {})) {
+for (const [operationPath, pathItem] of Object.entries(root.paths ?? {})) {
+  for (const [method, operation] of Object.entries(pathItem ?? {})) {
     if (!operation || typeof operation !== 'object' || !operation.operationId) {
       continue;
     }
@@ -61,6 +67,12 @@ for (const pathItem of Object.values(root.paths ?? {})) {
     const title = operationTitles[operation.operationId];
     if (title) {
       operation.summary = title;
+    }
+
+    const description = typeof operation.description === 'string' ? operation.description.trim() : '';
+    const genericDescription = /ViewSet|Override create/i.test(description);
+    if (!description || description.length < 70 || genericDescription) {
+      operation.description = `${title || operation.operationId} with the Gobii REST API endpoint ${method.toUpperCase()} ${operationPath}. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.`;
     }
   }
 }

--- a/docs/scripts/verify-seo.mjs
+++ b/docs/scripts/verify-seo.mjs
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const buildDir = path.join(root, 'build');
+const siteUrl = process.env.DOCS_SITE_URL || 'https://docs.gobii.ai';
+const failures = [];
+
+function walk(dir, callback) {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, callback);
+    } else {
+      callback(fullPath);
+    }
+  }
+}
+
+function fail(message) {
+  failures.push(message);
+}
+
+function readBuild(relativePath) {
+  return fs.readFileSync(path.join(buildDir, relativePath), 'utf8');
+}
+
+function htmlText(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isRedirectPage(html) {
+  return /<meta[^>]+http-equiv=["']refresh["']/i.test(html);
+}
+
+function readAttribute(tag, name) {
+  return tag?.match(new RegExp(`${name}=["']([^"']*)["']`, 'i'))?.[1] ?? '';
+}
+
+function findMetaContent(html, name) {
+  const tags = html.match(/<meta\b[^>]*>/gi) ?? [];
+  const tag = tags.find((candidate) => readAttribute(candidate, 'name').toLowerCase() === name);
+  return readAttribute(tag, 'content');
+}
+
+function findCanonical(html) {
+  const tags = html.match(/<link\b[^>]*>/gi) ?? [];
+  const tag = tags.find((candidate) => readAttribute(candidate, 'rel').toLowerCase() === 'canonical');
+  return readAttribute(tag, 'href');
+}
+
+function routeFromHtml(filePath) {
+  const relative = path.relative(buildDir, filePath).replace(/\\/g, '/');
+  if (relative === 'index.html') return '/';
+  return `/${relative.replace(/\/index\.html$/, '').replace(/\.html$/, '')}`;
+}
+
+if (!fs.existsSync(buildDir)) {
+  fail('build directory is missing');
+} else {
+  const robots = readBuild('robots.txt');
+  if (!robots.includes(`Sitemap: ${siteUrl}/sitemap.xml`)) {
+    fail('robots.txt does not point at the canonical sitemap');
+  }
+
+  const sitemap = readBuild('sitemap.xml');
+  if (!sitemap.includes(`<loc>${siteUrl}/getting-started/introduction</loc>`)) {
+    fail('sitemap.xml is missing the getting-started page');
+  }
+  if (sitemap.includes('.html</loc>')) {
+    fail('sitemap.xml contains .html URLs');
+  }
+
+  walk(buildDir, (filePath) => {
+    if (!filePath.endsWith('.html')) return;
+    if (path.basename(filePath) === '404.html') return;
+
+    const html = fs.readFileSync(filePath, 'utf8');
+    if (isRedirectPage(html)) return;
+
+    const route = routeFromHtml(filePath);
+    const expectedCanonical = `${siteUrl}${route === '/' ? '/' : route}`;
+    const canonical = findCanonical(html);
+    const description = findMetaContent(html, 'description');
+    const title = html.match(/<title\b[^>]*>([^<]+)<\/title>/i)?.[1];
+    const text = htmlText(html);
+
+    if (canonical !== expectedCanonical) {
+      fail(`${route} canonical mismatch: expected ${expectedCanonical}, got ${canonical || '(missing)'}`);
+    }
+    if (!description || description.length < 50) {
+      fail(`${route} is missing a useful meta description`);
+    }
+    if (!title || title.length < 8) {
+      fail(`${route} is missing a useful title`);
+    }
+    if (text.length < 180) {
+      fail(`${route} has too little prerendered body text`);
+    }
+  });
+}
+
+if (failures.length > 0) {
+  console.error('SEO verification failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('SEO verification passed.');

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -89,6 +89,93 @@ html {
   max-width: 860px;
 }
 
+.gobii-home {
+  margin: 0 auto;
+  max-width: 1120px;
+  padding: clamp(2.5rem, 7vw, 5.5rem) 1.25rem 4rem;
+}
+
+.gobii-home__hero {
+  align-items: end;
+  display: grid;
+  gap: 2rem;
+  min-height: min(58vh, 34rem);
+}
+
+.gobii-home__eyebrow {
+  color: var(--ifm-color-primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.85rem;
+  text-transform: uppercase;
+}
+
+.gobii-home h1 {
+  font-size: clamp(2.6rem, 7vw, 5.7rem);
+  letter-spacing: 0;
+  line-height: 0.95;
+  margin: 0;
+  max-width: 11ch;
+}
+
+.gobii-home__lede {
+  color: var(--ifm-color-emphasis-700);
+  font-size: clamp(1.04rem, 2vw, 1.24rem);
+  line-height: 1.65;
+  margin: 1.4rem 0 0;
+  max-width: 44rem;
+}
+
+.gobii-home__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.8rem;
+}
+
+.gobii-home__actions .button {
+  border-radius: 8px;
+}
+
+.gobii-home__links {
+  display: grid;
+  gap: 1px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 3rem;
+}
+
+.gobii-home__link {
+  border: 1px solid var(--gobii-doc-muted-border);
+  color: inherit;
+  min-height: 11rem;
+  padding: 1.1rem;
+  text-decoration: none;
+  transition: background-color 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.gobii-home__link:hover {
+  background: var(--gobii-doc-subtle-active);
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 42%, var(--gobii-doc-muted-border));
+  color: inherit;
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.gobii-home__link span {
+  color: var(--ifm-color-primary);
+  display: block;
+  font-weight: 800;
+  margin-bottom: 0.65rem;
+}
+
+.gobii-home__link p {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
 @media (min-width: 997px) {
   .container:has(.theme-api-markdown) {
     max-width: none;
@@ -330,6 +417,14 @@ html {
 }
 
 @media (max-width: 996px) {
+  .gobii-home__hero {
+    min-height: auto;
+  }
+
+  .gobii-home__links {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .navbar__brand {
     min-width: 0;
   }
@@ -359,5 +454,11 @@ html {
 
   .openapi-right-panel__container {
     margin-top: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .gobii-home__links {
+    grid-template-columns: 1fr;
   }
 }

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,6 +1,64 @@
 import React from 'react';
-import {Redirect} from '@docusaurus/router';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+
+const primaryLinks = [
+  {
+    title: 'Start with Gobii',
+    description: 'Understand Gobii agents, channels, organizations, files, and task credits.',
+    to: '/getting-started/introduction',
+  },
+  {
+    title: 'Build with the API',
+    description: 'Create agents, submit browser-use tasks, receive webhooks, and retrieve structured results.',
+    to: '/developers/developer-basics',
+  },
+  {
+    title: 'Explore the API reference',
+    description: 'Browse every REST endpoint with request parameters, response schemas, and code samples.',
+    to: '/api-reference/list-persistent-agents',
+  },
+  {
+    title: 'Self-host Gobii',
+    description: 'Run Gobii on your own infrastructure with Docker Compose and local configuration.',
+    to: '/self-hosted/overview',
+  },
+];
 
 export default function Home() {
-  return <Redirect to="/getting-started/introduction" />;
+  return (
+    <Layout
+      title="Gobii Docs"
+      description="Documentation for Gobii AI browser agents, browser-use task automation, API integrations, webhooks, MCP servers, and self-hosted deployments."
+    >
+      <main className="gobii-home">
+        <section className="gobii-home__hero">
+          <div>
+            <p className="gobii-home__eyebrow">Gobii Documentation</p>
+            <h1>AI browser agents that work across the web.</h1>
+            <p className="gobii-home__lede">
+              Learn how to create always-on agents, run browser-use tasks, integrate with the REST API, receive
+              webhook results, and operate Gobii in the cloud or on your own infrastructure.
+            </p>
+            <div className="gobii-home__actions">
+              <Link className="button button--primary" to="/getting-started/introduction">
+                Read the docs
+              </Link>
+              <Link className="button button--secondary" to="/api-reference/list-persistent-agents">
+                API reference
+              </Link>
+            </div>
+          </div>
+        </section>
+        <section className="gobii-home__links" aria-label="Documentation sections">
+          {primaryLinks.map((item) => (
+            <Link className="gobii-home__link" to={item.to} key={item.to}>
+              <span>{item.title}</span>
+              <p>{item.description}</p>
+            </Link>
+          ))}
+        </section>
+      </main>
+    </Layout>
+  );
 }

--- a/docs/static/openapi/GobiiAPI.yaml
+++ b/docs/static/openapi/GobiiAPI.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Gobii API
   version: 0.1.0
-  description: API for Gobii AI browser agents platform
+  description: REST API reference for Gobii AI browser agents, browser-use automation tasks, webhooks, authentication, request parameters, and response schemas.
 paths:
   /agents/:
     get:
@@ -37,6 +37,7 @@ paths:
         metadata:
           sidebarTitle: Agents - List
       summary: Get agents
+      description: Get agents with the Gobii REST API endpoint GET /agents/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
     post:
       operationId: createPersistentAgent
       summary: Create an Agent
@@ -68,6 +69,7 @@ paths:
       x-mint:
         metadata:
           sidebarTitle: Agent - Create
+      description: Create an Agent with the Gobii REST API endpoint POST /agents/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
   /agents/{id}/:
     get:
       operationId: getPersistentAgent
@@ -96,6 +98,7 @@ paths:
         metadata:
           sidebarTitle: Agent - Get
       summary: Get Agent
+      description: Get Agent with the Gobii REST API endpoint GET /agents/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
     put:
       operationId: updatePersistentAgent
       parameters:
@@ -135,9 +138,10 @@ paths:
         metadata:
           sidebarTitle: Agent - Update
       summary: Update Agent
+      description: Update Agent with the Gobii REST API endpoint PUT /agents/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
     patch:
       operationId: partialUpdatePersistentAgent
-      description: Update an agent's configuration
+      description: Update Agent with the Gobii REST API endpoint PATCH /agents/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       summary: Update Agent
       parameters:
         - in: path
@@ -197,10 +201,11 @@ paths:
         metadata:
           sidebarTitle: Agent - Delete
       summary: Delete Agent
+      description: Delete Agent with the Gobii REST API endpoint DELETE /agents/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
   /agents/{id}/activate/:
     post:
       operationId: activatePersistentAgent
-      description: Activates an agent processing.
+      description: Activate Agent with the Gobii REST API endpoint POST /agents/{id}/activate/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -241,7 +246,7 @@ paths:
   /agents/{id}/deactivate/:
     post:
       operationId: deactivatePersistentAgent
-      description: Deactivates an agent from processing.
+      description: Deactivate Agent with the Gobii REST API endpoint POST /agents/{id}/deactivate/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -323,7 +328,7 @@ paths:
   /agents/{id}/processing-status/:
     get:
       operationId: getPersistentAgentProcessingStatus
-      description: Gets the processing status of an agent's current timeline
+      description: Get Agent Processing Status with the Gobii REST API endpoint GET /agents/{id}/processing-status/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       summary: Get Agent Processing Status
       parameters:
         - in: path
@@ -389,10 +394,11 @@ paths:
         metadata:
           sidebarTitle: Agent Schedule - Preview
       summary: Preview Agent Schedule
+      description: Preview Agent Schedule with the Gobii REST API endpoint POST /agents/{id}/schedule/preview/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
   /agents/{id}/timeline/:
     get:
       operationId: getPersistentAgentTimeline
-      description: Gets the agent's current timeline
+      description: Get Agent Timeline with the Gobii REST API endpoint GET /agents/{id}/timeline/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       summary: Get Agent Timeline
       parameters:
         - in: path
@@ -446,10 +452,11 @@ paths:
         metadata:
           sidebarTitle: Web Tasks - List
       summary: List Web Tasks
+      description: List Web Tasks with the Gobii REST API endpoint GET /agents/{id}/web-tasks/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
   /agents/browser-use/:
     get:
       operationId: listAgents
-      description: List all browser-use profiles for the API key.
+      description: List browser-use Profiles with the Gobii REST API endpoint GET /agents/browser-use/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       summary: List browser-use Profiles
       parameters:
         - name: page
@@ -482,7 +489,7 @@ paths:
           sidebarTitle: Profiles - List
     post:
       operationId: createAgent
-      description: ViewSet for managing BrowserUseAgents.
+      description: Create browser-use Profile with the Gobii REST API endpoint POST /agents/browser-use/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       tags:
         - browser-use Tasks API
       requestBody:
@@ -515,9 +522,7 @@ paths:
   /agents/browser-use/{agentId}/tasks/:
     get:
       operationId: listTasks
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: List Tasks with the Gobii REST API endpoint GET /agents/browser-use/{agentId}/tasks/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: agentId
@@ -556,7 +561,7 @@ paths:
       summary: List Tasks
     post:
       operationId: assignTask
-      description: Override create to handle wait parameter results.
+      description: Create Task with the Gobii REST API endpoint POST /agents/browser-use/{agentId}/tasks/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: agentId
@@ -607,9 +612,7 @@ paths:
   /agents/browser-use/{agentId}/tasks/{id}/:
     get:
       operationId: getTask
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Get Task with the Gobii REST API endpoint GET /agents/browser-use/{agentId}/tasks/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: agentId
@@ -642,9 +645,7 @@ paths:
       summary: Get Task
     put:
       operationId: updateTask
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Update Task with the Gobii REST API endpoint PUT /agents/browser-use/{agentId}/tasks/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: agentId
@@ -688,9 +689,7 @@ paths:
       summary: Update Task
     patch:
       operationId: updateTaskStatusPartial
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Update Task with the Gobii REST API endpoint PATCH /agents/browser-use/{agentId}/tasks/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: agentId
@@ -734,9 +733,7 @@ paths:
       summary: Update Task
     delete:
       operationId: deleteTask
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Delete Task with the Gobii REST API endpoint DELETE /agents/browser-use/{agentId}/tasks/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: agentId
@@ -766,9 +763,7 @@ paths:
   /agents/browser-use/{agentId}/tasks/{id}/cancel/:
     post:
       operationId: cancelTask
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Cancel Task with the Gobii REST API endpoint POST /agents/browser-use/{agentId}/tasks/{id}/cancel/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: agentId
@@ -808,9 +803,7 @@ paths:
   /agents/browser-use/{agentId}/tasks/{id}/result/:
     get:
       operationId: getTaskResult
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Get Task Result with the Gobii REST API endpoint GET /agents/browser-use/{agentId}/tasks/{id}/result/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: agentId
@@ -844,7 +837,7 @@ paths:
   /agents/browser-use/{id}/:
     get:
       operationId: getAgent
-      description: ViewSet for managing BrowserUseAgents.
+      description: Get browser-use Profile with the Gobii REST API endpoint GET /agents/browser-use/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       summary: Get browser-use Profile
       parameters:
         - in: path
@@ -872,7 +865,7 @@ paths:
           sidebarTitle: Profile - Get
     put:
       operationId: updateAgent
-      description: ViewSet for managing BrowserUseAgents.
+      description: Update browser-use Profile with the Gobii REST API endpoint PUT /agents/browser-use/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -912,7 +905,7 @@ paths:
       summary: Update browser-use Profile
     patch:
       operationId: updateAgentStatusPartial
-      description: ViewSet for managing BrowserUseAgents.
+      description: Update browser-use Profile with the Gobii REST API endpoint PATCH /agents/browser-use/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -951,7 +944,7 @@ paths:
       summary: Update browser-use Profile
     delete:
       operationId: deleteAgent
-      description: ViewSet for managing BrowserUseAgents.
+      description: Delete browser-use Profile with the Gobii REST API endpoint DELETE /agents/browser-use/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -976,7 +969,7 @@ paths:
   /ping/:
     get:
       operationId: ping
-      description: Test API connectivity with a simple ping endpoint
+      description: Ping API with the Gobii REST API endpoint GET /ping/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       summary: Ping API
       tags:
         - Utilities
@@ -997,7 +990,7 @@ paths:
   /tasks/browser-use/:
     get:
       operationId: listAllTasks
-      description: List all browser-use tasks for the specified browser-use profile.
+      description: List browser-use Tasks with the Gobii REST API endpoint GET /tasks/browser-use/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       summary: List browser-use Tasks
       tags:
         - browser-use Tasks API
@@ -1017,7 +1010,7 @@ paths:
           sidebarTitle: Tasks - List
     post:
       operationId: assignTask2
-      description: Override create to handle wait parameter results.
+      description: Create Task with the Gobii REST API endpoint POST /tasks/browser-use/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       tags:
         - browser-use Tasks API
       requestBody:
@@ -1061,9 +1054,7 @@ paths:
   /tasks/browser-use/{id}/:
     get:
       operationId: getTask2
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Get Task with the Gobii REST API endpoint GET /tasks/browser-use/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -1090,9 +1081,7 @@ paths:
       summary: Get Task
     put:
       operationId: updateTask2
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Update Task with the Gobii REST API endpoint PUT /tasks/browser-use/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -1130,9 +1119,7 @@ paths:
       summary: Update Task
     patch:
       operationId: updateTaskStatusPartial2
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Update Task with the Gobii REST API endpoint PATCH /tasks/browser-use/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -1170,9 +1157,7 @@ paths:
       summary: Update Task
     delete:
       operationId: deleteTask2
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Delete Task with the Gobii REST API endpoint DELETE /tasks/browser-use/{id}/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -1196,9 +1181,7 @@ paths:
   /tasks/browser-use/{id}/cancel/:
     post:
       operationId: cancelTask2
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Cancel Task with the Gobii REST API endpoint POST /tasks/browser-use/{id}/cancel/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -1232,9 +1215,7 @@ paths:
   /tasks/browser-use/{id}/result/:
     get:
       operationId: getTaskResult2
-      description: |-
-        ViewSet for managing BrowserUseAgentTasks.
-        Supports both agent-specific and user-wide task operations.
+      description: Get Task Result with the Gobii REST API endpoint GET /tasks/browser-use/{id}/result/. Includes authentication, parameters, request body, response schema, and examples for AI browser agents and browser-use automation tasks.
       parameters:
         - in: path
           name: id
@@ -2051,5 +2032,8 @@ servers:
     description: Production server
 tags:
   - name: Agents API
+    description: Persistent Gobii agent endpoints for creating, scheduling, messaging, and managing AI browser agents.
   - name: browser-use Tasks API
+    description: browser-use profile and task endpoints for submitting browser automation jobs, polling status, and retrieving results.
   - name: Utilities
+    description: Utility endpoints for health checks and simple Gobii API integration verification.


### PR DESCRIPTION
## Summary
- replace the root client redirect with an indexable docs landing page
- add global docs metadata, Open Graph tags, and JSON-LD Organization/WebSite structured data
- enrich docs and generated OpenAPI descriptions so pages have useful snippets
- add a build-time SEO verifier for canonical URLs, descriptions, titles, sitemap, robots, and prerendered content

## Verification
- npm --prefix docs run build