### PR TITLE
Remove burn-rate cooldown and always step down to standard

### DIFF
--- a/api/agent/core/burn_control.py
+++ b/api/agent/core/burn_control.py
@@ -2,50 +2,26 @@
 
 from enum import Enum
 import logging
-from datetime import timedelta
 from decimal import Decimal, InvalidOperation
-from typing import Optional, Union
-from uuid import UUID, uuid4
+from typing import Optional
 
-from django.utils import timezone as dj_timezone
-
-from config import settings
-from config.redis_client import get_redis_client
-from .schedule_parser import ScheduleParser
-from .budget import AgentBudgetManager, BudgetContext
+from .budget import BudgetContext
 from .llm_config import (
+    AgentLLMTier,
     get_agent_baseline_llm_tier,
     get_credit_multiplier_for_tier,
-    get_next_lower_configured_tier,
     get_runtime_tier_override,
     set_runtime_tier_override,
 )
 from .prompt_context import get_agent_daily_credit_state
 from util.analytics import Analytics, AnalyticsEvent, AnalyticsSource
-from api.models import (
-    PersistentAgent,
-    PersistentAgentMessage,
-    PersistentAgentSystemStep,
-    PersistentAgentStep,
-)
+from api.models import PersistentAgent
 
 logger = logging.getLogger(__name__)
-
-BURN_RATE_COOLDOWN_SECONDS = int(getattr(settings, "BURN_RATE_COOLDOWN_SECONDS", 3600))
-BURN_FOLLOW_UP_SKIP_WINDOW_SECONDS = int(
-    getattr(settings, "BURN_FOLLOW_UP_SKIP_WINDOW_SECONDS", 2 * 60 * 60)
-)
-BURN_FOLLOW_UP_TTL_BUFFER_SECONDS = int(
-    getattr(settings, "BURN_FOLLOW_UP_TTL_BUFFER_SECONDS", 600)
-)
-BURN_RATE_USER_INACTIVITY_MINUTES = int(
-    getattr(settings, "BURN_RATE_USER_INACTIVITY_MINUTES", 60)
-)
 
 
 class BurnRateAction(str, Enum):
     NONE = "none"
-    PAUSED = "paused"
     STEPPED_DOWN = "stepped_down"
 
 
@@ -133,280 +109,6 @@ def _set_burn_24h_span_attributes(
         return None
 
 
-def burn_cooldown_key(agent_id: Union[str, UUID]) -> str:
-    """Return the Redis key used to mark an active burn-rate cooldown."""
-
-    return f"agent-burn-cooldown:{agent_id}"
-
-
-def burn_follow_up_key(agent_id: Union[str, UUID]) -> str:
-    """Return the Redis key used to dedupe scheduled burn-rate follow-ups."""
-
-    return f"agent-burn-followup:{agent_id}"
-
-
-def _next_scheduled_run(agent: PersistentAgent, *, now=None):
-    """Return the datetime of the next scheduled run for the agent, if known."""
-
-    now = now or dj_timezone.now()
-    schedule_str = getattr(agent, "schedule", None) or getattr(agent, "schedule_snapshot", None)
-    if not schedule_str:
-        return None
-
-    try:
-        schedule_obj = ScheduleParser.parse(schedule_str)
-    except Exception:
-        logger.warning("Failed to parse schedule for agent %s", agent.id, exc_info=True)
-        return None
-
-    if schedule_obj is None:
-        return None
-
-    try:
-        eta = schedule_obj.remaining_estimate(now)
-    except Exception:
-        logger.warning("Failed to compute next scheduled run for agent %s", agent.id, exc_info=True)
-        return None
-
-    if eta is None:
-        return None
-
-    if isinstance(eta, (int, float)):
-        eta = timedelta(seconds=eta)
-
-    try:
-        return now + eta
-    except Exception:
-        logger.warning("Failed to compute next scheduled datetime for agent %s", agent.id, exc_info=True)
-        return None
-
-
-def has_recent_user_message(agent_id: Union[str, UUID], *, window_minutes: int) -> bool:
-    """Return True if the agent received a non-peer inbound message recently."""
-
-    cutoff = dj_timezone.now() - timedelta(minutes=window_minutes)
-    try:
-        return PersistentAgentMessage.objects.filter(
-            owner_agent_id=agent_id,
-            is_outbound=False,
-            timestamp__gte=cutoff,
-            conversation__is_peer_dm=False,
-        ).exists()
-    except Exception:
-        logger.debug(
-            "Failed to check recent user messages for agent %s", agent_id, exc_info=True
-        )
-        return False
-
-
-def schedule_burn_follow_up(
-    agent: PersistentAgent,
-    cooldown_seconds: int,
-    redis_client=None,
-    follow_up_task=None,
-) -> Optional[str]:
-    """Schedule a delayed follow-up run to resume after a burn-rate pause."""
-
-    now = dj_timezone.now()
-    cooldown_ends_at = now + timedelta(seconds=max(1, int(cooldown_seconds)))
-    next_run = _next_scheduled_run(agent, now=now)
-    if next_run is not None:
-        horizon = now + timedelta(seconds=BURN_FOLLOW_UP_SKIP_WINDOW_SECONDS)
-        # Keep the optimization only when cron is expected shortly *after*
-        # cooldown ends. If cron lands during cooldown, we still need follow-up.
-        if cooldown_ends_at <= next_run <= horizon:
-            logger.info(
-                "Skipping burn-rate follow-up for agent %s: next cron/interval run at %s is after cooldown end %s and within skip window horizon %s.",
-                agent.id,
-                next_run,
-                cooldown_ends_at,
-                horizon,
-            )
-            return None
-
-    try:
-        from api.agent.core import event_processing as _event_processing  # type: ignore
-
-        process_agent_events_task = (
-            follow_up_task
-            or getattr(_event_processing, "process_agent_events_task", None)
-        )
-        if process_agent_events_task is None:
-            from ..tasks.process_events import process_agent_events_task  # noqa: WPS433
-    except Exception:
-        logger.exception("Failed to import process_agent_events_task for agent %s", agent.id)
-        return None
-
-    token = uuid4().hex
-    ttl_seconds = max(1, cooldown_seconds + BURN_FOLLOW_UP_TTL_BUFFER_SECONDS)
-    client = redis_client if redis_client is not None else get_redis_client()
-    try:
-        set_result = client.set(
-            burn_follow_up_key(agent.id),
-            token,
-            ex=ttl_seconds,
-        )
-        logger.debug(
-            "Burn follow-up token set result for agent %s: %s",
-            agent.id,
-            set_result,
-        )
-    except Exception:
-        logger.debug(
-            "Failed to persist burn follow-up token for agent %s", agent.id, exc_info=True
-        )
-        return None
-
-    if not set_result:
-        logger.debug(
-            "Redis refused burn follow-up token set for agent %s; skipping follow-up schedule.",
-            agent.id,
-        )
-        return None
-
-    try:
-        logger.info(
-            "Scheduling burn-rate follow-up for agent %s via %s (countdown=%s, ttl=%s)",
-            agent.id,
-            getattr(process_agent_events_task, "__name__", type(process_agent_events_task)),
-            cooldown_seconds,
-            ttl_seconds,
-        )
-        process_agent_events_task.apply_async(
-            args=[str(agent.id)],
-            kwargs={"burn_follow_up_token": token},
-            countdown=cooldown_seconds,
-        )
-    except Exception:
-        logger.error(
-            "Failed to schedule burn-rate follow-up for agent %s", agent.id, exc_info=True
-        )
-        return None
-
-    return token
-
-
-def pause_for_burn_rate(
-    agent: PersistentAgent,
-    *,
-    burn_rate: Decimal,
-    burn_threshold: Decimal,
-    burn_window: Optional[int],
-    budget_ctx: Optional[BudgetContext],
-    burn_24h_total: Optional[Decimal] = None,
-    burn_24h_threshold: Optional[Decimal] = None,
-    span=None,
-    redis_client=None,
-    follow_up_task=None,
-) -> None:
-    """Record a burn-rate pause, set cooldown markers, and schedule a follow-up."""
-
-    cooldown_seconds = max(1, int(BURN_RATE_COOLDOWN_SECONDS))
-    redis_client = redis_client if redis_client is not None else get_redis_client()
-
-    try:
-        redis_client.set(
-            burn_cooldown_key(agent.id),
-            "1",
-            ex=cooldown_seconds,
-        )
-    except Exception:
-        logger.debug(
-            "Failed to set burn-rate cooldown key for agent %s", agent.id, exc_info=True
-        )
-
-    follow_up_token = schedule_burn_follow_up(
-        agent,
-        cooldown_seconds,
-        redis_client=redis_client,
-        follow_up_task=follow_up_task,
-    )
-
-    window_text = f"{burn_window} minutes" if burn_window else "the recent window"
-    cooldown_minutes = round(cooldown_seconds / 60, 2)
-    description = (
-        "Paused processing due to elevated burn rate without recent user input. "
-        f"Current burn rate: {burn_rate} credits/hour over {window_text}; "
-        f"threshold: {burn_threshold} credits/hour. "
-        f"Will resume after cooldown (~{cooldown_minutes} minutes) or when triggered by new input."
-    )
-    if burn_24h_threshold is not None and burn_24h_threshold > Decimal("0"):
-        description += (
-            f" Rolling 24-hour burn: {burn_24h_total or Decimal('0')} credits; "
-            f"24-hour threshold: {burn_24h_threshold} credits."
-        )
-    step = PersistentAgentStep.objects.create(
-        agent=agent,
-        description=description,
-    )
-    PersistentAgentSystemStep.objects.create(
-        step=step,
-        code=PersistentAgentSystemStep.Code.BURN_RATE_COOLDOWN,
-    )
-
-    try:
-        analytics_props: dict[str, str] = {
-            "agent_id": str(agent.id),
-            "agent_name": agent.name,
-            "burn_rate_per_hour": str(burn_rate),
-            "burn_rate_threshold_per_hour": str(burn_threshold),
-        }
-        analytics_props.update(
-            _burn_24h_analytics_props(
-                burn_24h_total=burn_24h_total,
-                burn_24h_threshold=burn_24h_threshold,
-            )
-        )
-        if burn_window is not None:
-            analytics_props["burn_rate_window_minutes"] = str(burn_window)
-        props_with_org = Analytics.with_org_properties(
-            analytics_props,
-            organization=getattr(agent, "organization", None),
-        )
-        Analytics.track_event(
-            user_id=getattr(getattr(agent, "user", None), "id", None),
-            event=AnalyticsEvent.PERSISTENT_AGENT_BURN_RATE_LIMIT_REACHED,
-            source=AnalyticsSource.AGENT,
-            properties=props_with_org,
-        )
-    except Exception:
-        logger.debug(
-            "Failed to emit burn-rate limit analytics for agent %s", agent.id, exc_info=True
-        )
-
-    if span is not None:
-        try:
-            span.add_event("Burn-rate cooldown activated")
-            span.set_attribute("burn_rate.cooldown_seconds", cooldown_seconds)
-            span.set_attribute("burn_rate.value", float(burn_rate))
-            span.set_attribute("burn_rate.threshold", float(burn_threshold))
-            span.set_attribute("burn_rate.follow_up_token_present", bool(follow_up_token))
-            _set_burn_24h_span_attributes(
-                span,
-                burn_24h_total=burn_24h_total,
-                burn_24h_threshold=burn_24h_threshold,
-            )
-        except Exception:
-            logger.debug("Failed to set burn-rate span attributes for agent %s", agent.id, exc_info=True)
-
-    if budget_ctx is not None:
-        try:
-            AgentBudgetManager.close_cycle(
-                agent_id=budget_ctx.agent_id,
-                budget_id=budget_ctx.budget_id,
-            )
-            logger.info(
-                "Closed budget cycle for agent %s after burn-rate pause.",
-                agent.id,
-            )
-        except Exception:
-            logger.debug(
-                "Failed to close budget cycle for agent %s after burn pause.",
-                agent.id,
-                exc_info=True,
-            )
-
-
 def _step_down_runtime_tier(
     agent: PersistentAgent,
     *,
@@ -417,13 +119,13 @@ def _step_down_runtime_tier(
     burn_24h_threshold: Optional[Decimal] = None,
     span=None,
 ) -> bool:
-    """Apply a runtime tier downgrade when recent user activity makes pausing undesirable."""
+    """Apply a runtime tier downgrade to the lowest tier for this processing run."""
 
     if get_runtime_tier_override(agent) is not None:
         return False
 
     baseline_tier = get_agent_baseline_llm_tier(agent)
-    runtime_tier = get_next_lower_configured_tier(baseline_tier)
+    runtime_tier = AgentLLMTier.STANDARD
     if runtime_tier == baseline_tier:
         return False
 
@@ -488,7 +190,7 @@ def _step_down_runtime_tier(
             )
 
     logger.info(
-        "Agent %s runtime tier stepped down from %s to %s due to burn rate %s > %s with recent user input.",
+        "Agent %s runtime tier stepped down from %s to %s due to burn rate %s > %s.",
         agent.id,
         baseline_tier.value,
         runtime_tier.value,
@@ -521,7 +223,7 @@ def handle_burn_rate_limit(
             return BurnRateAction.NONE
     if daily_state is None:
         logger.warning(
-            "Daily credit state unavailable for agent %s; skipping burn-rate pause check.",
+            "Daily credit state unavailable for agent %s; skipping burn-rate check.",
             agent.id,
         )
         return BurnRateAction.NONE
@@ -531,47 +233,17 @@ def handle_burn_rate_limit(
         return BurnRateAction.NONE
     burn_rate, burn_threshold, burn_window, burn_24h_total, burn_24h_threshold = metrics
 
-    if has_recent_user_message(agent.id, window_minutes=BURN_RATE_USER_INACTIVITY_MINUTES):
-        if _step_down_runtime_tier(
-            agent,
-            burn_rate=burn_rate,
-            burn_threshold=burn_threshold,
-            burn_window=burn_window,
-            burn_24h_total=burn_24h_total,
-            burn_24h_threshold=burn_24h_threshold,
-            span=span,
-        ):
-            return BurnRateAction.STEPPED_DOWN
-        return BurnRateAction.NONE
-
-    # If a cooldown is already in place, do not schedule another.
-    try:
-        client = redis_client if redis_client is not None else get_redis_client()
-        if client.get(burn_cooldown_key(agent.id)):
-            return BurnRateAction.NONE
-    except Exception:
-        logger.warning(
-            "Failed cooldown check for agent %s; proceeding as if no cooldown is active.",
-            agent.id,
-            exc_info=True,
-        )
-
-    if follow_up_task is not None:
-        logger.debug("Burn-rate pause will schedule follow-up via override task for agent %s", agent.id)
-
-    pause_for_burn_rate(
+    if _step_down_runtime_tier(
         agent,
         burn_rate=burn_rate,
         burn_threshold=burn_threshold,
         burn_window=burn_window,
         burn_24h_total=burn_24h_total,
         burn_24h_threshold=burn_24h_threshold,
-        budget_ctx=budget_ctx,
         span=span,
-        redis_client=redis_client,
-        follow_up_task=follow_up_task,
-    )
-    return BurnRateAction.PAUSED
+    ):
+        return BurnRateAction.STEPPED_DOWN
+    return BurnRateAction.NONE
 
 
 def should_pause_for_burn_rate(
@@ -583,16 +255,17 @@ def should_pause_for_burn_rate(
     redis_client=None,
     follow_up_task=None,
 ) -> bool:
-    """Backwards-compatible pause helper built on top of unified burn control."""
+    """Backwards-compatible helper; burn-rate pauses are no longer applied."""
 
-    return handle_burn_rate_limit(
+    handle_burn_rate_limit(
         agent,
         budget_ctx=budget_ctx,
         span=span,
         daily_state=daily_state,
         redis_client=redis_client,
         follow_up_task=follow_up_task,
-    ) == BurnRateAction.PAUSED
+    )
+    return False
 
 
 def maybe_step_down_runtime_tier_for_burn_rate(

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -20,7 +20,6 @@ from decimal import Decimal
 from typing import Callable, List, Tuple, Union, Optional, Dict, Any, Literal
 from uuid import UUID
 
-import redis
 import sqlparse
 from opentelemetry import baggage, trace
 from pottery import Redlock
@@ -40,13 +39,8 @@ from .budget import (
     set_current_context as set_budget_context,
 )
 from .burn_control import (
-    BURN_RATE_COOLDOWN_SECONDS,
-    BURN_RATE_USER_INACTIVITY_MINUTES,
     BurnRateAction,
-    burn_cooldown_key,
-    burn_follow_up_key,
     handle_burn_rate_limit,
-    has_recent_user_message,
 )
 from .processing_flags import (
     clear_processing_lock_active,
@@ -4855,74 +4849,11 @@ def process_agent_events(
         clear_processing_queued_flag(persistent_agent_id, client=redis_client)
         return
 
-    follow_up_key = burn_follow_up_key(persistent_agent_id)
-    cooldown_key = burn_cooldown_key(persistent_agent_id)
-
-    # If this invocation is a scheduled burn-rate follow-up, ensure the token matches.
     if burn_follow_up_token:
-        stored_token = redis_client.get(follow_up_key)
-        stored_token_value = (
-            stored_token.decode() if isinstance(stored_token, (bytes, bytearray)) else stored_token
+        logger.info(
+            "Ignoring obsolete burn-rate follow-up token for agent %s.",
+            persistent_agent_id,
         )
-        if not stored_token_value or stored_token_value != burn_follow_up_token:
-            logger.info(
-                "Skipping burn-rate follow-up for agent %s (token missing or mismatched).",
-                persistent_agent_id,
-            )
-            span.add_event("Burn-rate follow-up skipped - token mismatch")
-            return
-        try:
-            redis_client.delete(follow_up_key)
-        except Exception:
-            logger.debug(
-                "Failed to clear burn follow-up token for agent %s", persistent_agent_id, exc_info=True
-            )
-    else:
-        # Respect active burn-rate cooldown unless a recent user message arrived.
-        try:
-            cooldown_value = redis_client.get(cooldown_key)
-            cooldown_active = bool(cooldown_value)
-        except Exception:
-            logger.warning(
-                "Failed to read burn-rate cooldown for agent %s; proceeding as if inactive.",
-                persistent_agent_id,
-                exc_info=True,
-            )
-            cooldown_active = False
-        if cooldown_active:
-            if has_recent_user_message(
-                persistent_agent_id,
-                window_minutes=BURN_RATE_USER_INACTIVITY_MINUTES,
-            ):
-                try:
-                    redis_client.delete(cooldown_key)
-                except Exception:
-                    logger.debug(
-                        "Failed to clear burn cooldown for agent %s after user interaction",
-                        persistent_agent_id,
-                        exc_info=True,
-                    )
-            else:
-                logger.info(
-                    "Skipping event processing for agent %s – burn-rate cooldown active.",
-                    persistent_agent_id,
-                )
-                span.add_event("Processing skipped - burn cooldown active")
-                clear_processing_queued_flag(persistent_agent_id)
-                return
-
-        # A normal run cancels any pending burn follow-up so we don't double-run.
-        try:
-            deleted = redis_client.delete(follow_up_key)
-            if isinstance(deleted, int) and deleted > 0:
-                logger.info(
-                    "Cleared pending burn-rate follow-up token for agent %s due to new processing run.",
-                    persistent_agent_id,
-                )
-        except redis.exceptions.RedisError as e:
-            logger.warning(
-                "Failed to clear burn-rate follow-up token for agent %s: %s", persistent_agent_id, e, exc_info=True
-            )
 
     if _should_skip_processing_for_inactive_or_deleted_agent(
         persistent_agent_id,
@@ -5518,7 +5449,6 @@ def _run_agent_loop(
     # Clear agent variables from any previous processing cycle
     clear_variables()
     clear_runtime_tier_override(agent)
-    span.set_attribute("burn.cooldown_seconds", BURN_RATE_COOLDOWN_SECONDS)
     max_runtime_seconds = int(getattr(settings, "AGENT_EVENT_PROCESSING_MAX_RUNTIME_SECONDS", 0))
     run_started_at = time.monotonic()
     if heartbeat:
@@ -5532,9 +5462,6 @@ def _run_agent_loop(
             exc_info=True,
         )
         redis_client = None
-    burn_follow_up_task = globals().get("process_agent_events_task")
-    span.set_attribute("burn.follow_up_task_present", bool(burn_follow_up_task))
-
     # Heuristic auto-enable: scan recent inbound messages for site keywords
     # and pre-enable relevant tools if there's capacity (no eviction)
     try:
@@ -5697,22 +5624,7 @@ def _run_agent_loop(
                     budget_ctx=budget_ctx,
                     span=iter_span,
                     daily_state=daily_state,
-                    redis_client=redis_client,
-                    follow_up_task=burn_follow_up_task,
                 )
-                if burn_rate_action == BurnRateAction.PAUSED:
-                    maybe_run_agent_judge(
-                        agent,
-                        tools=tools,
-                        extra_trigger_reasons=["burn_rate_throttled"],
-                    )
-                    logger.info(
-                        "Agent %s paused due to burn rate; exiting loop after %d iteration(s).",
-                        agent.id,
-                        i + 1,
-                    )
-                    return cumulative_token_usage
-
                 judge_trigger_reasons = []
                 if burn_rate_action == BurnRateAction.STEPPED_DOWN:
                     judge_trigger_reasons.append("burn_rate_tier_step_down")

--- a/tests/unit/test_agent_event_processing_credits.py
+++ b/tests/unit/test_agent_event_processing_credits.py
@@ -943,7 +943,7 @@ class PersistentAgentToolCreditTests(TestCase):
 
         self.assertEqual(state["burn_rate_threshold_per_hour"], Decimal("4.000"))
 
-    def test_daily_credit_state_multi_week_decay_enables_pause(self):
+    def test_daily_credit_state_multi_week_decay_exceeds_burn_rate_threshold(self):
         state = self._build_daily_state_with_inactivity(
             inactive_days=21,
             burn_rate_per_hour=Decimal("6"),
@@ -952,20 +952,14 @@ class PersistentAgentToolCreditTests(TestCase):
         self.assertEqual(state["burn_rate_threshold_per_hour"], Decimal("4.000"))
         self.assertEqual(state["burn_rate_per_hour"], Decimal("6"))
         self.assertLess(state["burn_rate_threshold_per_hour"], state["burn_rate_per_hour"])
-
-        with patch(
-            "api.agent.core.burn_control.has_recent_user_message",
-            return_value=False,
-        ), patch("api.agent.core.burn_control.pause_for_burn_rate") as pause_mock:
-            should_pause = bc.should_pause_for_burn_rate(
+        self.assertFalse(
+            bc.should_pause_for_burn_rate(
                 self.agent,
                 budget_ctx=None,
                 daily_state=state,
-                redis_client=MagicMock(get=MagicMock(return_value=None)),
+                redis_client=MagicMock(),
             )
-
-        self.assertTrue(should_pause)
-        pause_mock.assert_called_once()
+        )
 
     def test_daily_credit_state_uses_offpeak_threshold_at_night(self):
         now_value = datetime(2026, 3, 10, 3, 0, tzinfo=dt_timezone.utc)
@@ -1150,7 +1144,9 @@ class PersistentAgentToolCreditTests(TestCase):
         self.assertIn("2/2", usage_call.args[1])
         self.assertIn("browser_task_usage_warning", names)
 
-    def test_burn_rate_pause_schedules_follow_up_and_exits_loop(self):
+    def test_burn_rate_excess_steps_down_without_follow_up_or_cooldown_and_continues_loop(self):
+        self.agent.preferred_llm_tier = get_intelligence_tier("ultra_max")
+        self.agent.save(update_fields=["preferred_llm_tier"])
         fake_store: dict[str, str] = {}
 
         class FakeRedis:
@@ -1170,10 +1166,31 @@ class PersistentAgentToolCreditTests(TestCase):
             "burn_rate_threshold_per_hour": Decimal("3"),
             "burn_rate_window_minutes": 60,
         }
+        response = MagicMock()
+        response.choices = [
+            MagicMock(message=MagicMock(content="Done for now", tool_calls=[], function_call=None))
+        ]
+        token_usage = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "cached_tokens": 0,
+        }
+        observed = {}
 
-        with patch("api.agent.core.event_processing.get_redis_client", return_value=fake_redis), \
+        def capture_failover(*_args, **_kwargs):
+            observed["routing_tier"] = get_agent_llm_tier(self.agent)
+            return [{}]
+
+        with override_settings(GOBII_PROPRIETARY_MODE=True), \
+             patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}), \
+             patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1), \
+             patch("api.agent.core.event_processing.get_redis_client", return_value=fake_redis), \
              patch("api.agent.core.event_processing.get_agent_daily_credit_state", return_value=burn_state), \
-             patch("api.agent.core.event_processing.build_prompt_context") as build_prompt_mock, \
+             patch("api.agent.core.event_processing.build_prompt_context", return_value=([], 0, None)) as build_prompt_mock, \
+             patch("api.agent.core.event_processing.get_llm_config_with_failover", side_effect=capture_failover), \
+             patch("tasks.services.TaskCreditService.check_and_consume_credit_for_owner", return_value={"success": True, "credit": None}), \
+             patch("api.agent.core.event_processing._completion_with_failover", return_value=(response, token_usage)), \
              patch(
                  "api.agent.core.event_processing.process_agent_events_task",
                  create=True,
@@ -1189,16 +1206,11 @@ class PersistentAgentToolCreditTests(TestCase):
             )
 
         self.assertEqual(usage["total_tokens"], 0)
-        build_prompt_mock.assert_not_called()
-
-        follow_up_task.apply_async.assert_called_once()
-        _, kwargs = follow_up_task.apply_async.call_args
-        self.assertEqual(kwargs["countdown"], ep.BURN_RATE_COOLDOWN_SECONDS)
-        token = kwargs["kwargs"]["burn_follow_up_token"]
-        self.assertEqual(fake_store.get(bc.burn_follow_up_key(self.agent.id)), token)
-        self.assertTrue(fake_store.get(bc.burn_cooldown_key(self.agent.id)))
-
-        self.assertTrue(
+        build_prompt_mock.assert_called_once()
+        follow_up_task.apply_async.assert_not_called()
+        self.assertEqual(fake_store, {})
+        self.assertEqual(observed["routing_tier"], AgentLLMTier.STANDARD)
+        self.assertFalse(
             PersistentAgentSystemStep.objects.filter(
                 step__agent=self.agent,
                 code=PersistentAgentSystemStep.Code.BURN_RATE_COOLDOWN,
@@ -1207,99 +1219,10 @@ class PersistentAgentToolCreditTests(TestCase):
         track_event_mock.assert_called_once()
         track_kwargs = track_event_mock.call_args.kwargs
         self.assertEqual(track_kwargs["user_id"], self.user.id)
-        self.assertEqual(track_kwargs["event"], AnalyticsEvent.PERSISTENT_AGENT_BURN_RATE_LIMIT_REACHED)
-
-    def test_burn_rate_pause_schedules_follow_up_when_next_cron_is_within_cooldown(self):
-        fake_store: dict[str, str] = {}
-
-        class FakeRedis:
-            def get(self, key):
-                return fake_store.get(key)
-
-            def set(self, key, value, ex=None):
-                fake_store[key] = value
-                return True
-
-            def delete(self, key):
-                return 1 if fake_store.pop(key, None) is not None else 0
-
-        fake_redis = FakeRedis()
-        burn_state = {
-            "burn_rate_per_hour": Decimal("5"),
-            "burn_rate_threshold_per_hour": Decimal("3"),
-            "burn_rate_window_minutes": 60,
-        }
-
-        self.agent.schedule = "@hourly"
-        self.agent.save(update_fields=["schedule"])
-
-        with patch("api.agent.core.event_processing.get_redis_client", return_value=fake_redis), \
-             patch("api.agent.core.event_processing.get_agent_daily_credit_state", return_value=burn_state), \
-             patch("api.agent.core.event_processing.build_prompt_context") as build_prompt_mock, \
-             patch(
-                 "api.agent.core.event_processing.process_agent_events_task",
-                 create=True,
-             ) as follow_up_task:
-            follow_up_task.apply_async = MagicMock()
-
-            usage = ep._run_agent_loop(
-                self.agent,
-                is_first_run=True,
-                credit_snapshot=None,
-                run_sequence_number=1,
-            )
-
-        self.assertEqual(usage["total_tokens"], 0)
-        build_prompt_mock.assert_not_called()
-        follow_up_task.apply_async.assert_called_once()
-        _, kwargs = follow_up_task.apply_async.call_args
-        self.assertEqual(kwargs["countdown"], ep.BURN_RATE_COOLDOWN_SECONDS)
-        token = kwargs["kwargs"]["burn_follow_up_token"]
-        self.assertEqual(fake_store.get(bc.burn_follow_up_key(self.agent.id)), token)
-
-    def test_burn_rate_pause_skips_follow_up_when_next_cron_is_after_cooldown_but_soon(self):
-        fake_store: dict[str, str] = {}
-
-        class FakeRedis:
-            def get(self, key):
-                return fake_store.get(key)
-
-            def set(self, key, value, ex=None):
-                fake_store[key] = value
-                return True
-
-            def delete(self, key):
-                return 1 if fake_store.pop(key, None) is not None else 0
-
-        fake_redis = FakeRedis()
-        burn_state = {
-            "burn_rate_per_hour": Decimal("5"),
-            "burn_rate_threshold_per_hour": Decimal("3"),
-            "burn_rate_window_minutes": 60,
-        }
-        next_run = timezone.now() + timezone.timedelta(minutes=90)
-
-        with patch("api.agent.core.event_processing.get_redis_client", return_value=fake_redis), \
-             patch("api.agent.core.event_processing.get_agent_daily_credit_state", return_value=burn_state), \
-             patch("api.agent.core.event_processing.build_prompt_context") as build_prompt_mock, \
-             patch("api.agent.core.burn_control._next_scheduled_run", return_value=next_run), \
-             patch(
-                 "api.agent.core.event_processing.process_agent_events_task",
-                 create=True,
-             ) as follow_up_task:
-            follow_up_task.apply_async = MagicMock()
-
-            usage = ep._run_agent_loop(
-                self.agent,
-                is_first_run=True,
-                credit_snapshot=None,
-                run_sequence_number=1,
-            )
-
-        self.assertEqual(usage["total_tokens"], 0)
-        build_prompt_mock.assert_not_called()
-        follow_up_task.apply_async.assert_not_called()
-        self.assertIsNone(fake_store.get(bc.burn_follow_up_key(self.agent.id)))
+        self.assertEqual(
+            track_kwargs["event"],
+            AnalyticsEvent.PERSISTENT_AGENT_BURN_RATE_RUNTIME_TIER_STEPPED_DOWN,
+        )
 
     def test_burn_rate_rechecks_fresh_daily_state_each_iteration(self):
         fake_store: dict[str, str] = {}
@@ -1370,16 +1293,16 @@ class PersistentAgentToolCreditTests(TestCase):
 
         self.assertEqual(usage["total_tokens"], 0)
         self.assertEqual(burn_state_fn.call_count, 2)
-        follow_up_task.apply_async.assert_called_once()
-        self.assertTrue(fake_store.get(bc.burn_cooldown_key(self.agent.id)))
-        self.assertTrue(
+        follow_up_task.apply_async.assert_not_called()
+        self.assertEqual(fake_store, {})
+        self.assertFalse(
             PersistentAgentSystemStep.objects.filter(
                 step__agent=self.agent,
                 code=PersistentAgentSystemStep.Code.BURN_RATE_COOLDOWN,
             ).exists()
         )
 
-    def test_runtime_tier_step_down_activates_once_with_recent_user_message(self):
+    def test_runtime_tier_step_down_activates_once_to_standard(self):
         self.agent.preferred_llm_tier = get_intelligence_tier("ultra_max")
         self.agent.save(update_fields=["preferred_llm_tier"])
         burn_state = {
@@ -1391,7 +1314,6 @@ class PersistentAgentToolCreditTests(TestCase):
         try:
             with override_settings(GOBII_PROPRIETARY_MODE=True), \
                  patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}), \
-                 patch("api.agent.core.burn_control.has_recent_user_message", return_value=True), \
                  patch("api.agent.core.burn_control.Analytics.track_event") as track_event_mock:
                 stepped = bc.maybe_step_down_runtime_tier_for_burn_rate(
                     self.agent,
@@ -1407,15 +1329,15 @@ class PersistentAgentToolCreditTests(TestCase):
                 self.assertTrue(stepped)
                 self.assertFalse(stepped_again)
                 self.assertEqual(get_agent_baseline_llm_tier(self.agent), AgentLLMTier.ULTRA_MAX)
-                self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.ULTRA)
-                self.assertEqual(get_agent_llm_tier(self.agent), AgentLLMTier.ULTRA)
+                self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.STANDARD)
+                self.assertEqual(get_agent_llm_tier(self.agent), AgentLLMTier.STANDARD)
                 self.assertFalse(
                     PersistentAgentSystemStep.objects.filter(step__agent=self.agent).exists()
                 )
                 self.assertFalse(
                     PersistentAgentStep.objects.filter(
                         agent=self.agent,
-                        description__contains="baseline_tier=ultra_max;runtime_tier=ultra",
+                        description__contains="baseline_tier=ultra_max;runtime_tier=standard",
                     ).exists()
                 )
                 track_event_mock.assert_called_once()
@@ -1426,7 +1348,9 @@ class PersistentAgentToolCreditTests(TestCase):
         finally:
             clear_runtime_tier_override(self.agent)
 
-    def test_burn_rate_pause_preserves_hourly_only_when_24h_threshold_disabled(self):
+    def test_burn_rate_step_down_preserves_hourly_only_when_24h_threshold_disabled(self):
+        self.agent.preferred_llm_tier = get_intelligence_tier("ultra_max")
+        self.agent.save(update_fields=["preferred_llm_tier"])
         burn_state = {
             "burn_rate_per_hour": Decimal("5"),
             "burn_rate_threshold_per_hour": Decimal("3"),
@@ -1435,17 +1359,20 @@ class PersistentAgentToolCreditTests(TestCase):
             "burn_rate_threshold_24h": Decimal("0"),
         }
 
-        with patch("api.agent.core.burn_control.has_recent_user_message", return_value=False), \
-             patch("api.agent.core.burn_control.pause_for_burn_rate") as pause_mock:
-            action = bc.handle_burn_rate_limit(
-                self.agent,
-                budget_ctx=None,
-                daily_state=burn_state,
-                redis_client=MagicMock(get=MagicMock(return_value=None)),
-            )
+        try:
+            with override_settings(GOBII_PROPRIETARY_MODE=True), \
+                 patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}):
+                action = bc.handle_burn_rate_limit(
+                    self.agent,
+                    budget_ctx=None,
+                    daily_state=burn_state,
+                    redis_client=MagicMock(),
+                )
 
-        self.assertEqual(action, bc.BurnRateAction.PAUSED)
-        pause_mock.assert_called_once()
+            self.assertEqual(action, bc.BurnRateAction.STEPPED_DOWN)
+            self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.STANDARD)
+        finally:
+            clear_runtime_tier_override(self.agent)
 
     def test_burn_rate_gate_skips_action_when_24h_total_below_threshold(self):
         burn_state = {
@@ -1456,20 +1383,19 @@ class PersistentAgentToolCreditTests(TestCase):
             "burn_rate_threshold_24h": Decimal("100"),
         }
 
-        with patch("api.agent.core.burn_control.has_recent_user_message") as recent_mock, \
-             patch("api.agent.core.burn_control.pause_for_burn_rate") as pause_mock:
-            action = bc.handle_burn_rate_limit(
-                self.agent,
-                budget_ctx=None,
-                daily_state=burn_state,
-                redis_client=MagicMock(get=MagicMock(return_value=None)),
-            )
+        action = bc.handle_burn_rate_limit(
+            self.agent,
+            budget_ctx=None,
+            daily_state=burn_state,
+            redis_client=MagicMock(),
+        )
 
         self.assertEqual(action, bc.BurnRateAction.NONE)
-        recent_mock.assert_not_called()
-        pause_mock.assert_not_called()
+        self.assertIsNone(get_runtime_tier_override(self.agent))
 
-    def test_burn_rate_pause_requires_24h_total_above_configured_threshold(self):
+    def test_burn_rate_step_down_requires_24h_total_above_configured_threshold(self):
+        self.agent.preferred_llm_tier = get_intelligence_tier("ultra_max")
+        self.agent.save(update_fields=["preferred_llm_tier"])
         burn_state = {
             "burn_rate_per_hour": Decimal("5"),
             "burn_rate_threshold_per_hour": Decimal("3"),
@@ -1478,19 +1404,20 @@ class PersistentAgentToolCreditTests(TestCase):
             "burn_rate_threshold_24h": Decimal("100"),
         }
 
-        with patch("api.agent.core.burn_control.has_recent_user_message", return_value=False), \
-             patch("api.agent.core.burn_control.pause_for_burn_rate") as pause_mock:
-            action = bc.handle_burn_rate_limit(
-                self.agent,
-                budget_ctx=None,
-                daily_state=burn_state,
-                redis_client=MagicMock(get=MagicMock(return_value=None)),
-            )
+        try:
+            with override_settings(GOBII_PROPRIETARY_MODE=True), \
+                 patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}):
+                action = bc.handle_burn_rate_limit(
+                    self.agent,
+                    budget_ctx=None,
+                    daily_state=burn_state,
+                    redis_client=MagicMock(),
+                )
 
-        self.assertEqual(action, bc.BurnRateAction.PAUSED)
-        pause_mock.assert_called_once()
-        self.assertEqual(pause_mock.call_args.kwargs["burn_24h_total"], Decimal("101"))
-        self.assertEqual(pause_mock.call_args.kwargs["burn_24h_threshold"], Decimal("100"))
+            self.assertEqual(action, bc.BurnRateAction.STEPPED_DOWN)
+            self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.STANDARD)
+        finally:
+            clear_runtime_tier_override(self.agent)
 
     def test_runtime_tier_step_down_requires_24h_total_above_configured_threshold(self):
         self.agent.preferred_llm_tier = get_intelligence_tier("ultra_max")
@@ -1505,8 +1432,7 @@ class PersistentAgentToolCreditTests(TestCase):
 
         try:
             with override_settings(GOBII_PROPRIETARY_MODE=True), \
-                 patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}), \
-                 patch("api.agent.core.burn_control.has_recent_user_message", return_value=True):
+                 patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}):
                 action = bc.handle_burn_rate_limit(
                     self.agent,
                     budget_ctx=None,
@@ -1514,7 +1440,7 @@ class PersistentAgentToolCreditTests(TestCase):
                 )
 
             self.assertEqual(action, bc.BurnRateAction.STEPPED_DOWN)
-            self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.ULTRA)
+            self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.STANDARD)
         finally:
             clear_runtime_tier_override(self.agent)
 
@@ -1594,7 +1520,6 @@ class PersistentAgentToolCreditTests(TestCase):
 
         with override_settings(GOBII_PROPRIETARY_MODE=True), \
              patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}), \
-             patch("api.agent.core.burn_control.has_recent_user_message", return_value=True), \
              patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1), \
              patch("api.agent.core.event_processing.get_agent_daily_credit_state", return_value=burn_state), \
              patch("api.agent.core.event_processing.build_prompt_context", return_value=([], 0, None)), \
@@ -1609,7 +1534,7 @@ class PersistentAgentToolCreditTests(TestCase):
             )
 
         self.assertEqual(usage["total_tokens"], 0)
-        self.assertEqual(observed["routing_tier"], AgentLLMTier.ULTRA)
+        self.assertEqual(observed["routing_tier"], AgentLLMTier.STANDARD)
         self.assertEqual(get_runtime_tier_override(self.agent), None)
         self.assertFalse(
             PersistentAgentSystemStep.objects.filter(step__agent=self.agent).exists()
@@ -1617,7 +1542,7 @@ class PersistentAgentToolCreditTests(TestCase):
         self.assertFalse(
             PersistentAgentStep.objects.filter(
                 agent=self.agent,
-                description__contains="baseline_tier=ultra_max;runtime_tier=ultra",
+                description__contains="baseline_tier=ultra_max;runtime_tier=standard",
             ).exists()
         )
         self.assertFalse(

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -4528,42 +4528,6 @@ class OrchestratorHumanInputInterruptTests(TestCase):
     @patch("api.agent.core.event_processing._schedule_agent_follow_up")
     @patch("api.agent.core.event_processing.get_pending_drain_settings")
     @patch("api.agent.core.event_processing.maybe_run_agent_judge")
-    @patch("api.agent.core.event_processing.handle_burn_rate_limit", return_value=BurnRateAction.PAUSED)
-    @patch("api.agent.core.event_processing.seed_sqlite_skills", return_value=None)
-    @patch("api.agent.core.event_processing.seed_sqlite_agent_config", return_value=None)
-    @patch("api.agent.core.event_processing.get_agent_tools", return_value=[])
-    @patch("api.agent.core.event_processing.build_prompt_context")
-    def test_burn_rate_pause_triggers_judge_before_exiting_loop(
-        self,
-        mock_build_prompt,
-        _mock_tools,
-        _mock_seed_config,
-        _mock_seed_skills,
-        _mock_burn_control,
-        mock_judge,
-        mock_pending_settings,
-        _mock_follow_up,
-    ):
-        mock_pending_settings.return_value = PendingDrainSettings(
-            pending_set_ttl_seconds=123,
-            pending_drain_delay_seconds=10,
-            pending_drain_limit=50,
-            pending_drain_schedule_ttl_seconds=60,
-        )
-
-        usage = _run_agent_loop(self.agent, is_first_run=False)
-
-        self.assertEqual(usage.get("total_tokens"), 0)
-        mock_build_prompt.assert_not_called()
-        mock_judge.assert_called_once_with(
-            self.agent,
-            tools=[],
-            extra_trigger_reasons=["burn_rate_throttled"],
-        )
-
-    @patch("api.agent.core.event_processing._schedule_agent_follow_up")
-    @patch("api.agent.core.event_processing.get_pending_drain_settings")
-    @patch("api.agent.core.event_processing.maybe_run_agent_judge")
     @patch("api.agent.core.event_processing.handle_burn_rate_limit", return_value=BurnRateAction.STEPPED_DOWN)
     @patch("api.agent.core.event_processing.seed_sqlite_skills", return_value=None)
     @patch("api.agent.core.event_processing.seed_sqlite_agent_config", return_value=None)


### PR DESCRIPTION
## Summary
- Remove the one-hour burn-rate cooldown path, including Redis cooldown markers and delayed follow-up scheduling.
- Make burn-rate enforcement always step down to the lowest intelligence tier (`standard`) when thresholds are exceeded.
- Update event processing to ignore obsolete burn-rate follow-up tokens and continue processing in the same run.
- Refresh unit coverage to match the new burn-rate behavior.

## Testing
- Added and updated targeted unit tests for burn-rate step-down behavior and event-loop handling.
- Validated the affected Django test batch locally: `tests.unit.test_agent_event_processing_credits` and `tests.unit.test_event_processing` passed.