### PR TITLE
Preserve explicit message continuation across agent stop heuristics

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -3126,7 +3126,7 @@ def _finalize_tool_batch(
         elif is_error_status or tool_had_warning:
             followup_required = True
         elif (
-            effective_explicit_continue is not True
+            effective_explicit_continue is None
             and not allow_auto_sleep
             and not terminal_message_delivery_ok
             and not human_input_request_ok

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -2099,6 +2099,28 @@ def _message_tool_body_from_params(tool_name: str, tool_params: Dict[str, Any]) 
     return str(tool_params.get(body_key) or "") if body_key else ""
 
 
+def _message_tool_has_progress_intent(tool_name: str, tool_params: Dict[str, Any]) -> bool:
+    if tool_name not in MESSAGE_TOOL_NAMES:
+        return False
+    explicit_continue = _coerce_optional_bool(tool_params.get("will_continue_work"))
+    if explicit_continue is True:
+        return True
+    if explicit_continue is False:
+        return False
+    return _should_infer_message_tool_continuation(
+        _message_tool_body_from_params(tool_name, tool_params)
+    )
+
+
+def _message_tool_is_terminal(tool_name: str, tool_params: Dict[str, Any]) -> bool:
+    if tool_name not in MESSAGE_TOOL_NAMES:
+        return False
+    body = _message_tool_body_from_params(tool_name, tool_params)
+    if not body or _looks_like_blocking_human_input_request(body):
+        return False
+    return not _message_tool_has_progress_intent(tool_name, tool_params)
+
+
 def _tool_call_likely_terminal_message(call: Any) -> bool:
     tool_name = _get_tool_call_name(call)
     if tool_name not in MESSAGE_TOOL_NAMES:
@@ -2107,10 +2129,7 @@ def _tool_call_likely_terminal_message(call: Any) -> bool:
         _raw_args, tool_params = _parse_tool_call_params(_get_tool_call_arguments(call))
     except (TypeError, ValueError, json.JSONDecodeError):
         return False
-    body = _message_tool_body_from_params(tool_name, tool_params)
-    if not body:
-        return False
-    return not _looks_like_blocking_human_input_request(body) and not _should_infer_message_tool_continuation(body)
+    return _message_tool_is_terminal(tool_name, tool_params)
 
 
 def _should_skip_irrelevant_agent_config_mutation(
@@ -3042,20 +3061,14 @@ def _finalize_tool_batch(
             and result.get("skipped") is True
         )
         effective_explicit_continue = prepared.explicit_continue
-        delivered_terminal_message = False
         if tool_name in MESSAGE_TOOL_NAMES and not message_delivery_skipped:
             status_label = str(status or "").lower()
             if status_label in MESSAGE_SUCCESS_STATUSES:
                 message_delivery_ok = True
-                body_key = MESSAGE_TOOL_BODY_KEYS.get(tool_name)
-                body = str(prepared.tool_params.get(body_key) or "") if body_key else ""
-                if prepared.explicit_continue is True and _should_infer_message_tool_continuation(body):
+                if _message_tool_has_progress_intent(tool_name, prepared.tool_params):
                     progress_message_delivery_ok = True
                 else:
-                    delivered_terminal_message = True
                     terminal_message_delivery_ok = True
-                    if prepared.explicit_continue is True:
-                        effective_explicit_continue = False
 
         is_error_status = _is_error_status(result)
         tool_status = "error" if is_error_status else "complete"

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -3126,7 +3126,7 @@ def _finalize_tool_batch(
         elif is_error_status or tool_had_warning:
             followup_required = True
         elif (
-            effective_explicit_continue is None
+            effective_explicit_continue is not True
             and not allow_auto_sleep
             and not terminal_message_delivery_ok
             and not human_input_request_ok

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -1,5 +1,7 @@
 """Tests for event processing continuation decisions."""
 
+import json
+
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -10,15 +12,19 @@ from django.test import SimpleTestCase, TestCase, override_settings, tag
 from django.utils import timezone
 
 from api.agent.core.event_processing import (
+    _finalize_tool_batch,
     _contact_permission_params_from_misrouted_human_input,
     _process_agent_events_locked,
     _is_warning_status,
     _looks_like_blocking_human_input_request,
     _normalize_tool_params,
     _parse_tool_call_params,
+    _PreparedToolExecution,
     _sanitize_tool_name,
     _should_infer_message_tool_continuation,
     _should_imply_continue,
+    _ToolExecutionOutcome,
+    _tool_call_likely_terminal_message,
 )
 from django.urls import reverse
 
@@ -108,6 +114,88 @@ class ImpliedContinuationDecisionTests(SimpleTestCase):
         )
 
         self.assertFalse(result)
+
+
+@tag('batch_event_processing')
+class MessageToolExplicitContinuationTests(TestCase):
+    def setUp(self):
+        user = get_user_model().objects.create_user(
+            username="message-continuation@example.com",
+            email="message-continuation@example.com",
+            password="secret",
+        )
+        browser_agent = BrowserUseAgent.objects.create(user=user, name="MessageContinuationBA")
+        self.agent = PersistentAgent.objects.create(
+            user=user,
+            name="Message Continuation Agent",
+            charter="Handle user work.",
+            browser_use_agent=browser_agent,
+        )
+
+    def test_explicit_continue_true_is_not_overridden_by_message_heuristic(self):
+        body = (
+            "Sorry Yash! I was getting the searches set up — starting the actual profile discovery "
+            "right now. Will have the Excel sheet to you within a couple of hours!"
+        )
+        self.assertFalse(_should_infer_message_tool_continuation(body))
+        prepared = _PreparedToolExecution(
+            idx=1,
+            tool_name="send_chat_message",
+            tool_params={"body": body, "will_continue_work": True},
+            exec_params={"body": body, "will_continue_work": True},
+            pending_step=None,
+            credits_consumed=None,
+            consumed_credit=None,
+            call_id="call_1",
+            explicit_continue=True,
+            inferred_continue=False,
+            parallel_safe=False,
+            parallel_ineligible_reason=None,
+        )
+
+        finalized = _finalize_tool_batch(
+            self.agent,
+            [
+                _ToolExecutionOutcome(
+                    prepared=prepared,
+                    result={
+                        "status": "ok",
+                        "message": "Web chat message sent.",
+                        "message_id": str(uuid4()),
+                        "auto_sleep_ok": False,
+                    },
+                    duration_ms=1,
+                    updated_tools=None,
+                    variable_map={},
+                )
+            ],
+            attach_completion=lambda kwargs: None,
+            attach_prompt_archive=lambda step: None,
+        )
+
+        self.assertFalse(finalized.followup_required)
+        self.assertTrue(finalized.message_delivery_ok)
+        self.assertTrue(finalized.progress_message_delivery_ok)
+        self.assertFalse(finalized.terminal_message_delivery_ok)
+        self.assertIs(finalized.last_explicit_continue, True)
+
+    def test_preflight_terminal_message_detection_respects_explicit_continue_true(self):
+        call = {
+            "function": {
+                "name": "send_chat_message",
+                "arguments": json.dumps(
+                    {
+                        "body": (
+                            "Sorry Yash! I was getting the searches set up — starting the actual "
+                            "profile discovery right now."
+                        ),
+                        "will_continue_work": True,
+                    }
+                ),
+            }
+        }
+
+        self.assertFalse(_tool_call_likely_terminal_message(call))
 
 
 @tag('batch_event_processing')

--- a/tests/unit/test_event_processing_batch_sleep.py
+++ b/tests/unit/test_event_processing_batch_sleep.py
@@ -477,7 +477,7 @@ class TestBatchToolCallsWithSleep(TestCase):
         mock_send_chat.assert_called_once()
 
     @patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None})
-    @patch('api.agent.core.event_processing.execute_update_plan', return_value={"status": "ok"})
+    @patch('api.agent.core.event_processing.execute_update_plan', return_value={"status": "ok", "auto_sleep_ok": True})
     @patch('api.agent.core.event_processing.execute_enabled_tool', return_value={"status": "ok", "auto_sleep_ok": True})
     @patch('api.agent.core.event_processing.execute_send_chat_message', return_value={"status": "ok", "auto_sleep_ok": False})
     @patch('api.agent.core.event_processing.build_prompt_context')

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -883,7 +883,7 @@ class ImpliedSendTests(TestCase):
         self.assertFalse(finalized.followup_required)
         self.assertIs(finalized.last_explicit_continue, True)
 
-    def test_terminal_chat_marked_continue_is_treated_as_stop(self):
+    def test_terminal_chat_marked_continue_preserves_explicit_continue(self):
         final_chat = ep._ToolExecutionOutcome(
             prepared=ep._PreparedToolExecution(
                 idx=1,
@@ -925,10 +925,10 @@ class ImpliedSendTests(TestCase):
         )
 
         self.assertTrue(finalized.message_delivery_ok)
-        self.assertTrue(finalized.terminal_message_delivery_ok)
-        self.assertFalse(finalized.progress_message_delivery_ok)
+        self.assertFalse(finalized.terminal_message_delivery_ok)
+        self.assertTrue(finalized.progress_message_delivery_ok)
         self.assertFalse(finalized.followup_required)
-        self.assertIs(finalized.last_explicit_continue, False)
+        self.assertIs(finalized.last_explicit_continue, True)
 
     def test_prepare_tool_batch_skips_one_off_config_churn_before_terminal_message(self):
         self._add_inbound_web_message("What's the latest Bitcoin price right now?")
@@ -965,7 +965,7 @@ class ImpliedSendTests(TestCase):
                                         "Bitcoin is trading at $68,500.\n\n"
                                         "Sources:\n- https://example.test/price"
                                     ),
-                                    "will_continue_work": True,
+                                    "will_continue_work": False,
                                 }
                             ),
                         },


### PR DESCRIPTION
**Summary**
- Make explicit `will_continue_work=true` authoritative for message tools instead of letting body heuristics downgrade it.
- Share the same message-intent decision in both preflight terminal-message classification and post-execution finalization to avoid divergent behavior.
- Add regression coverage for the exact web-chat message shape that previously auto-stopped incorrectly.

**Testing**
- Ran `uv run python manage.py test api.agent.core.tests.test_event_processing.MessageToolExplicitContinuationTests --settings=config.test_settings`
- Verified the new regression tests pass