### PR TITLE
Add remote MCP server endpoint

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -13,11 +13,16 @@ class APIKeyAuthentication(authentication.BaseAuthentication):
     keyword = "X-Api-Key"
 
     def authenticate(self, request):
-        with traced("API Authenticate") as span:
-            raw_key = request.headers.get(self.keyword)
-            if not raw_key:
-                return None  # let other auth methods try (Session for admin)
+        raw_key = self.get_api_key(request)
+        if not raw_key:
+            return None  # let other auth methods try (Session for admin)
+        return self.authenticate_raw_key(request, raw_key)
 
+    def get_api_key(self, request):
+        return request.headers.get(self.keyword)
+
+    def authenticate_raw_key(self, request, raw_key):
+        with traced("API Authenticate") as span:
             prefix = raw_key[:8]
             with traced("API Key Lookup") as span:
                 try:
@@ -103,3 +108,18 @@ class APIKeyAuthentication(authentication.BaseAuthentication):
             raise exceptions.AuthenticationFailed(PERSONAL_USAGE_REQUIRES_TRIAL_MESSAGE)
 
         return api_key.user
+
+
+class MCPAPIKeyAuthentication(APIKeyAuthentication):
+    """Authenticate remote MCP clients with existing Gobii API keys."""
+
+    def get_api_key(self, request):
+        raw_key = request.headers.get(self.keyword)
+        if raw_key:
+            return raw_key
+
+        authorization = request.headers.get("Authorization", "")
+        scheme, separator, token = authorization.partition(" ")
+        if separator and scheme.lower() == "bearer" and token.strip():
+            return token.strip()
+        return None

--- a/api/mcp_views.py
+++ b/api/mcp_views.py
@@ -1,0 +1,281 @@
+import json
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.auth import MCPAPIKeyAuthentication
+from api.services.remote_mcp import (
+    MCPToolError,
+    MCP_PROTOCOL_VERSION,
+    SERVER_INFO,
+    call_tool,
+    list_tools,
+    make_tool_result,
+)
+
+
+JSON_RPC_PARSE_ERROR = -32700
+JSON_RPC_INVALID_REQUEST = -32600
+JSON_RPC_METHOD_NOT_FOUND = -32601
+JSON_RPC_INVALID_PARAMS = -32602
+JSON_RPC_HEADER_MISMATCH = -32001
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class GobiiMCPView(APIView):
+    """Streamable HTTP-compatible MCP endpoint for Gobii agent infrastructure."""
+
+    authentication_classes = [MCPAPIKeyAuthentication]
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["get", "post", "options"]
+
+    def get(self, request, *args, **kwargs):
+        if not _origin_is_allowed(request):
+            return _json_rpc_error_response(
+                JSON_RPC_INVALID_REQUEST,
+                "Origin is not allowed.",
+                http_status=403,
+            )
+        response = HttpResponse(status=405)
+        response["Allow"] = "POST, OPTIONS"
+        response["Cache-Control"] = "no-store"
+        return response
+
+    def options(self, request, *args, **kwargs):
+        if not _origin_is_allowed(request):
+            return _json_rpc_error_response(
+                JSON_RPC_INVALID_REQUEST,
+                "Origin is not allowed.",
+                http_status=403,
+            )
+        response = HttpResponse(status=204)
+        response["Allow"] = "POST, OPTIONS"
+        response["Access-Control-Allow-Headers"] = (
+            "Authorization, Content-Type, MCP-Protocol-Version, Mcp-Method, Mcp-Name, X-Api-Key"
+        )
+        response["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+        response["Access-Control-Max-Age"] = "600"
+        origin = request.headers.get("Origin")
+        if origin:
+            response["Access-Control-Allow-Origin"] = origin
+            response["Vary"] = "Origin"
+        return response
+
+    def post(self, request, *args, **kwargs):
+        if not _origin_is_allowed(request):
+            return _json_rpc_error_response(
+                JSON_RPC_INVALID_REQUEST,
+                "Origin is not allowed.",
+                http_status=403,
+            )
+
+        try:
+            payload = json.loads((request.body or b"{}").decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return _json_rpc_error_response(
+                JSON_RPC_PARSE_ERROR,
+                "Parse error.",
+                request_id=None,
+                http_status=400,
+            )
+
+        if not isinstance(payload, dict):
+            return _json_rpc_error_response(
+                JSON_RPC_INVALID_REQUEST,
+                "Request body must be a single JSON-RPC object.",
+                request_id=None,
+                http_status=400,
+            )
+
+        if _is_json_rpc_notification_or_response(payload):
+            return _accepted_response()
+
+        header_error = _validate_mcp_headers(request, payload)
+        if header_error is not None:
+            return _json_rpc_error_response(
+                JSON_RPC_HEADER_MISMATCH,
+                header_error,
+                request_id=payload.get("id"),
+                http_status=400,
+            )
+
+        response_payload, http_status = _handle_json_rpc_request(request, payload)
+        response = Response(response_payload, status=http_status)
+        response["Cache-Control"] = "no-store"
+        response["X-Content-Type-Options"] = "nosniff"
+        response["Vary"] = "Authorization, X-Api-Key"
+        return response
+
+
+def _handle_json_rpc_request(request, payload):
+    request_id = payload.get("id")
+    if payload.get("jsonrpc") != "2.0" or "method" not in payload:
+        return _json_rpc_error_payload(
+            JSON_RPC_INVALID_REQUEST,
+            "Invalid JSON-RPC request.",
+            request_id=request_id,
+        ), 400
+
+    method = payload.get("method")
+    params = payload.get("params") or {}
+    if not isinstance(params, dict):
+        return _json_rpc_error_payload(
+            JSON_RPC_INVALID_PARAMS,
+            "params must be an object.",
+            request_id=request_id,
+        ), 200
+
+    if method == "initialize":
+        return _json_rpc_success_payload(
+            request_id,
+            {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": SERVER_INFO,
+                "instructions": (
+                    "Use Gobii tools to create, manage, link, message, and attach files to "
+                    "persistent Gobii agents. Authenticate every request with your Gobii API key."
+                ),
+            },
+        ), 200
+
+    if method == "ping":
+        return _json_rpc_success_payload(request_id, {}), 200
+
+    if method == "tools/list":
+        return _json_rpc_success_payload(request_id, {"tools": list_tools()}), 200
+
+    if method == "tools/call":
+        tool_name = params.get("name")
+        arguments = params.get("arguments") or {}
+        if not isinstance(tool_name, str) or not tool_name:
+            return _json_rpc_error_payload(
+                JSON_RPC_INVALID_PARAMS,
+                "tools/call requires params.name.",
+                request_id=request_id,
+            ), 200
+        try:
+            result = make_tool_result(call_tool(request, tool_name, arguments))
+        except MCPToolError as exc:
+            payload = {"status": "error", "message": str(exc)}
+            if exc.data is not None:
+                payload["details"] = exc.data
+            result = make_tool_result(payload, is_error=True)
+        return _json_rpc_success_payload(request_id, result), 200
+
+    return _json_rpc_error_payload(
+        JSON_RPC_METHOD_NOT_FOUND,
+        f"Method not found: {method}",
+        request_id=request_id,
+    ), 200
+
+
+def _is_json_rpc_notification_or_response(payload):
+    if "method" not in payload and ("result" in payload or "error" in payload):
+        return True
+    if "method" in payload and "id" not in payload:
+        return True
+    return False
+
+
+def _accepted_response():
+    response = HttpResponse(status=202)
+    response["Cache-Control"] = "no-store"
+    return response
+
+
+def _json_rpc_success_payload(request_id, result):
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _json_rpc_error_payload(code, message, *, request_id=None):
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _json_rpc_error_response(code, message, *, request_id=None, http_status=200):
+    response = Response(
+        _json_rpc_error_payload(code, message, request_id=request_id),
+        status=http_status,
+    )
+    response["Cache-Control"] = "no-store"
+    response["X-Content-Type-Options"] = "nosniff"
+    return response
+
+
+def _validate_mcp_headers(request, payload):
+    method = payload.get("method")
+    header_method = request.headers.get("Mcp-Method")
+    if header_method and header_method != method:
+        return f"Mcp-Method header value does not match JSON-RPC method {method!r}."
+
+    if method == "tools/call":
+        params = payload.get("params") if isinstance(payload.get("params"), dict) else {}
+        body_name = params.get("name")
+        header_name = request.headers.get("Mcp-Name")
+        if header_name and header_name != body_name:
+            return "Mcp-Name header value does not match params.name."
+
+    return None
+
+
+def _origin_is_allowed(request):
+    origin = request.headers.get("Origin")
+    if not origin:
+        return True
+
+    parsed_origin = urlparse(origin)
+    if parsed_origin.scheme not in {"http", "https"} or not parsed_origin.netloc:
+        return False
+
+    request_host = request.get_host().lower()
+    origin_netloc = parsed_origin.netloc.lower()
+    if origin_netloc == request_host:
+        return True
+
+    if _origin_matches_trusted_origin(origin, parsed_origin):
+        return True
+
+    return _origin_matches_allowed_host(parsed_origin)
+
+
+def _origin_matches_trusted_origin(origin, parsed_origin):
+    normalized_origin = origin.rstrip("/")
+    for trusted in settings.CSRF_TRUSTED_ORIGINS:
+        trusted_value = trusted.rstrip("/")
+        if trusted_value == normalized_origin:
+            return True
+        trusted_parsed = urlparse(trusted_value)
+        if trusted_parsed.scheme != parsed_origin.scheme:
+            continue
+        trusted_netloc = trusted_parsed.netloc.lower()
+        origin_netloc = parsed_origin.netloc.lower()
+        if trusted_netloc.startswith("*.") and origin_netloc.endswith(trusted_netloc[1:]):
+            return True
+    return False
+
+
+def _origin_matches_allowed_host(parsed_origin):
+    hostname = (parsed_origin.hostname or "").lower()
+    netloc = parsed_origin.netloc.lower()
+    for allowed in settings.ALLOWED_HOSTS:
+        allowed_value = allowed.lower()
+        if allowed_value == "*":
+            continue
+        if allowed_value == netloc or allowed_value == hostname:
+            return True
+        if allowed_value.startswith(".") and (
+            hostname.endswith(allowed_value) or hostname == allowed_value[1:]
+        ):
+            return True
+    return False

--- a/api/models.py
+++ b/api/models.py
@@ -6582,7 +6582,7 @@ class PersistentAgent(models.Model):
         super().clean()
         if self.organization_id:
             self._validate_org_seats()
-        if self.schedule:
+        if self.schedule and not getattr(self, "_skip_unchanged_schedule_validation", False):
             try:
                 # Use the same parser that's used for task scheduling to ensure consistency.
                 from api.agent.core.schedule_parser import ScheduleParser

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -436,6 +436,7 @@ class PersistentAgentSerializer(serializers.ModelSerializer):
             'preferred_contact_endpoint_id',
             'preferred_contact_endpoint',
             'preferred_llm_tier',
+            'daily_credit_limit',
             'proactive_opt_in',
             'proactive_last_trigger_at',
             'template_code',
@@ -636,7 +637,7 @@ class PersistentAgentSerializer(serializers.ModelSerializer):
             # If incoming payload explicitly provided fields that differ from defaults,
             # ensure they are persisted after provisioning.
             post_create_updates = {}
-            for field in ('charter', 'schedule', 'is_active', 'life_state', 'whitelist_policy'):
+            for field in ('charter', 'schedule', 'is_active', 'life_state', 'whitelist_policy', 'daily_credit_limit'):
                 if field in validated_data and getattr(agent, field) != validated_data[field]:
                     setattr(agent, field, validated_data[field])
                     post_create_updates[field] = validated_data[field]

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -703,10 +703,18 @@ class PersistentAgentSerializer(serializers.ModelSerializer):
             instance.preferred_contact_endpoint = preferred_endpoint
             dirty_fields.add('preferred_contact_endpoint')
 
+        skip_unchanged_schedule_validation = self.partial and 'schedule' not in dirty_fields
+        if skip_unchanged_schedule_validation:
+            # Partial updates must not fail because an untouched persisted schedule
+            # cannot currently be parsed. Explicit schedule updates still validate.
+            instance._skip_unchanged_schedule_validation = True
         try:
             instance.full_clean()
         except DjangoValidationError as exc:
             raise serializers.ValidationError(exc.message_dict if hasattr(exc, 'message_dict') else exc.messages) from exc
+        finally:
+            if skip_unchanged_schedule_validation:
+                delattr(instance, '_skip_unchanged_schedule_validation')
 
         update_fields = list(dirty_fields)
         instance.save(update_fields=update_fields or None)

--- a/api/services/remote_mcp.py
+++ b/api/services/remote_mcp.py
@@ -1,8 +1,11 @@
 import base64
 import binascii
 import copy
+import datetime
 import json
+import time
 import uuid
+from decimal import Decimal
 
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.serializers.json import DjangoJSONEncoder
@@ -11,6 +14,15 @@ from django.db.models import Q
 
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
+from api.agent.core.llm_config import (
+    AgentLLMTier,
+    get_allowed_tier_rank,
+    get_llm_tier_description,
+    get_llm_tier_label,
+    get_system_default_tier,
+    resolve_intelligence_tier_for_owner,
+    resolve_preferred_tier_for_owner,
+)
 from api.agent.comms.message_service import inject_internal_web_message
 from api.agent.files.attachment_helpers import (
     AttachmentResolutionError,
@@ -27,21 +39,39 @@ from api.models import (
     build_web_user_address,
 )
 from api.serializers import PersistentAgentSerializer
+from api.services.agent_settings_resume import queue_settings_change_resume
+from api.services.daily_credit_limits import calculate_daily_credit_slider_bounds, get_tier_credit_multiplier
+from api.services.daily_credit_settings import get_daily_credit_settings_for_owner
 from console.agent_chat.timeline import (
     DEFAULT_PAGE_SIZE as TIMELINE_DEFAULT_PAGE_SIZE,
     MAX_PAGE_SIZE as TIMELINE_MAX_PAGE_SIZE,
     fetch_timeline_window,
+    serialize_message_event,
     serialize_processing_snapshot,
 )
 from pages.account_info_cache import invalidate_account_info_cache
 from util.trial_enforcement import can_user_use_personal_agents_and_api
 
 
-MCP_PROTOCOL_VERSION = "2025-06-18"
+MCP_PROTOCOL_VERSION = "2025-11-25"
 SERVER_INFO = {
     "name": "gobii",
     "title": "Gobii",
     "version": "2.19.0",
+}
+WAIT_DEFAULT_TIMEOUT_SECONDS = 10
+WAIT_MAX_TIMEOUT_SECONDS = 30
+WAIT_POLL_INTERVAL_SECONDS = 0.5
+WAIT_EVENT_TYPES = {"message", "steps", "thinking", "plan"}
+WAIT_FILTER_FIELDS = {
+    "from_actor_type",
+    "from_agent_id",
+    "to_agent_id",
+    "message_id",
+    "peer_link_id",
+    "channel",
+    "status",
+    "tool_name",
 }
 
 
@@ -59,6 +89,119 @@ def _agent_schema(description):
     }
 
 
+def _object_output(properties, *, required=()):
+    schema = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": True,
+    }
+    if required:
+        schema["required"] = list(required)
+    return schema
+
+
+def _array_output(item_schema):
+    return {"type": "array", "items": item_schema}
+
+
+_STRING_OR_NULL = {"type": ["string", "null"]}
+_INTEGER_OR_NULL = {"type": ["integer", "null"]}
+_NUMBER_OR_STRING = {"type": ["number", "string"]}
+_NUMBER_STRING_OR_NULL = {"type": ["integer", "number", "string", "null"]}
+_ID_OR_NULL = {"type": ["integer", "string", "null"]}
+_UUID_OUTPUT = {"type": "string", "format": "uuid"}
+
+_AGENT_REF_OUTPUT = _object_output(
+    {
+        "id": _UUID_OUTPUT,
+        "name": {"type": "string"},
+        "is_active": {"type": "boolean"},
+        "life_state": {"type": "string"},
+    },
+    required=("id", "name"),
+)
+
+_AGENT_OUTPUT = _object_output(
+    {
+        "id": _UUID_OUTPUT,
+        "name": {"type": "string"},
+        "charter": _STRING_OR_NULL,
+        "short_description": _STRING_OR_NULL,
+        "schedule": _STRING_OR_NULL,
+        "is_active": {"type": "boolean"},
+        "life_state": {"type": "string"},
+        "planning_state": _STRING_OR_NULL,
+        "whitelist_policy": {"type": "string"},
+        "created_at": _STRING_OR_NULL,
+        "updated_at": _STRING_OR_NULL,
+        "last_interaction_at": _STRING_OR_NULL,
+        "user_id": _STRING_OR_NULL,
+        "organization_id": _STRING_OR_NULL,
+        "browser_use_agent_id": _STRING_OR_NULL,
+        "preferred_contact_endpoint_id": _STRING_OR_NULL,
+        "preferred_llm_tier": _STRING_OR_NULL,
+        "daily_credit_limit": _INTEGER_OR_NULL,
+        "daily_credit_soft_target": _NUMBER_STRING_OR_NULL,
+        "daily_credit_hard_limit": _NUMBER_STRING_OR_NULL,
+        "proactive_opt_in": {"type": "boolean"},
+        "proactive_last_trigger_at": _STRING_OR_NULL,
+    },
+    required=("id", "name", "schedule", "is_active"),
+)
+
+_LINK_OUTPUT = _object_output(
+    {
+        "id": _UUID_OUTPUT,
+        "agent_a": _AGENT_REF_OUTPUT,
+        "agent_b": _AGENT_REF_OUTPUT,
+        "is_enabled": {"type": "boolean"},
+        "messages_per_window": {"type": "integer"},
+        "window_hours": {"type": "integer"},
+        "feature_flag": _STRING_OR_NULL,
+        "pair_key": {"type": "string"},
+        "created_by_user_id": _ID_OR_NULL,
+        "created_at": _STRING_OR_NULL,
+        "updated_at": _STRING_OR_NULL,
+    },
+    required=("id", "agent_a", "agent_b", "is_enabled"),
+)
+
+_TIMELINE_EVENT_OUTPUT = _object_output(
+    {
+        "kind": {"type": "string"},
+        "cursor": _STRING_OR_NULL,
+    },
+    required=("kind",),
+)
+
+_MESSAGE_OUTPUT = _object_output(
+    {
+        "id": _UUID_OUTPUT,
+        "owner_agent_id": _STRING_OR_NULL,
+        "conversation_id": _STRING_OR_NULL,
+        "is_outbound": {"type": "boolean"},
+        "body": {"type": "string"},
+        "timestamp": _STRING_OR_NULL,
+    },
+    required=("id", "body"),
+)
+
+_FILE_NODE_OUTPUT = _object_output(
+    {
+        "id": _UUID_OUTPUT,
+        "parent_id": _STRING_OR_NULL,
+        "name": {"type": "string"},
+        "path": {"type": "string"},
+        "node_type": {"type": "string"},
+        "size_bytes": _INTEGER_OR_NULL,
+        "mime_type": _STRING_OR_NULL,
+        "created_at": _STRING_OR_NULL,
+        "updated_at": _STRING_OR_NULL,
+    },
+    required=("id", "name", "path", "node_type"),
+)
+
+
 TOOL_DEFINITIONS = [
     {
         "name": "gobii_list_agents",
@@ -72,6 +215,16 @@ TOOL_DEFINITIONS = [
             },
             "additionalProperties": False,
         },
+        "outputSchema": _object_output(
+            {
+                "agents": _array_output(_AGENT_OUTPUT),
+                "page": {"type": "integer"},
+                "page_size": {"type": "integer"},
+                "total": {"type": "integer"},
+                "has_next": {"type": "boolean"},
+            },
+            required=("agents", "page", "page_size", "total", "has_next"),
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -84,6 +237,7 @@ TOOL_DEFINITIONS = [
             "required": ["agent_id"],
             "additionalProperties": False,
         },
+        "outputSchema": _object_output({"agent": _AGENT_OUTPUT}, required=("agent",)),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -97,6 +251,15 @@ TOOL_DEFINITIONS = [
                 "charter": {"type": "string", "description": "Instructions describing the agent's job."},
                 "schedule": {"type": ["string", "null"], "description": "Optional cron-like schedule, @daily, or @every interval."},
                 "is_active": {"type": "boolean", "default": True},
+                "preferred_llm_tier": {
+                    "type": "string",
+                    "description": "Preferred intelligence tier key, such as standard, premium, max, ultra, or ultra_max.",
+                },
+                "daily_credit_limit": {
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "description": "Soft daily credit target. Null means unlimited. Gobii enforces a hard stop at the configured multiplier.",
+                },
                 "whitelist_policy": {
                     "type": "string",
                     "enum": ["default", "manual"],
@@ -105,6 +268,7 @@ TOOL_DEFINITIONS = [
             },
             "additionalProperties": False,
         },
+        "outputSchema": _object_output({"agent": _AGENT_OUTPUT}, required=("agent",)),
         "annotations": {"destructiveHint": False},
     },
     {
@@ -119,12 +283,22 @@ TOOL_DEFINITIONS = [
                 "charter": {"type": "string"},
                 "schedule": {"type": ["string", "null"]},
                 "is_active": {"type": "boolean"},
+                "preferred_llm_tier": {
+                    "type": "string",
+                    "description": "Preferred intelligence tier key, such as standard, premium, max, ultra, or ultra_max.",
+                },
+                "daily_credit_limit": {
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "description": "Soft daily credit target. Null means unlimited.",
+                },
                 "whitelist_policy": {"type": "string", "enum": ["default", "manual"]},
                 "proactive_opt_in": {"type": "boolean"},
             },
             "required": ["agent_id"],
             "additionalProperties": False,
         },
+        "outputSchema": _object_output({"agent": _AGENT_OUTPUT}, required=("agent",)),
     },
     {
         "name": "gobii_archive_agent",
@@ -136,7 +310,85 @@ TOOL_DEFINITIONS = [
             "required": ["agent_id"],
             "additionalProperties": False,
         },
+        "outputSchema": _object_output(
+            {
+                "status": {"type": "string"},
+                "changed": {"type": "boolean"},
+                "agent": _AGENT_OUTPUT,
+            },
+            required=("status", "changed", "agent"),
+        ),
         "annotations": {"destructiveHint": True},
+    },
+    {
+        "name": "gobii_get_agent_config_options",
+        "title": "Get Agent Config Options",
+        "description": "Discover supported Gobii agent configuration fields, intelligence tiers, daily credit limits, schedules, and policies for this API key.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("Optional persistent agent UUID to include current per-agent config."),
+            },
+            "additionalProperties": False,
+        },
+        "outputSchema": _object_output(
+            {
+                "owner": _object_output(
+                    {
+                        "type": {"type": "string"},
+                        "id": {"type": ["integer", "string"]},
+                        "name": _STRING_OR_NULL,
+                    },
+                    required=("type", "id"),
+                ),
+                "agent": {"anyOf": [_AGENT_OUTPUT, {"type": "null"}]},
+                "fields": _object_output(
+                    {
+                        "preferred_llm_tier": _object_output(
+                            {
+                                "type": {"type": "string"},
+                                "current_system_default": {"type": "string"},
+                                "max_allowed_tier": {"type": "string"},
+                                "max_allowed_rank": {"type": "integer"},
+                                "options": _array_output(
+                                    _object_output(
+                                        {
+                                            "key": {"type": "string"},
+                                            "label": {"type": "string"},
+                                            "description": {"type": "string"},
+                                            "rank": {"type": "integer"},
+                                            "credit_multiplier": _NUMBER_OR_STRING,
+                                            "is_default": {"type": "boolean"},
+                                            "allowed": {"type": "boolean"},
+                                        },
+                                        required=("key", "label", "allowed"),
+                                    )
+                                ),
+                            },
+                            required=("type", "options"),
+                        ),
+                        "daily_credit_limit": _object_output(
+                            {
+                                "type": {"type": "string"},
+                                "null_behavior": {"type": "string"},
+                                "hard_limit_multiplier": _NUMBER_OR_STRING,
+                                "default_daily_credit_target": _NUMBER_OR_STRING,
+                                "recommended_min": _NUMBER_OR_STRING,
+                                "recommended_max": _NUMBER_OR_STRING,
+                                "step": _NUMBER_OR_STRING,
+                                "tier_credit_multiplier": _NUMBER_OR_STRING,
+                                "enforced_by_agent_runtime": {"type": "boolean"},
+                            },
+                            required=("type", "null_behavior"),
+                        ),
+                    },
+                    required=("preferred_llm_tier", "daily_credit_limit"),
+                ),
+                "unsupported_remote_mcp_v1_fields": _array_output({"type": "string"}),
+            },
+            required=("owner", "fields", "unsupported_remote_mcp_v1_fields"),
+        ),
+        "annotations": {"readOnlyHint": True},
     },
     {
         "name": "gobii_list_agent_links",
@@ -149,6 +401,7 @@ TOOL_DEFINITIONS = [
             },
             "additionalProperties": False,
         },
+        "outputSchema": _object_output({"links": _array_output(_LINK_OUTPUT)}, required=("links",)),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -166,6 +419,10 @@ TOOL_DEFINITIONS = [
             "required": ["agent_id", "peer_agent_id"],
             "additionalProperties": False,
         },
+        "outputSchema": _object_output(
+            {"link": _LINK_OUTPUT, "created": {"type": "boolean"}},
+            required=("link", "created"),
+        ),
         "annotations": {"destructiveHint": False},
     },
     {
@@ -181,6 +438,10 @@ TOOL_DEFINITIONS = [
             },
             "additionalProperties": False,
         },
+        "outputSchema": _object_output(
+            {"status": {"type": "string"}, "link": _LINK_OUTPUT},
+            required=("status", "link"),
+        ),
         "annotations": {"destructiveHint": True},
     },
     {
@@ -206,6 +467,30 @@ TOOL_DEFINITIONS = [
             "required": ["agent_id", "body"],
             "additionalProperties": False,
         },
+        "outputSchema": _object_output(
+            {
+                "status": {"type": "string"},
+                "accepted_state": {"type": "string"},
+                "message_id": _UUID_OUTPUT,
+                "agent_id": _UUID_OUTPUT,
+                "cursor": _STRING_OR_NULL,
+                "latest_cursor": _STRING_OR_NULL,
+                "created_at": _STRING_OR_NULL,
+                "actor": _object_output(
+                    {
+                        "type": {"type": "string"},
+                        "source": {"type": "string"},
+                        "user_id": {"type": ["integer", "string"]},
+                    },
+                    required=("type", "source"),
+                ),
+                "message": _MESSAGE_OUTPUT,
+                "timeline_event": _TIMELINE_EVENT_OUTPUT,
+                "conversation_id": _UUID_OUTPUT,
+                "attachment_count": {"type": "integer"},
+            },
+            required=("status", "message_id", "agent_id", "cursor", "latest_cursor"),
+        ),
     },
     {
         "name": "gobii_get_agent_timeline",
@@ -215,6 +500,10 @@ TOOL_DEFINITIONS = [
             "type": "object",
             "properties": {
                 "agent_id": _agent_schema("Persistent agent UUID."),
+                "after_cursor": {
+                    "type": ["string", "null"],
+                    "description": "Return events newer than this durable timeline cursor. Preferred for V1 clients.",
+                },
                 "cursor": {"type": ["string", "null"], "description": "Cursor from a previous timeline result."},
                 "direction": {"type": "string", "enum": ["initial", "older", "newer"], "default": "initial"},
                 "limit": {"type": "integer", "minimum": 1, "maximum": TIMELINE_MAX_PAGE_SIZE, "default": TIMELINE_DEFAULT_PAGE_SIZE},
@@ -222,6 +511,76 @@ TOOL_DEFINITIONS = [
             "required": ["agent_id"],
             "additionalProperties": False,
         },
+        "outputSchema": _object_output(
+            {
+                "events": _array_output(_TIMELINE_EVENT_OUTPUT),
+                "next_cursor": _STRING_OR_NULL,
+                "latest_cursor": _STRING_OR_NULL,
+                "oldest_cursor": _STRING_OR_NULL,
+                "newest_cursor": _STRING_OR_NULL,
+                "has_more": {"type": "boolean"},
+                "has_more_older": {"type": "boolean"},
+                "has_more_newer": {"type": "boolean"},
+                "processing_active": {"type": "boolean"},
+                "processing_snapshot": _object_output({}),
+            },
+            required=("events", "latest_cursor", "has_more"),
+        ),
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "gobii_wait_for_agent_event",
+        "title": "Wait For Agent Timeline Event",
+        "description": "Bounded long-poll over an agent's unified timeline using durable cursors and supported structured filters.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("Persistent agent UUID."),
+                "after_cursor": {
+                    "type": ["string", "null"],
+                    "description": "Only consider timeline events newer than this cursor.",
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": WAIT_MAX_TIMEOUT_SECONDS,
+                    "default": WAIT_DEFAULT_TIMEOUT_SECONDS,
+                },
+                "limit": {"type": "integer", "minimum": 1, "maximum": TIMELINE_MAX_PAGE_SIZE, "default": 20},
+                "event_types": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": sorted(WAIT_EVENT_TYPES)},
+                    "description": "Optional event kinds to match.",
+                },
+                "filters": {
+                    "type": "object",
+                    "properties": {
+                        "from_actor_type": {"type": "string", "enum": ["agent", "human_user", "external", "system"]},
+                        "from_agent_id": _agent_schema("Peer/source agent UUID for peer-agent message events."),
+                        "to_agent_id": _agent_schema("Target agent UUID for message events."),
+                        "message_id": {"type": "string", "format": "uuid"},
+                        "peer_link_id": {"type": "string", "format": "uuid"},
+                        "channel": {"type": "string"},
+                        "status": {"type": "string", "description": "Tool-call status for steps events."},
+                        "tool_name": {"type": "string", "description": "Tool name for steps events."},
+                    },
+                    "additionalProperties": False,
+                },
+            },
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        },
+        "outputSchema": _object_output(
+            {
+                "matched": {"type": "boolean"},
+                "timed_out": {"type": "boolean"},
+                "events": _array_output(_TIMELINE_EVENT_OUTPUT),
+                "next_cursor": _STRING_OR_NULL,
+                "latest_cursor": _STRING_OR_NULL,
+                "waited_seconds": _NUMBER_OR_STRING,
+            },
+            required=("matched", "timed_out", "events", "waited_seconds"),
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -234,6 +593,16 @@ TOOL_DEFINITIONS = [
             "required": ["agent_id"],
             "additionalProperties": False,
         },
+        "outputSchema": _object_output(
+            {
+                "filespace": _object_output(
+                    {"id": _UUID_OUTPUT, "name": {"type": "string"}},
+                    required=("id", "name"),
+                ),
+                "nodes": _array_output(_FILE_NODE_OUTPUT),
+            },
+            required=("filespace", "nodes"),
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -252,10 +621,21 @@ TOOL_DEFINITIONS = [
             "required": ["agent_id", "path", "content_base64"],
             "additionalProperties": False,
         },
+        "outputSchema": _object_output(
+            {
+                "status": {"type": "string"},
+                "path": {"type": "string"},
+                "node_id": _UUID_OUTPUT,
+                "filename": {"type": "string"},
+                "message": _STRING_OR_NULL,
+            },
+            required=("status",),
+        ),
     },
 ]
 
 TOOL_NAMES = {tool["name"] for tool in TOOL_DEFINITIONS}
+TOOL_BY_NAME = {tool["name"]: tool for tool in TOOL_DEFINITIONS}
 
 
 def list_tools():
@@ -281,6 +661,7 @@ def call_tool(request, name, arguments):
         raise MCPToolError("Tool arguments must be an object.")
     if name not in TOOL_NAMES:
         raise MCPToolError(f"Unknown tool: {name}")
+    _reject_unknown_arguments(name, arguments)
 
     handler = {
         "gobii_list_agents": _tool_list_agents,
@@ -288,11 +669,13 @@ def call_tool(request, name, arguments):
         "gobii_create_agent": _tool_create_agent,
         "gobii_update_agent": _tool_update_agent,
         "gobii_archive_agent": _tool_archive_agent,
+        "gobii_get_agent_config_options": _tool_get_agent_config_options,
         "gobii_list_agent_links": _tool_list_agent_links,
         "gobii_link_agents": _tool_link_agents,
         "gobii_unlink_agents": _tool_unlink_agents,
         "gobii_send_agent_message": _tool_send_agent_message,
         "gobii_get_agent_timeline": _tool_get_agent_timeline,
+        "gobii_wait_for_agent_event": _tool_wait_for_agent_event,
         "gobii_list_agent_files": _tool_list_agent_files,
         "gobii_upload_agent_file": _tool_upload_agent_file,
     }[name]
@@ -321,8 +704,17 @@ def _tool_get_agent(request, arguments):
 
 
 def _tool_create_agent(request, arguments):
-    allowed_fields = {"name", "charter", "schedule", "is_active", "whitelist_policy"}
+    allowed_fields = {
+        "name",
+        "charter",
+        "schedule",
+        "is_active",
+        "preferred_llm_tier",
+        "daily_credit_limit",
+        "whitelist_policy",
+    }
     payload = {key: arguments[key] for key in allowed_fields if key in arguments}
+    _normalize_agent_config_payload(request, payload)
     serializer = PersistentAgentSerializer(
         data=payload,
         context={"request": request, "organization": _request_organization(request)},
@@ -338,10 +730,20 @@ def _tool_create_agent(request, arguments):
 
 def _tool_update_agent(request, arguments):
     agent = _get_agent(request, arguments.get("agent_id"))
-    allowed_fields = {"name", "charter", "schedule", "is_active", "whitelist_policy", "proactive_opt_in"}
+    allowed_fields = {
+        "name",
+        "charter",
+        "schedule",
+        "is_active",
+        "preferred_llm_tier",
+        "daily_credit_limit",
+        "whitelist_policy",
+        "proactive_opt_in",
+    }
     payload = {key: arguments[key] for key in allowed_fields if key in arguments}
     if not payload:
         raise MCPToolError("At least one mutable field is required.")
+    _normalize_agent_config_payload(request, payload, agent=agent)
 
     serializer = PersistentAgentSerializer(
         agent,
@@ -350,10 +752,19 @@ def _tool_update_agent(request, arguments):
         context={"request": request, "organization": _request_organization(request)},
     )
     try:
+        previous_daily_credit_limit = agent.daily_credit_limit
+        previous_tier_id = agent.preferred_llm_tier_id
+        previous_tier_key = getattr(getattr(agent, "preferred_llm_tier", None), "key", "standard")
         serializer.is_valid(raise_exception=True)
         agent = serializer.save()
     except (DRFValidationError, DjangoValidationError) as exc:
         raise MCPToolError("Agent update failed.", _format_validation_error(exc)) from exc
+    _queue_agent_settings_resume_if_needed(
+        agent,
+        previous_daily_credit_limit=previous_daily_credit_limit,
+        previous_tier_id=previous_tier_id,
+        previous_tier_key=previous_tier_key,
+    )
 
     return {"agent": _serialize_agent(agent)}
 
@@ -366,6 +777,46 @@ def _tool_archive_agent(request, arguments):
         "status": "archived",
         "changed": changed,
         "agent": _serialize_agent(agent),
+    }
+
+
+def _tool_get_agent_config_options(request, arguments):
+    agent = None
+    if arguments.get("agent_id"):
+        agent = _get_agent(request, arguments.get("agent_id"))
+    owner = _agent_owner_for_request(request, agent=agent)
+    daily_credit_options = _build_daily_credit_options(owner, getattr(agent, "preferred_llm_tier", None))
+    return {
+        "owner": _serialize_owner_ref(owner),
+        "agent": _serialize_agent(agent) if agent else None,
+        "fields": {
+            "preferred_llm_tier": _build_intelligence_options(owner),
+            "daily_credit_limit": daily_credit_options,
+            "schedule": {
+                "type": "string_or_null",
+                "required": False,
+                "null_behavior": "unscheduled",
+                "accepted_formats": [
+                    "cron-like schedule expressions accepted by Gobii's ScheduleParser",
+                    "@daily",
+                    "@every interval",
+                ],
+            },
+            "whitelist_policy": {
+                "type": "string",
+                "options": [
+                    {"value": value, "label": label}
+                    for value, label in PersistentAgent.WhitelistPolicy.choices
+                ],
+            },
+            "is_active": {"type": "boolean"},
+            "proactive_opt_in": {"type": "boolean", "mutable_on_update": True},
+        },
+        "unsupported_remote_mcp_v1_fields": [
+            "arbitrary_url_file_fetch",
+            "ad_hoc_runtime_session",
+            "separate_task_or_run_abstraction",
+        ],
     }
 
 
@@ -462,9 +913,23 @@ def _tool_send_agent_message(request, arguments):
 
             transaction.on_commit(lambda: process_agent_events_task.delay(str(agent.id)))
 
+    event = serialize_message_event(message)
+    cursor = event.get("cursor")
     return {
         "status": "queued" if trigger_processing else "stored",
+        "accepted_state": "queued" if trigger_processing else "stored",
+        "message_id": str(message.id),
+        "agent_id": str(agent.id),
+        "cursor": cursor,
+        "latest_cursor": cursor,
+        "created_at": _iso(message.timestamp),
+        "actor": {
+            "type": "human_user",
+            "source": "remote_mcp",
+            "user_id": request.user.id,
+        },
         "message": _serialize_message(message),
+        "timeline_event": event,
         "conversation_id": str(conversation.id),
         "attachment_count": len(resolved_attachments),
     }
@@ -472,7 +937,8 @@ def _tool_send_agent_message(request, arguments):
 
 def _tool_get_agent_timeline(request, arguments):
     agent = _get_agent(request, arguments.get("agent_id"))
-    direction = arguments.get("direction") or "initial"
+    after_cursor = arguments.get("after_cursor")
+    direction = "newer" if after_cursor else arguments.get("direction") or "initial"
     if direction not in {"initial", "older", "newer"}:
         raise MCPToolError("direction must be one of initial, older, or newer.")
     limit = _bounded_int(
@@ -481,20 +947,81 @@ def _tool_get_agent_timeline(request, arguments):
         minimum=1,
         maximum=TIMELINE_MAX_PAGE_SIZE,
     )
-    cursor = arguments.get("cursor") or None
+    cursor = after_cursor or arguments.get("cursor") or None
     if cursor is not None and not isinstance(cursor, str):
-        raise MCPToolError("cursor must be a string.")
+        raise MCPToolError("cursor/after_cursor must be a string.")
+    _validate_timeline_cursor(cursor, "cursor/after_cursor")
 
     window = fetch_timeline_window(agent, cursor=cursor, direction=direction, limit=limit)
     return {
         "events": window.events,
+        "next_cursor": window.newest_cursor,
+        "latest_cursor": window.newest_cursor,
         "oldest_cursor": window.oldest_cursor,
         "newest_cursor": window.newest_cursor,
+        "has_more": window.has_more_newer if direction == "newer" else window.has_more_older,
         "has_more_older": window.has_more_older,
         "has_more_newer": window.has_more_newer,
         "processing_active": window.processing_active,
         "processing_snapshot": serialize_processing_snapshot(window.processing_snapshot),
     }
+
+
+def _tool_wait_for_agent_event(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    after_cursor = arguments.get("after_cursor") or None
+    if after_cursor is not None and not isinstance(after_cursor, str):
+        raise MCPToolError("after_cursor must be a string.")
+    _validate_timeline_cursor(after_cursor, "after_cursor")
+
+    timeout_seconds = _bounded_int(
+        arguments.get("timeout_seconds", WAIT_DEFAULT_TIMEOUT_SECONDS),
+        "timeout_seconds",
+        minimum=0,
+        maximum=WAIT_MAX_TIMEOUT_SECONDS,
+    )
+    limit = _bounded_int(arguments.get("limit", 20), "limit", minimum=1, maximum=TIMELINE_MAX_PAGE_SIZE)
+    event_types = _normalize_wait_event_types(arguments.get("event_types"))
+    filters = _normalize_wait_filters(arguments.get("filters"))
+
+    start = time.monotonic()
+    deadline = start + timeout_seconds
+    latest_cursor = after_cursor
+    events: list[dict] = []
+
+    while True:
+        direction = "newer" if latest_cursor else "initial"
+        window = fetch_timeline_window(agent, cursor=latest_cursor, direction=direction, limit=limit)
+        if window.newest_cursor:
+            latest_cursor = window.newest_cursor
+        events = [
+            event
+            for event in window.events
+            if _wait_event_matches(agent, event, event_types=event_types, filters=filters)
+        ]
+        if events:
+            waited_seconds = round(time.monotonic() - start, 3)
+            return {
+                "matched": True,
+                "timed_out": False,
+                "events": events,
+                "next_cursor": latest_cursor,
+                "latest_cursor": latest_cursor,
+                "waited_seconds": waited_seconds,
+            }
+        if time.monotonic() >= deadline:
+            waited_seconds = round(time.monotonic() - start, 3)
+            return {
+                "matched": False,
+                "timed_out": True,
+                "events": [],
+                "next_cursor": latest_cursor,
+                "latest_cursor": latest_cursor,
+                "waited_seconds": waited_seconds,
+            }
+        sleep_seconds = min(WAIT_POLL_INTERVAL_SECONDS, max(0, deadline - time.monotonic()))
+        if sleep_seconds:
+            time.sleep(sleep_seconds)
 
 
 def _tool_list_agent_files(request, arguments):
@@ -538,6 +1065,103 @@ def _tool_upload_agent_file(request, arguments):
     return result
 
 
+def _reject_unknown_arguments(name, arguments):
+    tool = TOOL_BY_NAME[name]
+    properties = tool.get("inputSchema", {}).get("properties", {})
+    unknown = sorted(set(arguments) - set(properties))
+    if unknown:
+        raise MCPToolError(
+            "Unsupported tool argument(s).",
+            {
+                "unsupported_fields": unknown,
+                "supported_fields": sorted(properties),
+            },
+        )
+
+
+def _normalize_agent_config_payload(request, payload, *, agent=None):
+    if "schedule" in payload and payload["schedule"] == "":
+        payload["schedule"] = None
+    if "preferred_llm_tier" in payload:
+        tier_value = payload.get("preferred_llm_tier")
+        if not isinstance(tier_value, str) or not tier_value.strip():
+            raise MCPToolError(
+                "preferred_llm_tier must be a supported intelligence tier key.",
+                {"field": "preferred_llm_tier"},
+            )
+        owner = _agent_owner_for_request(request, agent=agent)
+        requested_key = tier_value.strip().lower()
+        if requested_key not in {tier.value for tier in AgentLLMTier}:
+            raise MCPToolError(
+                "preferred_llm_tier is not a known intelligence tier key.",
+                {"field": "preferred_llm_tier", "requested": requested_key},
+            )
+        try:
+            resolved = resolve_preferred_tier_for_owner(owner, requested_key)
+            tier = resolve_intelligence_tier_for_owner(owner, requested_key)
+        except ValueError as exc:
+            raise MCPToolError(
+                "preferred_llm_tier is not supported for this API key.",
+                {"field": "preferred_llm_tier", "requested": requested_key},
+            ) from exc
+        if resolved.value != requested_key:
+            raise MCPToolError(
+                "preferred_llm_tier exceeds the owner plan or quota limit.",
+                {
+                    "field": "preferred_llm_tier",
+                    "requested": requested_key,
+                    "max_allowed": resolved.value,
+                },
+            )
+        payload["preferred_llm_tier"] = tier.key
+    if "daily_credit_limit" in payload:
+        payload["daily_credit_limit"] = _normalize_daily_credit_limit(payload.get("daily_credit_limit"))
+
+
+def _normalize_daily_credit_limit(value):
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise MCPToolError("daily_credit_limit must be a positive integer or null.", {"field": "daily_credit_limit"})
+    if isinstance(value, int):
+        limit = value
+    elif isinstance(value, float):
+        if not value.is_integer():
+            raise MCPToolError("daily_credit_limit must be a positive integer or null.", {"field": "daily_credit_limit"})
+        limit = int(value)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped.isdecimal():
+            raise MCPToolError("daily_credit_limit must be a positive integer or null.", {"field": "daily_credit_limit"})
+        limit = int(stripped)
+    else:
+        raise MCPToolError("daily_credit_limit must be a positive integer or null.", {"field": "daily_credit_limit"})
+    if limit < 1:
+        raise MCPToolError("daily_credit_limit must be a positive integer or null.", {"field": "daily_credit_limit"})
+    return limit
+
+
+def _queue_agent_settings_resume_if_needed(
+    agent,
+    *,
+    previous_daily_credit_limit,
+    previous_tier_id,
+    previous_tier_key,
+):
+    daily_limit_changed = agent.daily_credit_limit != previous_daily_credit_limit
+    preferred_tier_changed = agent.preferred_llm_tier_id != previous_tier_id
+    if not daily_limit_changed and not preferred_tier_changed:
+        return
+    queue_settings_change_resume(
+        agent,
+        daily_credit_limit_changed=daily_limit_changed,
+        previous_daily_credit_limit=previous_daily_credit_limit,
+        preferred_llm_tier_changed=preferred_tier_changed,
+        previous_preferred_llm_tier_key=previous_tier_key,
+        source="remote_mcp_update_agent",
+    )
+
+
 def _agent_queryset(request):
     organization = _request_organization(request)
     if organization is None and not can_user_use_personal_agents_and_api(request.user):
@@ -559,6 +1183,76 @@ def _request_organization(request):
     if isinstance(auth, ApiKey) and getattr(auth, "organization_id", None):
         return auth.organization
     return None
+
+
+def _agent_owner_for_request(request, *, agent=None):
+    if agent is not None:
+        return agent.organization or agent.user
+    return _request_organization(request) or request.user
+
+
+def _serialize_owner_ref(owner):
+    if owner is None:
+        return None
+    owner_meta = getattr(owner, "_meta", None)
+    model_name = getattr(owner_meta, "model_name", "")
+    if model_name == "organization":
+        return {"type": "organization", "id": str(owner.id), "name": getattr(owner, "name", "")}
+    return {"type": "user", "id": owner.id}
+
+
+def _build_intelligence_options(owner):
+    max_allowed = resolve_preferred_tier_for_owner(owner, AgentLLMTier.ULTRA_MAX.value)
+    max_allowed_rank = get_allowed_tier_rank(max_allowed)
+    tiers = list(
+        PersistentAgent._meta.get_field("preferred_llm_tier").remote_field.model.objects.order_by("rank", "key")
+    )
+    current_default = get_system_default_tier().value
+    options = []
+    for tier in tiers:
+        tier_key = tier.key
+        try:
+            tier_enum = AgentLLMTier(tier_key)
+            allowed = get_allowed_tier_rank(tier_enum) <= max_allowed_rank
+        except ValueError:
+            allowed = False
+        options.append(
+            {
+                "key": tier_key,
+                "label": get_llm_tier_label(tier_key, tier.display_name),
+                "description": get_llm_tier_description(tier_key),
+                "rank": tier.rank,
+                "credit_multiplier": tier.credit_multiplier,
+                "is_default": tier.is_default or tier_key == current_default,
+                "allowed": allowed,
+            }
+        )
+    return {
+        "type": "string",
+        "current_system_default": current_default,
+        "max_allowed_tier": max_allowed.value,
+        "max_allowed_rank": max_allowed_rank,
+        "options": options,
+    }
+
+
+def _build_daily_credit_options(owner, tier):
+    credit_settings = get_daily_credit_settings_for_owner(owner)
+    multiplier = get_tier_credit_multiplier(tier)
+    slider_bounds = calculate_daily_credit_slider_bounds(credit_settings, tier_multiplier=multiplier)
+    return {
+        "type": "integer_or_null",
+        "null_behavior": "unlimited",
+        "soft_target_description": "Preferred daily credit target before agents are asked to slow down.",
+        "hard_limit_description": "Gobii enforces a hard stop at soft target multiplied by hard_limit_multiplier.",
+        "hard_limit_multiplier": credit_settings.hard_limit_multiplier,
+        "default_daily_credit_target": credit_settings.default_daily_credit_target,
+        "recommended_min": slider_bounds["slider_min"],
+        "recommended_max": slider_bounds["slider_limit_max"],
+        "step": slider_bounds["slider_step"],
+        "tier_credit_multiplier": multiplier,
+        "enforced_by_agent_runtime": True,
+    }
 
 
 def _get_agent(request, raw_agent_id):
@@ -616,6 +1310,9 @@ def _serialize_agent(agent):
             str(agent.preferred_contact_endpoint_id) if agent.preferred_contact_endpoint_id else None
         ),
         "preferred_llm_tier": getattr(getattr(agent, "preferred_llm_tier", None), "key", None),
+        "daily_credit_limit": agent.daily_credit_limit,
+        "daily_credit_soft_target": agent.get_daily_credit_soft_target(),
+        "daily_credit_hard_limit": agent.get_daily_credit_hard_limit(),
         "proactive_opt_in": agent.proactive_opt_in,
         "proactive_last_trigger_at": _iso(agent.proactive_last_trigger_at),
     }
@@ -671,6 +1368,138 @@ def _serialize_file_node(node):
     }
 
 
+def _validate_timeline_cursor(cursor, key):
+    if not cursor:
+        return
+    parts = cursor.split(":", 2)
+    if len(parts) != 3:
+        raise MCPToolError(f"{key} must be a valid Gobii timeline cursor.")
+    value, kind, identifier = parts
+    try:
+        int(value)
+    except ValueError as exc:
+        raise MCPToolError(f"{key} must be a valid Gobii timeline cursor.") from exc
+    if kind not in {"message", "step", "thinking", "kanban", "plan"} or not identifier:
+        raise MCPToolError(f"{key} must be a valid Gobii timeline cursor.")
+
+
+def _normalize_wait_event_types(value):
+    if value in (None, []):
+        return None
+    if not isinstance(value, list):
+        raise MCPToolError("event_types must be an array.", {"field": "event_types"})
+    normalized = set()
+    invalid = []
+    for item in value:
+        if not isinstance(item, str):
+            invalid.append(item)
+            continue
+        event_type = item.strip()
+        if event_type not in WAIT_EVENT_TYPES:
+            invalid.append(item)
+        else:
+            normalized.add(event_type)
+    if invalid:
+        raise MCPToolError(
+            "event_types contains unsupported values.",
+            {"field": "event_types", "unsupported_values": invalid, "supported_values": sorted(WAIT_EVENT_TYPES)},
+        )
+    return normalized
+
+
+def _normalize_wait_filters(value):
+    if value in (None, {}):
+        return {}
+    if not isinstance(value, dict):
+        raise MCPToolError("filters must be an object.", {"field": "filters"})
+    unsupported = sorted(set(value) - WAIT_FILTER_FIELDS)
+    if unsupported:
+        raise MCPToolError(
+            "filters contains unsupported fields.",
+            {"unsupported_fields": unsupported, "supported_fields": sorted(WAIT_FILTER_FIELDS)},
+        )
+    filters = {}
+    for key, raw in value.items():
+        if raw in (None, ""):
+            continue
+        if key in {"from_agent_id", "to_agent_id", "message_id", "peer_link_id"}:
+            filters[key] = str(_parse_uuid(raw, key))
+        elif key in {"from_actor_type", "channel", "status", "tool_name"}:
+            if not isinstance(raw, str) or not raw.strip():
+                raise MCPToolError(f"filters.{key} must be a non-empty string.")
+            filters[key] = raw.strip()
+    if "from_actor_type" in filters and filters["from_actor_type"] not in {"agent", "human_user", "external", "system"}:
+        raise MCPToolError(
+            "filters.from_actor_type contains an unsupported value.",
+            {"field": "from_actor_type", "supported_values": ["agent", "human_user", "external", "system"]},
+        )
+    return filters
+
+
+def _wait_event_matches(agent, event, *, event_types, filters):
+    kind = event.get("kind")
+    if event_types is not None and kind not in event_types:
+        return False
+    if not filters:
+        return True
+    for key, expected in filters.items():
+        if event.get("kind") == "steps" and key in {"status", "tool_name"}:
+            if not _steps_event_has_value(event, key, expected):
+                return False
+            continue
+        if _wait_event_field_value(agent, event, key) != expected:
+            return False
+    return True
+
+
+def _steps_event_has_value(event, key, expected):
+    entry_key = "status" if key == "status" else "toolName"
+    return any((entry.get(entry_key) or "") == expected for entry in event.get("entries") or [])
+
+
+def _wait_event_field_value(agent, event, key):
+    kind = event.get("kind")
+    if kind == "message":
+        message = event.get("message") or {}
+        peer_agent = message.get("peerAgent") or {}
+        is_peer = bool(message.get("isPeer"))
+        is_outbound = bool(message.get("isOutbound"))
+        if key == "from_actor_type":
+            if is_peer:
+                return "agent"
+            if is_outbound:
+                return "agent"
+            if message.get("senderUserId"):
+                return "human_user"
+            return "external"
+        if key == "from_agent_id":
+            if is_peer and not is_outbound:
+                return peer_agent.get("id")
+            if is_outbound:
+                return str(agent.id)
+            return None
+        if key == "to_agent_id":
+            if is_peer and is_outbound:
+                return peer_agent.get("id")
+            if not is_outbound:
+                return str(agent.id)
+            return None
+        if key == "message_id":
+            return message.get("id")
+        if key == "peer_link_id":
+            return message.get("peerLinkId")
+        if key == "channel":
+            return message.get("channel")
+        return None
+    if kind == "steps":
+        if key == "from_actor_type":
+            return "system"
+        return None
+    if kind in {"thinking", "plan"} and key == "from_actor_type":
+        return "system"
+    return None
+
+
 def _required_string(arguments, key, *, allow_blank):
     value = arguments.get(key)
     if not isinstance(value, str):
@@ -716,7 +1545,21 @@ def _format_validation_error(exc):
 
 
 def _json_safe(value):
-    return json.loads(json.dumps(value, cls=DjangoJSONEncoder, default=str))
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+        return value.isoformat()
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, set):
+        return [_json_safe(item) for item in sorted(value, key=str)]
+    return str(value)
 
 
 def _iso(value):

--- a/api/services/remote_mcp.py
+++ b/api/services/remote_mcp.py
@@ -502,7 +502,10 @@ TOOL_DEFINITIONS = [
                 "agent_id": _agent_schema("Persistent agent UUID."),
                 "after_cursor": {
                     "type": ["string", "null"],
-                    "description": "Return events newer than this durable timeline cursor. Preferred for V1 clients.",
+                    "description": (
+                        "Return events strictly newer than this durable timeline cursor. "
+                        "The event with this exact cursor is excluded."
+                    ),
                 },
                 "cursor": {"type": ["string", "null"], "description": "Cursor from a previous timeline result."},
                 "direction": {"type": "string", "enum": ["initial", "older", "newer"], "default": "initial"},
@@ -538,7 +541,10 @@ TOOL_DEFINITIONS = [
                 "agent_id": _agent_schema("Persistent agent UUID."),
                 "after_cursor": {
                     "type": ["string", "null"],
-                    "description": "Only consider timeline events newer than this cursor.",
+                    "description": (
+                        "Only consider timeline events strictly newer than this cursor. The event with this exact cursor "
+                        "is excluded, even when filters.message_id references it."
+                    ),
                 },
                 "timeout_seconds": {
                     "type": "integer",
@@ -555,12 +561,38 @@ TOOL_DEFINITIONS = [
                 "filters": {
                     "type": "object",
                     "properties": {
-                        "from_actor_type": {"type": "string", "enum": ["agent", "human_user", "external", "system"]},
-                        "from_agent_id": _agent_schema("Peer/source agent UUID for peer-agent message events."),
-                        "to_agent_id": _agent_schema("Target agent UUID for message events."),
-                        "message_id": {"type": "string", "format": "uuid"},
-                        "peer_link_id": {"type": "string", "format": "uuid"},
-                        "channel": {"type": "string"},
+                        "from_actor_type": {
+                            "type": "string",
+                            "enum": ["agent", "human_user", "external", "system"],
+                            "description": (
+                                "Actor source derived from the serialized timeline event: agent for outbound or peer "
+                                "messages, human_user for inbound web user messages, external for other inbound "
+                                "messages, and system for steps/thinking/plan events."
+                            ),
+                        },
+                        "from_agent_id": _agent_schema(
+                            "Source agent UUID for message events: the owner agent on non-peer outbound messages, "
+                            "or the peer agent on inbound peer messages."
+                        ),
+                        "to_agent_id": _agent_schema(
+                            "Target agent UUID for message events: the owner agent on non-peer inbound messages, "
+                            "or the peer agent on outbound peer messages. Ordinary agent-to-human/external replies "
+                            "do not have a to_agent_id."
+                        ),
+                        "message_id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Timeline message UUID. Cursor strictness still applies.",
+                        },
+                        "peer_link_id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Peer-link UUID for peer message events.",
+                        },
+                        "channel": {
+                            "type": "string",
+                            "description": "Message channel from the serialized timeline event, such as web, email, or sms.",
+                        },
                         "status": {"type": "string", "description": "Tool-call status for steps events."},
                         "tool_name": {"type": "string", "description": "Tool name for steps events."},
                     },

--- a/api/services/remote_mcp.py
+++ b/api/services/remote_mcp.py
@@ -1,0 +1,723 @@
+import base64
+import binascii
+import copy
+import json
+import uuid
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import IntegrityError, transaction
+from django.db.models import Q
+
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
+from api.agent.comms.message_service import inject_internal_web_message
+from api.agent.files.attachment_helpers import (
+    AttachmentResolutionError,
+    create_message_attachments,
+    resolve_filespace_attachments,
+)
+from api.agent.files.filespace_service import get_or_create_default_filespace, write_bytes_to_dir
+from api.models import (
+    AgentFsNode,
+    AgentPeerLink,
+    ApiKey,
+    CommsChannel,
+    PersistentAgent,
+    build_web_user_address,
+)
+from api.serializers import PersistentAgentSerializer
+from console.agent_chat.timeline import (
+    DEFAULT_PAGE_SIZE as TIMELINE_DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE as TIMELINE_MAX_PAGE_SIZE,
+    fetch_timeline_window,
+    serialize_processing_snapshot,
+)
+from pages.account_info_cache import invalidate_account_info_cache
+from util.trial_enforcement import can_user_use_personal_agents_and_api
+
+
+MCP_PROTOCOL_VERSION = "2025-06-18"
+SERVER_INFO = {
+    "name": "gobii",
+    "title": "Gobii",
+    "version": "2.19.0",
+}
+
+
+class MCPToolError(Exception):
+    def __init__(self, message, data=None):
+        super().__init__(message)
+        self.data = data
+
+
+def _agent_schema(description):
+    return {
+        "type": "string",
+        "format": "uuid",
+        "description": description,
+    }
+
+
+TOOL_DEFINITIONS = [
+    {
+        "name": "gobii_list_agents",
+        "title": "List Gobii Agents",
+        "description": "List persistent Gobii agents accessible to the API key.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "page": {"type": "integer", "minimum": 1, "default": 1},
+                "page_size": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+            },
+            "additionalProperties": False,
+        },
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "gobii_get_agent",
+        "title": "Get Gobii Agent",
+        "description": "Retrieve details for one persistent Gobii agent.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"agent_id": _agent_schema("Persistent agent UUID.")},
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        },
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "gobii_create_agent",
+        "title": "Create Gobii Agent",
+        "description": "Create a persistent Gobii agent using the same provisioning path as the public Agent API.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Optional display name. Gobii generates one when omitted."},
+                "charter": {"type": "string", "description": "Instructions describing the agent's job."},
+                "schedule": {"type": ["string", "null"], "description": "Optional cron-like schedule, @daily, or @every interval."},
+                "is_active": {"type": "boolean", "default": True},
+                "whitelist_policy": {
+                    "type": "string",
+                    "enum": ["default", "manual"],
+                    "description": "Contact allowlist policy.",
+                },
+            },
+            "additionalProperties": False,
+        },
+        "annotations": {"destructiveHint": False},
+    },
+    {
+        "name": "gobii_update_agent",
+        "title": "Update Gobii Agent",
+        "description": "Update mutable persistent agent settings such as name, charter, schedule, active state, or whitelist policy.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("Persistent agent UUID."),
+                "name": {"type": "string"},
+                "charter": {"type": "string"},
+                "schedule": {"type": ["string", "null"]},
+                "is_active": {"type": "boolean"},
+                "whitelist_policy": {"type": "string", "enum": ["default", "manual"]},
+                "proactive_opt_in": {"type": "boolean"},
+            },
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "gobii_archive_agent",
+        "title": "Archive Gobii Agent",
+        "description": "Soft-delete a persistent Gobii agent using Gobii's normal archive/delete behavior.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"agent_id": _agent_schema("Persistent agent UUID.")},
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        },
+        "annotations": {"destructiveHint": True},
+    },
+    {
+        "name": "gobii_list_agent_links",
+        "title": "List Agent Links",
+        "description": "List peer-agent links for accessible agents.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("Optional agent UUID to filter links."),
+            },
+            "additionalProperties": False,
+        },
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "gobii_link_agents",
+        "title": "Link Gobii Agents",
+        "description": "Create or enable a peer-agent link between two accessible agents so they can coordinate.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("First persistent agent UUID."),
+                "peer_agent_id": _agent_schema("Second persistent agent UUID."),
+                "messages_per_window": {"type": "integer", "minimum": 1, "maximum": 500, "default": 30},
+                "window_hours": {"type": "integer", "minimum": 1, "maximum": 168, "default": 6},
+            },
+            "required": ["agent_id", "peer_agent_id"],
+            "additionalProperties": False,
+        },
+        "annotations": {"destructiveHint": False},
+    },
+    {
+        "name": "gobii_unlink_agents",
+        "title": "Unlink Gobii Agents",
+        "description": "Remove a peer-agent link while preserving historical peer conversation messages.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "peer_link_id": {"type": "string", "format": "uuid", "description": "Existing peer link UUID."},
+                "agent_id": _agent_schema("First persistent agent UUID when peer_link_id is omitted."),
+                "peer_agent_id": _agent_schema("Second persistent agent UUID when peer_link_id is omitted."),
+            },
+            "additionalProperties": False,
+        },
+        "annotations": {"destructiveHint": True},
+    },
+    {
+        "name": "gobii_send_agent_message",
+        "title": "Send Agent Message",
+        "description": "Send a web-chat message to a persistent agent and optionally attach existing filespace files.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("Persistent agent UUID."),
+                "body": {"type": "string", "description": "Message body sent to the agent."},
+                "attachment_file_paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional filespace paths such as /uploads/report.pdf to attach to the message.",
+                },
+                "trigger_processing": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Whether to queue the agent to process the inbound message.",
+                },
+            },
+            "required": ["agent_id", "body"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "gobii_get_agent_timeline",
+        "title": "Get Agent Timeline",
+        "description": "Fetch recent chat, task, thinking, and processing events for a persistent agent.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("Persistent agent UUID."),
+                "cursor": {"type": ["string", "null"], "description": "Cursor from a previous timeline result."},
+                "direction": {"type": "string", "enum": ["initial", "older", "newer"], "default": "initial"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": TIMELINE_MAX_PAGE_SIZE, "default": TIMELINE_DEFAULT_PAGE_SIZE},
+            },
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        },
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "gobii_list_agent_files",
+        "title": "List Agent Files",
+        "description": "List files and folders in an agent's default filespace.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"agent_id": _agent_schema("Persistent agent UUID.")},
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        },
+        "annotations": {"readOnlyHint": True},
+    },
+    {
+        "name": "gobii_upload_agent_file",
+        "title": "Upload Agent File",
+        "description": "Upload a small base64-encoded file into an agent's filespace for later use or message attachment.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("Persistent agent UUID."),
+                "path": {"type": "string", "description": "Filespace path where the file should be stored, e.g. /uploads/report.txt."},
+                "content_base64": {"type": "string", "description": "Base64-encoded file content."},
+                "mime_type": {"type": "string", "default": "application/octet-stream"},
+                "overwrite": {"type": "boolean", "default": False},
+            },
+            "required": ["agent_id", "path", "content_base64"],
+            "additionalProperties": False,
+        },
+    },
+]
+
+TOOL_NAMES = {tool["name"] for tool in TOOL_DEFINITIONS}
+
+
+def list_tools():
+    return copy.deepcopy(TOOL_DEFINITIONS)
+
+
+def make_tool_result(data, *, is_error=False):
+    safe_data = _json_safe(data)
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(safe_data, cls=DjangoJSONEncoder, indent=2),
+            }
+        ],
+        "structuredContent": safe_data,
+        "isError": bool(is_error),
+    }
+
+
+def call_tool(request, name, arguments):
+    if not isinstance(arguments, dict):
+        raise MCPToolError("Tool arguments must be an object.")
+    if name not in TOOL_NAMES:
+        raise MCPToolError(f"Unknown tool: {name}")
+
+    handler = {
+        "gobii_list_agents": _tool_list_agents,
+        "gobii_get_agent": _tool_get_agent,
+        "gobii_create_agent": _tool_create_agent,
+        "gobii_update_agent": _tool_update_agent,
+        "gobii_archive_agent": _tool_archive_agent,
+        "gobii_list_agent_links": _tool_list_agent_links,
+        "gobii_link_agents": _tool_link_agents,
+        "gobii_unlink_agents": _tool_unlink_agents,
+        "gobii_send_agent_message": _tool_send_agent_message,
+        "gobii_get_agent_timeline": _tool_get_agent_timeline,
+        "gobii_list_agent_files": _tool_list_agent_files,
+        "gobii_upload_agent_file": _tool_upload_agent_file,
+    }[name]
+    return handler(request, arguments)
+
+
+def _tool_list_agents(request, arguments):
+    page_size = _bounded_int(arguments.get("page_size", 20), "page_size", minimum=1, maximum=100)
+    page = _bounded_int(arguments.get("page", 1), "page", minimum=1, maximum=100000)
+    queryset = _agent_queryset(request)
+    total = queryset.count()
+    offset = (page - 1) * page_size
+    agents = list(queryset[offset:offset + page_size])
+    return {
+        "agents": [_serialize_agent(agent) for agent in agents],
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+        "has_next": offset + page_size < total,
+    }
+
+
+def _tool_get_agent(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    return {"agent": _serialize_agent(agent)}
+
+
+def _tool_create_agent(request, arguments):
+    allowed_fields = {"name", "charter", "schedule", "is_active", "whitelist_policy"}
+    payload = {key: arguments[key] for key in allowed_fields if key in arguments}
+    serializer = PersistentAgentSerializer(
+        data=payload,
+        context={"request": request, "organization": _request_organization(request)},
+    )
+    try:
+        serializer.is_valid(raise_exception=True)
+        agent = serializer.save()
+    except (DRFValidationError, DjangoValidationError) as exc:
+        raise MCPToolError("Agent creation failed.", _format_validation_error(exc)) from exc
+
+    return {"agent": _serialize_agent(agent)}
+
+
+def _tool_update_agent(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    allowed_fields = {"name", "charter", "schedule", "is_active", "whitelist_policy", "proactive_opt_in"}
+    payload = {key: arguments[key] for key in allowed_fields if key in arguments}
+    if not payload:
+        raise MCPToolError("At least one mutable field is required.")
+
+    serializer = PersistentAgentSerializer(
+        agent,
+        data=payload,
+        partial=True,
+        context={"request": request, "organization": _request_organization(request)},
+    )
+    try:
+        serializer.is_valid(raise_exception=True)
+        agent = serializer.save()
+    except (DRFValidationError, DjangoValidationError) as exc:
+        raise MCPToolError("Agent update failed.", _format_validation_error(exc)) from exc
+
+    return {"agent": _serialize_agent(agent)}
+
+
+def _tool_archive_agent(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    changed = agent.soft_delete()
+    invalidate_account_info_cache(request.user.id)
+    return {
+        "status": "archived",
+        "changed": changed,
+        "agent": _serialize_agent(agent),
+    }
+
+
+def _tool_list_agent_links(request, arguments):
+    accessible = _agent_queryset(request).only("id")
+    links = (
+        AgentPeerLink.objects.filter(Q(agent_a__in=accessible) | Q(agent_b__in=accessible))
+        .select_related("agent_a", "agent_b", "created_by")
+        .distinct()
+        .order_by("-created_at")
+    )
+    agent_id = arguments.get("agent_id")
+    if agent_id:
+        agent = _get_agent(request, agent_id)
+        links = links.filter(Q(agent_a=agent) | Q(agent_b=agent))
+
+    return {"links": [_serialize_peer_link(link) for link in links]}
+
+
+def _tool_link_agents(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    peer_agent = _get_agent(request, arguments.get("peer_agent_id"))
+    if agent.id == peer_agent.id:
+        raise MCPToolError("Cannot link an agent to itself.")
+
+    messages_per_window = _bounded_int(
+        arguments.get("messages_per_window", 30),
+        "messages_per_window",
+        minimum=1,
+        maximum=500,
+    )
+    window_hours = _bounded_int(arguments.get("window_hours", 6), "window_hours", minimum=1, maximum=168)
+    pair_key = AgentPeerLink.build_pair_key(agent.id, peer_agent.id)
+    link = AgentPeerLink.objects.filter(pair_key=pair_key).first()
+    created = False
+    if link is None:
+        link = AgentPeerLink(
+            agent_a=agent,
+            agent_b=peer_agent,
+            created_by=request.user,
+            messages_per_window=messages_per_window,
+            window_hours=window_hours,
+            is_enabled=True,
+        )
+        created = True
+    else:
+        link.messages_per_window = messages_per_window
+        link.window_hours = window_hours
+        link.is_enabled = True
+
+    try:
+        link.save()
+    except (DjangoValidationError, IntegrityError) as exc:
+        raise MCPToolError("Agent link could not be saved.", _format_validation_error(exc)) from exc
+
+    return {"link": _serialize_peer_link(link), "created": created}
+
+
+def _tool_unlink_agents(request, arguments):
+    link = _resolve_peer_link(request, arguments)
+    payload = _serialize_peer_link(link)
+    link.remove_preserving_history()
+    return {"status": "unlinked", "link": payload}
+
+
+def _tool_send_agent_message(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    body = _required_string(arguments, "body", allow_blank=False)
+    trigger_processing = _optional_bool(arguments.get("trigger_processing", True), "trigger_processing")
+    attachment_paths = arguments.get("attachment_file_paths") or []
+    if not isinstance(attachment_paths, list):
+        raise MCPToolError("attachment_file_paths must be an array of filespace paths.")
+
+    sender_address = build_web_user_address(user_id=request.user.id, agent_id=agent.id)
+    if not agent.is_sender_whitelisted(CommsChannel.WEB, sender_address):
+        raise MCPToolError("Authenticated user is not allowed to message this agent.")
+
+    try:
+        resolved_attachments = resolve_filespace_attachments(agent, attachment_paths)
+    except AttachmentResolutionError as exc:
+        raise MCPToolError(str(exc)) from exc
+
+    with transaction.atomic():
+        message, conversation = inject_internal_web_message(
+            agent.id,
+            body,
+            sender_user_id=request.user.id,
+            attachments=[],
+            trigger_processing=False,
+        )
+        create_message_attachments(message, resolved_attachments)
+        if trigger_processing:
+            from api.agent.tasks import process_agent_events_task
+
+            transaction.on_commit(lambda: process_agent_events_task.delay(str(agent.id)))
+
+    return {
+        "status": "queued" if trigger_processing else "stored",
+        "message": _serialize_message(message),
+        "conversation_id": str(conversation.id),
+        "attachment_count": len(resolved_attachments),
+    }
+
+
+def _tool_get_agent_timeline(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    direction = arguments.get("direction") or "initial"
+    if direction not in {"initial", "older", "newer"}:
+        raise MCPToolError("direction must be one of initial, older, or newer.")
+    limit = _bounded_int(
+        arguments.get("limit", TIMELINE_DEFAULT_PAGE_SIZE),
+        "limit",
+        minimum=1,
+        maximum=TIMELINE_MAX_PAGE_SIZE,
+    )
+    cursor = arguments.get("cursor") or None
+    if cursor is not None and not isinstance(cursor, str):
+        raise MCPToolError("cursor must be a string.")
+
+    window = fetch_timeline_window(agent, cursor=cursor, direction=direction, limit=limit)
+    return {
+        "events": window.events,
+        "oldest_cursor": window.oldest_cursor,
+        "newest_cursor": window.newest_cursor,
+        "has_more_older": window.has_more_older,
+        "has_more_newer": window.has_more_newer,
+        "processing_active": window.processing_active,
+        "processing_snapshot": serialize_processing_snapshot(window.processing_snapshot),
+    }
+
+
+def _tool_list_agent_files(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    filespace = get_or_create_default_filespace(agent)
+    nodes = (
+        AgentFsNode.objects.alive()
+        .filter(filespace=filespace)
+        .only("id", "parent_id", "name", "path", "node_type", "size_bytes", "mime_type", "created_at", "updated_at")
+        .order_by("parent_id", "node_type", "name")
+    )
+    return {
+        "filespace": {"id": str(filespace.id), "name": filespace.name},
+        "nodes": [_serialize_file_node(node) for node in nodes],
+    }
+
+
+def _tool_upload_agent_file(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    path = _required_string(arguments, "path", allow_blank=False)
+    content_base64 = _required_string(arguments, "content_base64", allow_blank=False)
+    mime_type = arguments.get("mime_type") or "application/octet-stream"
+    if not isinstance(mime_type, str):
+        raise MCPToolError("mime_type must be a string.")
+    overwrite = _optional_bool(arguments.get("overwrite", False), "overwrite")
+
+    try:
+        content = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise MCPToolError("content_base64 must be valid base64.") from exc
+
+    result = write_bytes_to_dir(
+        agent,
+        content,
+        path=path,
+        mime_type=mime_type,
+        overwrite=overwrite,
+    )
+    if result.get("status") != "ok":
+        raise MCPToolError(result.get("message") or "File upload failed.", result)
+    return result
+
+
+def _agent_queryset(request):
+    organization = _request_organization(request)
+    if organization is None and not can_user_use_personal_agents_and_api(request.user):
+        raise MCPToolError("Personal API access requires an active trial or plan.")
+
+    queryset = (
+        PersistentAgent.objects.non_eval()
+        .alive()
+        .select_related("browser_use_agent", "organization", "preferred_contact_endpoint", "preferred_llm_tier")
+        .order_by("-created_at")
+    )
+    if organization is not None:
+        return queryset.filter(organization=organization)
+    return queryset.filter(user=request.user)
+
+
+def _request_organization(request):
+    auth = getattr(request, "auth", None)
+    if isinstance(auth, ApiKey) and getattr(auth, "organization_id", None):
+        return auth.organization
+    return None
+
+
+def _get_agent(request, raw_agent_id):
+    agent_id = _parse_uuid(raw_agent_id, "agent_id")
+    agent = _agent_queryset(request).filter(id=agent_id).first()
+    if agent is None:
+        raise MCPToolError("Agent not found or inaccessible.")
+    return agent
+
+
+def _resolve_peer_link(request, arguments):
+    accessible = _agent_queryset(request).only("id")
+    peer_link_id = arguments.get("peer_link_id")
+    if peer_link_id:
+        link_id = _parse_uuid(peer_link_id, "peer_link_id")
+        link = (
+            AgentPeerLink.objects.filter(id=link_id)
+            .filter(Q(agent_a__in=accessible) | Q(agent_b__in=accessible))
+            .select_related("agent_a", "agent_b", "created_by")
+            .first()
+        )
+    else:
+        agent = _get_agent(request, arguments.get("agent_id"))
+        peer_agent = _get_agent(request, arguments.get("peer_agent_id"))
+        pair_key = AgentPeerLink.build_pair_key(agent.id, peer_agent.id)
+        link = (
+            AgentPeerLink.objects.filter(pair_key=pair_key)
+            .select_related("agent_a", "agent_b", "created_by")
+            .first()
+        )
+
+    if link is None:
+        raise MCPToolError("Peer link not found or inaccessible.")
+    return link
+
+
+def _serialize_agent(agent):
+    return {
+        "id": str(agent.id),
+        "name": agent.name,
+        "charter": agent.charter,
+        "short_description": agent.short_description,
+        "schedule": agent.schedule,
+        "is_active": agent.is_active,
+        "life_state": agent.life_state,
+        "planning_state": agent.planning_state,
+        "whitelist_policy": agent.whitelist_policy,
+        "created_at": _iso(agent.created_at),
+        "updated_at": _iso(agent.updated_at),
+        "last_interaction_at": _iso(agent.last_interaction_at),
+        "user_id": str(agent.user_id) if agent.user_id else None,
+        "organization_id": str(agent.organization_id) if agent.organization_id else None,
+        "browser_use_agent_id": str(agent.browser_use_agent_id) if agent.browser_use_agent_id else None,
+        "preferred_contact_endpoint_id": (
+            str(agent.preferred_contact_endpoint_id) if agent.preferred_contact_endpoint_id else None
+        ),
+        "preferred_llm_tier": getattr(getattr(agent, "preferred_llm_tier", None), "key", None),
+        "proactive_opt_in": agent.proactive_opt_in,
+        "proactive_last_trigger_at": _iso(agent.proactive_last_trigger_at),
+    }
+
+
+def _serialize_peer_link(link):
+    return {
+        "id": str(link.id),
+        "agent_a": _serialize_agent_ref(link.agent_a),
+        "agent_b": _serialize_agent_ref(link.agent_b),
+        "is_enabled": link.is_enabled,
+        "messages_per_window": link.messages_per_window,
+        "window_hours": link.window_hours,
+        "feature_flag": link.feature_flag or None,
+        "pair_key": link.pair_key,
+        "created_by_user_id": link.created_by_id,
+        "created_at": _iso(link.created_at),
+        "updated_at": _iso(link.updated_at),
+    }
+
+
+def _serialize_agent_ref(agent):
+    return {
+        "id": str(agent.id),
+        "name": agent.name,
+        "is_active": agent.is_active,
+        "life_state": agent.life_state,
+    }
+
+
+def _serialize_message(message):
+    return {
+        "id": str(message.id),
+        "owner_agent_id": str(message.owner_agent_id) if message.owner_agent_id else None,
+        "conversation_id": str(message.conversation_id) if message.conversation_id else None,
+        "is_outbound": message.is_outbound,
+        "body": message.body,
+        "timestamp": _iso(message.timestamp),
+    }
+
+
+def _serialize_file_node(node):
+    return {
+        "id": str(node.id),
+        "parent_id": str(node.parent_id) if node.parent_id else None,
+        "name": node.name,
+        "path": node.path,
+        "node_type": node.node_type,
+        "size_bytes": node.size_bytes,
+        "mime_type": node.mime_type or None,
+        "created_at": _iso(node.created_at),
+        "updated_at": _iso(node.updated_at),
+    }
+
+
+def _required_string(arguments, key, *, allow_blank):
+    value = arguments.get(key)
+    if not isinstance(value, str):
+        raise MCPToolError(f"{key} must be a string.")
+    if not allow_blank and not value.strip():
+        raise MCPToolError(f"{key} cannot be blank.")
+    return value.strip() if not allow_blank else value
+
+
+def _optional_bool(value, key):
+    if isinstance(value, bool):
+        return value
+    raise MCPToolError(f"{key} must be a boolean.")
+
+
+def _bounded_int(value, key, *, minimum, maximum):
+    if isinstance(value, bool):
+        raise MCPToolError(f"{key} must be an integer.")
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as exc:
+        raise MCPToolError(f"{key} must be an integer.") from exc
+    if number < minimum or number > maximum:
+        raise MCPToolError(f"{key} must be between {minimum} and {maximum}.")
+    return number
+
+
+def _parse_uuid(value, key):
+    try:
+        return uuid.UUID(str(value))
+    except (TypeError, ValueError) as exc:
+        raise MCPToolError(f"{key} must be a valid UUID.") from exc
+
+
+def _format_validation_error(exc):
+    if hasattr(exc, "detail"):
+        return _json_safe(exc.detail)
+    if hasattr(exc, "message_dict"):
+        return _json_safe(exc.message_dict)
+    if hasattr(exc, "messages"):
+        return _json_safe(exc.messages)
+    return {"message": str(exc)}
+
+
+def _json_safe(value):
+    return json.loads(json.dumps(value, cls=DjangoJSONEncoder, default=str))
+
+
+def _iso(value):
+    return value.isoformat() if value else None

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,6 +8,7 @@ from .views import (
     BrowserUseAgentTaskViewSet,
     PersistentAgentViewSet,
 )
+from .mcp_views import GobiiMCPView
 from .custom_tool_bridge import custom_tool_bridge_execute
 from .webhooks import (
     inbound_agent_webhook,
@@ -32,6 +33,7 @@ router.register(r'agents', PersistentAgentViewSet, basename='persistentagent')
 urlpatterns = [
     # Utility endpoints
     path("ping/", ping, name="ping"),
+    path("mcp/", GobiiMCPView.as_view(), name="remote-mcp"),
     path("custom-tools/bridge/execute/", custom_tool_bridge_execute, name="custom-tool-bridge-execute"),
     
     # Include the router URLs for agents

--- a/docs/content/developers/developer-agents.mdx
+++ b/docs/content/developers/developer-agents.mdx
@@ -9,6 +9,7 @@ state, schedule, and communication endpoints so you can trigger actions over tim
 teammate. Results may be received via webhook (preferred), or retrieved via a `GET` request.
 
 Agents run primarily via `browser-use`, along with other AI tools. Additionally, agents may be configured to use MCP servers to expand capabilities.
+If you want to connect an external AI client to Gobii itself over MCP, see the [Remote MCP Server](/developers/mcp-server) guide.
 
 Core capabilities include:
 

--- a/docs/content/developers/mcp-server.mdx
+++ b/docs/content/developers/mcp-server.mdx
@@ -129,13 +129,14 @@ Unsupported fields are not ignored. A tool call with unsupported arguments retur
 
 `gobii_send_agent_message` appends a web-chat message to the agent's unified timeline. It returns `message_id`, `agent_id`, `cursor`, `latest_cursor`, `created_at`, `accepted_state`, actor metadata, and the serialized timeline event.
 
-`gobii_get_agent_timeline` reads the unified timeline. Use `after_cursor` for events newer than a cursor, or `cursor` plus `direction` (`initial`, `older`, `newer`) for scroll-style reads. Results include `events`, `next_cursor`, `latest_cursor`, `oldest_cursor`, `newest_cursor`, `has_more`, and processing state. Events can include messages, tool/step clusters, thinking entries, and plan updates when those exist in the agent timeline.
+`gobii_get_agent_timeline` reads the unified timeline. Use `after_cursor` for events strictly newer than a cursor, or `cursor` plus `direction` (`initial`, `older`, `newer`) for scroll-style reads. The event with the exact `after_cursor` is excluded. Results include `events`, `next_cursor`, `latest_cursor`, `oldest_cursor`, `newest_cursor`, `has_more`, and processing state. Events can include messages, tool/step clusters, thinking entries, and plan updates when those exist in the agent timeline.
 
 `gobii_wait_for_agent_event` is the v1 wait primitive. It polls the same timeline for up to `timeout_seconds` with a server cap. Inputs include `agent_id`, `after_cursor`, `event_types`, and supported filters:
 
-- `from_actor_type`: `agent`, `human_user`, `external`, or `system`
-- `from_agent_id` / `to_agent_id`: supported for peer-agent and agent-owned message events
-- `message_id`, `peer_link_id`, and `channel`: supported for message events
+- `from_actor_type`: `agent`, `human_user`, `external`, or `system`, derived from the serialized event. Outbound or peer messages are `agent`; inbound web user messages are `human_user`; other inbound messages are `external`; steps/thinking/plan events are `system`.
+- `from_agent_id`: supported for message events from an agent. For non-peer outbound messages this is the owner agent; for inbound peer-agent messages this is the peer agent.
+- `to_agent_id`: supported for message events addressed to an agent. For non-peer inbound messages this is the owner agent; for outbound peer-agent messages this is the peer agent. Ordinary agent-to-human/external replies do not have a `to_agent_id`.
+- `message_id`, `peer_link_id`, and `channel`: supported for message events. `message_id` does not override `after_cursor`; to wait for a known message, pass a cursor captured before that message or omit `after_cursor` and rely on the recent initial timeline window.
 - `status` and `tool_name`: supported for tool/step events
 
 The wait tool returns `matched`, `timed_out`, `events`, `next_cursor`, `latest_cursor`, and `waited_seconds`.

--- a/docs/content/developers/mcp-server.mdx
+++ b/docs/content/developers/mcp-server.mdx
@@ -4,7 +4,9 @@ sidebarTitle: "Remote MCP Server"
 description: "Connect an MCP client to Gobii over HTTPS and use Gobii as agent infrastructure."
 ---
 
-Gobii exposes a remote Model Context Protocol (MCP) endpoint so external AI tools can create, manage, coordinate, message, and attach files to Gobii agents through your existing Gobii API key.
+Gobii exposes a remote Model Context Protocol (MCP) endpoint so external AI tools can create, manage, coordinate, message, wait on, and attach files to Gobii agents through your existing Gobii API key.
+
+Gobii MCP is a conversational agent-timeline API, not a task API. Each Gobii agent is a long-lived AI employee with one unified timeline, history, and context. MCP clients append messages to that timeline, read timeline events with durable cursors, and wait for matching timeline events. The MCP server does not create a separate task, run, conversation, or session abstraction for agent work.
 
 ## Endpoint
 
@@ -13,13 +15,14 @@ Use the Streamable HTTP endpoint:
 - Production: `https://gobii.ai/api/v1/mcp/`
 - Self-hosted/local: `http://localhost:8000/api/v1/mcp/`
 
-Gobii implements the MCP `2025-06-18` JSON-RPC flow over Streamable HTTP. Each request is a new `POST` with one JSON-RPC object. The endpoint returns `application/json` for requests and `202 Accepted` for notifications/responses. Gobii does not open a standalone GET SSE stream in v1, so `GET /api/v1/mcp/` returns `405 Method Not Allowed`.
+Gobii implements the MCP `2025-11-25` JSON-RPC flow over Streamable HTTP. Each request is a new `POST` with one JSON-RPC object. The endpoint returns `application/json` for requests and `202 Accepted` for notifications/responses. Gobii does not open a standalone GET SSE stream in v1, so `GET /api/v1/mcp/` returns `405 Method Not Allowed`.
 
 References:
 
-- MCP Streamable HTTP transport: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
-- MCP tools protocol: https://modelcontextprotocol.io/specification/2025-06-18/server/tools
-- MCP HTTP authorization guidance: https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+- MCP Streamable HTTP transport: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
+- MCP tools protocol and structured tool results: https://modelcontextprotocol.io/specification/2025-11-25/server/tools
+- MCP schema reference: https://modelcontextprotocol.io/specification/2025-11-25/schema
+- MCP HTTP authorization guidance: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
 
 ## Authentication
 
@@ -51,7 +54,7 @@ curl -X POST https://gobii.ai/api/v1/mcp/ \
     "id": "init-1",
     "method": "initialize",
     "params": {
-      "protocolVersion": "2025-06-18",
+      "protocolVersion": "2025-11-25",
       "capabilities": {},
       "clientInfo": {"name": "example-client", "version": "1.0.0"}
     }
@@ -97,15 +100,51 @@ Gobii also validates `Mcp-Method` and `Mcp-Name` request headers when clients se
 | `gobii_create_agent` | Create an agent through Gobii's normal provisioning path. |
 | `gobii_update_agent` | Update mutable agent settings. |
 | `gobii_archive_agent` | Soft-delete/archive an agent. |
+| `gobii_get_agent_config_options` | Discover supported agent config fields and option limits. |
 | `gobii_list_agent_links` | List peer-agent links. |
 | `gobii_link_agents` | Create or enable a peer-agent link. |
 | `gobii_unlink_agents` | Remove a peer-agent link while preserving history. |
 | `gobii_send_agent_message` | Send a web-chat message to an agent, optionally with existing filespace attachments. |
-| `gobii_get_agent_timeline` | Fetch recent timeline and processing state. |
+| `gobii_get_agent_timeline` | Fetch timeline events and processing state using durable cursors. |
+| `gobii_wait_for_agent_event` | Bounded long-poll for matching timeline events after a cursor. |
 | `gobii_list_agent_files` | List an agent's default filespace. |
 | `gobii_upload_agent_file` | Upload a small base64 file into the agent filespace. |
 
 Gobii does not expose MCP resources or prompts in v1. The current product capabilities map more cleanly to MCP tools.
+
+## Agent Config
+
+Use `gobii_get_agent_config_options` before setting operational config. It returns the current owner scope, supported fields, intelligence tiers, daily credit settings, schedule semantics, and policy options for the API key.
+
+`gobii_create_agent`, `gobii_update_agent`, and `gobii_get_agent` expose these real platform fields:
+
+- `preferred_llm_tier`: the agent's preferred intelligence level. Values are the configured Gobii intelligence tier keys, commonly `standard`, `premium`, `max`, `ultra`, and `ultra_max`. Plan and quota limits are enforced.
+- `daily_credit_limit`: the soft daily credit target. `null` means unlimited. Gobii derives and enforces the hard runtime stop from the configured hard-limit multiplier.
+- `schedule`: optional cron-like schedule, `@daily`, or `@every` interval. Omitted, empty, or `null` means unscheduled. Invalid schedules return an MCP tool result with `isError: true` and field details.
+- `whitelist_policy`, `is_active`, and `proactive_opt_in`: existing Gobii policy and lifecycle fields.
+
+Unsupported fields are not ignored. A tool call with unsupported arguments returns `isError: true` with `unsupported_fields` and `supported_fields`.
+
+## Timeline And Messaging
+
+`gobii_send_agent_message` appends a web-chat message to the agent's unified timeline. It returns `message_id`, `agent_id`, `cursor`, `latest_cursor`, `created_at`, `accepted_state`, actor metadata, and the serialized timeline event.
+
+`gobii_get_agent_timeline` reads the unified timeline. Use `after_cursor` for events newer than a cursor, or `cursor` plus `direction` (`initial`, `older`, `newer`) for scroll-style reads. Results include `events`, `next_cursor`, `latest_cursor`, `oldest_cursor`, `newest_cursor`, `has_more`, and processing state. Events can include messages, tool/step clusters, thinking entries, and plan updates when those exist in the agent timeline.
+
+`gobii_wait_for_agent_event` is the v1 wait primitive. It polls the same timeline for up to `timeout_seconds` with a server cap. Inputs include `agent_id`, `after_cursor`, `event_types`, and supported filters:
+
+- `from_actor_type`: `agent`, `human_user`, `external`, or `system`
+- `from_agent_id` / `to_agent_id`: supported for peer-agent and agent-owned message events
+- `message_id`, `peer_link_id`, and `channel`: supported for message events
+- `status` and `tool_name`: supported for tool/step events
+
+The wait tool returns `matched`, `timed_out`, `events`, `next_cursor`, `latest_cursor`, and `waited_seconds`.
+
+## Agent Links
+
+Agent links are symmetric peer-agent messaging links backed by Gobii's `AgentPeerLink` model. `gobii_link_agents` creates or re-enables a link between two accessible agents that share an owner or organization. The link enforces a rolling message quota with `messages_per_window` and `window_hours`.
+
+Linked-agent messages appear as peer direct-message events in each participating agent's unified timeline. The sender's timeline receives an outbound peer message and the recipient's timeline receives an inbound peer message. `gobii_unlink_agents` removes the link while preserving historical conversations and messages.
 
 ## Files And Attachments
 
@@ -117,10 +156,61 @@ Preferred flow:
 
 This keeps message calls small and uses Gobii's existing filespace and attachment models. Arbitrary URL fetching is intentionally not exposed through the MCP server v1. Very large files should be added to the agent filespace outside MCP, then referenced by path.
 
+## Hermes Example
+
+For Hermes, configure Gobii as a Streamable HTTP MCP server in the profile's `config.yaml`. Store the API key in the profile environment and reference it by variable name; do not paste keys into shared config or docs.
+
+```yaml
+mcp_servers:
+  gobii-local:
+    url: "http://localhost:8000/api/v1/mcp/"
+    headers:
+      Authorization: "Bearer ${GOBII_API_KEY}"
+    timeout: 60
+    connect_timeout: 10
+    tools:
+      include:
+        - gobii_list_agents
+        - gobii_get_agent
+        - gobii_create_agent
+        - gobii_update_agent
+        - gobii_archive_agent
+        - gobii_get_agent_config_options
+        - gobii_list_agent_links
+        - gobii_link_agents
+        - gobii_unlink_agents
+        - gobii_send_agent_message
+        - gobii_get_agent_timeline
+        - gobii_wait_for_agent_event
+        - gobii_list_agent_files
+        - gobii_upload_agent_file
+```
+
+For production, use `https://gobii.ai/api/v1/mcp/`. For preview deployments, create or request a fresh API key for the current preview database snapshot before testing; keys from older preview deployments may not exist in the new ephemeral database.
+
+## Smoke Test Flow
+
+Use this flow for local dev, preview, or production smoke testing. Archive temporary agents at the end when safe.
+
+1. `gobii_list_agents`
+2. `gobii_get_agent_config_options`
+3. `gobii_create_agent` twice without `schedule`
+4. `gobii_update_agent` on one agent with a supported `preferred_llm_tier` and `daily_credit_limit`
+5. `gobii_link_agents`
+6. `gobii_send_agent_message`
+7. `gobii_get_agent_timeline` and capture `latest_cursor`
+8. `gobii_wait_for_agent_event` with a cursor and a short timeout; verify both match and timeout behavior as appropriate
+9. `gobii_upload_agent_file`
+10. `gobii_list_agent_files`
+11. `gobii_unlink_agents`
+12. `gobii_archive_agent` for temporary agents
+
 ## Limitations
 
 - The endpoint is stateless and does not issue `Mcp-Session-Id` values.
 - Standalone GET SSE streams are not exposed in v1.
+- V1 does not implement MCP task augmentation, progress streams, or a fake Gobii task/run abstraction.
+- V2 may add resumable SSE/session support if it can map cleanly onto Gobii's durable timeline/event model.
 - Tool results include both MCP text content and `structuredContent`.
 - All tool calls run with the permissions of the provided Gobii API key.
 - Origin headers are validated for browser-originated requests to reduce DNS rebinding risk.

--- a/docs/content/developers/mcp-server.mdx
+++ b/docs/content/developers/mcp-server.mdx
@@ -1,0 +1,126 @@
+---
+title: "Remote MCP Server"
+sidebarTitle: "Remote MCP Server"
+description: "Connect an MCP client to Gobii over HTTPS and use Gobii as agent infrastructure."
+---
+
+Gobii exposes a remote Model Context Protocol (MCP) endpoint so external AI tools can create, manage, coordinate, message, and attach files to Gobii agents through your existing Gobii API key.
+
+## Endpoint
+
+Use the Streamable HTTP endpoint:
+
+- Production: `https://gobii.ai/api/v1/mcp/`
+- Self-hosted/local: `http://localhost:8000/api/v1/mcp/`
+
+Gobii implements the MCP `2025-06-18` JSON-RPC flow over Streamable HTTP. Each request is a new `POST` with one JSON-RPC object. The endpoint returns `application/json` for requests and `202 Accepted` for notifications/responses. Gobii does not open a standalone GET SSE stream in v1, so `GET /api/v1/mcp/` returns `405 Method Not Allowed`.
+
+References:
+
+- MCP Streamable HTTP transport: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+- MCP tools protocol: https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+- MCP HTTP authorization guidance: https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+
+## Authentication
+
+Use an existing Gobii API key. Send it on every request with either header:
+
+```http
+X-Api-Key: $GOBII_API_KEY
+```
+
+or:
+
+```http
+Authorization: Bearer $GOBII_API_KEY
+```
+
+Do not put API keys in query strings. Organization API keys scope tools to organization-owned agents; personal API keys scope tools to agents accessible to that user.
+
+## Client Request Shape
+
+Initialize:
+
+```bash
+curl -X POST https://gobii.ai/api/v1/mcp/ \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $GOBII_API_KEY" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "init-1",
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-06-18",
+      "capabilities": {},
+      "clientInfo": {"name": "example-client", "version": "1.0.0"}
+    }
+  }'
+```
+
+List tools:
+
+```bash
+curl -X POST https://gobii.ai/api/v1/mcp/ \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $GOBII_API_KEY" \
+  -d '{"jsonrpc":"2.0","id":"tools-1","method":"tools/list","params":{}}'
+```
+
+Call a tool:
+
+```bash
+curl -X POST https://gobii.ai/api/v1/mcp/ \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $GOBII_API_KEY" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "call-1",
+    "method": "tools/call",
+    "params": {
+      "name": "gobii_list_agents",
+      "arguments": {"page_size": 10}
+    }
+  }'
+```
+
+Gobii also validates `Mcp-Method` and `Mcp-Name` request headers when clients send them.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `gobii_list_agents` | List accessible persistent agents. |
+| `gobii_get_agent` | Retrieve one agent. |
+| `gobii_create_agent` | Create an agent through Gobii's normal provisioning path. |
+| `gobii_update_agent` | Update mutable agent settings. |
+| `gobii_archive_agent` | Soft-delete/archive an agent. |
+| `gobii_list_agent_links` | List peer-agent links. |
+| `gobii_link_agents` | Create or enable a peer-agent link. |
+| `gobii_unlink_agents` | Remove a peer-agent link while preserving history. |
+| `gobii_send_agent_message` | Send a web-chat message to an agent, optionally with existing filespace attachments. |
+| `gobii_get_agent_timeline` | Fetch recent timeline and processing state. |
+| `gobii_list_agent_files` | List an agent's default filespace. |
+| `gobii_upload_agent_file` | Upload a small base64 file into the agent filespace. |
+
+Gobii does not expose MCP resources or prompts in v1. The current product capabilities map more cleanly to MCP tools.
+
+## Files And Attachments
+
+Preferred flow:
+
+1. Upload a small file with `gobii_upload_agent_file`, or create/upload the file in the Gobii agent filespace through the product.
+2. Send a message with `gobii_send_agent_message`.
+3. Pass filespace paths in `attachment_file_paths`, for example `["/uploads/brief.pdf"]`.
+
+This keeps message calls small and uses Gobii's existing filespace and attachment models. Arbitrary URL fetching is intentionally not exposed through the MCP server v1. Very large files should be added to the agent filespace outside MCP, then referenced by path.
+
+## Limitations
+
+- The endpoint is stateless and does not issue `Mcp-Session-Id` values.
+- Standalone GET SSE streams are not exposed in v1.
+- Tool results include both MCP text content and `structuredContent`.
+- All tool calls run with the permissions of the provided Gobii API key.
+- Origin headers are validated for browser-originated requests to reduce DNS rebinding risk.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -52,6 +52,7 @@ const sidebars = {
       items: [
         'developers/developer-basics',
         'developers/developer-agents',
+        'developers/mcp-server',
         'developers/developer-tasks',
         'developers/structured-data',
         'developers/webhooks',

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -225,6 +225,93 @@ class RemoteMCPViewTests(TestCase):
         created_agent.refresh_from_db()
         self.assertTrue(created_agent.is_deleted)
 
+    def test_update_unscheduled_agent_config_without_schedule(self):
+        agent = self._create_agent(self.user, "Unscheduled Config Update")
+        self.assertIsNone(agent.schedule)
+
+        response = self._call_tool(
+            "gobii_update_agent",
+            {
+                "agent_id": str(agent.id),
+                "preferred_llm_tier": "premium",
+                "daily_credit_limit": 11,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["result"]["isError"])
+        agent.refresh_from_db()
+        self.assertIsNone(agent.schedule)
+        self.assertEqual(agent.preferred_llm_tier, self.premium_tier)
+        self.assertEqual(agent.daily_credit_limit, 11)
+
+    def test_update_unscheduled_agent_with_explicit_null_schedule(self):
+        agent = self._create_agent(self.user, "Explicit Null Schedule Update")
+        PersistentAgent.objects.filter(id=agent.id).update(schedule="@daily")
+
+        response = self._call_tool(
+            "gobii_update_agent",
+            {
+                "agent_id": str(agent.id),
+                "schedule": None,
+                "preferred_llm_tier": "premium",
+                "daily_credit_limit": 13,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["result"]["isError"])
+        agent.refresh_from_db()
+        self.assertIsNone(agent.schedule)
+        self.assertEqual(agent.preferred_llm_tier, self.premium_tier)
+        self.assertEqual(agent.daily_credit_limit, 13)
+
+    def test_update_agent_invalid_schedule_returns_structured_tool_error(self):
+        agent = self._create_agent(self.user, "Invalid Schedule Update")
+
+        response = self._call_tool(
+            "gobii_update_agent",
+            {
+                "agent_id": str(agent.id),
+                "schedule": "not a cron schedule",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = self._structured_content(response)
+        self.assertTrue(response.json()["result"]["isError"])
+        self.assertEqual(content["status"], "error")
+        self.assertIn("details", content)
+        self.assertIn("schedule", content["details"])
+
+        list_response = self._call_tool("gobii_list_agents")
+        self.assertEqual(list_response.status_code, 200)
+        self.assertFalse(list_response.json()["result"]["isError"])
+
+    def test_update_agent_omitted_schedule_does_not_revalidate_existing_schedule(self):
+        agent = self._create_agent(self.user, "Omitted Schedule Update")
+        PersistentAgent.objects.filter(id=agent.id).update(schedule="0 9 * * *")
+
+        with patch(
+            "api.agent.core.schedule_parser.ScheduleParser.parse",
+            side_effect=AssertionError("schedule was revalidated"),
+        ):
+            response = self._call_tool(
+                "gobii_update_agent",
+                {
+                    "agent_id": str(agent.id),
+                    "preferred_llm_tier": "premium",
+                    "daily_credit_limit": 17,
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["result"]["isError"])
+        agent.refresh_from_db()
+        self.assertEqual(agent.schedule, "0 9 * * *")
+        self.assertEqual(agent.preferred_llm_tier, self.premium_tier)
+        self.assertEqual(agent.daily_credit_limit, 17)
+
     def test_create_agent_accepts_null_schedule_and_returns_structured_validation_errors(self):
         with (
             patch.object(BrowserUseAgent, "select_random_proxy", return_value=None),

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -1,0 +1,230 @@
+import base64
+import json
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, tag
+
+from api.models import (
+    AgentPeerLink,
+    BrowserUseAgent,
+    IntelligenceTier,
+    PersistentAgent,
+    PersistentAgentMessage,
+    UserQuota,
+)
+from api.models import DEFAULT_INTELLIGENCE_TIER_KEY
+from api.models import ApiKey
+
+
+User = get_user_model()
+
+
+@tag("batch_mcp_tools")
+class RemoteMCPViewTests(TestCase):
+    def setUp(self):
+        self.tier, _ = IntelligenceTier.objects.update_or_create(
+            key=DEFAULT_INTELLIGENCE_TIER_KEY,
+            defaults={
+                "display_name": "Standard",
+                "rank": 10,
+                "credit_multiplier": "1.00",
+                "is_default": True,
+            },
+        )
+        self.user = User.objects.create_user(
+            username="mcp-user@example.com",
+            email="mcp-user@example.com",
+            password="password",
+        )
+        quota, _ = UserQuota.objects.get_or_create(user=self.user)
+        quota.agent_limit = 20
+        quota.save(update_fields=["agent_limit"])
+        self.raw_api_key, self.api_key = ApiKey.create_for_user(self.user, name="mcp")
+        self.other_user = User.objects.create_user(
+            username="mcp-other@example.com",
+            email="mcp-other@example.com",
+            password="password",
+        )
+        UserQuota.objects.get_or_create(user=self.other_user, defaults={"agent_limit": 20})
+
+    def _post_mcp(self, method, params=None, *, auth="x-api-key", extra_headers=None):
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "test-1",
+            "method": method,
+        }
+        if params is not None:
+            payload["params"] = params
+        headers = dict(extra_headers or {})
+        if auth == "x-api-key":
+            headers["HTTP_X_API_KEY"] = self.raw_api_key
+        elif auth == "bearer":
+            headers["HTTP_AUTHORIZATION"] = f"Bearer {self.raw_api_key}"
+        return self.client.post(
+            "/api/v1/mcp/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            **headers,
+        )
+
+    def _call_tool(self, name, arguments=None, *, auth="x-api-key"):
+        return self._post_mcp(
+            "tools/call",
+            {"name": name, "arguments": arguments or {}},
+            auth=auth,
+        )
+
+    def _create_agent(self, user, name):
+        with patch.object(BrowserUseAgent, "select_random_proxy", return_value=None):
+            browser_agent = BrowserUseAgent.objects.create(user=user, name=f"{name} Browser")
+        return PersistentAgent.objects.create(
+            user=user,
+            name=name,
+            charter=f"{name} charter",
+            browser_use_agent=browser_agent,
+            preferred_llm_tier=self.tier,
+        )
+
+    def _structured_content(self, response):
+        return response.json()["result"]["structuredContent"]
+
+    def test_requires_api_key(self):
+        response = self.client.post(
+            "/api/v1/mcp/",
+            data=json.dumps({"jsonrpc": "2.0", "id": "test-1", "method": "initialize"}),
+            content_type="application/json",
+        )
+
+        self.assertIn(response.status_code, [401, 403])
+
+    def test_initialize_accepts_existing_api_key_headers(self):
+        response = self._post_mcp("initialize")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["result"]["protocolVersion"], "2025-06-18")
+        self.assertIn("tools", payload["result"]["capabilities"])
+
+        bearer_response = self._post_mcp("initialize", auth="bearer")
+        self.assertEqual(bearer_response.status_code, 200)
+
+    def test_list_tools_and_scope_agent_listing(self):
+        agent = self._create_agent(self.user, "MCP Owned")
+        self._create_agent(self.other_user, "MCP Other")
+
+        tools_response = self._post_mcp("tools/list")
+        self.assertEqual(tools_response.status_code, 200)
+        tool_names = {tool["name"] for tool in tools_response.json()["result"]["tools"]}
+        self.assertIn("gobii_list_agents", tool_names)
+        self.assertIn("gobii_send_agent_message", tool_names)
+        self.assertIn("gobii_upload_agent_file", tool_names)
+
+        list_response = self._call_tool("gobii_list_agents")
+        self.assertEqual(list_response.status_code, 200)
+        content = self._structured_content(list_response)
+        self.assertEqual(content["total"], 1)
+        self.assertEqual(content["agents"][0]["id"], str(agent.id))
+
+    def test_lifecycle_tools_create_update_link_and_archive_agent(self):
+        existing_agent = self._create_agent(self.user, "Existing MCP Agent")
+
+        with (
+            patch.object(BrowserUseAgent, "select_random_proxy", return_value=None),
+            patch("api.services.persistent_agents.maybe_schedule_short_description"),
+            patch("api.services.persistent_agents.maybe_schedule_mini_description"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_tags"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_avatar"),
+            patch("api.agent.tasks.process_agent_events_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            create_response = self._call_tool(
+                "gobii_create_agent",
+                {
+                    "name": "Remote MCP Agent",
+                    "charter": "Coordinate MCP work.",
+                    "is_active": True,
+                },
+            )
+
+        self.assertEqual(create_response.status_code, 200)
+        created_agent_id = self._structured_content(create_response)["agent"]["id"]
+        created_agent = PersistentAgent.objects.get(id=created_agent_id)
+
+        update_response = self._call_tool(
+            "gobii_update_agent",
+            {"agent_id": created_agent_id, "charter": "Updated through MCP."},
+        )
+        self.assertEqual(update_response.status_code, 200)
+        created_agent.refresh_from_db()
+        self.assertEqual(created_agent.charter, "Updated through MCP.")
+
+        link_response = self._call_tool(
+            "gobii_link_agents",
+            {
+                "agent_id": str(existing_agent.id),
+                "peer_agent_id": created_agent_id,
+                "messages_per_window": 12,
+                "window_hours": 4,
+            },
+        )
+        self.assertEqual(link_response.status_code, 200)
+        link_content = self._structured_content(link_response)
+        self.assertTrue(link_content["created"])
+        self.assertTrue(AgentPeerLink.objects.filter(id=link_content["link"]["id"]).exists())
+
+        archive_response = self._call_tool("gobii_archive_agent", {"agent_id": created_agent_id})
+        self.assertEqual(archive_response.status_code, 200)
+        created_agent.refresh_from_db()
+        self.assertTrue(created_agent.is_deleted)
+
+    def test_file_upload_and_message_attachment_path(self):
+        agent = self._create_agent(self.user, "File MCP Agent")
+        encoded = base64.b64encode(b"hello from mcp").decode("ascii")
+
+        upload_response = self._call_tool(
+            "gobii_upload_agent_file",
+            {
+                "agent_id": str(agent.id),
+                "path": "/uploads/hello.txt",
+                "content_base64": encoded,
+                "mime_type": "text/plain",
+            },
+        )
+        self.assertEqual(upload_response.status_code, 200)
+        upload_content = self._structured_content(upload_response)
+        self.assertEqual(upload_content["path"], "/uploads/hello.txt")
+        node_id = upload_content["node_id"]
+
+        files_response = self._call_tool("gobii_list_agent_files", {"agent_id": str(agent.id)})
+        self.assertEqual(files_response.status_code, 200)
+        paths = {node["path"] for node in self._structured_content(files_response)["nodes"]}
+        self.assertIn("/uploads/hello.txt", paths)
+
+        with (
+            patch("api.agent.tasks.process_agent_events_task.delay") as process_delay,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            send_response = self._call_tool(
+                "gobii_send_agent_message",
+                {
+                    "agent_id": str(agent.id),
+                    "body": "Please inspect the attached file.",
+                    "attachment_file_paths": ["/uploads/hello.txt"],
+                },
+            )
+
+        self.assertEqual(send_response.status_code, 200)
+        message_id = self._structured_content(send_response)["message"]["id"]
+        message = PersistentAgentMessage.objects.get(id=message_id)
+        attachment = message.attachments.get()
+        self.assertEqual(str(attachment.filespace_node_id), node_id)
+        process_delay.assert_called_once_with(str(agent.id))
+
+    def test_origin_validation_rejects_untrusted_browser_origins(self):
+        response = self._post_mcp(
+            "initialize",
+            extra_headers={"HTTP_ORIGIN": "https://untrusted.example"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], -32600)

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -8,10 +8,15 @@ from django.test import TestCase, tag
 from api.models import (
     AgentPeerLink,
     BrowserUseAgent,
+    CommsChannel,
     IntelligenceTier,
     PersistentAgent,
+    PersistentAgentCommsEndpoint,
+    PersistentAgentConversation,
     PersistentAgentMessage,
     UserQuota,
+    build_web_agent_address,
+    build_web_user_address,
 )
 from api.models import DEFAULT_INTELLIGENCE_TIER_KEY
 from api.models import ApiKey
@@ -497,6 +502,126 @@ class RemoteMCPViewTests(TestCase):
         )
         self.assertEqual(unsupported_filter_response.status_code, 200)
         self.assertTrue(unsupported_filter_response.json()["result"]["isError"])
+
+    def test_wait_after_cursor_is_strict_for_message_id_filter(self):
+        agent = self._create_agent(self.user, "Strict Cursor MCP Agent")
+
+        with (
+            patch("api.agent.tasks.process_agent_events_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            send_response = self._call_tool(
+                "gobii_send_agent_message",
+                {
+                    "agent_id": str(agent.id),
+                    "body": "This message owns the cursor.",
+                    "trigger_processing": False,
+                },
+            )
+        self.assertEqual(send_response.status_code, 200)
+        send_content = self._structured_content(send_response)
+
+        wait_response = self._call_tool(
+            "gobii_wait_for_agent_event",
+            {
+                "agent_id": str(agent.id),
+                "after_cursor": send_content["cursor"],
+                "timeout_seconds": 0,
+                "event_types": ["message"],
+                "filters": {"message_id": send_content["message_id"]},
+            },
+        )
+
+        self.assertEqual(wait_response.status_code, 200)
+        wait_content = self._structured_content(wait_response)
+        self.assertFalse(wait_content["matched"])
+        self.assertTrue(wait_content["timed_out"])
+        self.assertEqual(wait_content["events"], [])
+
+    def test_wait_matches_agent_owned_outbound_message_filters(self):
+        agent = self._create_agent(self.user, "Outbound Wait MCP Agent")
+
+        initial_response = self._call_tool("gobii_get_agent_timeline", {"agent_id": str(agent.id), "limit": 5})
+        self.assertEqual(initial_response.status_code, 200)
+        initial_cursor = self._structured_content(initial_response)["latest_cursor"]
+
+        agent_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
+            channel=CommsChannel.WEB,
+            address=build_web_agent_address(agent.id),
+            defaults={"owner_agent": agent},
+        )
+        if agent_endpoint.owner_agent_id != agent.id:
+            agent_endpoint.owner_agent = agent
+            agent_endpoint.save(update_fields=["owner_agent"])
+        user_address = build_web_user_address(self.user.id, agent.id)
+        user_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
+            channel=CommsChannel.WEB,
+            address=user_address,
+        )
+        conversation, _ = PersistentAgentConversation.objects.get_or_create(
+            channel=CommsChannel.WEB,
+            address=user_address,
+            defaults={"owner_agent": agent, "display_name": self.user.email},
+        )
+        if conversation.owner_agent_id != agent.id:
+            conversation.owner_agent = agent
+            conversation.save(update_fields=["owner_agent"])
+        message = PersistentAgentMessage.objects.create(
+            owner_agent=agent,
+            from_endpoint=agent_endpoint,
+            to_endpoint=user_endpoint,
+            conversation=conversation,
+            is_outbound=True,
+            body="Agent reply visible through timeline.",
+            raw_payload={"source": "unit_test"},
+        )
+
+        timeline_response = self._call_tool(
+            "gobii_get_agent_timeline",
+            {"agent_id": str(agent.id), "after_cursor": initial_cursor, "limit": 5},
+        )
+        self.assertEqual(timeline_response.status_code, 200)
+        timeline_content = self._structured_content(timeline_response)
+        self.assertEqual(timeline_content["events"][-1]["message"]["id"], str(message.id))
+
+        wait_response = self._call_tool(
+            "gobii_wait_for_agent_event",
+            {
+                "agent_id": str(agent.id),
+                "after_cursor": initial_cursor,
+                "timeout_seconds": 0,
+                "event_types": ["message"],
+                "filters": {
+                    "from_actor_type": "agent",
+                    "from_agent_id": str(agent.id),
+                    "message_id": str(message.id),
+                    "channel": "web",
+                },
+            },
+        )
+        self.assertEqual(wait_response.status_code, 200)
+        wait_content = self._structured_content(wait_response)
+        self.assertTrue(wait_content["matched"])
+        self.assertFalse(wait_content["timed_out"])
+        self.assertEqual(wait_content["events"][0]["message"]["id"], str(message.id))
+
+        outbound_to_agent_response = self._call_tool(
+            "gobii_wait_for_agent_event",
+            {
+                "agent_id": str(agent.id),
+                "after_cursor": initial_cursor,
+                "timeout_seconds": 0,
+                "event_types": ["message"],
+                "filters": {
+                    "to_agent_id": str(agent.id),
+                    "message_id": str(message.id),
+                },
+            },
+        )
+        self.assertEqual(outbound_to_agent_response.status_code, 200)
+        outbound_to_agent_content = self._structured_content(outbound_to_agent_response)
+        self.assertFalse(outbound_to_agent_content["matched"])
+        self.assertTrue(outbound_to_agent_content["timed_out"])
 
     def test_origin_validation_rejects_untrusted_browser_origins(self):
         response = self._post_mcp(

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -32,6 +32,15 @@ class RemoteMCPViewTests(TestCase):
                 "is_default": True,
             },
         )
+        self.premium_tier, _ = IntelligenceTier.objects.update_or_create(
+            key="premium",
+            defaults={
+                "display_name": "Premium",
+                "rank": 20,
+                "credit_multiplier": "2.00",
+                "is_default": False,
+            },
+        )
         self.user = User.objects.create_user(
             username="mcp-user@example.com",
             email="mcp-user@example.com",
@@ -102,7 +111,7 @@ class RemoteMCPViewTests(TestCase):
         response = self._post_mcp("initialize")
         self.assertEqual(response.status_code, 200)
         payload = response.json()
-        self.assertEqual(payload["result"]["protocolVersion"], "2025-06-18")
+        self.assertEqual(payload["result"]["protocolVersion"], "2025-11-25")
         self.assertIn("tools", payload["result"]["capabilities"])
 
         bearer_response = self._post_mcp("initialize", auth="bearer")
@@ -116,7 +125,9 @@ class RemoteMCPViewTests(TestCase):
         self.assertEqual(tools_response.status_code, 200)
         tool_names = {tool["name"] for tool in tools_response.json()["result"]["tools"]}
         self.assertIn("gobii_list_agents", tool_names)
+        self.assertIn("gobii_get_agent_config_options", tool_names)
         self.assertIn("gobii_send_agent_message", tool_names)
+        self.assertIn("gobii_wait_for_agent_event", tool_names)
         self.assertIn("gobii_upload_agent_file", tool_names)
 
         list_response = self._call_tool("gobii_list_agents")
@@ -149,14 +160,37 @@ class RemoteMCPViewTests(TestCase):
         self.assertEqual(create_response.status_code, 200)
         created_agent_id = self._structured_content(create_response)["agent"]["id"]
         created_agent = PersistentAgent.objects.get(id=created_agent_id)
+        self.assertIsNone(created_agent.schedule)
 
         update_response = self._call_tool(
             "gobii_update_agent",
-            {"agent_id": created_agent_id, "charter": "Updated through MCP."},
+            {
+                "agent_id": created_agent_id,
+                "charter": "Updated through MCP.",
+                "preferred_llm_tier": "premium",
+                "daily_credit_limit": 7,
+            },
         )
         self.assertEqual(update_response.status_code, 200)
         created_agent.refresh_from_db()
         self.assertEqual(created_agent.charter, "Updated through MCP.")
+        self.assertEqual(created_agent.preferred_llm_tier, self.premium_tier)
+        self.assertEqual(created_agent.daily_credit_limit, 7)
+
+        config_response = self._call_tool(
+            "gobii_get_agent_config_options",
+            {"agent_id": created_agent_id},
+        )
+        self.assertEqual(config_response.status_code, 200)
+        config_content = self._structured_content(config_response)
+        self.assertIn("preferred_llm_tier", config_content["fields"])
+        self.assertIn("daily_credit_limit", config_content["fields"])
+        tier_keys = {
+            option["key"]
+            for option in config_content["fields"]["preferred_llm_tier"]["options"]
+        }
+        self.assertIn("standard", tier_keys)
+        self.assertIn("premium", tier_keys)
 
         link_response = self._call_tool(
             "gobii_link_agents",
@@ -172,10 +206,87 @@ class RemoteMCPViewTests(TestCase):
         self.assertTrue(link_content["created"])
         self.assertTrue(AgentPeerLink.objects.filter(id=link_content["link"]["id"]).exists())
 
+        list_links_response = self._call_tool(
+            "gobii_list_agent_links",
+            {"agent_id": str(existing_agent.id)},
+        )
+        self.assertEqual(list_links_response.status_code, 200)
+        self.assertEqual(len(self._structured_content(list_links_response)["links"]), 1)
+
+        unlink_response = self._call_tool(
+            "gobii_unlink_agents",
+            {"peer_link_id": link_content["link"]["id"]},
+        )
+        self.assertEqual(unlink_response.status_code, 200)
+        self.assertFalse(AgentPeerLink.objects.filter(id=link_content["link"]["id"]).exists())
+
         archive_response = self._call_tool("gobii_archive_agent", {"agent_id": created_agent_id})
         self.assertEqual(archive_response.status_code, 200)
         created_agent.refresh_from_db()
         self.assertTrue(created_agent.is_deleted)
+
+    def test_create_agent_accepts_null_schedule_and_returns_structured_validation_errors(self):
+        with (
+            patch.object(BrowserUseAgent, "select_random_proxy", return_value=None),
+            patch("api.services.persistent_agents.maybe_schedule_short_description"),
+            patch("api.services.persistent_agents.maybe_schedule_mini_description"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_tags"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_avatar"),
+            patch("api.agent.tasks.process_agent_events_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            create_response = self._call_tool(
+                "gobii_create_agent",
+                {
+                    "name": "Remote MCP Null Schedule",
+                    "charter": "No schedule should be accepted.",
+                    "schedule": None,
+                },
+            )
+
+        self.assertEqual(create_response.status_code, 200)
+        created_agent_id = self._structured_content(create_response)["agent"]["id"]
+        created_agent = PersistentAgent.objects.get(id=created_agent_id)
+        self.assertIsNone(created_agent.schedule)
+
+        invalid_response = self._call_tool(
+            "gobii_create_agent",
+            {
+                "name": "Remote MCP Invalid Schedule",
+                "charter": "Invalid schedule should be a tool error.",
+                "schedule": "not a cron schedule",
+            },
+        )
+        self.assertEqual(invalid_response.status_code, 200)
+        invalid_content = self._structured_content(invalid_response)
+        self.assertTrue(invalid_response.json()["result"]["isError"])
+        self.assertEqual(invalid_content["status"], "error")
+        self.assertIn("details", invalid_content)
+        self.assertIn("schedule", invalid_content["details"])
+
+        list_response = self._call_tool("gobii_list_agents")
+        self.assertEqual(list_response.status_code, 200)
+        self.assertFalse(list_response.json()["result"]["isError"])
+
+    def test_unsupported_tool_arguments_are_structured_errors(self):
+        response = self._call_tool(
+            "gobii_create_agent",
+            {"name": "Unsupported Field", "runtime_session": "fake"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = self._structured_content(response)
+        self.assertTrue(response.json()["result"]["isError"])
+        self.assertIn("runtime_session", content["details"]["unsupported_fields"])
+
+        credit_response = self._call_tool(
+            "gobii_create_agent",
+            {"name": "Bad Credit Limit", "daily_credit_limit": 7.5},
+        )
+        self.assertEqual(credit_response.status_code, 200)
+        credit_content = self._structured_content(credit_response)
+        self.assertTrue(credit_response.json()["result"]["isError"])
+        self.assertEqual(credit_content["details"]["field"], "daily_credit_limit")
 
     def test_file_upload_and_message_attachment_path(self):
         agent = self._create_agent(self.user, "File MCP Agent")
@@ -214,11 +325,91 @@ class RemoteMCPViewTests(TestCase):
             )
 
         self.assertEqual(send_response.status_code, 200)
-        message_id = self._structured_content(send_response)["message"]["id"]
+        send_content = self._structured_content(send_response)
+        message_id = send_content["message_id"]
+        self.assertEqual(send_content["agent_id"], str(agent.id))
+        self.assertTrue(send_content["cursor"])
+        self.assertEqual(send_content["latest_cursor"], send_content["cursor"])
         message = PersistentAgentMessage.objects.get(id=message_id)
         attachment = message.attachments.get()
         self.assertEqual(str(attachment.filespace_node_id), node_id)
         process_delay.assert_called_once_with(str(agent.id))
+
+    def test_timeline_cursor_reads_and_wait_filters(self):
+        agent = self._create_agent(self.user, "Timeline MCP Agent")
+
+        initial_response = self._call_tool("gobii_get_agent_timeline", {"agent_id": str(agent.id), "limit": 5})
+        self.assertEqual(initial_response.status_code, 200)
+        initial_cursor = self._structured_content(initial_response)["latest_cursor"]
+
+        timeout_response = self._call_tool(
+            "gobii_wait_for_agent_event",
+            {
+                "agent_id": str(agent.id),
+                "after_cursor": initial_cursor,
+                "timeout_seconds": 0,
+                "event_types": ["message"],
+            },
+        )
+        self.assertEqual(timeout_response.status_code, 200)
+        timeout_content = self._structured_content(timeout_response)
+        self.assertFalse(timeout_content["matched"])
+        self.assertTrue(timeout_content["timed_out"])
+
+        with (
+            patch("api.agent.tasks.process_agent_events_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            send_response = self._call_tool(
+                "gobii_send_agent_message",
+                {
+                    "agent_id": str(agent.id),
+                    "body": "Cursor-visible message.",
+                    "trigger_processing": False,
+                },
+            )
+        self.assertEqual(send_response.status_code, 200)
+        send_content = self._structured_content(send_response)
+
+        newer_response = self._call_tool(
+            "gobii_get_agent_timeline",
+            {"agent_id": str(agent.id), "after_cursor": initial_cursor, "limit": 5},
+        )
+        self.assertEqual(newer_response.status_code, 200)
+        newer_content = self._structured_content(newer_response)
+        self.assertEqual(newer_content["events"][-1]["message"]["id"], send_content["message_id"])
+
+        wait_response = self._call_tool(
+            "gobii_wait_for_agent_event",
+            {
+                "agent_id": str(agent.id),
+                "after_cursor": initial_cursor,
+                "timeout_seconds": 0,
+                "event_types": ["message"],
+                "filters": {
+                    "from_actor_type": "human_user",
+                    "to_agent_id": str(agent.id),
+                    "message_id": send_content["message_id"],
+                },
+            },
+        )
+        self.assertEqual(wait_response.status_code, 200)
+        wait_content = self._structured_content(wait_response)
+        self.assertTrue(wait_content["matched"])
+        self.assertFalse(wait_content["timed_out"])
+        self.assertEqual(wait_content["events"][0]["message"]["id"], send_content["message_id"])
+
+        unsupported_filter_response = self._call_tool(
+            "gobii_wait_for_agent_event",
+            {
+                "agent_id": str(agent.id),
+                "after_cursor": initial_cursor,
+                "timeout_seconds": 0,
+                "filters": {"correlation_id": "unsupported"},
+            },
+        )
+        self.assertEqual(unsupported_filter_response.status_code, 200)
+        self.assertTrue(unsupported_filter_response.json()["result"]["isError"])
 
     def test_origin_validation_rejects_untrusted_browser_origins(self):
         response = self._post_mcp(
@@ -228,3 +419,12 @@ class RemoteMCPViewTests(TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()["error"]["code"], -32600)
+
+    def test_inaccessible_agent_returns_tool_error(self):
+        other_agent = self._create_agent(self.other_user, "Other User Agent")
+
+        response = self._call_tool("gobii_get_agent", {"agent_id": str(other_agent.id)})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["result"]["isError"])
+        self.assertEqual(self._structured_content(response)["status"], "error")


### PR DESCRIPTION
## Summary
- Adds authenticated remote MCP endpoint at `/api/v1/mcp/` using Streamable HTTP-style JSON-RPC over POST.
- Reuses existing Gobii API keys via `X-Api-Key` and MCP-friendly `Authorization: Bearer` headers.
- Exposes v1 Gobii MCP tools for agent lifecycle, peer links, messaging/timeline, filespace listing, file upload, and filespace attachment paths.
- Adds developer docs covering setup, auth, tool surface, file/attachment flow, limitations, and official MCP references.

## MCP protocol notes
- Implements MCP protocol version `2025-06-18` with `initialize`, `ping`, `tools/list`, and `tools/call`.
- Returns JSON responses for POST requests and `202 Accepted` for notifications/responses.
- Does not expose standalone GET SSE or session IDs in v1; GET returns `405`.
- Validates Origin headers and optional `Mcp-Method` / `Mcp-Name` routing headers.

## Validation
- `uv run --python 3.13 python -m py_compile api/auth.py api/mcp_views.py api/services/remote_mcp.py api/urls.py tests/unit/test_remote_mcp.py`
- `uv run --python 3.13 python manage.py test tests.unit.test_remote_mcp --settings=config.test_settings`
- `uv run --python 3.13 python manage.py test tests.unit.test_remote_mcp tests.unit.test_api.BrowserUseAgentViewSetTests.test_list_agents_authenticated_user tests.unit.test_api.BrowserUseAgentViewSetTests.test_list_agents_unauthenticated tests.unit.test_api.OrganizationApiKeyTests --settings=config.test_settings`
- `uv run --python 3.13 python manage.py check --settings=config.test_settings`
- `git diff --check -- api/auth.py api/urls.py api/mcp_views.py api/services/remote_mcp.py tests/unit/test_remote_mcp.py docs/content/developers/mcp-server.mdx docs/content/developers/developer-agents.mdx docs/sidebars.js`

## Notes
- Full suite intentionally not run per repo instruction; targeted tests only.
- Docs build was not run because docs node_modules are not installed locally.