### PR TITLE
Normalize Discord outbound message bodies before sending

### DIFF
--- a/api/services/discord_bot.py
+++ b/api/services/discord_bot.py
@@ -44,7 +44,7 @@ from api.services.discord_messages import (
     ensure_discord_agent_endpoint,
     schedule_discord_inbound_processing,
 )
-from util.text_sanitizer import decode_unicode_escapes
+from util.text_sanitizer import decode_unicode_character_escapes
 
 logger = logging.getLogger(__name__)
 
@@ -898,7 +898,7 @@ def send_channel_message(
     attachments: Iterable[ResolvedAttachment] | None = None,
 ) -> PersistentAgentMessage:
     resolved_attachments = list(attachments or [])
-    body = decode_unicode_escapes(body)
+    body = decode_unicode_character_escapes(body)
     if not body and not resolved_attachments:
         raise ValueError("message is required when attachments is empty.")
     if len(resolved_attachments) > DISCORD_WEBHOOK_MAX_FILES:

--- a/api/services/discord_bot.py
+++ b/api/services/discord_bot.py
@@ -44,6 +44,7 @@ from api.services.discord_messages import (
     ensure_discord_agent_endpoint,
     schedule_discord_inbound_processing,
 )
+from util.text_sanitizer import decode_unicode_escapes
 
 logger = logging.getLogger(__name__)
 
@@ -897,6 +898,7 @@ def send_channel_message(
     attachments: Iterable[ResolvedAttachment] | None = None,
 ) -> PersistentAgentMessage:
     resolved_attachments = list(attachments or [])
+    body = decode_unicode_escapes(body)
     if not body and not resolved_attachments:
         raise ValueError("message is required when attachments is empty.")
     if len(resolved_attachments) > DISCORD_WEBHOOK_MAX_FILES:

--- a/tests/unit/test_discord_bot.py
+++ b/tests/unit/test_discord_bot.py
@@ -674,12 +674,12 @@ class NativeDiscordBotTests(TestCase):
         message = send_channel_message(
             self.agent,
             channel_id="10",
-            body=r"Company \u2500 Approach \u2500 Weakness",
+            body=r"Company \u2500 Approach \u2500 Weakness\nUse \n literally",
         )
 
-        self.assertEqual(message.body, "Company \u2500 Approach \u2500 Weakness")
+        self.assertEqual(message.body, "Company ─ Approach ─ Weakness\\nUse \\n literally")
         send_call = post_mock.call_args_list[1]
-        self.assertEqual(send_call.kwargs["json"]["content"], "Company \u2500 Approach \u2500 Weakness")
+        self.assertEqual(send_call.kwargs["json"]["content"], "Company ─ Approach ─ Weakness\\nUse \\n literally")
 
     @tag("batch_agent_webhooks")
     @patch.dict(os.environ, {"GOBII_ENCRYPTION_KEY": "native-discord-tests"}, clear=False)

--- a/tests/unit/test_discord_bot.py
+++ b/tests/unit/test_discord_bot.py
@@ -655,6 +655,34 @@ class NativeDiscordBotTests(TestCase):
 
     @tag("batch_agent_webhooks")
     @patch.dict(os.environ, {"GOBII_ENCRYPTION_KEY": "native-discord-tests"}, clear=False)
+    @patch("api.services.discord_bot.requests.get")
+    @patch("api.services.discord_bot.requests.post")
+    def test_webhook_outbound_send_decodes_literal_unicode_escapes(self, post_mock, get_mock):
+        get_mock.return_value = _response([{"id": "10", "name": "general", "type": 0}])
+        guild = self._guild()
+        PersistentAgentDiscordChannelSubscription.objects.create(
+            agent=self.agent,
+            guild=guild,
+            channel_id="10",
+            channel_name="general",
+        )
+        post_mock.side_effect = [
+            _response({"id": "wh1", "token": "token1", "name": "Gobii"}),
+            _response({"id": "discord-message-1", "channel_id": "10"}),
+        ]
+
+        message = send_channel_message(
+            self.agent,
+            channel_id="10",
+            body=r"Company \u2500 Approach \u2500 Weakness",
+        )
+
+        self.assertEqual(message.body, "Company \u2500 Approach \u2500 Weakness")
+        send_call = post_mock.call_args_list[1]
+        self.assertEqual(send_call.kwargs["json"]["content"], "Company \u2500 Approach \u2500 Weakness")
+
+    @tag("batch_agent_webhooks")
+    @patch.dict(os.environ, {"GOBII_ENCRYPTION_KEY": "native-discord-tests"}, clear=False)
     @patch("api.services.discord_bot.build_public_agent_avatar_thumbnail_url", return_value="https://app.example.test/public/agents/avatar.png")
     @patch("api.services.discord_bot.requests.get")
     @patch("api.services.discord_bot.requests.post")

--- a/tests/unit/test_text_sanitization.py
+++ b/tests/unit/test_text_sanitization.py
@@ -4,6 +4,7 @@ from util.text_sanitizer import (
     strip_control_chars,
     strip_markdown_for_sms,
     normalize_whitespace,
+    decode_unicode_character_escapes,
     decode_unicode_escapes,
     strip_llm_artifacts,
     strip_redundant_blockquote_quotes,
@@ -50,6 +51,13 @@ class TextSanitizationTests(TestCase):
 @tag("batch_text_sanitization")
 class DecodeUnicodeEscapesTests(TestCase):
     """Tests for decoding JSON/Python-style unicode escape sequences."""
+
+    def test_decode_unicode_character_escapes_preserves_common_backslash_sequences(self):
+        text = r"Divider \u2500 newline \n tab \t quote \" hex \x41"
+
+        result = decode_unicode_character_escapes(text)
+
+        self.assertEqual(result, "Divider ─ newline \\n tab \\t quote \\\" hex \\x41")
 
     def test_decode_em_dash(self):
         """\\u2014 should decode to em dash."""

--- a/util/text_sanitizer.py
+++ b/util/text_sanitizer.py
@@ -8,6 +8,7 @@ __all__ = [
     "strip_control_chars",
     "strip_markdown_for_sms",
     "normalize_whitespace",
+    "decode_unicode_character_escapes",
     "decode_unicode_escapes",
     "strip_llm_artifacts",
     "strip_redundant_blockquote_quotes",
@@ -146,6 +147,13 @@ def _decode_unicode_character_escapes(value: str) -> str:
         i += 1
 
     return "".join(result)
+
+
+def decode_unicode_character_escapes(value: str | None) -> str:
+    """Decode only Unicode character escape sequences, preserving ordinary backslash escapes."""
+    if not isinstance(value, str):
+        return ""
+    return _decode_unicode_character_escapes(value)
 
 
 def sanitize_notification_preview_text(value: str | None) -> str:


### PR DESCRIPTION
## Summary
- Decode literal Unicode escape sequences in native Discord outbound messages before the webhook payload is built.
- Keep the stored message body, sent content, and webhook echo handling aligned on the same normalized text.
- Add regression coverage for escaped Unicode content such as `\u2500`.

## Testing
- Ran targeted unit tests for the Discord webhook send path.
- Verified the existing outbound metadata test still passes after normalization changes.