### PR TITLE
Add a first-data timeout for streamed LiteLLM calls

### DIFF
--- a/api/agent/core/llm_utils.py
+++ b/api/agent/core/llm_utils.py
@@ -1,13 +1,18 @@
 """Shared helpers for constructing LiteLLM completion calls."""
 import json
 import logging
+import queue
+import threading
 import time
 from typing import Any, Iterable
 
 from django.conf import settings
 import litellm
 
-from api.services.system_settings import get_litellm_timeout_seconds
+from api.services.system_settings import (
+    get_litellm_first_data_timeout_seconds,
+    get_litellm_timeout_seconds,
+)
 from api.utils.json_schema import sanitize_tool_parameters_schema_for_llm
 from .token_usage import extract_reasoning_content
 _HINT_KEYS = (
@@ -58,6 +63,70 @@ _RETRYABLE_ERRORS = (
 )
 
 
+class _FirstDataTimeoutStream:
+    class _StreamError:
+        def __init__(self, exc: Exception) -> None:
+            self.exc = exc
+
+    def __init__(
+        self,
+        stream: Any,
+        *,
+        timeout_seconds: int,
+        model: str,
+        provider: str | None,
+    ) -> None:
+        self._stream = stream
+        self._timeout_seconds = timeout_seconds
+        self._model = model
+        self._provider = provider
+        self._received_first_chunk = False
+        self._timed_out = False
+
+    def __iter__(self) -> "_FirstDataTimeoutStream":
+        return self
+
+    def __next__(self) -> Any:
+        if self._timed_out:
+            raise StopIteration
+        if self._received_first_chunk:
+            return next(self._stream)
+
+        result_queue: queue.Queue[Any | _FirstDataTimeoutStream._StreamError] = queue.Queue(maxsize=1)
+
+        def _read_first_chunk() -> None:
+            try:
+                result_queue.put(next(self._stream))
+            except Exception as exc:
+                result_queue.put(self._StreamError(exc))
+
+        thread = threading.Thread(target=_read_first_chunk, daemon=True)
+        thread.start()
+        try:
+            result = result_queue.get(timeout=self._timeout_seconds)
+        except queue.Empty:
+            self._timed_out = True
+            self.close()
+            raise litellm.Timeout(
+                message=f"LiteLLM stream produced no data within {self._timeout_seconds} seconds",
+                model=self._model,
+                llm_provider=self._provider or "unknown",
+            )
+
+        if isinstance(result, self._StreamError):
+            raise result.exc
+        self._received_first_chunk = True
+        return result
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def close(self) -> None:
+        close = getattr(self._stream, "close", None)
+        if callable(close):
+            close()
+
+
 def _attach_response_duration(response: Any, duration_ms: int | None) -> None:
     if response is None or duration_ms is None:
         return
@@ -70,6 +139,20 @@ def _attach_response_duration(response: Any, duration_ms: int | None) -> None:
         model_extra = getattr(response, "model_extra", None)
         if isinstance(model_extra, dict):
             model_extra["request_duration_ms"] = duration_ms
+
+
+def _wrap_stream_with_first_data_timeout(
+    stream: Any,
+    *,
+    model: str,
+    provider: str | None,
+) -> _FirstDataTimeoutStream:
+    return _FirstDataTimeoutStream(
+        stream,
+        timeout_seconds=get_litellm_first_data_timeout_seconds(),
+        model=model,
+        provider=provider,
+    )
 
 
 def _first_message_from_response(response: Any) -> Any:
@@ -369,6 +452,11 @@ def run_completion(
                 duration_ms = int(round((time.monotonic() - start_time) * 1000))
             else:
                 response = litellm.completion(**kwargs)
+                response = _wrap_stream_with_first_data_timeout(
+                    response,
+                    model=model,
+                    provider=provider_hint,
+                )
             if not kwargs.get("stream"):
                 raise_if_empty_litellm_response(response, model=model, provider=provider_hint)
                 raise_if_invalid_litellm_response(response, model=model, provider=provider_hint)

--- a/api/agent/core/llm_utils.py
+++ b/api/agent/core/llm_utils.py
@@ -4,7 +4,9 @@ import logging
 import queue
 import threading
 import time
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
+
+from asgiref.sync import async_to_sync
 
 from django.conf import settings
 import litellm
@@ -72,14 +74,22 @@ class _FirstDataTimeoutStream:
         self,
         stream: Any,
         *,
+        create_stream: Callable[[], Any],
         timeout_seconds: int,
         model: str,
         provider: str | None,
+        initial_attempt: int,
+        max_attempts: int,
+        backoff_seconds: float,
     ) -> None:
         self._stream = stream
+        self._create_stream = create_stream
         self._timeout_seconds = timeout_seconds
         self._model = model
         self._provider = provider
+        self._attempt = initial_attempt
+        self._max_attempts = max_attempts
+        self._backoff_seconds = backoff_seconds
         self._received_first_chunk = False
         self._timed_out = False
 
@@ -92,7 +102,37 @@ class _FirstDataTimeoutStream:
         if self._received_first_chunk:
             return next(self._stream)
 
-        result_queue: queue.Queue[Any | _FirstDataTimeoutStream._StreamError] = queue.Queue(maxsize=1)
+        while True:
+            try:
+                result = self._read_first_chunk()
+            except _RETRYABLE_ERRORS as exc:
+                self._retry_or_raise(exc)
+                continue
+            self._received_first_chunk = True
+            return result
+
+    def _retry_or_raise(self, exc: Exception) -> None:
+        while True:
+            if self._attempt >= self._max_attempts:
+                raise exc
+            self.close()
+            logger.warning(
+                "LiteLLM request failed with %s; retrying (%d/%d)",
+                type(exc).__name__,
+                self._attempt,
+                self._max_attempts,
+            )
+            if self._backoff_seconds > 0:
+                time.sleep(self._backoff_seconds * (2 ** (self._attempt - 1)))
+            self._attempt += 1
+            try:
+                self._stream = self._create_stream()
+                return
+            except _RETRYABLE_ERRORS as retry_exc:
+                exc = retry_exc
+
+    def _read_first_chunk(self) -> Any:
+        result_queue: queue.Queue[Any] = queue.Queue(maxsize=1)
 
         def _read_first_chunk() -> None:
             try:
@@ -115,16 +155,26 @@ class _FirstDataTimeoutStream:
 
         if isinstance(result, self._StreamError):
             raise result.exc
-        self._received_first_chunk = True
         return result
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._stream, name)
 
     def close(self) -> None:
+        aclose = getattr(self._stream, "aclose", None)
+        if callable(aclose):
+            try:
+                async_to_sync(aclose)()
+            except Exception:
+                logger.debug("Failed to async-close LiteLLM stream", exc_info=True)
+            return
+
         close = getattr(self._stream, "close", None)
         if callable(close):
-            close()
+            try:
+                close()
+            except Exception:
+                logger.debug("Failed to close LiteLLM stream", exc_info=True)
 
 
 def _attach_response_duration(response: Any, duration_ms: int | None) -> None:
@@ -144,14 +194,22 @@ def _attach_response_duration(response: Any, duration_ms: int | None) -> None:
 def _wrap_stream_with_first_data_timeout(
     stream: Any,
     *,
+    create_stream: Callable[[], Any],
     model: str,
     provider: str | None,
+    initial_attempt: int,
+    max_attempts: int,
+    backoff_seconds: float,
 ) -> _FirstDataTimeoutStream:
     return _FirstDataTimeoutStream(
         stream,
+        create_stream=create_stream,
         timeout_seconds=get_litellm_first_data_timeout_seconds(),
         model=model,
         provider=provider,
+        initial_attempt=initial_attempt,
+        max_attempts=max_attempts,
+        backoff_seconds=backoff_seconds,
     )
 
 
@@ -454,8 +512,12 @@ def run_completion(
                 response = litellm.completion(**kwargs)
                 response = _wrap_stream_with_first_data_timeout(
                     response,
+                    create_stream=lambda: litellm.completion(**kwargs),
                     model=model,
                     provider=provider_hint,
+                    initial_attempt=attempt,
+                    max_attempts=max_attempts,
+                    backoff_seconds=backoff_seconds,
                 )
             if not kwargs.get("stream"):
                 raise_if_empty_litellm_response(response, model=model, provider=provider_hint)

--- a/api/services/system_settings.py
+++ b/api/services/system_settings.py
@@ -106,6 +106,17 @@ SYSTEM_SETTING_DEFINITIONS = (
         min_value=1,
     ),
     SystemSettingDefinition(
+        key="LITELLM_FIRST_DATA_TIMEOUT_SECONDS",
+        label="LiteLLM first data timeout",
+        description="Timeout for streamed LiteLLM requests to produce their first chunk.",
+        value_type=VALUE_TYPE_INT,
+        env_var="LITELLM_FIRST_DATA_TIMEOUT_SECONDS",
+        default_getter=lambda: settings.LITELLM_FIRST_DATA_TIMEOUT_SECONDS,
+        category="LLM",
+        unit="seconds",
+        min_value=1,
+    ),
+    SystemSettingDefinition(
         key="MAX_PARALLEL_TOOL_CALLS",
         label="Max parallel tool calls",
         description="Maximum number of safe tool calls that can run concurrently in one batch.",
@@ -463,6 +474,10 @@ def get_mcp_stdio_timeout_seconds() -> float:
 
 def get_litellm_timeout_seconds() -> int:
     return int(get_setting_value("LITELLM_TIMEOUT_SECONDS"))
+
+
+def get_litellm_first_data_timeout_seconds() -> int:
+    return int(get_setting_value("LITELLM_FIRST_DATA_TIMEOUT_SECONDS"))
 
 
 def get_max_parallel_tool_calls() -> int:

--- a/config/settings.py
+++ b/config/settings.py
@@ -175,6 +175,11 @@ SOLUTIONS_PARTNER_BILLING_ACCESS = env.bool("SOLUTIONS_PARTNER_BILLING_ACCESS", 
 MAX_PREFERRED_PROVIDER_STREAK = env.int("MAX_PREFERRED_PROVIDER_STREAK", default=3)
 # Default timeout (seconds) for LiteLLM requests
 LITELLM_TIMEOUT_SECONDS = env.int("LITELLM_TIMEOUT_SECONDS", default=300)
+# Timeout (seconds) for streamed LiteLLM requests to produce their first chunk
+LITELLM_FIRST_DATA_TIMEOUT_SECONDS = env.int(
+    "LITELLM_FIRST_DATA_TIMEOUT_SECONDS",
+    default=30,
+)
 # Default timeout (seconds) for MCP tool execution over HTTP
 MCP_HTTP_REQUEST_TIMEOUT_SECONDS = env.float(
     "MCP_HTTP_REQUEST_TIMEOUT_SECONDS",

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -45,6 +45,12 @@ class _BlockingFirstChunkStream:
         self.released.set()
 
 
+class _AsyncClosableBlockingFirstChunkStream(_BlockingFirstChunkStream):
+    async def aclose(self):
+        self.closed = True
+        self.released.set()
+
+
 class RunCompletionReasoningTests(TestCase):
     @tag("batch_event_llm")
     @patch("api.agent.core.llm_utils.litellm.completion")
@@ -208,6 +214,7 @@ class RunCompletionReasoningTests(TestCase):
         self.assertFalse(stream.closed)
 
     @tag("batch_event_llm")
+    @override_settings(LITELLM_MAX_RETRIES=1)
     @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=0.01)
     @patch("api.agent.core.llm_utils.litellm.completion")
     def test_streaming_first_chunk_timeout_raises_litellm_timeout(
@@ -230,6 +237,59 @@ class RunCompletionReasoningTests(TestCase):
         self.assertTrue(stream.started.wait(timeout=1))
 
     @tag("batch_event_llm")
+    @override_settings(LITELLM_MAX_RETRIES=2, LITELLM_RETRY_BACKOFF_SECONDS=0)
+    @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=0.01)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_streaming_first_chunk_timeout_uses_retry_budget(
+        self,
+        mock_completion,
+        _mock_first_data_timeout,
+    ):
+        stalled_stream = _BlockingFirstChunkStream()
+        retry_stream = _ClosableStream(["retry-chunk"])
+        mock_completion.side_effect = [stalled_stream, retry_stream]
+
+        result = run_completion(
+            model="mock-model",
+            messages=[],
+            params={},
+            stream=True,
+        )
+
+        self.assertEqual(next(result), "retry-chunk")
+        self.assertTrue(stalled_stream.closed)
+        self.assertEqual(mock_completion.call_count, 2)
+
+    @tag("batch_event_llm")
+    @override_settings(LITELLM_MAX_RETRIES=3, LITELLM_RETRY_BACKOFF_SECONDS=0)
+    @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=0.01)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_streaming_retry_budget_covers_replacement_stream_creation(
+        self,
+        mock_completion,
+        _mock_first_data_timeout,
+    ):
+        stalled_stream = _BlockingFirstChunkStream()
+        retry_stream = _ClosableStream(["retry-chunk"])
+        mock_completion.side_effect = [
+            stalled_stream,
+            litellm.Timeout("timeout", model="mock-model", llm_provider="mock"),
+            retry_stream,
+        ]
+
+        result = run_completion(
+            model="mock-model",
+            messages=[],
+            params={},
+            stream=True,
+        )
+
+        self.assertEqual(next(result), "retry-chunk")
+        self.assertTrue(stalled_stream.closed)
+        self.assertEqual(mock_completion.call_count, 3)
+
+    @tag("batch_event_llm")
+    @override_settings(LITELLM_MAX_RETRIES=1)
     @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=0.01)
     @patch("api.agent.core.llm_utils.litellm.completion")
     def test_streaming_first_chunk_timeout_closes_underlying_stream(
@@ -238,6 +298,29 @@ class RunCompletionReasoningTests(TestCase):
         _mock_first_data_timeout,
     ):
         stream = _BlockingFirstChunkStream()
+        mock_completion.return_value = stream
+
+        result = run_completion(
+            model="mock-model",
+            messages=[],
+            params={},
+            stream=True,
+        )
+
+        with self.assertRaises(litellm.Timeout):
+            next(result)
+        self.assertTrue(stream.closed)
+
+    @tag("batch_event_llm")
+    @override_settings(LITELLM_MAX_RETRIES=1)
+    @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=0.01)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_streaming_first_chunk_timeout_async_closes_underlying_stream(
+        self,
+        mock_completion,
+        _mock_first_data_timeout,
+    ):
+        stream = _AsyncClosableBlockingFirstChunkStream()
         mock_completion.return_value = stream
 
         result = run_completion(

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -1,3 +1,4 @@
+import threading
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -6,6 +7,42 @@ import litellm
 
 from api.agent.core.llm_utils import InvalidLiteLLMResponseError, run_completion
 from tests.utils.token_usage import make_completion_response
+
+
+class _ClosableStream:
+    def __init__(self, chunks):
+        self.chunks = iter(chunks)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self.chunks)
+
+    def close(self):
+        self.closed = True
+
+
+class _BlockingFirstChunkStream:
+    def __init__(self):
+        self.closed = False
+        self.started = threading.Event()
+        self.released = threading.Event()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.started.set()
+        self.released.wait(timeout=5)
+        if self.closed:
+            raise StopIteration
+        return "late-chunk"
+
+    def close(self):
+        self.closed = True
+        self.released.set()
 
 
 class RunCompletionReasoningTests(TestCase):
@@ -128,6 +165,91 @@ class RunCompletionReasoningTests(TestCase):
 
         _, kwargs = mock_completion.call_args
         self.assertEqual(kwargs.get("timeout"), 42)
+
+    @tag("batch_event_llm")
+    @override_settings(LITELLM_TIMEOUT_SECONDS=321)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_streaming_completion_is_wrapped_for_first_data_timeout(self, mock_completion):
+        stream = _ClosableStream(["first-chunk"])
+        mock_completion.return_value = stream
+
+        result = run_completion(
+            model="mock-model",
+            messages=[],
+            params={},
+            stream=True,
+        )
+
+        self.assertIsNot(result, stream)
+        self.assertEqual(next(result), "first-chunk")
+        _, kwargs = mock_completion.call_args
+        self.assertEqual(kwargs.get("timeout"), 321)
+
+    @tag("batch_event_llm")
+    @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=1)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_streaming_first_chunk_succeeds_within_timeout(
+        self,
+        mock_completion,
+        _mock_first_data_timeout,
+    ):
+        stream = _ClosableStream(["first-chunk", "second-chunk"])
+        mock_completion.return_value = stream
+
+        result = run_completion(
+            model="mock-model",
+            messages=[],
+            params={},
+            stream=True,
+        )
+
+        self.assertEqual(next(result), "first-chunk")
+        self.assertEqual(next(result), "second-chunk")
+        self.assertFalse(stream.closed)
+
+    @tag("batch_event_llm")
+    @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=0.01)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_streaming_first_chunk_timeout_raises_litellm_timeout(
+        self,
+        mock_completion,
+        _mock_first_data_timeout,
+    ):
+        stream = _BlockingFirstChunkStream()
+        mock_completion.return_value = stream
+
+        result = run_completion(
+            model="mock-model",
+            messages=[],
+            params={},
+            stream=True,
+        )
+
+        with self.assertRaises(litellm.Timeout):
+            next(result)
+        self.assertTrue(stream.started.wait(timeout=1))
+
+    @tag("batch_event_llm")
+    @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=0.01)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_streaming_first_chunk_timeout_closes_underlying_stream(
+        self,
+        mock_completion,
+        _mock_first_data_timeout,
+    ):
+        stream = _BlockingFirstChunkStream()
+        mock_completion.return_value = stream
+
+        result = run_completion(
+            model="mock-model",
+            messages=[],
+            params={},
+            stream=True,
+        )
+
+        with self.assertRaises(litellm.Timeout):
+            next(result)
+        self.assertTrue(stream.closed)
 
     @tag("batch_event_llm")
     @override_settings(LITELLM_MAX_RETRIES=2, LITELLM_RETRY_BACKOFF_SECONDS=0)


### PR DESCRIPTION
## Summary
- Add a configurable `LITELLM_FIRST_DATA_TIMEOUT_SECONDS` setting for streamed LiteLLM requests.
- Abort streamed completions if no first chunk arrives within the configured deadline while preserving the existing overall request timeout.
- Wrap streamed responses centrally in `api/agent/core/llm_utils.py` so the behavior applies consistently.
- Add unit coverage for first-chunk success, timeout, stream closing, and existing non-streaming timeout behavior.

## Testing
- Added focused unit tests for the new streaming timeout wrapper and settings integration.
- Verified the `tests.unit.test_llm_utils` module passes locally.