### PR TITLE
Fix immersive billing upgrade navigation to pricing

### DIFF
--- a/frontend/src/screens/billing/BillingScreen.tsx
+++ b/frontend/src/screens/billing/BillingScreen.tsx
@@ -255,7 +255,10 @@ export function BillingScreen({ initialData }: BillingScreenProps) {
     track(AnalyticsEvent.CTA_FREE_UPGRADE_PLAN, {
       source: 'billing',
     })
-    window.location.assign('/pricing/')
+    const opened = window.open('/pricing/', '_top')
+    if (!opened) {
+      window.location.assign('/pricing/')
+    }
   }, [])
 
   const showPlanAction = !isOrg && isProprietaryMode && initialData.contextType === 'personal'

--- a/frontend/src/screens/billing/BillingScreen.tsx
+++ b/frontend/src/screens/billing/BillingScreen.tsx
@@ -255,8 +255,9 @@ export function BillingScreen({ initialData }: BillingScreenProps) {
     track(AnalyticsEvent.CTA_FREE_UPGRADE_PLAN, {
       source: 'billing',
     })
-    const opened = window.open('/pricing/', '_top')
-    if (!opened) {
+    try {
+      window.top?.location.assign('/pricing/')
+    } catch {
       window.location.assign('/pricing/')
     }
   }, [])


### PR DESCRIPTION
## Summary
- Updated the immersive billing page free-user `Upgrade` action to open `/pricing/` in the top-level window.
- Added a fallback to `window.location.assign` so navigation still works if top-level opening is blocked.
- Left paid-user plan change behavior unchanged.

## Testing
- `npm run build:app --prefix frontend`
- Verified the frontend build completes successfully after the navigation change.