### PR TITLE
Treat all tool calls from the newest completion as fresh

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from functools import partial
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 from uuid import UUID, uuid4
 
 import zstandard as zstd
@@ -4205,13 +4205,14 @@ def _get_unified_history_prompt(
     tool_call_records: List[ToolCallResultRecord] = []
     browser_task_result_record_ids: Dict[str, str] = {}
     recency_positions: Dict[str, int] = {}
-    fresh_tool_call_step_id: Optional[str] = None
+    fresh_tool_call_step_ids: Set[str] = set()
     if steps:
         step_lookup = {str(step.id): step for step in steps}
+        tool_call_completion_ids: Dict[str, Optional[str]] = {}
         tool_call_results = (
             PersistentAgentToolCall.objects
             .filter(step_id__in=list(step_lookup.keys()))
-            .values("step_id", "result", "tool_name")
+            .values("step_id", "result", "tool_name", "step__completion_id")
         )
         for row in tool_call_results:
             step_id = str(row["step_id"])
@@ -4221,6 +4222,8 @@ def _get_unified_history_prompt(
             result_text = row.get("result") or ""
             if not result_text:
                 continue
+            completion_id = row.get("step__completion_id")
+            tool_call_completion_ids[step_id] = str(completion_id) if completion_id else None
             tool_call_records.append(
                 ToolCallResultRecord(
                     step_id=step_id,
@@ -4230,10 +4233,16 @@ def _get_unified_history_prompt(
                 )
             )
         if tool_call_records:
-            tool_call_step_ids = {record.step_id for record in tool_call_records}
-            most_recent_step_id = str(steps[0].id)
-            if most_recent_step_id in tool_call_step_ids:
-                fresh_tool_call_step_id = most_recent_step_id
+            newest_record = max(tool_call_records, key=lambda record: record.created_at)
+            newest_completion_id = tool_call_completion_ids.get(newest_record.step_id)
+            if newest_completion_id:
+                fresh_tool_call_step_ids = {
+                    record.step_id
+                    for record in tool_call_records
+                    if tool_call_completion_ids.get(record.step_id) == newest_completion_id
+                }
+            else:
+                fresh_tool_call_step_ids = {newest_record.step_id}
 
             # Build recency position map: most recent = 0, then 1, 2, etc.
             ordered_records = sorted(tool_call_records, key=lambda r: r.created_at, reverse=True)
@@ -4250,7 +4259,7 @@ def _get_unified_history_prompt(
     tool_result_prompt_info = prepare_tool_results_for_prompt(
         tool_call_records,
         recency_positions=recency_positions,
-        fresh_tool_call_step_id=fresh_tool_call_step_id,
+        fresh_tool_call_step_ids=fresh_tool_call_step_ids,
     )
 
     # format steps (group meta/params/result components together)

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -135,10 +135,14 @@ def prepare_tool_results_for_prompt(
     *,
     recency_positions: Dict[str, int],
     fresh_tool_call_step_id: Optional[str] = None,
+    fresh_tool_call_step_ids: Optional[Set[str]] = None,
 ) -> Dict[str, ToolResultPromptInfo]:
     prompt_info: Dict[str, ToolResultPromptInfo] = {}
     rows: List[Tuple] = []
     csv_candidates: List[Tuple[str, str, ResultAnalysis]] = []
+    fresh_step_ids = set(fresh_tool_call_step_ids or ())
+    if fresh_tool_call_step_id:
+        fresh_step_ids.add(fresh_tool_call_step_id)
     short_id_map = _build_short_result_id_map(
         [
             record.step_id
@@ -167,9 +171,7 @@ def prepare_tool_results_for_prompt(
         is_analysis_eligible = record.tool_name.startswith(SCHEMA_ELIGIBLE_TOOL_PREFIXES)
 
         recency_position = recency_positions.get(record.step_id)
-        is_fresh_tool_call = bool(
-            fresh_tool_call_step_id and record.step_id == fresh_tool_call_step_id
-        )
+        is_fresh_tool_call = record.step_id in fresh_step_ids
 
         # Extract context hint for lightning-fast agent decisions
         # This is optimistic - if extraction fails, we just skip it
@@ -717,15 +719,15 @@ def _build_prompt_preview(
     tiers = PREVIEW_TIERS_SQLITE if is_sqlite else PREVIEW_TIERS_EXTERNAL
     tier_count = len(tiers)
 
-    # No position means meta only (old result beyond tier range)
-    if recency_position is None or recency_position >= tier_count:
-        return None, False
-
     # For fresh tool calls under ~10K tokens, return full result inline
     # wrapped as a "pre-executed" SQLite query result to prime the agent's
     # mental model that inspection is already done
     if is_fresh_tool_call and full_bytes <= FRESH_RESULT_INLINE_THRESHOLD:
         return _wrap_as_sqlite_result(result_text, full_bytes), True
+
+    # No position means meta only (old result beyond tier range)
+    if recency_position is None or recency_position >= tier_count:
+        return None, False
 
     max_bytes = tiers[recency_position]
 

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -683,6 +683,69 @@ class PreviewByteLimitTests(SimpleTestCase):
         self.assertFalse(is_inline)
         self.assertLess(len(preview), len(medium_text))
 
+    def test_fresh_tool_call_step_ids_inline_multiple_records(self):
+        """Every record in the fresh step set should get the one-time full inline preview."""
+        from api.agent.core.tool_results import (
+            FRESH_RESULT_INLINE_THRESHOLD,
+            ToolCallResultRecord,
+            prepare_tool_results_for_prompt,
+        )
+
+        first_text = "a" * (FRESH_RESULT_INLINE_THRESHOLD - 10000)
+        second_text = "b" * (FRESH_RESULT_INLINE_THRESHOLD - 9000)
+        records = [
+            ToolCallResultRecord(
+                step_id="step-a",
+                tool_name="http_request",
+                created_at=datetime.now(timezone.utc),
+                result_text=first_text,
+            ),
+            ToolCallResultRecord(
+                step_id="step-b",
+                tool_name="http_request",
+                created_at=datetime.now(timezone.utc),
+                result_text=second_text,
+            ),
+        ]
+
+        info = prepare_tool_results_for_prompt(
+            records,
+            recency_positions={},
+            fresh_tool_call_step_ids={"step-a", "step-b"},
+        )
+
+        self.assertTrue(info["step-a"].is_inline)
+        self.assertTrue(info["step-b"].is_inline)
+        self.assertIn("[FULL RESULT", info["step-a"].preview_text)
+        self.assertIn("[FULL RESULT", info["step-b"].preview_text)
+        self.assertIn("ONE-TIME VIEW", info["step-a"].preview_text)
+        self.assertIn("ONE-TIME VIEW", info["step-b"].preview_text)
+
+    def test_non_fresh_step_id_without_recency_gets_meta_only(self):
+        """Fresh step sets should not change old result preview behavior."""
+        from api.agent.core.tool_results import (
+            FRESH_RESULT_INLINE_THRESHOLD,
+            ToolCallResultRecord,
+            prepare_tool_results_for_prompt,
+        )
+
+        result_text = "z" * (FRESH_RESULT_INLINE_THRESHOLD - 10000)
+        record = ToolCallResultRecord(
+            step_id="old-step",
+            tool_name="http_request",
+            created_at=datetime.now(timezone.utc),
+            result_text=result_text,
+        )
+
+        info = prepare_tool_results_for_prompt(
+            [record],
+            recency_positions={},
+            fresh_tool_call_step_ids={"new-step"},
+        )
+
+        self.assertFalse(info["old-step"].is_inline)
+        self.assertIsNone(info["old-step"].preview_text)
+
 
 @tag("batch_tool_results")
 class CsvAutoLoadTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
- Mark every tool call produced by the newest LLM completion as fresh when building unified prompt history.
- Derive freshness from `step__completion_id` so multi-tool batches share the same fresh preview behavior.
- Keep the existing single-step freshness argument as a compatibility fallback.
- Add focused unit coverage for multi-record freshness and old-result meta-only behavior.

## Testing
- Added unit tests for fresh multi-tool batches and non-fresh preview handling.
- Local validation: `uv run python manage.py test tests.unit.test_tool_results_schema --settings=config.test_settings` passed.