### PR TITLE
Soften docs sidebar and headings

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -5,12 +5,14 @@ const sidebars = {
   docsSidebar: [
     {
       type: 'category',
-      label: 'Getting Started',
+      label: '👋 Getting Started',
+      collapsed: false,
       items: ['getting-started/introduction'],
     },
     {
       type: 'category',
-      label: 'Core Concepts',
+      label: '✨ Core Concepts',
+      collapsed: false,
       items: [
         'core-concepts/agents',
         'core-concepts/agent-contacts',
@@ -21,7 +23,8 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Advanced Usage',
+      label: '🧭 Advanced Usage',
+      collapsed: false,
       items: [
         'core-concepts/intelligence-selector',
         'core-concepts/organizations',
@@ -32,7 +35,8 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Console Guides',
+      label: '🖥️ Console Guides',
+      collapsed: false,
       items: [
         'console-guides/overview',
         'console-guides/live-chat-guide',
@@ -43,7 +47,8 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Developers',
+      label: '🛠️ Developers',
+      collapsed: false,
       items: [
         'developers/developer-basics',
         'developers/developer-agents',
@@ -54,17 +59,18 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Self-Hosted',
+      label: '🏠 Self-Hosted',
+      collapsed: false,
       items: ['self-hosted/overview'],
     },
     {
       type: 'category',
-      label: 'API Reference',
+      label: '⚙️ API Reference',
       link: {
         type: 'doc',
         id: 'api-reference/gobii-api',
       },
-      collapsed: false,
+      collapsed: true,
       items: apiSidebar.apisidebar.slice(1),
     },
   ],

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -7,6 +7,7 @@
   --ifm-color-primary-lighter: #5896f2;
   --ifm-color-primary-lightest: #82b1f6;
   --ifm-code-font-size: 0.92rem;
+  --ifm-heading-font-weight: 520;
   --ifm-navbar-height: 4rem;
   --ifm-border-radius: 8px;
   --gobii-doc-panel-background: #ffffff;
@@ -89,6 +90,18 @@ html {
   max-width: 860px;
 }
 
+.theme-doc-markdown :where(h1, h2, h3),
+.theme-api-markdown :where(h1, h2, h3),
+.markdown :where(h1, h2, h3) {
+  font-weight: 520;
+  letter-spacing: 0;
+}
+
+.theme-doc-markdown h1,
+.theme-api-markdown h1 {
+  font-weight: 500;
+}
+
 .gobii-home {
   margin: 0 auto;
   max-width: 1120px;
@@ -113,6 +126,7 @@ html {
 
 .gobii-home h1 {
   font-size: clamp(2.6rem, 7vw, 5.7rem);
+  font-weight: 500;
   letter-spacing: 0;
   line-height: 0.95;
   margin: 0;
@@ -225,6 +239,7 @@ html {
 
 .theme-api-markdown .openapi__heading {
   font-size: 2rem;
+  font-weight: 500;
   letter-spacing: 0;
   margin-bottom: 0.7rem !important;
 }
@@ -272,6 +287,7 @@ html {
 
 .openapi-left-panel__container .openapi-tabs__heading {
   font-size: 1.45rem;
+  font-weight: 520;
 }
 
 .openapi-left-panel__container .openapi-tabs__response-header {
@@ -389,7 +405,7 @@ html {
 
 .theme-doc-sidebar-container .menu__link--active {
   background: var(--gobii-doc-subtle-active);
-  font-weight: 600;
+  font-weight: 560;
 }
 
 .theme-doc-sidebar-container .menu__link--sublist-caret::after {


### PR DESCRIPTION
## Summary
- add friendly emoji markers to top-level docs sidebar categories
- keep user-facing sections expanded by default while collapsing API Reference
- soften heading and active-sidebar font weights so the docs feel less dense

## Verification
- npm --prefix docs run build