### PR TITLE
Limit LOC budget to core product code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
       matrix:
         include:
           - batch: shard_01
-            tag: batch_pages batch_sms batch_console_email_oauth batch_token_usage batch_event_parallel batch_allowlist_direction batch_tool_costs batch_output_schema batch_soft_expiration batch_console_api_keys batch_console_allowlist batch_pa_shutdown_triggers
+            tag: batch_pages batch_sms batch_console_email_oauth batch_token_usage batch_event_parallel batch_allowlist_direction batch_tool_costs batch_output_schema batch_soft_expiration batch_console_api_keys batch_console_allowlist batch_pa_shutdown_triggers complexity_guardrails_batch
           - batch: shard_02
             tag: batch_mcp_tools batch_human_input batch_eval_fingerprint batch_user_flags batch_api_agents batch_api_tasks pipedream_jit_connect batch_browser_task_db batch_agent_transfer batch_periodic batch_mcp_admin mcp_org_assignment_batch
           - batch: shard_03

--- a/docs/ci-guardrails.md
+++ b/docs/ci-guardrails.md
@@ -2,7 +2,7 @@
 
 CI enforces two hard budgets before the expensive test shards run:
 
-- Source LoC: nonblank lines in tracked application, test, and frontend source files.
+- Source LoC: nonblank lines in tracked core product source files.
 - Prompt size: rendered prompt messages plus JSON tool definitions for normal explicit-send, web-chat implied-send, and planning first-run paths.
 
 Run locally:
@@ -11,7 +11,7 @@ Run locally:
 uv run python scripts/check_complexity_budgets.py
 ```
 
-The LoC guardrail intentionally excludes generated assets, migrations, vendor/build outputs, media/cache, docs, CI metadata, and the guardrail tooling itself. The budget targets product source size; CI and budget metadata are excluded so this bootstrap PR can freeze the current application baseline without raising it.
+The LoC guardrail intentionally excludes generated assets, migrations, vendor/build outputs, media/cache, docs, CI metadata, and the guardrail tooling itself. It also excludes unit/integration tests and dedicated eval assets such as `api/evals/`, eval-only settings, eval UI files, and synthetic eval tool definitions. The budget targets core product source size; product files that merely reference eval/test concepts still count unless they are in one of the explicit excluded test or eval paths.
 
 Intentional budget increases require approval. After approval, update the committed limits from the approved branch:
 

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "fb5583d40d41c21d70585c151f94e70050bb64e0",
+  "baseline_sha": "bfc3e9c29c990535787792ea38c2d89a6e189317",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
@@ -34,7 +34,25 @@
     "unit": "utf8_bytes"
   },
   "source_loc": {
-    "description": "Nonblank lines in tracked application/test/frontend source files.",
+    "description": "Nonblank lines in tracked core product source files, excluding tests and dedicated eval assets.",
+    "exclude_eval_files": [
+      "api/agent/eval_agents.py",
+      "api/agent/tools/eval_synthetic_tools.py",
+      "api/management/commands/run_evals.py",
+      "config/eval_local_settings.py",
+      "config/eval_postgres_settings.py",
+      "console/templates/console/evals.html",
+      "console/templates/console/evals_detail.html",
+      "frontend/src/api/evals.ts",
+      "frontend/src/screens/EvalsDetailScreen.tsx",
+      "frontend/src/screens/EvalsScreen.tsx"
+    ],
+    "exclude_eval_prefixes": [
+      "api/evals/",
+      "api/templates/evals/",
+      "console/evals/",
+      "frontend/src/components/evals/"
+    ],
     "exclude_filenames": [
       "package-lock.json",
       "uv.lock"
@@ -63,7 +81,26 @@
       "static/frontend/",
       "vendor/"
     ],
-    "file_count": 1360,
+    "exclude_test_file_suffixes": [
+      ".js",
+      ".jsx",
+      ".py",
+      ".ts",
+      ".tsx"
+    ],
+    "exclude_test_files": [
+      "config/minimal_test_settings.py",
+      "config/test_settings.py"
+    ],
+    "exclude_test_parts": [
+      "/__tests__/",
+      "/tests/"
+    ],
+    "exclude_test_prefixes": [
+      "frontend/src/test/",
+      "tests/"
+    ],
+    "file_count": 992,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -84,14 +121,12 @@
       "pages/",
       "proprietary/",
       "sandbox_server/server/",
-      "sandbox_server/tests/",
       "setup/",
       "static/css/",
       "static/js/",
       "tasks/",
       "templates/",
       "templatetags/",
-      "tests/",
       "util/"
     ],
     "include_suffixes": [
@@ -112,6 +147,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 405737
+    "limit": 274460
   }
 }

--- a/scripts/check_complexity_budgets.py
+++ b/scripts/check_complexity_budgets.py
@@ -37,14 +37,12 @@ SOURCE_ROOTS = (
     "pages/",
     "proprietary/",
     "sandbox_server/server/",
-    "sandbox_server/tests/",
     "setup/",
     "static/css/",
     "static/js/",
     "tasks/",
     "templates/",
     "templatetags/",
-    "tests/",
     "util/",
 )
 SOURCE_FILES = {
@@ -98,6 +96,43 @@ EXCLUDED_FILENAMES = {
     "package-lock.json",
     "uv.lock",
 }
+TEST_EXCLUDED_PREFIXES = (
+    "frontend/src/test/",
+    "tests/",
+)
+TEST_EXCLUDED_PARTS = (
+    "/__tests__/",
+    "/tests/",
+)
+TEST_EXCLUDED_FILES = {
+    "config/minimal_test_settings.py",
+    "config/test_settings.py",
+}
+TEST_FILE_SUFFIXES = {
+    ".js",
+    ".jsx",
+    ".py",
+    ".ts",
+    ".tsx",
+}
+EVAL_EXCLUDED_PREFIXES = (
+    "api/evals/",
+    "api/templates/evals/",
+    "console/evals/",
+    "frontend/src/components/evals/",
+)
+EVAL_EXCLUDED_FILES = {
+    "api/agent/eval_agents.py",
+    "api/agent/tools/eval_synthetic_tools.py",
+    "api/management/commands/run_evals.py",
+    "config/eval_local_settings.py",
+    "config/eval_postgres_settings.py",
+    "console/templates/console/evals.html",
+    "console/templates/console/evals_detail.html",
+    "frontend/src/api/evals.ts",
+    "frontend/src/screens/EvalsDetailScreen.tsx",
+    "frontend/src/screens/EvalsScreen.tsx",
+}
 
 
 @dataclass(frozen=True)
@@ -130,6 +165,37 @@ def _git_files() -> list[str]:
     ]
 
 
+def _is_test_source(path: str) -> bool:
+    if path in TEST_EXCLUDED_FILES:
+        return True
+    if any(path.startswith(prefix) for prefix in TEST_EXCLUDED_PREFIXES):
+        return True
+    normalized = f"/{path}"
+    if any(part in normalized for part in TEST_EXCLUDED_PARTS):
+        return True
+
+    path_obj = Path(path)
+    if path_obj.suffix not in TEST_FILE_SUFFIXES:
+        return False
+
+    name = path_obj.name
+    return (
+        name.startswith("test_")
+        or name.endswith("_test.py")
+        or any(
+            name.endswith(f".{kind}{path_obj.suffix}")
+            for kind in ("test", "spec")
+        )
+    )
+
+
+def _is_eval_source(path: str) -> bool:
+    return path in EVAL_EXCLUDED_FILES or any(
+        path.startswith(prefix)
+        for prefix in EVAL_EXCLUDED_PREFIXES
+    )
+
+
 def _is_counted_source(path: str) -> bool:
     if path in EXCLUDED_FILENAMES:
         return False
@@ -137,6 +203,8 @@ def _is_counted_source(path: str) -> bool:
         return False
     normalized = f"/{path}"
     if any(part in normalized for part in EXCLUDED_PARTS):
+        return False
+    if _is_test_source(path) or _is_eval_source(path):
         return False
     if path in SOURCE_FILES:
         return True
@@ -377,13 +445,19 @@ def _budget_metadata(baseline_sha: str) -> dict[str, Any]:
         "baseline_sha": baseline_sha,
         "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
         "source_loc": {
-            "description": "Nonblank lines in tracked application/test/frontend source files.",
+            "description": "Nonblank lines in tracked core product source files, excluding tests and dedicated eval assets.",
             "include_roots": list(SOURCE_ROOTS),
             "include_files": sorted(SOURCE_FILES),
             "include_suffixes": sorted(SOURCE_SUFFIXES),
             "exclude_prefixes": list(EXCLUDED_PREFIXES),
             "exclude_parts": list(EXCLUDED_PARTS),
             "exclude_filenames": sorted(EXCLUDED_FILENAMES),
+            "exclude_test_prefixes": list(TEST_EXCLUDED_PREFIXES),
+            "exclude_test_parts": list(TEST_EXCLUDED_PARTS),
+            "exclude_test_files": sorted(TEST_EXCLUDED_FILES),
+            "exclude_test_file_suffixes": sorted(TEST_FILE_SUFFIXES),
+            "exclude_eval_prefixes": list(EVAL_EXCLUDED_PREFIXES),
+            "exclude_eval_files": sorted(EVAL_EXCLUDED_FILES),
         },
         "prompt_size": {
             "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",

--- a/tests/unit/test_complexity_budgets.py
+++ b/tests/unit/test_complexity_budgets.py
@@ -1,0 +1,90 @@
+from django.test import SimpleTestCase, tag
+
+from scripts import check_complexity_budgets as budgets
+
+
+@tag("complexity_guardrails_batch")
+class ComplexityBudgetSourceFilterTests(SimpleTestCase):
+    def assert_counted(self, path: str) -> None:
+        self.assertTrue(budgets._is_counted_source(path), path)
+
+    def assert_not_counted(self, path: str) -> None:
+        self.assertFalse(budgets._is_counted_source(path), path)
+
+    def test_counts_core_product_paths_even_with_eval_or_test_words(self):
+        counted_paths = (
+            "api/services/evaluation_summary.py",
+            "api/services/contest_results.py",
+            "api/services/latest_activity.py",
+            "api/agent/tools/spawn_web_task.py",
+            "api/templates/admin/test_sms_form.html",
+            "console/usage_views.py",
+            "frontend/src/components/mcp/McpServerTestModal.tsx",
+            "frontend/src/api/llmConfig.ts",
+            "frontend/src/components/agentChat/TestimonialPanel.tsx",
+        )
+
+        for path in counted_paths:
+            with self.subTest(path=path):
+                self.assert_counted(path)
+
+    def test_excludes_unit_and_integration_test_assets(self):
+        test_paths = (
+            "tests/unit/test_agent.py",
+            "api/agent/core/tests/test_event_processing.py",
+            "api/agent/core/tests/__init__.py",
+            "sandbox_server/tests/test_files.py",
+            "frontend/src/api/agentChat.test.ts",
+            "frontend/src/components/agentChat/AgentChatLayout.spec.tsx",
+            "frontend/src/test/setup.ts",
+            "config/minimal_test_settings.py",
+            "config/test_settings.py",
+        )
+
+        for path in test_paths:
+            with self.subTest(path=path):
+                self.assert_not_counted(path)
+
+    def test_excludes_dedicated_eval_assets(self):
+        eval_paths = (
+            "api/evals/runner.py",
+            "api/evals/scenarios/weather_lookup.py",
+            "api/agent/eval_agents.py",
+            "api/agent/tools/eval_synthetic_tools.py",
+            "api/management/commands/run_evals.py",
+            "api/templates/evals/sim/weather.html",
+            "console/evals/consumers.py",
+            "console/templates/console/evals.html",
+            "config/eval_local_settings.py",
+            "config/eval_postgres_settings.py",
+            "frontend/src/api/evals.ts",
+            "frontend/src/components/evals/CompareModal.tsx",
+            "frontend/src/screens/EvalsScreen.tsx",
+        )
+
+        for path in eval_paths:
+            with self.subTest(path=path):
+                self.assert_not_counted(path)
+
+    def test_budget_file_source_metadata_matches_filter_constants(self):
+        committed = budgets._load_budget()["source_loc"]
+        generated = budgets._budget_metadata("test-sha")["source_loc"]
+
+        metadata_keys = (
+            "description",
+            "include_roots",
+            "include_files",
+            "include_suffixes",
+            "exclude_prefixes",
+            "exclude_parts",
+            "exclude_filenames",
+            "exclude_test_prefixes",
+            "exclude_test_parts",
+            "exclude_test_files",
+            "exclude_test_file_suffixes",
+            "exclude_eval_prefixes",
+            "exclude_eval_files",
+        )
+        for key in metadata_keys:
+            with self.subTest(key=key):
+                self.assertEqual(committed[key], generated[key])


### PR DESCRIPTION
## Summary
- exclude unit/integration tests from the source LoC budget
- exclude dedicated eval suites, harness, settings, and eval UI assets from the source LoC budget
- update the committed LoC baseline and document the include/exclude rules
- add deterministic filter tests and register the CI batch tag

## Validation
- env -u VIRTUAL_ENV uv run python manage.py test tests.unit.test_complexity_budgets --settings=config.test_settings
- env -u VIRTUAL_ENV uv run python manage.py test --settings=config.test_settings --tag complexity_guardrails_batch
- env -u VIRTUAL_ENV uv run python scripts/check_test_tags.py
- env -u VIRTUAL_ENV uv run python scripts/check_complexity_budgets.py
- git diff --check