### PR TITLE
Preflight Pipedream app connections before calling remote tools

### DIFF
--- a/api/agent/tools/mcp_manager.py
+++ b/api/agent/tools/mcp_manager.py
@@ -2361,6 +2361,37 @@ class MCPToolManager:
 
         if server_name == self.PIPEDREAM_RUNTIME_NAME:
             app_slug = self._pd_app_slug_for_tool_call(info.tool_name, params)
+            if app_slug:
+                try:
+                    from ...services.pipedream_connections import (
+                        CONNECTED_ACCOUNTS_CACHE_TTL_SECONDS,
+                        PipedreamConnectionError,
+                        list_pipedream_connected_accounts,
+                    )
+
+                    connected_accounts = list_pipedream_connected_accounts(agent, app_slug=app_slug)
+                    if not connected_accounts and PipedreamConnectSession.objects.filter(
+                        agent=agent,
+                        app_slug=app_slug,
+                        status=PipedreamConnectSession.Status.SUCCESS,
+                        updated_at__gte=timezone.now() - timedelta(
+                            seconds=CONNECTED_ACCOUNTS_CACHE_TTL_SECONDS + 5
+                        ),
+                    ).exists():
+                        connected_accounts = list_pipedream_connected_accounts(
+                            agent,
+                            app_slug=app_slug,
+                            force_refresh=True,
+                        )
+                except PipedreamConnectionError as exc:
+                    return {"status": "error", "message": str(exc)}
+                if not connected_accounts:
+                    jit_url = _build_jit_connect_url(str(agent.id), app_slug)
+                    return {
+                        "status": "action_required",
+                        "result": f"Authorization required. Please connect your account via: {jit_url}",
+                        "connect_url": jit_url,
+                    }
             try:
                 client = self._get_pipedream_agent_client(agent, app_slug=app_slug)
             except RuntimeError as exc:

--- a/api/agent/tools/mcp_manager.py
+++ b/api/agent/tools/mcp_manager.py
@@ -2364,25 +2364,11 @@ class MCPToolManager:
             if app_slug:
                 try:
                     from ...services.pipedream_connections import (
-                        CONNECTED_ACCOUNTS_CACHE_TTL_SECONDS,
                         PipedreamConnectionError,
                         list_pipedream_connected_accounts,
                     )
 
                     connected_accounts = list_pipedream_connected_accounts(agent, app_slug=app_slug)
-                    if not connected_accounts and PipedreamConnectSession.objects.filter(
-                        agent=agent,
-                        app_slug=app_slug,
-                        status=PipedreamConnectSession.Status.SUCCESS,
-                        updated_at__gte=timezone.now() - timedelta(
-                            seconds=CONNECTED_ACCOUNTS_CACHE_TTL_SECONDS + 5
-                        ),
-                    ).exists():
-                        connected_accounts = list_pipedream_connected_accounts(
-                            agent,
-                            app_slug=app_slug,
-                            force_refresh=True,
-                        )
                 except PipedreamConnectionError as exc:
                     return {"status": "error", "message": str(exc)}
                 if not connected_accounts:

--- a/api/services/pipedream_connections.py
+++ b/api/services/pipedream_connections.py
@@ -217,7 +217,8 @@ def list_pipedream_connected_accounts(
         page_size=page_size,
         max_pages=max_pages,
     )
-    cache.set(cache_key, _serialize_cached_accounts(accounts), CONNECTED_ACCOUNTS_CACHE_TTL_SECONDS)
+    if accounts:
+        cache.set(cache_key, _serialize_cached_accounts(accounts), CONNECTED_ACCOUNTS_CACHE_TTL_SECONDS)
     return accounts
 
 

--- a/tests/unit/test_console_mcp_servers.py
+++ b/tests/unit/test_console_mcp_servers.py
@@ -1025,6 +1025,21 @@ class PipedreamAppsAPITests(TestCase):
         self.assertEqual(refreshed_result, [])
         self.assertEqual(mock_lookup.call_count, 2)
 
+    @patch("api.services.pipedream_connections._list_pipedream_connected_accounts")
+    def test_connected_account_lookup_does_not_cache_empty_results(self, mock_lookup):
+        agent = _create_console_test_agent(user=self.user, name="Uncached Empty Connection Agent")
+        mock_lookup.side_effect = [
+            [],
+            [PipedreamConnectedAccount(id="apn_trello", app_slug="trello")],
+        ]
+
+        first_result = list_pipedream_connected_accounts(agent, app_slug="trello")
+        second_result = list_pipedream_connected_accounts(agent, app_slug="trello")
+
+        self.assertEqual(first_result, [])
+        self.assertEqual([account.id for account in second_result], ["apn_trello"])
+        self.assertEqual(mock_lookup.call_count, 2)
+
     @patch("console.pipedream_apps_api.PipedreamCatalogService.get_apps")
     def test_get_returns_user_scope_apps(self, mock_get_apps):
         PipedreamAppSelection.objects.create(

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -3978,8 +3978,13 @@ class MCPToolIntegrationTests(TestCase):
         with (
             patch.object(manager, "_ensure_runtime_registered", return_value=True),
             patch.object(manager, "_select_agent_proxy_url", return_value=(None, None)),
+            patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[object()]),
             patch.object(manager, "_get_pipedream_agent_client", return_value=client) as mock_get_client,
-            patch.object(manager, "_execute_async", new=MagicMock(return_value={"result": {"ok": True}})) as mock_execute,
+            patch.object(
+                manager,
+                "_execute_async",
+                new=MagicMock(return_value={"result": {"ok": True}}),
+            ) as mock_execute,
             patch.object(manager, "_run_coroutine_sync", side_effect=lambda value: value),
         ):
             result = manager.execute_mcp_tool(

--- a/tests/unit/test_pipedream_connect.py
+++ b/tests/unit/test_pipedream_connect.py
@@ -18,6 +18,7 @@ from api.models import (
 )
 from api.agent.tools.mcp_manager import MCPToolManager, MCPToolInfo
 from api.integrations.pipedream_connect import create_connect_session
+from api.services.pipedream_connections import PipedreamConnectionError
 from api.webhooks import pipedream_connect_webhook
 
 
@@ -213,10 +214,11 @@ class PipedreamManagerConnectLinkTests(TestCase):
     def setUp(self):
         Site.objects.update_or_create(id=1, defaults={"domain": "example.com", "name": "example"})
 
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[object()])
     @patch("api.integrations.pipedream_connect.create_connect_session")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
-    def test_execute_tool_rewrites_connect_link(self, mock_exec, mock_loop, mock_create):
+    def test_execute_tool_rewrites_connect_link(self, mock_exec, mock_loop, mock_create, _mock_accounts):
         # Arrange agent
         User = get_user_model()
         user = User.objects.create_user(username="p3@example.com")
@@ -251,10 +253,11 @@ class PipedreamManagerConnectLinkTests(TestCase):
         self.assertEqual(res.get("status"), "action_required")
         self.assertIn("example.com/connect", res.get("connect_url"))
 
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[object()])
     @patch("api.integrations.pipedream_connect.create_connect_session")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
-    def test_execute_tool_blocks_expired_connect_link(self, mock_exec, mock_loop, mock_create):
+    def test_execute_tool_blocks_expired_connect_link(self, mock_exec, mock_loop, mock_create, _mock_accounts):
         User = get_user_model()
         user = User.objects.create_user(username="p4@example.com")
         with patch.object(BrowserUseAgent, 'select_random_proxy', return_value=None):
@@ -294,10 +297,11 @@ class PipedreamManagerConnectLinkTests(TestCase):
         self.assertIsNone(res.get("connect_url"))
         self.assertIn("expired", res.get("result", "").lower())
 
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[object()])
     @patch("api.integrations.pipedream_connect.create_connect_session")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
-    def test_execute_tool_reuses_pending_session(self, mock_exec, mock_loop, mock_create):
+    def test_execute_tool_reuses_pending_session(self, mock_exec, mock_loop, mock_create, _mock_accounts):
         User = get_user_model()
         user = User.objects.create_user(username="reuse@example.com")
         with patch.object(BrowserUseAgent, 'select_random_proxy', return_value=None):
@@ -345,3 +349,195 @@ class PipedreamManagerConnectLinkTests(TestCase):
         mock_create.assert_not_called()
         session.refresh_from_db()
         self.assertEqual(session.status, PipedreamConnectSession.Status.PENDING)
+
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[])
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
+    def test_execute_tool_returns_connect_link_when_app_has_no_account(
+        self,
+        mock_exec,
+        mock_loop,
+        mock_accounts,
+    ):
+        User = get_user_model()
+        user = User.objects.create_user(username="missing-account@example.com")
+        with patch.object(BrowserUseAgent, 'select_random_proxy', return_value=None):
+            bua = BrowserUseAgent.objects.create(user=user, name="bua-missing")
+        agent = PersistentAgent.objects.create(user=user, name="agent-missing", charter="c", browser_use_agent=bua)
+
+        mgr = MCPToolManager()
+        _setup_pipedream_tool(mgr, agent)
+
+        res = mgr.execute_mcp_tool(agent, "google_sheets-add-single-row", {"sheetId": "sheet", "worksheetId": "1"})
+
+        self.assertEqual(res.get("status"), "action_required")
+        connect_url = res.get("connect_url", "")
+        self.assertIn("/connect/pipedream/", connect_url)
+        self.assertIn(str(agent.id), connect_url)
+        self.assertIn("/google_sheets/", connect_url)
+        self.assertIn("Authorization required", res.get("result", ""))
+        mock_accounts.assert_called_once_with(agent, app_slug="google_sheets")
+        mock_exec.assert_not_called()
+        mock_loop.assert_not_called()
+
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[object()])
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
+    def test_execute_tool_proceeds_when_app_has_account(
+        self,
+        mock_exec,
+        mock_loop,
+        mock_accounts,
+    ):
+        User = get_user_model()
+        user = User.objects.create_user(username="connected@example.com")
+        with patch.object(BrowserUseAgent, 'select_random_proxy', return_value=None):
+            bua = BrowserUseAgent.objects.create(user=user, name="bua-connected")
+        agent = PersistentAgent.objects.create(user=user, name="agent-connected", charter="c", browser_use_agent=bua)
+
+        mgr = MCPToolManager()
+        _setup_pipedream_tool(mgr, agent)
+
+        response = MagicMock()
+        response.is_error = False
+        response.data = {"ok": True}
+        response.content = []
+        loop = MagicMock()
+        loop.run_until_complete.side_effect = lambda _: response
+        mock_loop.return_value = loop
+        mock_exec.return_value = response
+
+        res = mgr.execute_mcp_tool(agent, "google_sheets-add-single-row", {"sheetId": "sheet", "worksheetId": "1"})
+
+        self.assertEqual(res.get("status"), "success")
+        self.assertEqual(res.get("result"), {"ok": True})
+        mock_accounts.assert_called_once_with(agent, app_slug="google_sheets")
+        mock_exec.assert_called_once()
+
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts")
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
+    def test_recent_success_session_refreshes_empty_account_cache(
+        self,
+        mock_exec,
+        mock_loop,
+        mock_accounts,
+    ):
+        User = get_user_model()
+        user = User.objects.create_user(username="recent-success@example.com")
+        with patch.object(BrowserUseAgent, 'select_random_proxy', return_value=None):
+            bua = BrowserUseAgent.objects.create(user=user, name="bua-recent-success")
+        agent = PersistentAgent.objects.create(user=user, name="agent-recent-success", charter="c", browser_use_agent=bua)
+        PipedreamConnectSession.objects.create(
+            agent=agent,
+            external_user_id=str(agent.id),
+            conversation_id=str(agent.id),
+            app_slug="google_sheets",
+            connect_token="ctok_recent_success",
+            webhook_secret="secret",
+            status=PipedreamConnectSession.Status.SUCCESS,
+            account_id="apn_recent",
+        )
+
+        mgr = MCPToolManager()
+        _setup_pipedream_tool(mgr, agent)
+        mock_accounts.side_effect = [[], [object()]]
+
+        response = MagicMock()
+        response.is_error = False
+        response.data = {"ok": True}
+        response.content = []
+        loop = MagicMock()
+        loop.run_until_complete.side_effect = lambda _: response
+        mock_loop.return_value = loop
+        mock_exec.return_value = response
+
+        res = mgr.execute_mcp_tool(agent, "google_sheets-add-single-row", {"sheetId": "sheet", "worksheetId": "1"})
+
+        self.assertEqual(res.get("status"), "success")
+        self.assertEqual(res.get("result"), {"ok": True})
+        self.assertEqual(mock_accounts.call_count, 2)
+        mock_accounts.assert_any_call(agent, app_slug="google_sheets")
+        mock_accounts.assert_any_call(agent, app_slug="google_sheets", force_refresh=True)
+        mock_exec.assert_called_once()
+
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[])
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
+    def test_retrieve_options_preflights_app_from_component_key(
+        self,
+        mock_exec,
+        mock_loop,
+        mock_accounts,
+    ):
+        User = get_user_model()
+        user = User.objects.create_user(username="options-missing@example.com")
+        with patch.object(BrowserUseAgent, 'select_random_proxy', return_value=None):
+            bua = BrowserUseAgent.objects.create(user=user, name="bua-options")
+        agent = PersistentAgent.objects.create(user=user, name="agent-options", charter="c", browser_use_agent=bua)
+
+        mgr = MCPToolManager()
+        config = _ensure_pipedream_config()
+        tool = MCPToolInfo(
+            str(config.id),
+            "retrieve_options",
+            "pipedream",
+            "retrieve_options",
+            "Retrieve component options",
+            {},
+        )
+        mgr._initialized = True
+        mgr._tools_cache = {str(config.id): [tool]}
+        mgr._get_pipedream_access_token = MagicMock(return_value="pd_token")
+        PersistentAgentEnabledTool.objects.create(
+            agent=agent,
+            tool_full_name=tool.full_name,
+            tool_server=tool.server_name,
+            tool_name=tool.tool_name,
+            server_config=config,
+        )
+
+        res = mgr.execute_mcp_tool(
+            agent,
+            "retrieve_options",
+            {
+                "componentKey": "google_sheets-add-single-row",
+                "propName": "spreadsheetId",
+            },
+        )
+
+        self.assertEqual(res.get("status"), "action_required")
+        self.assertIn("/google_sheets/", res.get("connect_url", ""))
+        mock_accounts.assert_called_once_with(agent, app_slug="google_sheets")
+        mock_exec.assert_not_called()
+        mock_loop.assert_not_called()
+
+    @patch(
+        "api.services.pipedream_connections.list_pipedream_connected_accounts",
+        side_effect=PipedreamConnectionError("Pipedream account lookup failed."),
+    )
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
+    @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
+    def test_execute_tool_returns_error_when_connection_lookup_fails(
+        self,
+        mock_exec,
+        mock_loop,
+        mock_accounts,
+    ):
+        User = get_user_model()
+        user = User.objects.create_user(username="lookup-error@example.com")
+        with patch.object(BrowserUseAgent, 'select_random_proxy', return_value=None):
+            bua = BrowserUseAgent.objects.create(user=user, name="bua-lookup-error")
+        agent = PersistentAgent.objects.create(user=user, name="agent-lookup-error", charter="c", browser_use_agent=bua)
+
+        mgr = MCPToolManager()
+        _setup_pipedream_tool(mgr, agent)
+
+        res = mgr.execute_mcp_tool(agent, "google_sheets-add-single-row", {"sheetId": "sheet", "worksheetId": "1"})
+
+        self.assertEqual(res.get("status"), "error")
+        self.assertIn("Pipedream account lookup failed", res.get("message", ""))
+        self.assertNotIn("connect_url", res)
+        mock_accounts.assert_called_once_with(agent, app_slug="google_sheets")
+        mock_exec.assert_not_called()
+        mock_loop.assert_not_called()

--- a/tests/unit/test_pipedream_connect.py
+++ b/tests/unit/test_pipedream_connect.py
@@ -414,53 +414,6 @@ class PipedreamManagerConnectLinkTests(TestCase):
         mock_accounts.assert_called_once_with(agent, app_slug="google_sheets")
         mock_exec.assert_called_once()
 
-    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts")
-    @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
-    @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
-    def test_recent_success_session_refreshes_empty_account_cache(
-        self,
-        mock_exec,
-        mock_loop,
-        mock_accounts,
-    ):
-        User = get_user_model()
-        user = User.objects.create_user(username="recent-success@example.com")
-        with patch.object(BrowserUseAgent, 'select_random_proxy', return_value=None):
-            bua = BrowserUseAgent.objects.create(user=user, name="bua-recent-success")
-        agent = PersistentAgent.objects.create(user=user, name="agent-recent-success", charter="c", browser_use_agent=bua)
-        PipedreamConnectSession.objects.create(
-            agent=agent,
-            external_user_id=str(agent.id),
-            conversation_id=str(agent.id),
-            app_slug="google_sheets",
-            connect_token="ctok_recent_success",
-            webhook_secret="secret",
-            status=PipedreamConnectSession.Status.SUCCESS,
-            account_id="apn_recent",
-        )
-
-        mgr = MCPToolManager()
-        _setup_pipedream_tool(mgr, agent)
-        mock_accounts.side_effect = [[], [object()]]
-
-        response = MagicMock()
-        response.is_error = False
-        response.data = {"ok": True}
-        response.content = []
-        loop = MagicMock()
-        loop.run_until_complete.side_effect = lambda _: response
-        mock_loop.return_value = loop
-        mock_exec.return_value = response
-
-        res = mgr.execute_mcp_tool(agent, "google_sheets-add-single-row", {"sheetId": "sheet", "worksheetId": "1"})
-
-        self.assertEqual(res.get("status"), "success")
-        self.assertEqual(res.get("result"), {"ok": True})
-        self.assertEqual(mock_accounts.call_count, 2)
-        mock_accounts.assert_any_call(agent, app_slug="google_sheets")
-        mock_accounts.assert_any_call(agent, app_slug="google_sheets", force_refresh=True)
-        mock_exec.assert_called_once()
-
     @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[])
     @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)

--- a/tests/unit/test_pipedream_greenhouse.py
+++ b/tests/unit/test_pipedream_greenhouse.py
@@ -94,10 +94,11 @@ class PipedreamGreenhouseConnectTests(TestCase):
         self.assertEqual(session.connect_token, "ctok_gh")
         self.assertIn("pipedream.com/_static/connect.html", session.connect_link_url)
 
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[object()])
     @patch("api.integrations.pipedream_connect.create_connect_session")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
-    def test_execute_tool_rewrites_connect_link_greenhouse(self, mock_exec, mock_loop, mock_create):
+    def test_execute_tool_rewrites_connect_link_greenhouse(self, mock_exec, mock_loop, mock_create, _mock_accounts):
         """Connect Link rewrite works for Greenhouse app/tool names."""
         # Arrange agent
         User = get_user_model()

--- a/tests/unit/test_pipedream_trello.py
+++ b/tests/unit/test_pipedream_trello.py
@@ -96,10 +96,11 @@ class PipedreamTrelloManagerTests(TestCase):
         Site.objects.update_or_create(id=1, defaults={"domain": "example.com", "name": "example"})
 
     @override_settings(GOBII_PROPRIETARY_MODE=False)
+    @patch("api.services.pipedream_connections.list_pipedream_connected_accounts", return_value=[object()])
     @patch("api.integrations.pipedream_connect.create_connect_session")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._ensure_event_loop")
     @patch("api.agent.tools.mcp_manager.MCPToolManager._execute_async", new_callable=MagicMock)
-    def test_execute_tool_rewrites_connect_link_trello(self, mock_exec, mock_loop, mock_create):
+    def test_execute_tool_rewrites_connect_link_trello(self, mock_exec, mock_loop, mock_create, _mock_accounts):
         """Connect link extraction and rewrite works for Trello tools."""
 
         User = get_user_model()


### PR DESCRIPTION
## Summary
- Added a Pipedream app-connection preflight so app-scoped MCP tools return a Gobii connect link immediately when no active account exists.
- Kept the existing connect-link rewrite path as a fallback for responses that still surface Pipedream auth URLs.
- Reused the connected-account lookup cache, with a refresh path for recently completed connects to avoid stale negative results.
- Updated Pipedream-focused unit tests and a few adjacent mocked execution tests to reflect the new preflight behavior.

## Testing
- Added unit coverage for missing-account, connected-account, lookup-error, and `retrieve_options` component-key preflight cases.
- Verified the targeted Pipedream test modules and the affected adjacent MCP/Pipedream execution tests pass locally.