### PR TITLE
Remove stale outbound-message heuristic from redundant research plan skip

### DIFF
--- a/api/agent/tools/plan.py
+++ b/api/agent/tools/plan.py
@@ -384,7 +384,7 @@ def build_redundant_research_plan_skip_result(agent, params: dict[str, Any]) -> 
         return None
 
     will_continue_work = _coerce_optional_bool(params.get("will_continue_work"))
-    if will_continue_work is False or _has_outbound_since_latest_inbound(agent):
+    if will_continue_work is False:
         return {
             "status": "ok",
             "message": (
@@ -488,22 +488,6 @@ def _validate_update_plan_params(agent, params: dict[str, Any]) -> dict[str, Any
     file_items = _validate_file_deliverables(params.get("files"), errors)
     message_items = _validate_message_deliverables(agent, params.get("messages"), errors)
     return {"errors": errors, "plan": plan_items, "files": file_items, "messages": message_items}
-
-
-def _has_outbound_since_latest_inbound(agent) -> bool:
-    latest_inbound_at = (
-        PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=False)
-        .order_by("-timestamp")
-        .values_list("timestamp", flat=True)
-        .first()
-    )
-    if latest_inbound_at is None:
-        return False
-    return PersistentAgentMessage.objects.filter(
-        owner_agent=agent,
-        is_outbound=True,
-        timestamp__gt=latest_inbound_at,
-    ).exists()
 
 
 def _format_plan_validation_message(errors: list[str]) -> str:

--- a/api/agent/tools/tests/test_plan.py
+++ b/api/agent/tools/tests/test_plan.py
@@ -8,7 +8,15 @@ from api.agent.tools.plan import (
     execute_update_plan,
     get_update_plan_tool,
 )
-from api.models import BrowserUseAgent, PersistentAgent, PersistentAgentKanbanCard
+from api.models import (
+    BrowserUseAgent,
+    CommsChannel,
+    PersistentAgent,
+    PersistentAgentCommsEndpoint,
+    PersistentAgentConversation,
+    PersistentAgentKanbanCard,
+    PersistentAgentMessage,
+)
 
 
 @tag("batch_agent_tools")
@@ -122,6 +130,64 @@ class UpdatePlanResearchSuppressionTests(TestCase):
         PersistentAgentKanbanCard.objects.create(
             assigned_agent=self.agent,
             title="Write investment memo",
+            status=PersistentAgentKanbanCard.Status.TODO,
+            priority=1,
+        )
+
+        result = build_redundant_research_plan_skip_result(
+            self.agent,
+            {
+                "plan": [
+                    {"step": "Research source set", "status": "done"},
+                    {"step": "Synthesize investment memo", "status": "done"},
+                ],
+                "will_continue_work": True,
+            },
+        )
+
+        self.assertIsNotNone(result)
+        self.assertTrue(result["skipped"])
+        self.assertFalse(result["auto_sleep_ok"])
+
+    def test_old_outbound_message_does_not_turn_redundant_plan_skip_into_sleep(self):
+        agent_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.WEB,
+            address="plan-research-agent",
+            is_primary=True,
+        )
+        user_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            channel=CommsChannel.WEB,
+            address="plan-research-user",
+        )
+        conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.WEB,
+            address=user_endpoint.address,
+        )
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            conversation=conversation,
+            from_endpoint=user_endpoint,
+            is_outbound=False,
+            body="Previous run request.",
+        )
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            conversation=conversation,
+            from_endpoint=agent_endpoint,
+            is_outbound=True,
+            body="Previous run final report.",
+        )
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Research source set",
+            status=PersistentAgentKanbanCard.Status.DOING,
+            priority=2,
+        )
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Synthesize investment memo",
             status=PersistentAgentKanbanCard.Status.TODO,
             priority=1,
         )


### PR DESCRIPTION
## Summary
- Remove the outbound-message history check from redundant research plan suppression so only an explicit `will_continue_work: false` can auto-sleep the agent
- Add a regression test covering old outbound history to ensure a recurring run does not stop prematurely

## Testing
- Ran `uv run python manage.py test api.agent.tools.tests.test_plan.UpdatePlanResearchSuppressionTests --settings=config.test_settings`
- Ran `uv run python manage.py test api.agent.tools.tests.test_plan --settings=config.test_settings`