### PR TITLE
Add remote MCP agent debug trace tool

### DIFF
--- a/api/openrouter.py
+++ b/api/openrouter.py
@@ -6,24 +6,25 @@ from django.conf import settings
 from observability import trace
 
 DEFAULT_API_BASE = "https://openrouter.ai/api/v1"
+DEFAULT_ATTRIBUTION_TITLE = "Gobii"
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer('gobii.utils')
 
 
 def get_attribution_headers() -> Dict[str, str]:
     """Build the attribution headers required by OpenRouter."""
-    referer = getattr(settings, "PUBLIC_SITE_URL", "") or ""
-    title = getattr(settings, "PUBLIC_BRAND_NAME", "") or ""
+    referer = settings.PUBLIC_SITE_URL or ""
+    title = settings.OPENROUTER_ATTRIBUTION_TITLE or DEFAULT_ATTRIBUTION_TITLE
 
     headers: Dict[str, str] = {}
     if referer:
         headers["HTTP-Referer"] = str(referer)
     if title:
-        headers["X-Title"] = str(title)
+        headers["X-Title"] = str(title).strip() or DEFAULT_ATTRIBUTION_TITLE
 
     logger.debug("OpenRouter attribution headers: %s", headers)
 
     return headers
 
 
-__all__ = ["DEFAULT_API_BASE", "get_attribution_headers"]
+__all__ = ["DEFAULT_API_BASE", "DEFAULT_ATTRIBUTION_TITLE", "get_attribution_headers"]

--- a/api/services/agent_debug_trace.py
+++ b/api/services/agent_debug_trace.py
@@ -1,0 +1,753 @@
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone as dt_timezone
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from django.db.models import Count
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from api.models import (
+    EvalRunTask,
+    PersistentAgent,
+    PersistentAgentCompletion,
+    PersistentAgentStep,
+)
+from console.agent_audit.events import Cursor, fetch_audit_events
+from console.agent_audit.serializers import serialize_prompt_meta
+from console.agent_chat.timeline import (
+    MAX_PAGE_SIZE as TIMELINE_MAX_PAGE_SIZE,
+    fetch_timeline_window,
+    serialize_processing_snapshot,
+)
+
+
+DEBUG_TRACE_TOOL_NAME = "gobii_get_agent_debug_trace"
+DEBUG_TRACE_DEFAULT_LIMIT = 20
+DEBUG_TRACE_MAX_LIMIT = 50
+DEBUG_TRACE_DEFAULT_RECENT_MINUTES = 60
+DEBUG_TRACE_MAX_RECENT_MINUTES = 7 * 24 * 60
+DEBUG_TRACE_DETAIL_LEVELS = ("summary", "standard", "verbose")
+DEBUG_TRACE_INCLUDE_SECTIONS = (
+    "timeline",
+    "audit_events",
+    "completions",
+    "eval_debug_artifacts",
+    "diagnostics",
+)
+DEBUG_TRACE_DEFAULT_INCLUDE = DEBUG_TRACE_INCLUDE_SECTIONS
+REDACTED = "[REDACTED]"
+
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b("
+    r"api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|bearer|"
+    r"authorization|password|passwd|secret|client[_-]?secret|private[_-]?key|"
+    r"cookie|set-cookie"
+    r")\b\s*[:=]\s*([^\s,;]+)"
+)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b")
+_OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b")
+_STRIPE_SECRET_RE = re.compile(r"\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{12,}\b")
+_GITHUB_TOKEN_RE = re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b")
+_SLACK_TOKEN_RE = re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")
+_AWS_ACCESS_KEY_RE = re.compile(r"\bA(?:KIA|SIA)[A-Z0-9]{16}\b")
+_HIGH_ENTROPY_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(token|secret|password|api[_-]?key)\b\s*[:=]\s*[A-Za-z0-9_./+=-]{12,}"
+)
+
+_SENSITIVE_EXACT_KEYS = {
+    "api_key",
+    "apikey",
+    "x_api_key",
+    "authorization",
+    "auth",
+    "auth_header",
+    "bearer",
+    "password",
+    "passwd",
+    "secret",
+    "client_secret",
+    "private_key",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "session_token",
+    "cookie",
+    "set_cookie",
+    "webhook_secret",
+    "token",
+    "key",
+    "credentials",
+    "credential",
+}
+
+
+class AgentDebugTraceValidationError(ValueError):
+    def __init__(self, message: str, data: dict[str, Any] | None = None):
+        super().__init__(message)
+        self.data = data
+
+
+@dataclass(frozen=True)
+class DebugTraceBounds:
+    since: datetime | None
+    until: datetime | None
+    recent_minutes: int | None
+
+
+def build_agent_debug_trace(
+    agent: PersistentAgent,
+    *,
+    limit: int = DEBUG_TRACE_DEFAULT_LIMIT,
+    cursor: str | None = None,
+    recent_minutes: int | None = None,
+    recent_minutes_provided: bool = False,
+    since: str | None = None,
+    until: str | None = None,
+    include: tuple[str, ...] = DEBUG_TRACE_DEFAULT_INCLUDE,
+    detail: str = "standard",
+    eval_run_id: UUID | None = None,
+) -> dict[str, Any]:
+    if detail not in DEBUG_TRACE_DETAIL_LEVELS:
+        raise AgentDebugTraceValidationError(
+            "detail must be one of summary, standard, or verbose.",
+            {"field": "detail", "supported_values": list(DEBUG_TRACE_DETAIL_LEVELS)},
+        )
+    if cursor and Cursor.decode(cursor) is None:
+        raise AgentDebugTraceValidationError(
+            "cursor must be a valid Gobii audit/debug cursor.",
+            {"field": "cursor"},
+        )
+    include = _normalize_include(include)
+    limit = max(1, min(int(limit), DEBUG_TRACE_MAX_LIMIT))
+    bounds = _resolve_bounds(
+        cursor=cursor,
+        recent_minutes=recent_minutes,
+        recent_minutes_provided=recent_minutes_provided,
+        since=since,
+        until=until,
+    )
+    requested_at = timezone.now()
+
+    warnings: list[str] = [
+        "Debug traces are sanitized previews. Prompt archive payloads and raw secret-bearing values are not returned."
+    ]
+    payload: dict[str, Any] = {
+        "agent": _serialize_agent_debug_ref(agent),
+        "scope": {
+            "agent_id": str(agent.id),
+            "requested_at": _iso(requested_at),
+            "since": _iso(bounds.since),
+            "until": _iso(bounds.until),
+            "recent_minutes": bounds.recent_minutes,
+            "cursor": cursor,
+            "limit": limit,
+            "include": list(include),
+            "detail": detail,
+            "eval_run_id": str(eval_run_id) if eval_run_id else None,
+        },
+        "redaction": {
+            "mode": "standard",
+            "replacement": REDACTED,
+            "notes": [
+                "Sensitive keys and common credential/token patterns are redacted recursively.",
+                "Long strings are truncated by detail level.",
+                "Prompt archives are represented by metadata and IDs only.",
+            ],
+        },
+        "warnings": warnings,
+    }
+
+    if "timeline" in include:
+        payload["timeline"] = _build_timeline_section(agent, limit=limit, cursor=cursor, bounds=bounds, detail=detail)
+    if "audit_events" in include:
+        audit_section = _build_audit_events_section(agent, limit=limit, cursor=cursor, bounds=bounds, detail=detail)
+        payload["audit_events"] = audit_section["events"]
+        payload["audit"] = {
+            "source": "console.agent_audit.events.fetch_audit_events",
+            "has_more": audit_section["has_more"],
+            "next_cursor": audit_section["next_cursor"],
+            "returned": len(audit_section["events"]),
+        }
+    if "completions" in include:
+        payload["completions"] = _build_completions_section(agent, limit=limit, bounds=bounds, detail=detail)
+    if "eval_debug_artifacts" in include:
+        payload["eval_debug_artifacts"] = _build_eval_debug_artifacts_section(
+            agent,
+            limit=min(limit, 10),
+            bounds=bounds,
+            detail=detail,
+            eval_run_id=eval_run_id,
+        )
+    if "diagnostics" in include:
+        payload["diagnostics"] = _build_diagnostics_section(payload)
+
+    return payload
+
+
+def _normalize_include(include: tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
+    if include in (None, ()):
+        return DEBUG_TRACE_DEFAULT_INCLUDE
+    if not isinstance(include, (tuple, list)):
+        raise AgentDebugTraceValidationError(
+            "include must be an array of debug sections.",
+            {"field": "include", "supported_values": list(DEBUG_TRACE_INCLUDE_SECTIONS)},
+        )
+    normalized: list[str] = []
+    unsupported: list[Any] = []
+    for item in include:
+        if not isinstance(item, str):
+            unsupported.append(item)
+            continue
+        section = item.strip()
+        if section not in DEBUG_TRACE_INCLUDE_SECTIONS:
+            unsupported.append(item)
+            continue
+        if section not in normalized:
+            normalized.append(section)
+    if unsupported:
+        raise AgentDebugTraceValidationError(
+            "include contains unsupported debug sections.",
+            {
+                "field": "include",
+                "unsupported_values": unsupported,
+                "supported_values": list(DEBUG_TRACE_INCLUDE_SECTIONS),
+            },
+        )
+    if not normalized:
+        raise AgentDebugTraceValidationError(
+            "include must request at least one debug section.",
+            {"field": "include", "supported_values": list(DEBUG_TRACE_INCLUDE_SECTIONS)},
+        )
+    return tuple(normalized)
+
+
+def _resolve_bounds(
+    *,
+    cursor: str | None,
+    recent_minutes: int | None,
+    recent_minutes_provided: bool,
+    since: str | None,
+    until: str | None,
+) -> DebugTraceBounds:
+    if since and recent_minutes_provided and recent_minutes is not None:
+        raise AgentDebugTraceValidationError(
+            "Use either since or recent_minutes, not both.",
+            {"fields": ["since", "recent_minutes"]},
+        )
+
+    until_dt = _parse_iso_datetime(until, "until") if until else timezone.now()
+    since_dt = _parse_iso_datetime(since, "since") if since else None
+    resolved_recent = recent_minutes
+    if resolved_recent is None and not recent_minutes_provided and not cursor and since_dt is None:
+        resolved_recent = DEBUG_TRACE_DEFAULT_RECENT_MINUTES
+    if resolved_recent is not None:
+        if resolved_recent < 1 or resolved_recent > DEBUG_TRACE_MAX_RECENT_MINUTES:
+            raise AgentDebugTraceValidationError(
+                f"recent_minutes must be between 1 and {DEBUG_TRACE_MAX_RECENT_MINUTES}.",
+                {"field": "recent_minutes", "maximum": DEBUG_TRACE_MAX_RECENT_MINUTES},
+            )
+        since_dt = until_dt - timedelta(minutes=resolved_recent)
+
+    if since_dt and until_dt and since_dt > until_dt:
+        raise AgentDebugTraceValidationError(
+            "since must be earlier than until.",
+            {"fields": ["since", "until"]},
+        )
+    if since_dt and until_dt and until_dt - since_dt > timedelta(minutes=DEBUG_TRACE_MAX_RECENT_MINUTES):
+        raise AgentDebugTraceValidationError(
+            "Debug trace time windows cannot exceed 7 days.",
+            {"fields": ["since", "until"], "maximum_minutes": DEBUG_TRACE_MAX_RECENT_MINUTES},
+        )
+    return DebugTraceBounds(since=since_dt, until=until_dt, recent_minutes=resolved_recent)
+
+
+def _parse_iso_datetime(raw: str, field: str):
+    if not isinstance(raw, str) or not raw.strip():
+        raise AgentDebugTraceValidationError(f"{field} must be an ISO8601 datetime string.", {"field": field})
+    parsed = parse_datetime(raw.strip())
+    if parsed is None:
+        raise AgentDebugTraceValidationError(f"{field} must be an ISO8601 datetime string.", {"field": field})
+    if timezone.is_naive(parsed):
+        parsed = timezone.make_aware(parsed, timezone.get_current_timezone())
+    return parsed
+
+
+def _serialize_agent_debug_ref(agent: PersistentAgent) -> dict[str, Any]:
+    return {
+        "id": str(agent.id),
+        "name": agent.name,
+        "is_active": agent.is_active,
+        "life_state": agent.life_state,
+        "planning_state": agent.planning_state,
+        "schedule": agent.schedule,
+        "organization_id": str(agent.organization_id) if agent.organization_id else None,
+        "user_id": str(agent.user_id) if agent.user_id else None,
+        "preferred_llm_tier": getattr(getattr(agent, "preferred_llm_tier", None), "key", None),
+        "created_at": _iso(agent.created_at),
+        "updated_at": _iso(agent.updated_at),
+        "last_interaction_at": _iso(agent.last_interaction_at),
+    }
+
+
+def _build_timeline_section(
+    agent: PersistentAgent,
+    *,
+    limit: int,
+    cursor: str | None,
+    bounds: DebugTraceBounds,
+    detail: str,
+) -> dict[str, Any]:
+    timeline_limit = min(limit, TIMELINE_MAX_PAGE_SIZE)
+    window = fetch_timeline_window(
+        agent,
+        cursor=None,
+        direction="initial",
+        limit=timeline_limit,
+    )
+    events = [
+        _sanitize_debug_value(event, detail=detail)
+        for event in window.events
+        if _event_in_bounds(event, bounds)
+    ]
+    return {
+        "events": events,
+        "latest_cursor": window.newest_cursor,
+        "oldest_cursor": window.oldest_cursor,
+        "newest_cursor": window.newest_cursor,
+        "has_more_older": window.has_more_older,
+        "has_more_newer": window.has_more_newer,
+        "processing_active": window.processing_active,
+        "processing_snapshot": _sanitize_debug_value(
+            serialize_processing_snapshot(window.processing_snapshot),
+            detail=detail,
+        ),
+        "cursor_note": "Timeline events are always the latest bounded window; use gobii_get_agent_timeline for full timeline paging.",
+    }
+
+
+def _build_audit_events_section(
+    agent: PersistentAgent,
+    *,
+    limit: int,
+    cursor: str | None,
+    bounds: DebugTraceBounds,
+    detail: str,
+) -> dict[str, Any]:
+    events, has_more, next_cursor = fetch_audit_events(
+        agent,
+        cursor=cursor,
+        limit=limit,
+        at=bounds.until,
+    )
+    bounded_events = [
+        _sanitize_audit_event(event, detail=detail)
+        for event in events
+        if _event_in_bounds(event, bounds)
+    ]
+    return {"events": bounded_events[:limit], "has_more": has_more, "next_cursor": next_cursor}
+
+
+def _build_completions_section(
+    agent: PersistentAgent,
+    *,
+    limit: int,
+    bounds: DebugTraceBounds,
+    detail: str,
+) -> dict[str, Any]:
+    queryset = PersistentAgentCompletion.objects.filter(agent=agent).order_by("-created_at", "-id")
+    queryset = _apply_created_bounds(queryset, "created_at", bounds)
+    completions = list(queryset[:limit])
+    completion_ids = [completion.id for completion in completions]
+
+    prompt_archives_by_completion_id: dict[Any, Any] = {}
+    tool_counts_by_completion_id: dict[Any, int] = {}
+    if completion_ids:
+        steps_with_archives = (
+            PersistentAgentStep.objects.filter(
+                agent=agent,
+                completion_id__in=completion_ids,
+                llm_prompt_archive__isnull=False,
+            )
+            .select_related("llm_prompt_archive")
+            .order_by("completion_id", "-created_at", "-id")
+        )
+        for step in steps_with_archives:
+            prompt_archives_by_completion_id.setdefault(step.completion_id, step.llm_prompt_archive)
+
+        tool_counts = (
+            PersistentAgentStep.objects.filter(
+                agent=agent,
+                completion_id__in=completion_ids,
+                tool_call__isnull=False,
+            )
+            .values("completion_id")
+            .annotate(count=Count("id"))
+        )
+        tool_counts_by_completion_id = {
+            item["completion_id"]: item["count"]
+            for item in tool_counts
+        }
+
+    items = [
+        _serialize_completion_debug(
+            completion,
+            prompt_archive=prompt_archives_by_completion_id.get(completion.id),
+            tool_call_count=tool_counts_by_completion_id.get(completion.id, 0),
+            detail=detail,
+        )
+        for completion in completions
+    ]
+    totals = _completion_totals(items)
+    return {
+        "items": items,
+        "returned": len(items),
+        "totals_for_returned": totals,
+    }
+
+
+def _serialize_completion_debug(
+    completion: PersistentAgentCompletion,
+    *,
+    prompt_archive,
+    tool_call_count: int,
+    detail: str,
+) -> dict[str, Any]:
+    return {
+        "id": str(completion.id),
+        "timestamp": _iso(completion.created_at),
+        "completion_type": completion.completion_type,
+        "response_id": sanitize_text(completion.response_id or "", detail=detail) or None,
+        "llm_model": completion.llm_model,
+        "llm_provider": completion.llm_provider,
+        "llm_tool_names": _sanitize_debug_value(completion.llm_tool_names or [], detail=detail),
+        "request_duration_ms": completion.request_duration_ms,
+        "usage": {
+            "prompt_tokens": completion.prompt_tokens,
+            "completion_tokens": completion.completion_tokens,
+            "total_tokens": completion.total_tokens,
+            "cached_tokens": completion.cached_tokens,
+        },
+        "cost": {
+            "input_cost_total": _decimal_to_string(completion.input_cost_total),
+            "input_cost_uncached": _decimal_to_string(completion.input_cost_uncached),
+            "input_cost_cached": _decimal_to_string(completion.input_cost_cached),
+            "output_cost": _decimal_to_string(completion.output_cost),
+            "total_cost": _decimal_to_string(completion.total_cost),
+            "credits_cost": _decimal_to_string(completion.credits_cost),
+        },
+        "billing": {
+            "plan": completion.billing_plan,
+            "is_trial": completion.billing_is_trial,
+            "billed": completion.billed,
+            "billed_at": _iso(completion.billed_at),
+        },
+        "thinking_preview": sanitize_text(completion.thinking_content or "", detail=detail) or None,
+        "prompt_archive": serialize_prompt_meta(prompt_archive) if prompt_archive else None,
+        "tool_call_count": tool_call_count,
+    }
+
+
+def _completion_totals(items: list[dict[str, Any]]) -> dict[str, Any]:
+    totals: dict[str, Any] = {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cached_tokens": 0,
+        "total_cost": Decimal("0"),
+        "credits_cost": Decimal("0"),
+    }
+    for item in items:
+        usage = item.get("usage") or {}
+        for key in ("prompt_tokens", "completion_tokens", "total_tokens", "cached_tokens"):
+            value = usage.get(key)
+            if isinstance(value, int):
+                totals[key] += value
+        cost = item.get("cost") or {}
+        for key in ("total_cost", "credits_cost"):
+            value = cost.get(key)
+            if value not in (None, ""):
+                totals[key] += Decimal(str(value))
+    totals["total_cost"] = _decimal_to_string(totals["total_cost"])
+    totals["credits_cost"] = _decimal_to_string(totals["credits_cost"])
+    return totals
+
+
+def _build_eval_debug_artifacts_section(
+    agent: PersistentAgent,
+    *,
+    limit: int,
+    bounds: DebugTraceBounds,
+    detail: str,
+    eval_run_id: UUID | None,
+) -> dict[str, Any]:
+    queryset = (
+        EvalRunTask.objects.filter(run__agent=agent)
+        .select_related("run")
+        .order_by("-updated_at", "sequence")
+    )
+    queryset = _apply_created_bounds(queryset, "updated_at", bounds)
+    if eval_run_id is not None:
+        queryset = queryset.filter(run_id=eval_run_id)
+    tasks = list(queryset[:limit])
+    return {
+        "items": [_serialize_eval_task_debug(task, detail=detail) for task in tasks],
+        "returned": len(tasks),
+    }
+
+
+def _serialize_eval_task_debug(task: EvalRunTask, *, detail: str) -> dict[str, Any]:
+    run = task.run
+    return {
+        "id": task.id,
+        "run_id": str(task.run_id),
+        "scenario_slug": run.scenario_slug,
+        "scenario_version": run.scenario_version,
+        "status": task.status,
+        "sequence": task.sequence,
+        "name": task.name,
+        "assertion_type": task.assertion_type,
+        "expected_summary": sanitize_text(task.expected_summary or "", detail=detail),
+        "observed_summary": sanitize_text(task.observed_summary or "", detail=detail),
+        "artifact_links": {
+            "message_id": str(task.first_message_id) if task.first_message_id else None,
+            "step_id": str(task.first_step_id) if task.first_step_id else None,
+            "browser_task_id": str(task.first_browser_task_id) if task.first_browser_task_id else None,
+        },
+        "debug_artifacts": _sanitize_debug_value(task.debug_artifacts or {}, detail=detail),
+        "llm_question": sanitize_text(task.llm_question or "", detail=detail),
+        "llm_answer": sanitize_text(task.llm_answer or "", detail=detail),
+        "llm_model": task.llm_model,
+        "started_at": _iso(task.started_at),
+        "finished_at": _iso(task.finished_at),
+        "usage": {
+            "prompt_tokens": task.prompt_tokens,
+            "completion_tokens": task.completion_tokens,
+            "total_tokens": task.total_tokens,
+            "cached_tokens": task.cached_tokens,
+        },
+        "cost": {
+            "input_cost_total": _decimal_to_string(task.input_cost_total),
+            "input_cost_uncached": _decimal_to_string(task.input_cost_uncached),
+            "input_cost_cached": _decimal_to_string(task.input_cost_cached),
+            "output_cost": _decimal_to_string(task.output_cost),
+            "total_cost": _decimal_to_string(task.total_cost),
+            "credits_cost": _decimal_to_string(task.credits_cost),
+        },
+    }
+
+
+def _build_diagnostics_section(payload: dict[str, Any]) -> dict[str, Any]:
+    audit_events = payload.get("audit_events") or []
+    recent_errors = [event for event in audit_events if event.get("kind") == "error"]
+    timeline = payload.get("timeline") or {}
+    return {
+        "processing_active": bool(timeline.get("processing_active")),
+        "recent_error_count": len(recent_errors),
+        "recent_error_samples": recent_errors[:5],
+        "audit_events_returned": len(audit_events),
+        "timeline_events_returned": len(timeline.get("events") or []),
+    }
+
+
+def _sanitize_audit_event(event: dict[str, Any], *, detail: str) -> dict[str, Any]:
+    kind = event.get("kind")
+    if kind == "completion":
+        return {
+            "kind": "completion",
+            "id": event.get("id"),
+            "timestamp": event.get("timestamp"),
+            "completion_type": event.get("completion_type"),
+            "response_id": sanitize_text(event.get("response_id") or "", detail=detail) or None,
+            "prompt_tokens": event.get("prompt_tokens"),
+            "completion_tokens": event.get("completion_tokens"),
+            "total_tokens": event.get("total_tokens"),
+            "cached_tokens": event.get("cached_tokens"),
+            "llm_model": event.get("llm_model"),
+            "llm_provider": event.get("llm_provider"),
+            "llm_tool_names": _sanitize_debug_value(event.get("llm_tool_names") or [], detail=detail),
+            "thinking_preview": sanitize_text(event.get("thinking") or "", detail=detail) or None,
+            "prompt_archive": _sanitize_debug_value(event.get("prompt_archive"), detail=detail),
+            "tool_calls": [
+                _sanitize_audit_event(tool_call, detail=detail)
+                for tool_call in event.get("tool_calls") or []
+                if isinstance(tool_call, dict)
+            ],
+        }
+    if kind == "tool_call":
+        return {
+            "kind": "tool_call",
+            "id": event.get("id"),
+            "timestamp": event.get("timestamp"),
+            "completion_id": event.get("completion_id"),
+            "tool_name": event.get("tool_name"),
+            "parameters": _sanitize_debug_value(event.get("parameters"), detail=detail),
+            "result_summary": _sanitize_debug_value(event.get("result"), detail=detail),
+            "execution_duration_ms": event.get("execution_duration_ms"),
+            "prompt_archive": _sanitize_debug_value(event.get("prompt_archive"), detail=detail),
+        }
+    if kind == "message":
+        return {
+            "kind": "message",
+            "id": event.get("id"),
+            "timestamp": event.get("timestamp"),
+            "is_outbound": event.get("is_outbound"),
+            "channel": event.get("channel"),
+            "body_text": sanitize_text(event.get("body_text") or "", detail=detail),
+            "body_html": sanitize_text(event.get("body_html") or "", detail=detail) if detail == "verbose" else None,
+            "attachments": _sanitize_debug_value(event.get("attachments") or [], detail=detail),
+            "peer_agent": _sanitize_debug_value(event.get("peer_agent"), detail=detail),
+            "peer_link_id": event.get("peer_link_id"),
+            "self_agent_name": event.get("self_agent_name"),
+        }
+    if kind == "step":
+        return {
+            "kind": "step",
+            "id": event.get("id"),
+            "timestamp": event.get("timestamp"),
+            "description": sanitize_text(event.get("description") or "", detail=detail),
+            "completion_id": event.get("completion_id"),
+            "is_system": event.get("is_system"),
+            "system_code": event.get("system_code"),
+            "system_notes": sanitize_text(event.get("system_notes") or "", detail=detail),
+        }
+    if kind == "system_message":
+        return {
+            "kind": "system_message",
+            "id": event.get("id"),
+            "timestamp": event.get("timestamp"),
+            "delivered_at": event.get("delivered_at"),
+            "body": sanitize_text(event.get("body") or "", detail=detail),
+            "is_active": event.get("is_active"),
+            "broadcast_id": event.get("broadcast_id"),
+            "created_by": _sanitize_debug_value(event.get("created_by"), detail=detail),
+        }
+    if kind == "error":
+        return {
+            "kind": "error",
+            "id": event.get("id"),
+            "timestamp": event.get("timestamp"),
+            "category": event.get("category"),
+            "source": event.get("source"),
+            "level": event.get("level"),
+            "message": sanitize_text(event.get("message") or "", detail=detail),
+            "exception_class": event.get("exception_class"),
+            "traceback_preview": sanitize_text(event.get("traceback") or "", detail=detail),
+            "context": _sanitize_debug_value(event.get("context") or {}, detail=detail),
+            "completion_id": event.get("completion_id"),
+        }
+    return _sanitize_debug_value(event, detail=detail)
+
+
+def _sanitize_debug_value(value: Any, *, detail: str, depth: int = 0) -> Any:
+    if depth > 5:
+        return sanitize_text(value, detail="summary")
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, Decimal):
+        return _decimal_to_string(value)
+    if isinstance(value, str):
+        return sanitize_text(value, detail=detail)
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if _is_sensitive_key(key_text):
+                sanitized[key_text] = REDACTED
+            else:
+                sanitized[key_text] = _sanitize_debug_value(item, detail=detail, depth=depth + 1)
+        return sanitized
+    if isinstance(value, (list, tuple, set)):
+        values = list(value)
+        item_limit = 10 if detail == "summary" else 25 if detail == "standard" else 50
+        sanitized_items = [
+            _sanitize_debug_value(item, detail=detail, depth=depth + 1)
+            for item in values[:item_limit]
+        ]
+        if len(values) > item_limit:
+            sanitized_items.append({"truncated": len(values) - item_limit})
+        return sanitized_items
+    if hasattr(value, "pk") and hasattr(value, "_meta"):
+        return {
+            "type": value._meta.label_lower,
+            "id": str(value.pk),
+        }
+    return sanitize_text(value, detail=detail)
+
+
+def sanitize_text(value: Any, *, detail: str) -> str:
+    text = str(value or "")
+    if not text:
+        return ""
+    for pattern in (
+        _BEARER_RE,
+        _JWT_RE,
+        _OPENAI_KEY_RE,
+        _STRIPE_SECRET_RE,
+        _GITHUB_TOKEN_RE,
+        _SLACK_TOKEN_RE,
+        _AWS_ACCESS_KEY_RE,
+    ):
+        text = pattern.sub(REDACTED, text)
+    text = _SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}={REDACTED}", text)
+    text = _HIGH_ENTROPY_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}={REDACTED}", text)
+    limit = _string_limit(detail)
+    if len(text) > limit:
+        return text[: limit - 15] + "...[truncated]"
+    return text
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "_", key.lower()).strip("_")
+    if normalized in _SENSITIVE_EXACT_KEYS:
+        return True
+    return normalized.endswith(("_api_key", "_access_token", "_refresh_token", "_secret", "_password", "_private_key"))
+
+
+def _string_limit(detail: str) -> int:
+    if detail == "summary":
+        return 400
+    if detail == "verbose":
+        return 4000
+    return 1200
+
+
+def _apply_created_bounds(queryset, field_name: str, bounds: DebugTraceBounds):
+    if bounds.since is not None:
+        queryset = queryset.filter(**{f"{field_name}__gte": bounds.since})
+    if bounds.until is not None:
+        queryset = queryset.filter(**{f"{field_name}__lte": bounds.until})
+    return queryset
+
+
+def _event_in_bounds(event: dict[str, Any], bounds: DebugTraceBounds) -> bool:
+    timestamp = event.get("timestamp")
+    if not timestamp:
+        return True
+    parsed = parse_datetime(str(timestamp))
+    if parsed is None:
+        return True
+    if timezone.is_naive(parsed):
+        parsed = timezone.make_aware(parsed, timezone.get_current_timezone())
+    if bounds.since is not None and parsed < bounds.since:
+        return False
+    if bounds.until is not None and parsed > bounds.until:
+        return False
+    return True
+
+
+def _iso(dt) -> str | None:
+    if dt is None:
+        return None
+    if timezone.is_naive(dt):
+        dt = timezone.make_aware(dt, timezone.get_current_timezone())
+    return dt.astimezone(dt_timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _decimal_to_string(value: Decimal | int | str | None) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/api/services/remote_mcp.py
+++ b/api/services/remote_mcp.py
@@ -40,6 +40,18 @@ from api.models import (
 )
 from api.serializers import PersistentAgentSerializer
 from api.services.agent_settings_resume import queue_settings_change_resume
+from api.services.agent_debug_trace import (
+    DEBUG_TRACE_DEFAULT_INCLUDE,
+    DEBUG_TRACE_DEFAULT_LIMIT,
+    DEBUG_TRACE_DEFAULT_RECENT_MINUTES,
+    DEBUG_TRACE_DETAIL_LEVELS,
+    DEBUG_TRACE_INCLUDE_SECTIONS,
+    DEBUG_TRACE_MAX_LIMIT,
+    DEBUG_TRACE_MAX_RECENT_MINUTES,
+    DEBUG_TRACE_TOOL_NAME,
+    AgentDebugTraceValidationError,
+    build_agent_debug_trace,
+)
 from api.services.daily_credit_limits import calculate_daily_credit_slider_bounds, get_tier_credit_multiplier
 from api.services.daily_credit_settings import get_daily_credit_settings_for_owner
 from console.agent_chat.timeline import (
@@ -199,6 +211,70 @@ _FILE_NODE_OUTPUT = _object_output(
         "updated_at": _STRING_OR_NULL,
     },
     required=("id", "name", "path", "node_type"),
+)
+
+_DEBUG_TRACE_EVENT_OUTPUT = _object_output(
+    {
+        "kind": {"type": "string"},
+        "id": _STRING_OR_NULL,
+        "timestamp": _STRING_OR_NULL,
+    },
+    required=("kind",),
+)
+
+_DEBUG_TRACE_OUTPUT = _object_output(
+    {
+        "agent": _AGENT_REF_OUTPUT,
+        "scope": _object_output(
+            {
+                "agent_id": _UUID_OUTPUT,
+                "requested_at": _STRING_OR_NULL,
+                "since": _STRING_OR_NULL,
+                "until": _STRING_OR_NULL,
+                "recent_minutes": _INTEGER_OR_NULL,
+                "cursor": _STRING_OR_NULL,
+                "limit": {"type": "integer"},
+                "include": _array_output({"type": "string"}),
+                "detail": {"type": "string"},
+                "eval_run_id": _STRING_OR_NULL,
+            },
+            required=("agent_id", "limit", "include", "detail"),
+        ),
+        "timeline": _object_output(
+            {
+                "events": _array_output(_TIMELINE_EVENT_OUTPUT),
+                "latest_cursor": _STRING_OR_NULL,
+                "oldest_cursor": _STRING_OR_NULL,
+                "newest_cursor": _STRING_OR_NULL,
+                "has_more_older": {"type": "boolean"},
+                "has_more_newer": {"type": "boolean"},
+                "processing_active": {"type": "boolean"},
+                "processing_snapshot": _object_output({}),
+            }
+        ),
+        "audit_events": _array_output(_DEBUG_TRACE_EVENT_OUTPUT),
+        "audit": _object_output(
+            {
+                "source": {"type": "string"},
+                "has_more": {"type": "boolean"},
+                "next_cursor": _STRING_OR_NULL,
+                "returned": {"type": "integer"},
+            }
+        ),
+        "completions": _object_output({}),
+        "eval_debug_artifacts": _object_output({}),
+        "diagnostics": _object_output({}),
+        "redaction": _object_output(
+            {
+                "mode": {"type": "string"},
+                "replacement": {"type": "string"},
+                "notes": _array_output({"type": "string"}),
+            },
+            required=("mode", "replacement"),
+        ),
+        "warnings": _array_output({"type": "string"}),
+    },
+    required=("agent", "scope", "redaction", "warnings"),
 )
 
 
@@ -532,6 +608,71 @@ TOOL_DEFINITIONS = [
         "annotations": {"readOnlyHint": True},
     },
     {
+        "name": DEBUG_TRACE_TOOL_NAME,
+        "title": "Get Agent Debug Trace",
+        "description": (
+            "Fetch bounded, sanitized debugging information for one accessible Gobii agent, including "
+            "recent timeline/audit events, tool calls, completions, prompt archive metadata, usage/cost, "
+            "eval artifacts, and diagnostics. Raw prompt archives and secret-like values are not returned."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": _agent_schema("Persistent agent UUID."),
+                "cursor": {
+                    "type": ["string", "null"],
+                    "description": "Optional audit/debug cursor returned as audit.next_cursor for older debug events.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": DEBUG_TRACE_MAX_LIMIT,
+                    "default": DEBUG_TRACE_DEFAULT_LIMIT,
+                    "description": "Maximum items per bounded debug section.",
+                },
+                "recent_minutes": {
+                    "type": ["integer", "null"],
+                    "minimum": 1,
+                    "maximum": DEBUG_TRACE_MAX_RECENT_MINUTES,
+                    "default": DEBUG_TRACE_DEFAULT_RECENT_MINUTES,
+                    "description": (
+                        "Recent time window when no cursor or explicit since is supplied. Null disables "
+                        "the time window and relies on limit/cursor bounds."
+                    ),
+                },
+                "since": {
+                    "type": ["string", "null"],
+                    "description": "Optional ISO8601 lower time bound. Cannot be combined with recent_minutes.",
+                },
+                "until": {
+                    "type": ["string", "null"],
+                    "description": "Optional ISO8601 upper time bound. Defaults to request time.",
+                },
+                "include": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": list(DEBUG_TRACE_INCLUDE_SECTIONS)},
+                    "default": list(DEBUG_TRACE_DEFAULT_INCLUDE),
+                    "description": "Optional debug sections to include.",
+                },
+                "detail": {
+                    "type": "string",
+                    "enum": list(DEBUG_TRACE_DETAIL_LEVELS),
+                    "default": "standard",
+                    "description": "Controls sanitized preview length; verbose still redacts secrets and omits raw prompts.",
+                },
+                "eval_run_id": {
+                    "type": ["string", "null"],
+                    "format": "uuid",
+                    "description": "Optional eval run UUID to filter eval debug artifacts for this agent.",
+                },
+            },
+            "required": ["agent_id"],
+            "additionalProperties": False,
+        },
+        "outputSchema": _DEBUG_TRACE_OUTPUT,
+        "annotations": {"readOnlyHint": True},
+    },
+    {
         "name": "gobii_wait_for_agent_event",
         "title": "Wait For Agent Timeline Event",
         "description": "Bounded long-poll over an agent's unified timeline using durable cursors and supported structured filters.",
@@ -707,6 +848,7 @@ def call_tool(request, name, arguments):
         "gobii_unlink_agents": _tool_unlink_agents,
         "gobii_send_agent_message": _tool_send_agent_message,
         "gobii_get_agent_timeline": _tool_get_agent_timeline,
+        DEBUG_TRACE_TOOL_NAME: _tool_get_agent_debug_trace,
         "gobii_wait_for_agent_event": _tool_wait_for_agent_event,
         "gobii_list_agent_files": _tool_list_agent_files,
         "gobii_upload_agent_file": _tool_upload_agent_file,
@@ -997,6 +1139,54 @@ def _tool_get_agent_timeline(request, arguments):
         "processing_active": window.processing_active,
         "processing_snapshot": serialize_processing_snapshot(window.processing_snapshot),
     }
+
+
+def _tool_get_agent_debug_trace(request, arguments):
+    agent = _get_agent(request, arguments.get("agent_id"))
+    limit = _bounded_int(
+        arguments.get("limit", DEBUG_TRACE_DEFAULT_LIMIT),
+        "limit",
+        minimum=1,
+        maximum=DEBUG_TRACE_MAX_LIMIT,
+    )
+    cursor = _optional_string(arguments, "cursor")
+    detail = arguments.get("detail", "standard")
+    if not isinstance(detail, str) or detail not in DEBUG_TRACE_DETAIL_LEVELS:
+        raise MCPToolError(
+            "detail must be one of summary, standard, or verbose.",
+            {"field": "detail", "supported_values": list(DEBUG_TRACE_DETAIL_LEVELS)},
+        )
+    include = arguments.get("include", list(DEBUG_TRACE_DEFAULT_INCLUDE))
+    recent_minutes = None
+    recent_minutes_provided = "recent_minutes" in arguments
+    if recent_minutes_provided and arguments.get("recent_minutes") is not None:
+        recent_minutes = _bounded_int(
+            arguments.get("recent_minutes"),
+            "recent_minutes",
+            minimum=1,
+            maximum=DEBUG_TRACE_MAX_RECENT_MINUTES,
+        )
+    since = _optional_string(arguments, "since")
+    until = _optional_string(arguments, "until")
+    eval_run_id = None
+    if arguments.get("eval_run_id"):
+        eval_run_id = _parse_uuid(arguments.get("eval_run_id"), "eval_run_id")
+
+    try:
+        return build_agent_debug_trace(
+            agent,
+            limit=limit,
+            cursor=cursor,
+            recent_minutes=recent_minutes,
+            recent_minutes_provided=recent_minutes_provided,
+            since=since,
+            until=until,
+            include=include,
+            detail=detail,
+            eval_run_id=eval_run_id,
+        )
+    except AgentDebugTraceValidationError as exc:
+        raise MCPToolError(str(exc), exc.data) from exc
 
 
 def _tool_wait_for_agent_event(request, arguments):
@@ -1539,6 +1729,17 @@ def _required_string(arguments, key, *, allow_blank):
     if not allow_blank and not value.strip():
         raise MCPToolError(f"{key} cannot be blank.")
     return value.strip() if not allow_blank else value
+
+
+def _optional_string(arguments, key, *, allow_blank=False):
+    value = arguments.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise MCPToolError(f"{key} must be a string.")
+    if not allow_blank and not value.strip():
+        raise MCPToolError(f"{key} cannot be blank.")
+    return value if allow_blank else value.strip()
 
 
 def _optional_bool(value, key):

--- a/api/services/remote_mcp.py
+++ b/api/services/remote_mcp.py
@@ -5,8 +5,11 @@ import datetime
 import json
 import time
 import uuid
+from dataclasses import dataclass
 from decimal import Decimal
+from types import SimpleNamespace
 
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import IntegrityError, transaction
@@ -35,6 +38,8 @@ from api.models import (
     AgentPeerLink,
     ApiKey,
     CommsChannel,
+    Organization,
+    OrganizationMembership,
     PersistentAgent,
     build_web_user_address,
 )
@@ -122,6 +127,23 @@ _NUMBER_OR_STRING = {"type": ["number", "string"]}
 _NUMBER_STRING_OR_NULL = {"type": ["integer", "number", "string", "null"]}
 _ID_OR_NULL = {"type": ["integer", "string", "null"]}
 _UUID_OUTPUT = {"type": "string", "format": "uuid"}
+_SCOPE_PARAM_PROPERTIES = {
+    "user_id": {
+        "type": ["integer", "string", "null"],
+        "description": (
+            "Optional target Django user id. Staff/superuser API keys only; "
+            "ordinary API keys receive a structured tool error when this is supplied."
+        ),
+    },
+    "organization_id": {
+        "type": ["string", "null"],
+        "format": "uuid",
+        "description": (
+            "Optional target organization UUID. Staff/superuser API keys only; "
+            "ordinary API keys receive a structured tool error when this is supplied."
+        ),
+    },
+}
 
 _AGENT_REF_OUTPUT = _object_output(
     {
@@ -213,6 +235,19 @@ _FILE_NODE_OUTPUT = _object_output(
     required=("id", "name", "path", "node_type"),
 )
 
+_ACCESS_METADATA_OUTPUT = _object_output(
+    {
+        "admin_access": {"type": "boolean"},
+        "access_scope": {"type": "string"},
+        "operator_user_id": _ID_OR_NULL,
+        "target_user_id": _ID_OR_NULL,
+        "target_organization_id": _STRING_OR_NULL,
+        "requested_user_id": _ID_OR_NULL,
+        "requested_organization_id": _STRING_OR_NULL,
+    },
+    required=("admin_access", "access_scope"),
+)
+
 _DEBUG_TRACE_EVENT_OUTPUT = _object_output(
     {
         "kind": {"type": "string"},
@@ -273,6 +308,7 @@ _DEBUG_TRACE_OUTPUT = _object_output(
             required=("mode", "replacement"),
         ),
         "warnings": _array_output({"type": "string"}),
+        "access": _ACCESS_METADATA_OUTPUT,
     },
     required=("agent", "scope", "redaction", "warnings"),
 )
@@ -288,6 +324,7 @@ TOOL_DEFINITIONS = [
             "properties": {
                 "page": {"type": "integer", "minimum": 1, "default": 1},
                 "page_size": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "additionalProperties": False,
         },
@@ -298,6 +335,7 @@ TOOL_DEFINITIONS = [
                 "page_size": {"type": "integer"},
                 "total": {"type": "integer"},
                 "has_next": {"type": "boolean"},
+                "access": _ACCESS_METADATA_OUTPUT,
             },
             required=("agents", "page", "page_size", "total", "has_next"),
         ),
@@ -309,11 +347,14 @@ TOOL_DEFINITIONS = [
         "description": "Retrieve details for one persistent Gobii agent.",
         "inputSchema": {
             "type": "object",
-            "properties": {"agent_id": _agent_schema("Persistent agent UUID.")},
+            "properties": {"agent_id": _agent_schema("Persistent agent UUID."), **_SCOPE_PARAM_PROPERTIES},
             "required": ["agent_id"],
             "additionalProperties": False,
         },
-        "outputSchema": _object_output({"agent": _AGENT_OUTPUT}, required=("agent",)),
+        "outputSchema": _object_output(
+            {"agent": _AGENT_OUTPUT, "access": _ACCESS_METADATA_OUTPUT},
+            required=("agent",),
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -341,10 +382,14 @@ TOOL_DEFINITIONS = [
                     "enum": ["default", "manual"],
                     "description": "Contact allowlist policy.",
                 },
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "additionalProperties": False,
         },
-        "outputSchema": _object_output({"agent": _AGENT_OUTPUT}, required=("agent",)),
+        "outputSchema": _object_output(
+            {"agent": _AGENT_OUTPUT, "access": _ACCESS_METADATA_OUTPUT},
+            required=("agent",),
+        ),
         "annotations": {"destructiveHint": False},
     },
     {
@@ -370,11 +415,15 @@ TOOL_DEFINITIONS = [
                 },
                 "whitelist_policy": {"type": "string", "enum": ["default", "manual"]},
                 "proactive_opt_in": {"type": "boolean"},
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "required": ["agent_id"],
             "additionalProperties": False,
         },
-        "outputSchema": _object_output({"agent": _AGENT_OUTPUT}, required=("agent",)),
+        "outputSchema": _object_output(
+            {"agent": _AGENT_OUTPUT, "access": _ACCESS_METADATA_OUTPUT},
+            required=("agent",),
+        ),
     },
     {
         "name": "gobii_archive_agent",
@@ -382,7 +431,7 @@ TOOL_DEFINITIONS = [
         "description": "Soft-delete a persistent Gobii agent using Gobii's normal archive/delete behavior.",
         "inputSchema": {
             "type": "object",
-            "properties": {"agent_id": _agent_schema("Persistent agent UUID.")},
+            "properties": {"agent_id": _agent_schema("Persistent agent UUID."), **_SCOPE_PARAM_PROPERTIES},
             "required": ["agent_id"],
             "additionalProperties": False,
         },
@@ -391,6 +440,7 @@ TOOL_DEFINITIONS = [
                 "status": {"type": "string"},
                 "changed": {"type": "boolean"},
                 "agent": _AGENT_OUTPUT,
+                "access": _ACCESS_METADATA_OUTPUT,
             },
             required=("status", "changed", "agent"),
         ),
@@ -404,6 +454,7 @@ TOOL_DEFINITIONS = [
             "type": "object",
             "properties": {
                 "agent_id": _agent_schema("Optional persistent agent UUID to include current per-agent config."),
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "additionalProperties": False,
         },
@@ -418,6 +469,7 @@ TOOL_DEFINITIONS = [
                     required=("type", "id"),
                 ),
                 "agent": {"anyOf": [_AGENT_OUTPUT, {"type": "null"}]},
+                "access": _ACCESS_METADATA_OUTPUT,
                 "fields": _object_output(
                     {
                         "preferred_llm_tier": _object_output(
@@ -474,10 +526,14 @@ TOOL_DEFINITIONS = [
             "type": "object",
             "properties": {
                 "agent_id": _agent_schema("Optional agent UUID to filter links."),
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "additionalProperties": False,
         },
-        "outputSchema": _object_output({"links": _array_output(_LINK_OUTPUT)}, required=("links",)),
+        "outputSchema": _object_output(
+            {"links": _array_output(_LINK_OUTPUT), "access": _ACCESS_METADATA_OUTPUT},
+            required=("links",),
+        ),
         "annotations": {"readOnlyHint": True},
     },
     {
@@ -491,12 +547,13 @@ TOOL_DEFINITIONS = [
                 "peer_agent_id": _agent_schema("Second persistent agent UUID."),
                 "messages_per_window": {"type": "integer", "minimum": 1, "maximum": 500, "default": 30},
                 "window_hours": {"type": "integer", "minimum": 1, "maximum": 168, "default": 6},
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "required": ["agent_id", "peer_agent_id"],
             "additionalProperties": False,
         },
         "outputSchema": _object_output(
-            {"link": _LINK_OUTPUT, "created": {"type": "boolean"}},
+            {"link": _LINK_OUTPUT, "created": {"type": "boolean"}, "access": _ACCESS_METADATA_OUTPUT},
             required=("link", "created"),
         ),
         "annotations": {"destructiveHint": False},
@@ -511,11 +568,12 @@ TOOL_DEFINITIONS = [
                 "peer_link_id": {"type": "string", "format": "uuid", "description": "Existing peer link UUID."},
                 "agent_id": _agent_schema("First persistent agent UUID when peer_link_id is omitted."),
                 "peer_agent_id": _agent_schema("Second persistent agent UUID when peer_link_id is omitted."),
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "additionalProperties": False,
         },
         "outputSchema": _object_output(
-            {"status": {"type": "string"}, "link": _LINK_OUTPUT},
+            {"status": {"type": "string"}, "link": _LINK_OUTPUT, "access": _ACCESS_METADATA_OUTPUT},
             required=("status", "link"),
         ),
         "annotations": {"destructiveHint": True},
@@ -539,6 +597,7 @@ TOOL_DEFINITIONS = [
                     "default": True,
                     "description": "Whether to queue the agent to process the inbound message.",
                 },
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "required": ["agent_id", "body"],
             "additionalProperties": False,
@@ -564,6 +623,7 @@ TOOL_DEFINITIONS = [
                 "timeline_event": _TIMELINE_EVENT_OUTPUT,
                 "conversation_id": _UUID_OUTPUT,
                 "attachment_count": {"type": "integer"},
+                "access": _ACCESS_METADATA_OUTPUT,
             },
             required=("status", "message_id", "agent_id", "cursor", "latest_cursor"),
         ),
@@ -586,6 +646,7 @@ TOOL_DEFINITIONS = [
                 "cursor": {"type": ["string", "null"], "description": "Cursor from a previous timeline result."},
                 "direction": {"type": "string", "enum": ["initial", "older", "newer"], "default": "initial"},
                 "limit": {"type": "integer", "minimum": 1, "maximum": TIMELINE_MAX_PAGE_SIZE, "default": TIMELINE_DEFAULT_PAGE_SIZE},
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "required": ["agent_id"],
             "additionalProperties": False,
@@ -602,6 +663,7 @@ TOOL_DEFINITIONS = [
                 "has_more_newer": {"type": "boolean"},
                 "processing_active": {"type": "boolean"},
                 "processing_snapshot": _object_output({}),
+                "access": _ACCESS_METADATA_OUTPUT,
             },
             required=("events", "latest_cursor", "has_more"),
         ),
@@ -665,6 +727,7 @@ TOOL_DEFINITIONS = [
                     "format": "uuid",
                     "description": "Optional eval run UUID to filter eval debug artifacts for this agent.",
                 },
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "required": ["agent_id"],
             "additionalProperties": False,
@@ -739,6 +802,7 @@ TOOL_DEFINITIONS = [
                     },
                     "additionalProperties": False,
                 },
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "required": ["agent_id"],
             "additionalProperties": False,
@@ -751,6 +815,7 @@ TOOL_DEFINITIONS = [
                 "next_cursor": _STRING_OR_NULL,
                 "latest_cursor": _STRING_OR_NULL,
                 "waited_seconds": _NUMBER_OR_STRING,
+                "access": _ACCESS_METADATA_OUTPUT,
             },
             required=("matched", "timed_out", "events", "waited_seconds"),
         ),
@@ -762,7 +827,7 @@ TOOL_DEFINITIONS = [
         "description": "List files and folders in an agent's default filespace.",
         "inputSchema": {
             "type": "object",
-            "properties": {"agent_id": _agent_schema("Persistent agent UUID.")},
+            "properties": {"agent_id": _agent_schema("Persistent agent UUID."), **_SCOPE_PARAM_PROPERTIES},
             "required": ["agent_id"],
             "additionalProperties": False,
         },
@@ -773,6 +838,7 @@ TOOL_DEFINITIONS = [
                     required=("id", "name"),
                 ),
                 "nodes": _array_output(_FILE_NODE_OUTPUT),
+                "access": _ACCESS_METADATA_OUTPUT,
             },
             required=("filespace", "nodes"),
         ),
@@ -790,6 +856,7 @@ TOOL_DEFINITIONS = [
                 "content_base64": {"type": "string", "description": "Base64-encoded file content."},
                 "mime_type": {"type": "string", "default": "application/octet-stream"},
                 "overwrite": {"type": "boolean", "default": False},
+                **_SCOPE_PARAM_PROPERTIES,
             },
             "required": ["agent_id", "path", "content_base64"],
             "additionalProperties": False,
@@ -801,6 +868,7 @@ TOOL_DEFINITIONS = [
                 "node_id": _UUID_OUTPUT,
                 "filename": {"type": "string"},
                 "message": _STRING_OR_NULL,
+                "access": _ACCESS_METADATA_OUTPUT,
             },
             required=("status",),
         ),
@@ -856,28 +924,56 @@ def call_tool(request, name, arguments):
     return handler(request, arguments)
 
 
+@dataclass(frozen=True)
+class MCPScope:
+    user: object
+    organization: object | None
+    explicit_user_id: bool
+    explicit_organization_id: bool
+    admin_access: bool
+    operator_user_id: object | None = None
+    requested_user_id: object | None = None
+    requested_organization_id: object | None = None
+
+
+@dataclass(frozen=True)
+class MCPAgentAccess:
+    agent: PersistentAgent
+    scope: MCPScope
+    admin_access: bool
+
+
 def _tool_list_agents(request, arguments):
     page_size = _bounded_int(arguments.get("page_size", 20), "page_size", minimum=1, maximum=100)
     page = _bounded_int(arguments.get("page", 1), "page", minimum=1, maximum=100000)
-    queryset = _agent_queryset(request)
+    scope = _resolve_mcp_scope(request, arguments)
+    queryset = _agent_queryset_for_scope(scope)
     total = queryset.count()
     offset = (page - 1) * page_size
     agents = list(queryset[offset:offset + page_size])
-    return {
-        "agents": [_serialize_agent(agent) for agent in agents],
-        "page": page,
-        "page_size": page_size,
-        "total": total,
-        "has_next": offset + page_size < total,
-    }
+    return _with_access_metadata(
+        {
+            "agents": [_serialize_agent(agent) for agent in agents],
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "has_next": offset + page_size < total,
+        },
+        scope=scope,
+    )
 
 
 def _tool_get_agent(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
-    return {"agent": _serialize_agent(agent)}
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    return _with_access_metadata(
+        {"agent": _serialize_agent(access.agent)},
+        access=access,
+        agent=access.agent,
+    )
 
 
 def _tool_create_agent(request, arguments):
+    scope = _resolve_mcp_scope(request, arguments)
     allowed_fields = {
         "name",
         "charter",
@@ -888,10 +984,10 @@ def _tool_create_agent(request, arguments):
         "whitelist_policy",
     }
     payload = {key: arguments[key] for key in allowed_fields if key in arguments}
-    _normalize_agent_config_payload(request, payload)
+    _normalize_agent_config_payload(request, payload, scope=scope)
     serializer = PersistentAgentSerializer(
         data=payload,
-        context={"request": request, "organization": _request_organization(request)},
+        context={"request": _scoped_request(request, scope), "organization": scope.organization},
     )
     try:
         serializer.is_valid(raise_exception=True)
@@ -899,11 +995,12 @@ def _tool_create_agent(request, arguments):
     except (DRFValidationError, DjangoValidationError) as exc:
         raise MCPToolError("Agent creation failed.", _format_validation_error(exc)) from exc
 
-    return {"agent": _serialize_agent(agent)}
+    return _with_access_metadata({"agent": _serialize_agent(agent)}, scope=scope, agent=agent)
 
 
 def _tool_update_agent(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    agent = access.agent
     allowed_fields = {
         "name",
         "charter",
@@ -917,13 +1014,13 @@ def _tool_update_agent(request, arguments):
     payload = {key: arguments[key] for key in allowed_fields if key in arguments}
     if not payload:
         raise MCPToolError("At least one mutable field is required.")
-    _normalize_agent_config_payload(request, payload, agent=agent)
+    _normalize_agent_config_payload(request, payload, agent=agent, scope=access.scope)
 
     serializer = PersistentAgentSerializer(
         agent,
         data=payload,
         partial=True,
-        context={"request": request, "organization": _request_organization(request)},
+        context={"request": _scoped_request(request, access.scope), "organization": agent.organization},
     )
     try:
         previous_daily_credit_limit = agent.daily_credit_limit
@@ -940,79 +1037,103 @@ def _tool_update_agent(request, arguments):
         previous_tier_key=previous_tier_key,
     )
 
-    return {"agent": _serialize_agent(agent)}
+    return _with_access_metadata({"agent": _serialize_agent(agent)}, access=access, agent=agent)
 
 
 def _tool_archive_agent(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    agent = access.agent
     changed = agent.soft_delete()
-    invalidate_account_info_cache(request.user.id)
-    return {
+    invalidate_account_info_cache(agent.user_id)
+    return _with_access_metadata(
+        {
         "status": "archived",
         "changed": changed,
         "agent": _serialize_agent(agent),
-    }
+        },
+        access=access,
+        agent=agent,
+    )
 
 
 def _tool_get_agent_config_options(request, arguments):
     agent = None
+    access = None
+    scope = _resolve_mcp_scope(request, arguments)
     if arguments.get("agent_id"):
-        agent = _get_agent(request, arguments.get("agent_id"))
-    owner = _agent_owner_for_request(request, agent=agent)
+        access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+        agent = access.agent
+        scope = access.scope
+    owner = _agent_owner_for_request(request, agent=agent, scope=scope)
     daily_credit_options = _build_daily_credit_options(owner, getattr(agent, "preferred_llm_tier", None))
-    return {
-        "owner": _serialize_owner_ref(owner),
-        "agent": _serialize_agent(agent) if agent else None,
-        "fields": {
-            "preferred_llm_tier": _build_intelligence_options(owner),
-            "daily_credit_limit": daily_credit_options,
-            "schedule": {
-                "type": "string_or_null",
-                "required": False,
-                "null_behavior": "unscheduled",
-                "accepted_formats": [
-                    "cron-like schedule expressions accepted by Gobii's ScheduleParser",
-                    "@daily",
-                    "@every interval",
-                ],
+    return _with_access_metadata(
+        {
+            "owner": _serialize_owner_ref(owner),
+            "agent": _serialize_agent(agent) if agent else None,
+            "fields": {
+                "preferred_llm_tier": _build_intelligence_options(owner),
+                "daily_credit_limit": daily_credit_options,
+                "schedule": {
+                    "type": "string_or_null",
+                    "required": False,
+                    "null_behavior": "unscheduled",
+                    "accepted_formats": [
+                        "cron-like schedule expressions accepted by Gobii's ScheduleParser",
+                        "@daily",
+                        "@every interval",
+                    ],
+                },
+                "whitelist_policy": {
+                    "type": "string",
+                    "options": [
+                        {"value": value, "label": label}
+                        for value, label in PersistentAgent.WhitelistPolicy.choices
+                    ],
+                },
+                "is_active": {"type": "boolean"},
+                "proactive_opt_in": {"type": "boolean", "mutable_on_update": True},
             },
-            "whitelist_policy": {
-                "type": "string",
-                "options": [
-                    {"value": value, "label": label}
-                    for value, label in PersistentAgent.WhitelistPolicy.choices
-                ],
-            },
-            "is_active": {"type": "boolean"},
-            "proactive_opt_in": {"type": "boolean", "mutable_on_update": True},
+            "unsupported_remote_mcp_v1_fields": [
+                "arbitrary_url_file_fetch",
+                "ad_hoc_runtime_session",
+                "separate_task_or_run_abstraction",
+            ],
         },
-        "unsupported_remote_mcp_v1_fields": [
-            "arbitrary_url_file_fetch",
-            "ad_hoc_runtime_session",
-            "separate_task_or_run_abstraction",
-        ],
-    }
+        access=access,
+        scope=scope,
+        agent=agent,
+    )
 
 
 def _tool_list_agent_links(request, arguments):
-    accessible = _agent_queryset(request).only("id")
-    links = (
-        AgentPeerLink.objects.filter(Q(agent_a__in=accessible) | Q(agent_b__in=accessible))
-        .select_related("agent_a", "agent_b", "created_by")
-        .distinct()
-        .order_by("-created_at")
-    )
+    scope = _resolve_mcp_scope(request, arguments)
+    access = None
     agent_id = arguments.get("agent_id")
     if agent_id:
-        agent = _get_agent(request, agent_id)
+        access = _get_agent_access(request, agent_id, arguments)
+        agent = access.agent
+        links = AgentPeerLink.objects.filter(Q(agent_a=agent) | Q(agent_b=agent))
+    else:
+        accessible = _agent_queryset_for_scope(scope).only("id")
+        links = AgentPeerLink.objects.filter(Q(agent_a__in=accessible) | Q(agent_b__in=accessible)).distinct()
+
+    links = links.select_related("agent_a", "agent_b", "created_by").order_by("-created_at")
+    if agent_id:
         links = links.filter(Q(agent_a=agent) | Q(agent_b=agent))
 
-    return {"links": [_serialize_peer_link(link) for link in links]}
+    return _with_access_metadata(
+        {"links": [_serialize_peer_link(link) for link in links]},
+        access=access,
+        scope=scope,
+        agent=access.agent if access else None,
+    )
 
 
 def _tool_link_agents(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
-    peer_agent = _get_agent(request, arguments.get("peer_agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    peer_access = _get_agent_access(request, arguments.get("peer_agent_id"), arguments)
+    agent = access.agent
+    peer_agent = peer_access.agent
     if agent.id == peer_agent.id:
         raise MCPToolError("Cannot link an agent to itself.")
 
@@ -1046,25 +1167,35 @@ def _tool_link_agents(request, arguments):
     except (DjangoValidationError, IntegrityError) as exc:
         raise MCPToolError("Agent link could not be saved.", _format_validation_error(exc)) from exc
 
-    return {"link": _serialize_peer_link(link), "created": created}
+    return _with_access_metadata(
+        {"link": _serialize_peer_link(link), "created": created},
+        access=access if access.admin_access else peer_access,
+        agent=agent,
+    )
 
 
 def _tool_unlink_agents(request, arguments):
-    link = _resolve_peer_link(request, arguments)
+    link, access = _resolve_peer_link_access(request, arguments)
     payload = _serialize_peer_link(link)
     link.remove_preserving_history()
-    return {"status": "unlinked", "link": payload}
+    return _with_access_metadata(
+        {"status": "unlinked", "link": payload},
+        access=access,
+        agent=link.agent_a,
+    )
 
 
 def _tool_send_agent_message(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    agent = access.agent
     body = _required_string(arguments, "body", allow_blank=False)
     trigger_processing = _optional_bool(arguments.get("trigger_processing", True), "trigger_processing")
     attachment_paths = arguments.get("attachment_file_paths") or []
     if not isinstance(attachment_paths, list):
         raise MCPToolError("attachment_file_paths must be an array of filespace paths.")
 
-    sender_address = build_web_user_address(user_id=request.user.id, agent_id=agent.id)
+    sender_user = _message_sender_user(request, access)
+    sender_address = build_web_user_address(user_id=sender_user.id, agent_id=agent.id)
     if not agent.is_sender_whitelisted(CommsChannel.WEB, sender_address):
         raise MCPToolError("Authenticated user is not allowed to message this agent.")
 
@@ -1077,7 +1208,7 @@ def _tool_send_agent_message(request, arguments):
         message, conversation = inject_internal_web_message(
             agent.id,
             body,
-            sender_user_id=request.user.id,
+            sender_user_id=sender_user.id,
             attachments=[],
             trigger_processing=False,
         )
@@ -1089,28 +1220,33 @@ def _tool_send_agent_message(request, arguments):
 
     event = serialize_message_event(message)
     cursor = event.get("cursor")
-    return {
-        "status": "queued" if trigger_processing else "stored",
-        "accepted_state": "queued" if trigger_processing else "stored",
-        "message_id": str(message.id),
-        "agent_id": str(agent.id),
-        "cursor": cursor,
-        "latest_cursor": cursor,
-        "created_at": _iso(message.timestamp),
-        "actor": {
-            "type": "human_user",
-            "source": "remote_mcp",
-            "user_id": request.user.id,
+    return _with_access_metadata(
+        {
+            "status": "queued" if trigger_processing else "stored",
+            "accepted_state": "queued" if trigger_processing else "stored",
+            "message_id": str(message.id),
+            "agent_id": str(agent.id),
+            "cursor": cursor,
+            "latest_cursor": cursor,
+            "created_at": _iso(message.timestamp),
+            "actor": {
+                "type": "human_user",
+                "source": "remote_mcp",
+                "user_id": sender_user.id,
+            },
+            "message": _serialize_message(message),
+            "timeline_event": event,
+            "conversation_id": str(conversation.id),
+            "attachment_count": len(resolved_attachments),
         },
-        "message": _serialize_message(message),
-        "timeline_event": event,
-        "conversation_id": str(conversation.id),
-        "attachment_count": len(resolved_attachments),
-    }
+        access=access,
+        agent=agent,
+    )
 
 
 def _tool_get_agent_timeline(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    agent = access.agent
     after_cursor = arguments.get("after_cursor")
     direction = "newer" if after_cursor else arguments.get("direction") or "initial"
     if direction not in {"initial", "older", "newer"}:
@@ -1127,22 +1263,27 @@ def _tool_get_agent_timeline(request, arguments):
     _validate_timeline_cursor(cursor, "cursor/after_cursor")
 
     window = fetch_timeline_window(agent, cursor=cursor, direction=direction, limit=limit)
-    return {
-        "events": window.events,
-        "next_cursor": window.newest_cursor,
-        "latest_cursor": window.newest_cursor,
-        "oldest_cursor": window.oldest_cursor,
-        "newest_cursor": window.newest_cursor,
-        "has_more": window.has_more_newer if direction == "newer" else window.has_more_older,
-        "has_more_older": window.has_more_older,
-        "has_more_newer": window.has_more_newer,
-        "processing_active": window.processing_active,
-        "processing_snapshot": serialize_processing_snapshot(window.processing_snapshot),
-    }
+    return _with_access_metadata(
+        {
+            "events": window.events,
+            "next_cursor": window.newest_cursor,
+            "latest_cursor": window.newest_cursor,
+            "oldest_cursor": window.oldest_cursor,
+            "newest_cursor": window.newest_cursor,
+            "has_more": window.has_more_newer if direction == "newer" else window.has_more_older,
+            "has_more_older": window.has_more_older,
+            "has_more_newer": window.has_more_newer,
+            "processing_active": window.processing_active,
+            "processing_snapshot": serialize_processing_snapshot(window.processing_snapshot),
+        },
+        access=access,
+        agent=agent,
+    )
 
 
 def _tool_get_agent_debug_trace(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    agent = access.agent
     limit = _bounded_int(
         arguments.get("limit", DEBUG_TRACE_DEFAULT_LIMIT),
         "limit",
@@ -1173,7 +1314,7 @@ def _tool_get_agent_debug_trace(request, arguments):
         eval_run_id = _parse_uuid(arguments.get("eval_run_id"), "eval_run_id")
 
     try:
-        return build_agent_debug_trace(
+        result = build_agent_debug_trace(
             agent,
             limit=limit,
             cursor=cursor,
@@ -1185,12 +1326,14 @@ def _tool_get_agent_debug_trace(request, arguments):
             detail=detail,
             eval_run_id=eval_run_id,
         )
+        return _with_access_metadata(result, access=access, agent=agent)
     except AgentDebugTraceValidationError as exc:
         raise MCPToolError(str(exc), exc.data) from exc
 
 
 def _tool_wait_for_agent_event(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    agent = access.agent
     after_cursor = arguments.get("after_cursor") or None
     if after_cursor is not None and not isinstance(after_cursor, str):
         raise MCPToolError("after_cursor must be a string.")
@@ -1223,31 +1366,40 @@ def _tool_wait_for_agent_event(request, arguments):
         ]
         if events:
             waited_seconds = round(time.monotonic() - start, 3)
-            return {
-                "matched": True,
-                "timed_out": False,
-                "events": events,
-                "next_cursor": latest_cursor,
-                "latest_cursor": latest_cursor,
-                "waited_seconds": waited_seconds,
-            }
+            return _with_access_metadata(
+                {
+                    "matched": True,
+                    "timed_out": False,
+                    "events": events,
+                    "next_cursor": latest_cursor,
+                    "latest_cursor": latest_cursor,
+                    "waited_seconds": waited_seconds,
+                },
+                access=access,
+                agent=agent,
+            )
         if time.monotonic() >= deadline:
             waited_seconds = round(time.monotonic() - start, 3)
-            return {
-                "matched": False,
-                "timed_out": True,
-                "events": [],
-                "next_cursor": latest_cursor,
-                "latest_cursor": latest_cursor,
-                "waited_seconds": waited_seconds,
-            }
+            return _with_access_metadata(
+                {
+                    "matched": False,
+                    "timed_out": True,
+                    "events": [],
+                    "next_cursor": latest_cursor,
+                    "latest_cursor": latest_cursor,
+                    "waited_seconds": waited_seconds,
+                },
+                access=access,
+                agent=agent,
+            )
         sleep_seconds = min(WAIT_POLL_INTERVAL_SECONDS, max(0, deadline - time.monotonic()))
         if sleep_seconds:
             time.sleep(sleep_seconds)
 
 
 def _tool_list_agent_files(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    agent = access.agent
     filespace = get_or_create_default_filespace(agent)
     nodes = (
         AgentFsNode.objects.alive()
@@ -1255,14 +1407,19 @@ def _tool_list_agent_files(request, arguments):
         .only("id", "parent_id", "name", "path", "node_type", "size_bytes", "mime_type", "created_at", "updated_at")
         .order_by("parent_id", "node_type", "name")
     )
-    return {
-        "filespace": {"id": str(filespace.id), "name": filespace.name},
-        "nodes": [_serialize_file_node(node) for node in nodes],
-    }
+    return _with_access_metadata(
+        {
+            "filespace": {"id": str(filespace.id), "name": filespace.name},
+            "nodes": [_serialize_file_node(node) for node in nodes],
+        },
+        access=access,
+        agent=agent,
+    )
 
 
 def _tool_upload_agent_file(request, arguments):
-    agent = _get_agent(request, arguments.get("agent_id"))
+    access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+    agent = access.agent
     path = _required_string(arguments, "path", allow_blank=False)
     content_base64 = _required_string(arguments, "content_base64", allow_blank=False)
     mime_type = arguments.get("mime_type") or "application/octet-stream"
@@ -1284,7 +1441,7 @@ def _tool_upload_agent_file(request, arguments):
     )
     if result.get("status") != "ok":
         raise MCPToolError(result.get("message") or "File upload failed.", result)
-    return result
+    return _with_access_metadata(result, access=access, agent=agent)
 
 
 def _reject_unknown_arguments(name, arguments):
@@ -1301,7 +1458,7 @@ def _reject_unknown_arguments(name, arguments):
         )
 
 
-def _normalize_agent_config_payload(request, payload, *, agent=None):
+def _normalize_agent_config_payload(request, payload, *, agent=None, scope=None):
     if "schedule" in payload and payload["schedule"] == "":
         payload["schedule"] = None
     if "preferred_llm_tier" in payload:
@@ -1311,7 +1468,7 @@ def _normalize_agent_config_payload(request, payload, *, agent=None):
                 "preferred_llm_tier must be a supported intelligence tier key.",
                 {"field": "preferred_llm_tier"},
             )
-        owner = _agent_owner_for_request(request, agent=agent)
+        owner = _agent_owner_for_request(request, agent=agent, scope=scope)
         requested_key = tier_value.strip().lower()
         if requested_key not in {tier.value for tier in AgentLLMTier}:
             raise MCPToolError(
@@ -1384,20 +1541,117 @@ def _queue_agent_settings_resume_if_needed(
     )
 
 
-def _agent_queryset(request):
-    organization = _request_organization(request)
-    if organization is None and not can_user_use_personal_agents_and_api(request.user):
-        raise MCPToolError("Personal API access requires an active trial or plan.")
+def _resolve_mcp_scope(request, arguments):
+    explicit_user_id = _scope_argument_supplied(arguments, "user_id")
+    explicit_organization_id = _scope_argument_supplied(arguments, "organization_id")
 
-    queryset = (
+    if (explicit_user_id or explicit_organization_id) and not _is_mcp_admin_user(request.user):
+        raise MCPToolError(
+            "user_id and organization_id are restricted to staff/superuser API keys.",
+            {
+                "code": "admin_scope_required",
+                "fields": [
+                    field
+                    for field in ("user_id", "organization_id")
+                    if _scope_argument_supplied(arguments, field)
+                ],
+            },
+        )
+
+    user = None
+    organization = None
+    requested_user_id = None
+    requested_organization_id = None
+
+    if explicit_organization_id:
+        requested_organization_id = str(_parse_uuid(arguments.get("organization_id"), "organization_id"))
+        organization = Organization.objects.filter(id=requested_organization_id).first()
+        if organization is None:
+            raise MCPToolError(
+                "Organization not found.",
+                {"code": "organization_not_found", "field": "organization_id"},
+            )
+        if not organization.is_active:
+            raise MCPToolError(
+                "Organization is inactive.",
+                {"code": "organization_inactive", "field": "organization_id"},
+            )
+    elif explicit_user_id:
+        organization = None
+    else:
+        organization = _request_organization(request)
+
+    if explicit_user_id:
+        requested_user_id = _parse_user_id(arguments.get("user_id"))
+        user_model = get_user_model()
+        user = user_model.objects.filter(id=requested_user_id).first()
+        if user is None:
+            raise MCPToolError("User not found.", {"code": "user_not_found", "field": "user_id"})
+        if not user.is_active:
+            raise MCPToolError("User is inactive.", {"code": "user_inactive", "field": "user_id"})
+    elif organization is not None and explicit_organization_id:
+        user = _default_user_for_organization(organization)
+    else:
+        user = request.user
+
+    if organization is not None and explicit_user_id:
+        if not OrganizationMembership.objects.filter(
+            org=organization,
+            user=user,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        ).exists():
+            raise MCPToolError(
+                "user_id is not an active member of organization_id.",
+                {
+                    "code": "user_not_in_organization",
+                    "field": "user_id",
+                    "organization_id": str(organization.id),
+                },
+            )
+
+    admin_access = bool(
+        (explicit_user_id or explicit_organization_id)
+        and _is_mcp_admin_user(request.user)
+        and _scope_differs_from_default(request, user=user, organization=organization)
+    )
+    return MCPScope(
+        user=user,
+        organization=organization,
+        explicit_user_id=explicit_user_id,
+        explicit_organization_id=explicit_organization_id,
+        admin_access=admin_access,
+        operator_user_id=getattr(request.user, "id", None),
+        requested_user_id=requested_user_id,
+        requested_organization_id=requested_organization_id,
+    )
+
+
+def _agent_base_queryset():
+    return (
         PersistentAgent.objects.non_eval()
         .alive()
-        .select_related("browser_use_agent", "organization", "preferred_contact_endpoint", "preferred_llm_tier")
+        .select_related("user", "browser_use_agent", "organization", "preferred_contact_endpoint", "preferred_llm_tier")
         .order_by("-created_at")
     )
-    if organization is not None:
-        return queryset.filter(organization=organization)
-    return queryset.filter(user=request.user)
+
+
+def _agent_queryset_for_scope(scope):
+    if (
+        scope.organization is None
+        and not scope.admin_access
+        and not _is_mcp_admin_user(scope.user)
+        and not can_user_use_personal_agents_and_api(scope.user)
+    ):
+        raise MCPToolError("Personal API access requires an active trial or plan.")
+
+    queryset = _agent_base_queryset()
+    if scope.organization is not None:
+        return queryset.filter(organization=scope.organization)
+    return queryset.filter(user=scope.user)
+
+
+def _agent_queryset(request):
+    return _agent_queryset_for_scope(_resolve_mcp_scope(request, {}))
 
 
 def _request_organization(request):
@@ -1407,9 +1661,108 @@ def _request_organization(request):
     return None
 
 
-def _agent_owner_for_request(request, *, agent=None):
+def _scope_argument_supplied(arguments, key):
+    return key in arguments and arguments.get(key) not in (None, "")
+
+
+def _is_mcp_admin_user(user):
+    return bool(
+        getattr(user, "is_authenticated", False)
+        and (getattr(user, "is_staff", False) or getattr(user, "is_superuser", False))
+    )
+
+
+def _scope_differs_from_default(request, *, user, organization):
+    default_organization = _request_organization(request)
+    if default_organization is not None:
+        return organization is None or organization.id != default_organization.id
+    return organization is not None or getattr(user, "id", None) != getattr(request.user, "id", None)
+
+
+def _parse_user_id(value):
+    if isinstance(value, bool):
+        raise MCPToolError("user_id must be a valid Django user id.", {"field": "user_id"})
+    try:
+        user_id = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise MCPToolError("user_id must be a valid Django user id.", {"field": "user_id"}) from exc
+    if user_id < 1:
+        raise MCPToolError("user_id must be a valid Django user id.", {"field": "user_id"})
+    return user_id
+
+
+def _default_user_for_organization(organization):
+    if organization.created_by_id and organization.created_by.is_active:
+        if OrganizationMembership.objects.filter(
+            org=organization,
+            user=organization.created_by,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        ).exists():
+            return organization.created_by
+
+    membership = (
+        OrganizationMembership.objects.select_related("user")
+        .filter(
+            org=organization,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+        .order_by("role", "user__date_joined")
+        .first()
+    )
+    if membership and membership.user and membership.user.is_active:
+        return membership.user
+
+    raise MCPToolError(
+        "Organization has no active user that can own scoped agent operations.",
+        {"code": "organization_has_no_active_users", "field": "organization_id"},
+    )
+
+
+def _scoped_request(request, scope):
+    return SimpleNamespace(user=scope.user, auth=getattr(request, "auth", None))
+
+
+def _message_sender_user(request, access):
+    if access.admin_access:
+        return access.agent.user
+    return request.user
+
+
+def _with_access_metadata(payload, *, access=None, scope=None, agent=None):
+    if access is not None:
+        scope = access.scope
+        admin_access = access.admin_access
+    else:
+        admin_access = bool(scope and scope.admin_access)
+
+    if not admin_access or scope is None:
+        return payload
+
+    target_user_id = getattr(agent, "user_id", None) if agent is not None else getattr(scope.user, "id", None)
+    target_organization_id = (
+        getattr(agent, "organization_id", None)
+        if agent is not None
+        else getattr(scope.organization, "id", None)
+    )
+    payload["access"] = {
+        "admin_access": True,
+        "access_scope": "staff_cross_account",
+        "operator_user_id": str(scope.operator_user_id) if scope.operator_user_id is not None else None,
+        "target_user_id": str(target_user_id) if target_user_id is not None else None,
+        "target_organization_id": str(target_organization_id) if target_organization_id is not None else None,
+        "requested_user_id": str(scope.requested_user_id) if scope.requested_user_id is not None else None,
+        "requested_organization_id": (
+            str(scope.requested_organization_id) if scope.requested_organization_id is not None else None
+        ),
+    }
+    return payload
+
+
+def _agent_owner_for_request(request, *, agent=None, scope=None):
     if agent is not None:
         return agent.organization or agent.user
+    if scope is not None:
+        return scope.organization or scope.user
     return _request_organization(request) or request.user
 
 
@@ -1477,16 +1830,31 @@ def _build_daily_credit_options(owner, tier):
     }
 
 
-def _get_agent(request, raw_agent_id):
+def _get_agent_access(request, raw_agent_id, arguments):
     agent_id = _parse_uuid(raw_agent_id, "agent_id")
-    agent = _agent_queryset(request).filter(id=agent_id).first()
-    if agent is None:
-        raise MCPToolError("Agent not found or inaccessible.")
-    return agent
+    scope = _resolve_mcp_scope(request, arguments or {})
+    agent = _agent_queryset_for_scope(scope).filter(id=agent_id).first()
+    if agent is not None:
+        return MCPAgentAccess(agent=agent, scope=scope, admin_access=scope.admin_access)
+
+    if _is_mcp_admin_user(request.user) and not (scope.explicit_user_id or scope.explicit_organization_id):
+        agent = _agent_base_queryset().filter(id=agent_id).first()
+        if agent is not None:
+            return MCPAgentAccess(agent=agent, scope=scope, admin_access=True)
+
+    raise MCPToolError(
+        "Agent not found or inaccessible.",
+        {"code": "agent_not_found_or_inaccessible", "field": "agent_id"},
+    )
 
 
-def _resolve_peer_link(request, arguments):
-    accessible = _agent_queryset(request).only("id")
+def _get_agent(request, raw_agent_id):
+    return _get_agent_access(request, raw_agent_id, {}).agent
+
+
+def _resolve_peer_link_access(request, arguments):
+    scope = _resolve_mcp_scope(request, arguments)
+    accessible = _agent_queryset_for_scope(scope).only("id")
     peer_link_id = arguments.get("peer_link_id")
     if peer_link_id:
         link_id = _parse_uuid(peer_link_id, "peer_link_id")
@@ -1496,19 +1864,37 @@ def _resolve_peer_link(request, arguments):
             .select_related("agent_a", "agent_b", "created_by")
             .first()
         )
+        admin_access = scope.admin_access
+        if link is None and _is_mcp_admin_user(request.user) and not (scope.explicit_user_id or scope.explicit_organization_id):
+            link = (
+                AgentPeerLink.objects.filter(id=link_id)
+                .select_related("agent_a", "agent_b", "created_by")
+                .first()
+            )
+            admin_access = link is not None
     else:
-        agent = _get_agent(request, arguments.get("agent_id"))
-        peer_agent = _get_agent(request, arguments.get("peer_agent_id"))
+        access = _get_agent_access(request, arguments.get("agent_id"), arguments)
+        peer_access = _get_agent_access(request, arguments.get("peer_agent_id"), arguments)
+        agent = access.agent
+        peer_agent = peer_access.agent
         pair_key = AgentPeerLink.build_pair_key(agent.id, peer_agent.id)
         link = (
             AgentPeerLink.objects.filter(pair_key=pair_key)
             .select_related("agent_a", "agent_b", "created_by")
             .first()
         )
+        admin_access = access.admin_access or peer_access.admin_access
 
     if link is None:
-        raise MCPToolError("Peer link not found or inaccessible.")
-    return link
+        raise MCPToolError(
+            "Peer link not found or inaccessible.",
+            {"code": "peer_link_not_found_or_inaccessible"},
+        )
+    return link, MCPAgentAccess(agent=link.agent_a, scope=scope, admin_access=admin_access)
+
+
+def _resolve_peer_link(request, arguments):
+    return _resolve_peer_link_access(request, arguments)[0]
 
 
 def _serialize_agent(agent):

--- a/config/settings.py
+++ b/config/settings.py
@@ -273,6 +273,12 @@ PUBLIC_BRAND_NAME = env(
     "PUBLIC_BRAND_NAME",
     default=_proprietary_default("brand", "PUBLIC_BRAND_NAME", fallback="Agent Platform"),
 )
+OPENROUTER_ATTRIBUTION_TITLE = env(
+    "OPENROUTER_ATTRIBUTION_TITLE",
+    default=_proprietary_default("brand", "OPENROUTER_ATTRIBUTION_TITLE", fallback="Gobii"),
+)
+
+
 def _public_site_url_default(*, debug: bool | None = None) -> str:
     debug_mode = DEBUG if debug is None else debug
     if debug_mode:

--- a/docs/content/developers/mcp-server.mdx
+++ b/docs/content/developers/mcp-server.mdx
@@ -106,6 +106,7 @@ Gobii also validates `Mcp-Method` and `Mcp-Name` request headers when clients se
 | `gobii_unlink_agents` | Remove a peer-agent link while preserving history. |
 | `gobii_send_agent_message` | Send a web-chat message to an agent, optionally with existing filespace attachments. |
 | `gobii_get_agent_timeline` | Fetch timeline events and processing state using durable cursors. |
+| `gobii_get_agent_debug_trace` | Fetch bounded, sanitized debugging context for one accessible agent. |
 | `gobii_wait_for_agent_event` | Bounded long-poll for matching timeline events after a cursor. |
 | `gobii_list_agent_files` | List an agent's default filespace. |
 | `gobii_upload_agent_file` | Upload a small base64 file into the agent filespace. |
@@ -140,6 +141,40 @@ Unsupported fields are not ignored. A tool call with unsupported arguments retur
 - `status` and `tool_name`: supported for tool/step events
 
 The wait tool returns `matched`, `timed_out`, `events`, `next_cursor`, `latest_cursor`, and `waited_seconds`.
+
+## Debug Traces
+
+`gobii_get_agent_debug_trace` pulls a bounded support/debug view for one agent that the API key can already access. It reuses Gobii's audit timeline data and keeps the normal long-lived agent timeline model; it does not create a separate run, task, or conversation.
+
+Inputs:
+
+- `agent_id` is required.
+- `limit` defaults to `20` and is capped at `50` per returned section.
+- `recent_minutes` defaults to `60` when no cursor or explicit `since` is supplied. Set it to `null` to rely only on `limit` and cursor bounds.
+- `since` and `until` accept ISO8601 timestamps. Time windows are capped at seven days.
+- `cursor` accepts the previous response's `audit.next_cursor` for older audit/debug events.
+- `include` can request any of `timeline`, `audit_events`, `completions`, `eval_debug_artifacts`, and `diagnostics`.
+- `detail` can be `summary`, `standard`, or `verbose`. All levels still redact secrets and omit raw prompt archive payloads.
+- `eval_run_id` can narrow eval debug artifacts to one eval run owned by the same agent.
+
+Outputs include agent metadata, request scope, sanitized timeline/audit events, completion model/usage/cost metadata, prompt archive IDs and token-fit metadata, eval task debug artifacts when present, diagnostics, warnings, and redaction notes. Business and validation failures return normal MCP tool results with `isError: true`; they are not transport failures.
+
+Sanitization is intentionally conservative. The tool recursively redacts sensitive key names and common credential patterns such as bearer tokens, API keys, private keys, cookies, and access tokens. It returns IDs, timestamps, tool names and status summaries, sanitized parameters/results, prompt archive metadata, usage/cost fields, and artifact links/IDs. It does not return full environment values, authorization headers, raw prompt archive payloads, or arbitrary unbounded transcripts.
+
+Example:
+
+```json
+{
+  "name": "gobii_get_agent_debug_trace",
+  "arguments": {
+    "agent_id": "00000000-0000-0000-0000-000000000000",
+    "limit": 20,
+    "recent_minutes": 120,
+    "include": ["audit_events", "completions", "diagnostics"],
+    "detail": "standard"
+  }
+}
+```
 
 ## Agent Links
 
@@ -182,6 +217,7 @@ mcp_servers:
         - gobii_unlink_agents
         - gobii_send_agent_message
         - gobii_get_agent_timeline
+        - gobii_get_agent_debug_trace
         - gobii_wait_for_agent_event
         - gobii_list_agent_files
         - gobii_upload_agent_file
@@ -200,11 +236,12 @@ Use this flow for local dev, preview, or production smoke testing. Archive tempo
 5. `gobii_link_agents`
 6. `gobii_send_agent_message`
 7. `gobii_get_agent_timeline` and capture `latest_cursor`
-8. `gobii_wait_for_agent_event` with a cursor and a short timeout; verify both match and timeout behavior as appropriate
-9. `gobii_upload_agent_file`
-10. `gobii_list_agent_files`
-11. `gobii_unlink_agents`
-12. `gobii_archive_agent` for temporary agents
+8. `gobii_get_agent_debug_trace`; verify returned sections are bounded and sanitized
+9. `gobii_wait_for_agent_event` with a cursor and a short timeout; verify both match and timeout behavior as appropriate
+10. `gobii_upload_agent_file`
+11. `gobii_list_agent_files`
+12. `gobii_unlink_agents`
+13. `gobii_archive_agent` for temporary agents
 
 ## Limitations
 
@@ -215,3 +252,4 @@ Use this flow for local dev, preview, or production smoke testing. Archive tempo
 - Tool results include both MCP text content and `structuredContent`.
 - All tool calls run with the permissions of the provided Gobii API key.
 - Origin headers are validated for browser-originated requests to reduce DNS rebinding risk.
+- Debug traces are sanitized support artifacts, not full audit exports. Use staff audit tooling for raw prompt archive inspection where policy allows it.

--- a/tests/unit/test_llm_failover.py
+++ b/tests/unit/test_llm_failover.py
@@ -1,4 +1,5 @@
 """Unit tests for LLM failover (DB-only)."""
+import json
 import os
 import uuid
 from datetime import timedelta
@@ -23,7 +24,7 @@ from api.agent.core.llm_config import (
     get_agent_judge_llm_config,
 )
 from console.api_views import _build_completion_params
-from api.openrouter import DEFAULT_API_BASE
+from api.openrouter import DEFAULT_ATTRIBUTION_TITLE
 from tests.utils.llm_seed import clear_llm_db, get_intelligence_tier, seed_persistent_basic
 
 
@@ -218,10 +219,10 @@ class TestLLMFailover(TestCase):
     def test_openrouter_configs_include_attribution_headers(self):
         seed_persistent_basic(include_openrouter=True)
         referer = "https://example.com"
-        title = "Example App"
+        leaky_title = "Gobii Meta Gobii Skill Eval"
         with override_settings(
             PUBLIC_SITE_URL=referer,
-            PUBLIC_BRAND_NAME=title,
+            PUBLIC_BRAND_NAME=leaky_title,
         ):
             with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "openrouter-key"}, clear=True):
                 configs = get_llm_config_with_failover(token_count=12000)
@@ -230,23 +231,83 @@ class TestLLMFailover(TestCase):
                 _, _, params = openrouter_configs[0]
                 self.assertEqual(
                     params.get("extra_headers"),
-                    {"HTTP-Referer": referer, "X-Title": title},
+                    {"HTTP-Referer": referer, "X-Title": DEFAULT_ATTRIBUTION_TITLE},
                 )
+                self.assertNotIn("Meta Gobii", params["extra_headers"]["X-Title"])
+                self.assertNotIn("Skill Eval", params["extra_headers"]["X-Title"])
 
     def test_get_provider_config_includes_openrouter_headers(self):
         referer = "https://example.com/app"
-        title = "Example App"
+        leaky_title = "Gobii Meta Gobii Skill Eval"
         with override_settings(
             PUBLIC_SITE_URL=referer,
-            PUBLIC_BRAND_NAME=title,
+            PUBLIC_BRAND_NAME=leaky_title,
         ):
             with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "openrouter-key"}, clear=True):
                 model, params = get_provider_config("openrouter_glm")
                 self.assertEqual(model, "openrouter/z-ai/glm-4.5")
                 self.assertEqual(
                     params.get("extra_headers"),
-                    {"HTTP-Referer": referer, "X-Title": title},
+                    {"HTTP-Referer": referer, "X-Title": DEFAULT_ATTRIBUTION_TITLE},
                 )
+                self.assertNotIn("Meta Gobii", params["extra_headers"]["X-Title"])
+                self.assertNotIn("Skill Eval", params["extra_headers"]["X-Title"])
+
+    def test_eval_routing_profile_openrouter_headers_use_generic_public_title(self):
+        clear_llm_db()
+        LLMProvider = apps.get_model('api', 'LLMProvider')
+        PersistentModelEndpoint = apps.get_model('api', 'PersistentModelEndpoint')
+        LLMRoutingProfile = apps.get_model('api', 'LLMRoutingProfile')
+        ProfileTokenRange = apps.get_model('api', 'ProfileTokenRange')
+        ProfilePersistentTier = apps.get_model('api', 'ProfilePersistentTier')
+        ProfilePersistentTierEndpoint = apps.get_model('api', 'ProfilePersistentTierEndpoint')
+
+        provider = LLMProvider.objects.create(
+            key='openrouter',
+            display_name='OpenRouter',
+            enabled=True,
+            env_var_name='OPENROUTER_API_KEY',
+            browser_backend='OPENAI_COMPAT',
+        )
+        endpoint = PersistentModelEndpoint.objects.create(
+            key='meta_gobii_eval_model',
+            provider=provider,
+            enabled=True,
+            litellm_model='openrouter/z-ai/glm-4.5',
+            supports_tool_choice=True,
+        )
+        profile = LLMRoutingProfile.objects.create(
+            name='meta_gobii_skill_eval',
+            display_name='Gobii Meta Gobii Skill Eval',
+            description='Eval routing profile that must not leak to OpenRouter attribution.',
+            is_active=False,
+            is_eval_snapshot=True,
+        )
+        token_range = ProfileTokenRange.objects.create(profile=profile, name='default', min_tokens=0, max_tokens=None)
+        tier = ProfilePersistentTier.objects.create(
+            token_range=token_range,
+            order=1,
+            intelligence_tier=get_intelligence_tier("standard"),
+        )
+        ProfilePersistentTierEndpoint.objects.create(tier=tier, endpoint=endpoint, weight=1.0)
+
+        referer = "https://evals.example.com"
+        with override_settings(
+            PUBLIC_SITE_URL=referer,
+            PUBLIC_BRAND_NAME='Gobii Meta Gobii Skill Eval',
+        ):
+            with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "openrouter-key"}, clear=True):
+                configs = get_llm_config_with_failover(routing_profile=profile, token_count=100)
+
+        self.assertEqual(len(configs), 1)
+        _provider, _model, params = configs[0]
+        self.assertEqual(
+            params.get("extra_headers"),
+            {"HTTP-Referer": referer, "X-Title": DEFAULT_ATTRIBUTION_TITLE},
+        )
+        public_headers = json.dumps(params["extra_headers"])
+        self.assertNotIn("meta_gobii_skill_eval", public_headers)
+        self.assertNotIn("Gobii Meta Gobii Skill Eval", public_headers)
 
     def test_gpt5_temperature_is_forced(self):
         """Runtime configuration coerces GPT-5 to temperature=1 even without overrides."""

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import uuid
 from decimal import Decimal
 from datetime import timedelta
 from unittest.mock import patch
@@ -73,6 +74,14 @@ class RemoteMCPViewTests(TestCase):
             password="password",
         )
         UserQuota.objects.get_or_create(user=self.other_user, defaults={"agent_limit": 20})
+        self.staff_user = User.objects.create_user(
+            username="mcp-staff@example.com",
+            email="mcp-staff@example.com",
+            password="password",
+            is_staff=True,
+        )
+        UserQuota.objects.get_or_create(user=self.staff_user, defaults={"agent_limit": 20})
+        self.raw_staff_api_key, self.staff_api_key = ApiKey.create_for_user(self.staff_user, name="mcp-staff")
 
     def _post_mcp(self, method, params=None, *, auth="x-api-key", extra_headers=None, api_key=None):
         payload = {
@@ -188,12 +197,210 @@ class RemoteMCPViewTests(TestCase):
         self.assertIn("sanitized", debug_tool["description"])
         self.assertEqual(debug_tool["inputSchema"]["properties"]["limit"]["maximum"], 50)
         self.assertIn("audit_events", debug_tool["inputSchema"]["properties"]["include"]["items"]["enum"])
+        self.assertIn("user_id", debug_tool["inputSchema"]["properties"])
+        self.assertIn("organization_id", debug_tool["inputSchema"]["properties"])
 
         list_response = self._call_tool("gobii_list_agents")
         self.assertEqual(list_response.status_code, 200)
         content = self._structured_content(list_response)
         self.assertEqual(content["total"], 1)
         self.assertEqual(content["agents"][0]["id"], str(agent.id))
+        self.assertNotIn("access", content)
+
+    def test_non_admin_scope_params_return_structured_tool_error(self):
+        other_agent = self._create_agent(self.other_user, "Scoped Other Agent")
+
+        list_response = self._call_tool(
+            "gobii_list_agents",
+            {"user_id": self.other_user.id},
+        )
+        self.assertEqual(list_response.status_code, 200)
+        self.assertTrue(list_response.json()["result"]["isError"])
+        list_content = self._structured_content(list_response)
+        self.assertEqual(list_content["status"], "error")
+        self.assertEqual(list_content["details"]["code"], "admin_scope_required")
+        self.assertIn("user_id", list_content["details"]["fields"])
+
+        get_response = self._call_tool(
+            "gobii_get_agent",
+            {"agent_id": str(other_agent.id), "user_id": self.other_user.id},
+        )
+        self.assertEqual(get_response.status_code, 200)
+        self.assertTrue(get_response.json()["result"]["isError"])
+        self.assertEqual(self._structured_content(get_response)["details"]["code"], "admin_scope_required")
+
+    def test_staff_can_cross_account_get_debug_and_timeline_by_agent_id(self):
+        other_agent = self._create_agent(self.other_user, "Staff Cross Account Agent")
+        self._create_web_message(
+            other_agent,
+            "Investigate this. Authorization: Bearer staff-cross-account-secret",
+        )
+
+        get_response = self._call_tool(
+            "gobii_get_agent",
+            {"agent_id": str(other_agent.id)},
+            api_key=self.raw_staff_api_key,
+        )
+        self.assertEqual(get_response.status_code, 200)
+        get_content = self._structured_content(get_response)
+        self.assertFalse(get_response.json()["result"]["isError"])
+        self.assertEqual(get_content["agent"]["id"], str(other_agent.id))
+        self.assertEqual(get_content["access"]["admin_access"], True)
+        self.assertEqual(get_content["access"]["access_scope"], "staff_cross_account")
+        self.assertEqual(get_content["access"]["target_user_id"], str(self.other_user.id))
+
+        timeline_response = self._call_tool(
+            "gobii_get_agent_timeline",
+            {"agent_id": str(other_agent.id), "limit": 5},
+            api_key=self.raw_staff_api_key,
+        )
+        self.assertEqual(timeline_response.status_code, 200)
+        timeline_content = self._structured_content(timeline_response)
+        self.assertFalse(timeline_response.json()["result"]["isError"])
+        self.assertEqual(timeline_content["access"]["target_user_id"], str(self.other_user.id))
+
+        debug_response = self._call_tool(
+            "gobii_get_agent_debug_trace",
+            {
+                "agent_id": str(other_agent.id),
+                "limit": 5,
+                "include": ["audit_events"],
+            },
+            api_key=self.raw_staff_api_key,
+        )
+        self.assertEqual(debug_response.status_code, 200)
+        debug_content = self._structured_content(debug_response)
+        self.assertFalse(debug_response.json()["result"]["isError"])
+        self.assertEqual(debug_content["agent"]["id"], str(other_agent.id))
+        self.assertEqual(debug_content["access"]["target_user_id"], str(self.other_user.id))
+        serialized = json.dumps(debug_content)
+        self.assertNotIn("staff-cross-account-secret", serialized)
+        self.assertIn("[REDACTED]", serialized)
+
+    def test_staff_can_use_scoped_list_agents(self):
+        self._create_agent(self.user, "Default User Agent")
+        other_agent = self._create_agent(self.other_user, "Scoped Listed Agent")
+
+        response = self._call_tool(
+            "gobii_list_agents",
+            {"user_id": self.other_user.id},
+            api_key=self.raw_staff_api_key,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = self._structured_content(response)
+        self.assertFalse(response.json()["result"]["isError"])
+        self.assertEqual(content["total"], 1)
+        self.assertEqual(content["agents"][0]["id"], str(other_agent.id))
+        self.assertEqual(content["access"]["admin_access"], True)
+        self.assertEqual(content["access"]["requested_user_id"], str(self.other_user.id))
+
+    def test_staff_can_create_agent_in_scoped_user_and_org_contexts(self):
+        org = Organization.objects.create(name="Scoped MCP Org", slug="scoped-mcp-org", created_by=self.other_user)
+        org.billing.purchased_seats = 1
+        org.billing.save(update_fields=["purchased_seats"])
+        OrganizationMembership.objects.create(
+            org=org,
+            user=self.other_user,
+            role=OrganizationMembership.OrgRole.OWNER,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+
+        with (
+            patch.object(BrowserUseAgent, "select_random_proxy", return_value=None),
+            patch("api.services.persistent_agents.maybe_schedule_short_description"),
+            patch("api.services.persistent_agents.maybe_schedule_mini_description"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_tags"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_avatar"),
+            patch("api.agent.tasks.process_agent_events_task.delay"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            user_response = self._call_tool(
+                "gobii_create_agent",
+                {
+                    "name": "Scoped User Created Agent",
+                    "charter": "Created for another user by staff.",
+                    "user_id": self.other_user.id,
+                },
+                api_key=self.raw_staff_api_key,
+            )
+            org_response = self._call_tool(
+                "gobii_create_agent",
+                {
+                    "name": "Scoped Org Created Agent",
+                    "charter": "Created for another organization by staff.",
+                    "organization_id": str(org.id),
+                },
+                api_key=self.raw_staff_api_key,
+            )
+
+        self.assertEqual(user_response.status_code, 200)
+        user_content = self._structured_content(user_response)
+        self.assertFalse(user_response.json()["result"]["isError"])
+        user_agent = PersistentAgent.objects.get(id=user_content["agent"]["id"])
+        self.assertEqual(user_agent.user_id, self.other_user.id)
+        self.assertIsNone(user_agent.organization_id)
+        self.assertEqual(user_content["access"]["requested_user_id"], str(self.other_user.id))
+
+        self.assertEqual(org_response.status_code, 200)
+        org_content = self._structured_content(org_response)
+        self.assertFalse(org_response.json()["result"]["isError"])
+        org_agent = PersistentAgent.objects.get(id=org_content["agent"]["id"])
+        self.assertEqual(org_agent.organization_id, org.id)
+        self.assertEqual(org_agent.user_id, self.other_user.id)
+        self.assertEqual(org_content["access"]["requested_organization_id"], str(org.id))
+
+    def test_staff_cross_account_update_agent_records_access_metadata(self):
+        other_agent = self._create_agent(self.other_user, "Staff Mutated Agent")
+
+        response = self._call_tool(
+            "gobii_update_agent",
+            {
+                "agent_id": str(other_agent.id),
+                "user_id": self.other_user.id,
+                "charter": "Updated by staff through scoped Remote MCP.",
+            },
+            api_key=self.raw_staff_api_key,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = self._structured_content(response)
+        self.assertFalse(response.json()["result"]["isError"])
+        other_agent.refresh_from_db()
+        self.assertEqual(other_agent.charter, "Updated by staff through scoped Remote MCP.")
+        self.assertEqual(content["access"]["admin_access"], True)
+        self.assertEqual(content["access"]["target_user_id"], str(self.other_user.id))
+
+    def test_staff_scope_invalid_targets_return_structured_tool_errors(self):
+        missing_user_response = self._call_tool(
+            "gobii_list_agents",
+            {"user_id": 999999},
+            api_key=self.raw_staff_api_key,
+        )
+        self.assertEqual(missing_user_response.status_code, 200)
+        self.assertTrue(missing_user_response.json()["result"]["isError"])
+        self.assertEqual(self._structured_content(missing_user_response)["details"]["code"], "user_not_found")
+
+        missing_org_response = self._call_tool(
+            "gobii_list_agents",
+            {"organization_id": str(uuid.uuid4())},
+            api_key=self.raw_staff_api_key,
+        )
+        self.assertEqual(missing_org_response.status_code, 200)
+        self.assertTrue(missing_org_response.json()["result"]["isError"])
+        self.assertEqual(self._structured_content(missing_org_response)["details"]["code"], "organization_not_found")
+
+        missing_agent_response = self._call_tool(
+            "gobii_get_agent",
+            {"agent_id": str(uuid.uuid4())},
+            api_key=self.raw_staff_api_key,
+        )
+        self.assertEqual(missing_agent_response.status_code, 200)
+        self.assertTrue(missing_agent_response.json()["result"]["isError"])
+        self.assertEqual(
+            self._structured_content(missing_agent_response)["details"]["code"],
+            "agent_not_found_or_inaccessible",
+        )
 
     def test_lifecycle_tools_create_update_link_and_archive_agent(self):
         existing_agent = self._create_agent(self.user, "Existing MCP Agent")

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -1,19 +1,31 @@
 import base64
 import json
+from decimal import Decimal
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
+from django.utils import timezone
 
 from api.models import (
     AgentPeerLink,
     BrowserUseAgent,
     CommsChannel,
+    EvalRun,
+    EvalRunTask,
     IntelligenceTier,
+    Organization,
+    OrganizationMembership,
     PersistentAgent,
     PersistentAgentCommsEndpoint,
     PersistentAgentConversation,
+    PersistentAgentCompletion,
+    PersistentAgentError,
     PersistentAgentMessage,
+    PersistentAgentPromptArchive,
+    PersistentAgentStep,
+    PersistentAgentToolCall,
     UserQuota,
     build_web_agent_address,
     build_web_user_address,
@@ -62,7 +74,7 @@ class RemoteMCPViewTests(TestCase):
         )
         UserQuota.objects.get_or_create(user=self.other_user, defaults={"agent_limit": 20})
 
-    def _post_mcp(self, method, params=None, *, auth="x-api-key", extra_headers=None):
+    def _post_mcp(self, method, params=None, *, auth="x-api-key", extra_headers=None, api_key=None):
         payload = {
             "jsonrpc": "2.0",
             "id": "test-1",
@@ -71,10 +83,11 @@ class RemoteMCPViewTests(TestCase):
         if params is not None:
             payload["params"] = params
         headers = dict(extra_headers or {})
+        raw_api_key = api_key or self.raw_api_key
         if auth == "x-api-key":
-            headers["HTTP_X_API_KEY"] = self.raw_api_key
+            headers["HTTP_X_API_KEY"] = raw_api_key
         elif auth == "bearer":
-            headers["HTTP_AUTHORIZATION"] = f"Bearer {self.raw_api_key}"
+            headers["HTTP_AUTHORIZATION"] = f"Bearer {raw_api_key}"
         return self.client.post(
             "/api/v1/mcp/",
             data=json.dumps(payload),
@@ -82,22 +95,57 @@ class RemoteMCPViewTests(TestCase):
             **headers,
         )
 
-    def _call_tool(self, name, arguments=None, *, auth="x-api-key"):
+    def _call_tool(self, name, arguments=None, *, auth="x-api-key", api_key=None):
         return self._post_mcp(
             "tools/call",
             {"name": name, "arguments": arguments or {}},
             auth=auth,
+            api_key=api_key,
         )
 
-    def _create_agent(self, user, name):
+    def _create_agent(self, user, name, *, organization=None):
         with patch.object(BrowserUseAgent, "select_random_proxy", return_value=None):
             browser_agent = BrowserUseAgent.objects.create(user=user, name=f"{name} Browser")
         return PersistentAgent.objects.create(
             user=user,
+            organization=organization,
             name=name,
             charter=f"{name} charter",
             browser_use_agent=browser_agent,
             preferred_llm_tier=self.tier,
+        )
+
+    def _create_web_message(self, agent, body, *, is_outbound=False):
+        agent_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
+            channel=CommsChannel.WEB,
+            address=build_web_agent_address(agent.id),
+            defaults={"owner_agent": agent},
+        )
+        if agent_endpoint.owner_agent_id != agent.id:
+            agent_endpoint.owner_agent = agent
+            agent_endpoint.save(update_fields=["owner_agent"])
+        user_address = build_web_user_address(agent.user_id, agent.id)
+        user_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
+            channel=CommsChannel.WEB,
+            address=user_address,
+        )
+        conversation, _ = PersistentAgentConversation.objects.get_or_create(
+            channel=CommsChannel.WEB,
+            address=user_address,
+            defaults={"owner_agent": agent, "display_name": agent.user.email},
+        )
+        if conversation.owner_agent_id != agent.id:
+            conversation.owner_agent = agent
+            conversation.save(update_fields=["owner_agent"])
+
+        return PersistentAgentMessage.objects.create(
+            owner_agent=agent,
+            from_endpoint=agent_endpoint if is_outbound else user_endpoint,
+            to_endpoint=user_endpoint if is_outbound else None,
+            conversation=conversation,
+            is_outbound=is_outbound,
+            body=body,
+            raw_payload={"source": "unit_test"},
         )
 
     def _structured_content(self, response):
@@ -133,7 +181,13 @@ class RemoteMCPViewTests(TestCase):
         self.assertIn("gobii_get_agent_config_options", tool_names)
         self.assertIn("gobii_send_agent_message", tool_names)
         self.assertIn("gobii_wait_for_agent_event", tool_names)
+        self.assertIn("gobii_get_agent_debug_trace", tool_names)
         self.assertIn("gobii_upload_agent_file", tool_names)
+
+        debug_tool = next(tool for tool in tools_response.json()["result"]["tools"] if tool["name"] == "gobii_get_agent_debug_trace")
+        self.assertIn("sanitized", debug_tool["description"])
+        self.assertEqual(debug_tool["inputSchema"]["properties"]["limit"]["maximum"], 50)
+        self.assertIn("audit_events", debug_tool["inputSchema"]["properties"]["include"]["items"]["enum"])
 
         list_response = self._call_tool("gobii_list_agents")
         self.assertEqual(list_response.status_code, 200)
@@ -622,6 +676,202 @@ class RemoteMCPViewTests(TestCase):
         outbound_to_agent_content = self._structured_content(outbound_to_agent_response)
         self.assertFalse(outbound_to_agent_content["matched"])
         self.assertTrue(outbound_to_agent_content["timed_out"])
+
+    def test_agent_debug_trace_returns_bounded_sanitized_audit_info(self):
+        agent = self._create_agent(self.user, "Debug Trace MCP Agent")
+        self._create_web_message(
+            agent,
+            "Investigate the job. Authorization: Bearer message-secret-token",
+        )
+        completion = PersistentAgentCompletion.objects.create(
+            agent=agent,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+            response_id="resp-debug",
+            prompt_tokens=11,
+            completion_tokens=7,
+            total_tokens=18,
+            cached_tokens=3,
+            llm_model="debug-model",
+            llm_provider="debug-provider",
+            llm_tool_names=["http_request"],
+            thinking_content="reasoning with api_key=thinking-secret-token",
+            input_cost_total=Decimal("0.011"),
+            input_cost_uncached=Decimal("0.010"),
+            input_cost_cached=Decimal("0.001"),
+            output_cost=Decimal("0.007"),
+            total_cost=Decimal("0.018"),
+            credits_cost=Decimal("0.500"),
+            billed=True,
+        )
+        step = PersistentAgentStep.objects.create(
+            agent=agent,
+            completion=completion,
+            description="Tool call with password=step-secret-token",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="http_request",
+            tool_params={
+                "url": "https://example.test/data",
+                "api_key": "params-secret-token",
+                "headers": {"Authorization": "Bearer params-bearer-secret"},
+            },
+            result="Fetched ok with sk-live-resultsecret1234567890",
+            status="complete",
+            execution_duration_ms=42,
+        )
+        PersistentAgentPromptArchive.objects.create(
+            agent=agent,
+            step=step,
+            rendered_at=timezone.now(),
+            storage_key="prompt_archives/raw-secret-storage-key.json.zst",
+            raw_bytes=1000,
+            compressed_bytes=400,
+            tokens_before=100,
+            tokens_after=80,
+            tokens_saved=20,
+        )
+        PersistentAgentError.objects.create(
+            agent=agent,
+            completion=completion,
+            category=PersistentAgentError.Category.TOOL_PERSISTENCE,
+            source="tests.remote_mcp",
+            message="Tool failed with access_token=error-secret-token",
+            exception_class="RuntimeError",
+            traceback="Traceback with Bearer traceback-secret-token",
+            context={"password": "context-secret-token", "attempt": 1},
+        )
+        run = EvalRun.objects.create(
+            agent=agent,
+            initiated_by=self.user,
+            scenario_slug="debug_trace_scenario",
+            status=EvalRun.Status.COMPLETED,
+        )
+        EvalRunTask.objects.create(
+            run=run,
+            sequence=1,
+            name="verify_trace",
+            status=EvalRunTask.Status.FAILED,
+            assertion_type="manual",
+            observed_summary="Observed api_key=observed-secret-token",
+            debug_artifacts={
+                "params": {"url": "https://example.test/data", "api_key": "artifact-secret-token"},
+                "messages": ["summary with Bearer artifact-bearer-secret"],
+            },
+            first_step=step,
+        )
+
+        response = self._call_tool(
+            "gobii_get_agent_debug_trace",
+            {
+                "agent_id": str(agent.id),
+                "limit": 10,
+                "include": ["audit_events", "completions", "eval_debug_artifacts", "diagnostics"],
+                "detail": "standard",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["result"]["isError"])
+        content = self._structured_content(response)
+        self.assertEqual(content["agent"]["id"], str(agent.id))
+        self.assertEqual(content["audit"]["source"], "console.agent_audit.events.fetch_audit_events")
+        self.assertLessEqual(len(content["audit_events"]), 10)
+        event_kinds = {event["kind"] for event in content["audit_events"]}
+        self.assertTrue({"message", "tool_call", "completion", "error"}.issubset(event_kinds))
+        self.assertEqual(content["completions"]["items"][0]["cost"]["total_cost"], "0.018000")
+        self.assertEqual(content["completions"]["items"][0]["prompt_archive"]["tokens_saved"], 20)
+        self.assertEqual(content["eval_debug_artifacts"]["items"][0]["scenario_slug"], "debug_trace_scenario")
+        self.assertGreaterEqual(content["diagnostics"]["recent_error_count"], 1)
+
+        serialized = json.dumps(content)
+        for secret in (
+            "message-secret-token",
+            "thinking-secret-token",
+            "params-secret-token",
+            "params-bearer-secret",
+            "sk-live-resultsecret1234567890",
+            "step-secret-token",
+            "error-secret-token",
+            "traceback-secret-token",
+            "context-secret-token",
+            "artifact-secret-token",
+            "artifact-bearer-secret",
+            "observed-secret-token",
+            "raw-secret-storage-key",
+        ):
+            self.assertNotIn(secret, serialized)
+        self.assertIn("[REDACTED]", serialized)
+
+    def test_agent_debug_trace_enforces_access_scope_for_other_org_agents(self):
+        org = Organization.objects.create(name="MCP Org", slug="mcp-org", created_by=self.user)
+        org.billing.purchased_seats = 1
+        org.billing.save(update_fields=["purchased_seats"])
+        OrganizationMembership.objects.create(
+            org=org,
+            user=self.user,
+            role=OrganizationMembership.OrgRole.OWNER,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+        raw_org_key, _ = ApiKey.create_for_org(org, created_by=self.user, name="mcp-org")
+        other_org = Organization.objects.create(name="Other MCP Org", slug="other-mcp-org", created_by=self.other_user)
+        other_org.billing.purchased_seats = 1
+        other_org.billing.save(update_fields=["purchased_seats"])
+        OrganizationMembership.objects.create(
+            org=other_org,
+            user=self.other_user,
+            role=OrganizationMembership.OrgRole.OWNER,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+        other_agent = self._create_agent(self.other_user, "Other Org Debug Agent", organization=other_org)
+
+        response = self._call_tool(
+            "gobii_get_agent_debug_trace",
+            {"agent_id": str(other_agent.id)},
+            api_key=raw_org_key,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["result"]["isError"])
+        self.assertEqual(self._structured_content(response)["status"], "error")
+        self.assertIn("not found or inaccessible", self._structured_content(response)["message"])
+
+    def test_agent_debug_trace_limit_and_recent_window_are_enforced(self):
+        agent = self._create_agent(self.user, "Debug Trace Window Agent")
+        old_message = self._create_web_message(agent, "Old debug event")
+        old_timestamp = timezone.now() - timedelta(hours=2)
+        PersistentAgentMessage.objects.filter(id=old_message.id).update(timestamp=old_timestamp)
+
+        for index in range(3):
+            self._create_web_message(agent, f"Recent debug event {index}")
+
+        response = self._call_tool(
+            "gobii_get_agent_debug_trace",
+            {
+                "agent_id": str(agent.id),
+                "limit": 2,
+                "recent_minutes": 30,
+                "include": ["audit_events"],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = self._structured_content(response)
+        self.assertLessEqual(len(content["audit_events"]), 2)
+        bodies = [event.get("body_text") for event in content["audit_events"] if event.get("kind") == "message"]
+        self.assertTrue(all(body != "Old debug event" for body in bodies))
+
+        invalid_response = self._call_tool(
+            "gobii_get_agent_debug_trace",
+            {
+                "agent_id": str(agent.id),
+                "limit": 2,
+                "recent_minutes": 30,
+                "since": timezone.now().isoformat(),
+            },
+        )
+        self.assertEqual(invalid_response.status_code, 200)
+        self.assertTrue(invalid_response.json()["result"]["isError"])
 
     def test_origin_validation_rejects_untrusted_browser_origins(self):
         response = self._post_mcp(


### PR DESCRIPTION
## Summary
- add gobii_get_agent_debug_trace for bounded, sanitized agent debugging over Remote MCP
- reuse existing staff audit event serializers/fetch path and add completion usage/cost plus eval debug artifact metadata
- document debug trace usage, privacy, bounds, and smoke flow

## Validation
- uv run python manage.py test tests.unit.test_remote_mcp --settings=config.test_settings
- uv run python manage.py test tests.unit.test_agent_audit_api.StaffAgentAuditAPITests.test_audit_api_returns_error_events tests.unit.test_agent_audit_api.StaffAgentAuditAPITests.test_audit_api_returns_completion_reasoning --settings=config.test_settings
- uv run python manage.py check --settings=config.test_settings
- uv run ruff check api/services/agent_debug_trace.py api/services/remote_mcp.py tests/unit/test_remote_mcp.py
- git diff --check

## Update: admin scoping + OpenRouter attribution hygiene
- added staff/operator Remote MCP scoping with optional `user_id` / `organization_id`, preserving default tenant-scoped behavior for normal API keys
- added centralized scope/access metadata for cross-account results and structured `admin_scope_required` errors for non-admin scoped attempts
- added regression coverage so OpenRouter attribution preserves `HTTP-Referer` but always uses generic `X-Title: Gobii`, preventing eval/profile names such as `Gobii Meta Gobii Skill Eval` from appearing publicly

## Additional validation
- uv run python manage.py test tests.unit.test_remote_mcp --settings=config.test_settings --parallel auto
- uv run python manage.py test tests.unit.test_llm_failover --settings=config.test_settings --parallel auto
- uv run ruff check api/services/remote_mcp.py api/openrouter.py tests/unit/test_remote_mcp.py tests/unit/test_llm_failover.py
- GitHub CI: success at 916071e1a8013733dbea6acba0d54227f1eeccf9
- GitHub Docs: success at 916071e1a8013733dbea6acba0d54227f1eeccf9
- Infra Preview Deploy: success, preview-ready
- Preview MCP smoke: staff scoped `gobii_list_agents(user_id=4)`, cross-account `gobii_get_agent`, `gobii_get_agent_timeline`, and `gobii_get_agent_debug_trace` returned `admin_access: true` metadata; temporary non-staff key was denied scoped access with `admin_scope_required` and then deleted
- Preview OpenRouter attribution check: `get_attribution_headers()` returned `X-Title: Gobii` and `HTTP-Referer: https://gobii.ai`
