### PR TITLE
Support Custom OAuth Apps with Pipedream

### DIFF
--- a/api/agent/tools/mcp_manager.py
+++ b/api/agent/tools/mcp_manager.py
@@ -76,6 +76,7 @@ from ...services.pipedream_apps import (
     build_owner_key,
     get_effective_pipedream_app_slugs_for_agent,
     get_platform_pipedream_app_slugs,
+    get_pipedream_oauth_app_id,
     normalize_app_slugs,
 )
 
@@ -2849,6 +2850,9 @@ class MCPToolManager:
         }
         if app_slug:
             headers["x-pd-app-slug"] = app_slug
+            oauth_app_id = get_pipedream_oauth_app_id(app_slug)
+            if oauth_app_id:
+                headers["x-pd-oauth-app-id"] = oauth_app_id
         return headers
 
     def _pd_parse_tool(self, tool_name: str) -> Optional[str]:
@@ -2870,10 +2874,17 @@ class MCPToolManager:
         component_key = str(params.get("componentKey") or params.get("component_key") or "").strip()
         return self._pd_parse_tool(component_key)
 
+    def _pd_agent_client_cache_key(self, agent_key: str, app_slug: Optional[str]) -> str:
+        oauth_app_id = get_pipedream_oauth_app_id(app_slug)
+        cache_key = f"{agent_key}:{app_slug or ''}"
+        if oauth_app_id:
+            cache_key = f"{cache_key}:{oauth_app_id}"
+        return cache_key
+
     def _get_pipedream_agent_client(self, agent: PersistentAgent, app_slug: Optional[str]) -> Client:
         """Get or create a Pipedream client for an agent/app pair."""
         agent_key = str(agent.id)
-        cache_key = f"{agent_key}:{app_slug or ''}"
+        cache_key = self._pd_agent_client_cache_key(agent_key, app_slug)
         if cache_key in self._pd_agent_clients:
             client = self._pd_agent_clients[cache_key]
             # Ensure Authorization header is current

--- a/api/integrations/pipedream_connect.py
+++ b/api/integrations/pipedream_connect.py
@@ -2,6 +2,7 @@ import logging
 import secrets
 from datetime import datetime, timedelta
 from typing import Tuple, Optional
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import requests
 from django.contrib.sites.models import Site
@@ -12,6 +13,7 @@ from django.utils import timezone
 from api.models import PersistentAgent
 from api.models import PipedreamConnectSession
 from api.agent.tools.mcp_manager import get_mcp_manager
+from api.services.pipedream_apps import get_pipedream_oauth_app_id
 
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,20 @@ def _https_base_url() -> str:
     current_site = Site.objects.get_current()
     domain = current_site.domain.strip().rstrip('/')
     return f"https://{domain}"
+
+
+def _append_connect_link_params(link: str, *, app_slug: str) -> str:
+    app = (app_slug or "").strip()
+    if not app:
+        return link
+
+    parsed = urlparse(link)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query["app"] = app
+    oauth_app_id = get_pipedream_oauth_app_id(app)
+    if oauth_app_id:
+        query["oauthAppId"] = oauth_app_id
+    return urlunparse(parsed._replace(query=urlencode(query)))
 
 
 def create_connect_session(agent: PersistentAgent, app_slug: str) -> Tuple[PipedreamConnectSession, Optional[str]]:
@@ -127,12 +143,14 @@ def create_connect_session(agent: PersistentAgent, app_slug: str) -> Tuple[Piped
             session.save(update_fields=["status", "updated_at"])
             return session, None
 
-        # Append &app=...
-        app = (app_slug or "").strip()
-        final_url = f"{link}{'&' if '?' in link else '?'}app={app}" if app else link
+        final_url = _append_connect_link_params(str(link), app_slug=app_slug or "")
         logger.info(
-            "PD Connect: token created session=%s app=%s expires_at=%s final_url_has_app=%s",
-            str(session.id), app or "", str(session.expires_at) if session.expires_at else "", "app=" in final_url
+            "PD Connect: token created session=%s app=%s expires_at=%s final_url_has_app=%s final_url_has_oauth_app=%s",
+            str(session.id),
+            app_slug or "",
+            str(session.expires_at) if session.expires_at else "",
+            "app=" in final_url,
+            "oauthAppId=" in final_url,
         )
         return session, final_url
     except Exception as e:

--- a/api/services/mcp_config_validation.py
+++ b/api/services/mcp_config_validation.py
@@ -2,8 +2,11 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
+from api.pipedream_app_utils import normalize_app_slug
+
 
 _ENVIRONMENT_VARIABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+PIPEDREAM_OAUTH_APP_IDS_METADATA_KEY = "pipedream_oauth_app_ids"
 
 
 def is_valid_environment_variable_name(name: Any) -> bool:
@@ -77,4 +80,28 @@ def validate_mcp_metadata_environment_references(metadata: Mapping[Any, Any]) ->
             "brightdata_search_fallback_zone_env must be an environment variable name like "
             "WEB_UNLOCKER_ZONE_FALLBACK."
         )
+
+    oauth_app_ids = metadata.get(PIPEDREAM_OAUTH_APP_IDS_METADATA_KEY)
+    if oauth_app_ids is not None:
+        if not isinstance(oauth_app_ids, Mapping):
+            errors.append("metadata.pipedream_oauth_app_ids must be a JSON object.")
+        else:
+            invalid_entries = []
+            for app_slug, oauth_app_id in oauth_app_ids.items():
+                normalized_slug = normalize_app_slug(app_slug)
+                if (
+                    not normalized_slug
+                    or "," in normalized_slug
+                    or not isinstance(oauth_app_id, str)
+                    or not oauth_app_id.strip()
+                ):
+                    invalid_entries.append(str(app_slug))
+            if invalid_entries:
+                preview = ", ".join(repr(name) for name in invalid_entries[:5])
+                if len(invalid_entries) > 5:
+                    preview = f"{preview}, ..."
+                errors.append(
+                    "metadata.pipedream_oauth_app_ids must map app slug strings "
+                    f"to non-empty OAuth app ID strings. Invalid entries: {preview}."
+                )
     return errors

--- a/api/services/pipedream_apps.py
+++ b/api/services/pipedream_apps.py
@@ -14,6 +14,7 @@ from django.db.models import Q, QuerySet
 
 from api.pipedream_app_utils import normalize_app_slug, normalize_app_slugs
 from api.models import MCPServerConfig, PersistentAgent, PersistentAgentEnabledTool, PipedreamAppSelection
+from api.services.mcp_config_validation import PIPEDREAM_OAUTH_APP_IDS_METADATA_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +115,31 @@ def get_platform_pipedream_app_slugs() -> list[str]:
     if config is not None and config.prefetch_apps:
         return normalize_app_slugs(config.prefetch_apps)
     return normalize_app_slugs(str(settings.PIPEDREAM_PREFETCH_APPS).split(","))
+
+
+def get_pipedream_oauth_app_id(app_slug: object) -> str:
+    normalized_slug = normalize_app_slug(app_slug)
+    if not normalized_slug or "," in normalized_slug:
+        return ""
+
+    config = (
+        MCPServerConfig.objects.filter(
+            scope=MCPServerConfig.Scope.PLATFORM,
+            name=PIPEDREAM_RUNTIME_NAME,
+            is_active=True,
+        )
+        .only("metadata")
+        .first()
+    )
+    metadata = config.metadata if config is not None and isinstance(config.metadata, dict) else {}
+    raw_mapping = metadata.get(PIPEDREAM_OAUTH_APP_IDS_METADATA_KEY)
+    if not isinstance(raw_mapping, dict):
+        return ""
+
+    for raw_slug, oauth_app_id in raw_mapping.items():
+        if normalize_app_slug(raw_slug) == normalized_slug and isinstance(oauth_app_id, str):
+            return oauth_app_id.strip()
+    return ""
 
 
 def get_owner_selected_app_slugs(owner_scope: str, owner_user=None, owner_org=None) -> list[str]:

--- a/tests/unit/test_pipedream_connect.py
+++ b/tests/unit/test_pipedream_connect.py
@@ -18,6 +18,8 @@ from api.models import (
 )
 from api.agent.tools.mcp_manager import MCPToolManager, MCPToolInfo
 from api.integrations.pipedream_connect import create_connect_session
+from api.services.mcp_config_validation import validate_mcp_metadata_environment_references
+from api.services.pipedream_apps import get_pipedream_oauth_app_id
 from api.services.pipedream_connections import PipedreamConnectionError
 from api.webhooks import pipedream_connect_webhook
 
@@ -41,6 +43,22 @@ def _ensure_pipedream_config():
     if not config.url:
         config.url = "https://pipedream.example.com"
         config.save(update_fields=["url"])
+    return config
+
+
+def _ensure_platform_pipedream_config(metadata=None):
+    config, _ = MCPServerConfig.objects.update_or_create(
+        scope=MCPServerConfig.Scope.PLATFORM,
+        name="pipedream",
+        defaults={
+            "display_name": "Pipedream",
+            "description": "Pipedream test config",
+            "url": "https://pipedream.example.com",
+            "prefetch_apps": ["google_sheets", "notion"],
+            "metadata": metadata or {},
+            "is_active": True,
+        },
+    )
     return config
 
 
@@ -88,6 +106,81 @@ class PipedreamConnectHelperTests(TestCase):
 
         self.assertEqual(headers["x-pd-app-slug"], "google_sheets")
         self.assertEqual(headers["x-pd-tool-mode"], "tools-only")
+        self.assertNotIn("x-pd-oauth-app-id", headers)
+
+    def test_pipedream_oauth_app_id_helper_normalizes_metadata_slugs(self):
+        _ensure_platform_pipedream_config(
+            metadata={
+                "pipedream_oauth_app_ids": {
+                    " Notion ": " oa_notion ",
+                },
+            }
+        )
+
+        self.assertEqual(get_pipedream_oauth_app_id("notion"), "oa_notion")
+        self.assertEqual(get_pipedream_oauth_app_id(" Notion "), "oa_notion")
+        self.assertEqual(get_pipedream_oauth_app_id("google_sheets"), "")
+
+    def test_pipedream_oauth_app_id_metadata_validation_rejects_invalid_shape(self):
+        errors = validate_mcp_metadata_environment_references(
+            {"pipedream_oauth_app_ids": {"notion": "oa_notion"}}
+        )
+        self.assertEqual(errors, [])
+
+        errors = validate_mcp_metadata_environment_references(
+            {"pipedream_oauth_app_ids": {"notion": ""}}
+        )
+        self.assertTrue(any("pipedream_oauth_app_ids" in error for error in errors))
+
+        errors = validate_mcp_metadata_environment_references(
+            {"pipedream_oauth_app_ids": ["notion", "oa_notion"]}
+        )
+        self.assertTrue(any("pipedream_oauth_app_ids" in error for error in errors))
+
+    def test_pipedream_headers_include_oauth_app_id_for_mapped_single_app(self):
+        _ensure_platform_pipedream_config(
+            metadata={"pipedream_oauth_app_ids": {"notion": "oa_notion"}}
+        )
+        mgr = MCPToolManager()
+        mgr._get_pipedream_access_token = MagicMock(return_value="pd_token")
+
+        headers = mgr._pd_build_headers(
+            app_slug="notion",
+            external_user_id="agent-id",
+            conversation_id="conversation-id",
+        )
+
+        self.assertEqual(headers["x-pd-app-slug"], "notion")
+        self.assertEqual(headers["x-pd-oauth-app-id"], "oa_notion")
+
+    def test_pipedream_headers_omit_oauth_app_id_for_discovery_app_list(self):
+        _ensure_platform_pipedream_config(
+            metadata={"pipedream_oauth_app_ids": {"notion": "oa_notion"}}
+        )
+        mgr = MCPToolManager()
+        mgr._get_pipedream_access_token = MagicMock(return_value="pd_token")
+
+        headers = mgr._pd_build_headers(
+            app_slug="notion,google_sheets",
+            external_user_id="agent-id",
+            conversation_id="conversation-id",
+        )
+
+        self.assertEqual(headers["x-pd-app-slug"], "notion,google_sheets")
+        self.assertNotIn("x-pd-oauth-app-id", headers)
+
+    def test_pipedream_agent_client_cache_key_includes_oauth_app_id_when_mapped(self):
+        mgr = MCPToolManager()
+        self.assertEqual(mgr._pd_agent_client_cache_key("agent-id", "notion"), "agent-id:notion")
+
+        _ensure_platform_pipedream_config(
+            metadata={"pipedream_oauth_app_ids": {"notion": "oa_notion"}}
+        )
+
+        self.assertEqual(
+            mgr._pd_agent_client_cache_key("agent-id", "notion"),
+            "agent-id:notion:oa_notion",
+        )
 
     @patch("api.integrations.pipedream_connect.requests.post")
     @patch("api.integrations.pipedream_connect.get_mcp_manager")
@@ -121,9 +214,43 @@ class PipedreamConnectHelperTests(TestCase):
         # Assert
         self.assertTrue(isinstance(session, PipedreamConnectSession))
         self.assertIn("app=google_sheets", url)
+        self.assertNotIn("oauthAppId=", url)
         self.assertEqual(session.connect_token, "ctok_abc")
         # Stored link is the Pipedream connect link
         self.assertIn("pipedream.com/_static/connect.html", session.connect_link_url)
+
+    @patch("api.integrations.pipedream_connect.requests.post")
+    @patch("api.integrations.pipedream_connect.get_mcp_manager")
+    def test_create_connect_session_appends_oauth_app_id_for_mapped_app(self, mock_get_mgr, mock_post):
+        _ensure_platform_pipedream_config(
+            metadata={"pipedream_oauth_app_ids": {"notion": "oa_notion"}}
+        )
+        User = get_user_model()
+        user = User.objects.create_user(username="notion-user@example.com")
+        bua = _create_browser_agent(user)
+        agent = PersistentAgent.objects.create(user=user, name="a", charter="c", browser_use_agent=bua)
+
+        mgr = MagicMock()
+        mgr._get_pipedream_access_token.return_value = "pd_token"
+        mock_get_mgr.return_value = mgr
+
+        resp = MagicMock()
+        future_expires = (timezone.now() + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        resp.json.return_value = {
+            "token": "ctok_notion",
+            "connect_link_url": "https://pipedream.com/_static/connect.html?token=ctok_notion",
+            "expires_at": future_expires,
+        }
+        resp.raise_for_status.return_value = None
+        mock_post.return_value = resp
+
+        from django.test import override_settings
+        with override_settings(PIPEDREAM_PROJECT_ID="proj_123", PIPEDREAM_ENVIRONMENT="development"):
+            session, url = create_connect_session(agent, "notion")
+
+        self.assertTrue(isinstance(session, PipedreamConnectSession))
+        self.assertIn("app=notion", url)
+        self.assertIn("oauthAppId=oa_notion", url)
 
     @patch("api.integrations.pipedream_connect.requests.post")
     @patch("api.integrations.pipedream_connect.get_mcp_manager")


### PR DESCRIPTION
## Summary
- Add platform metadata support for mapping Pipedream app slugs to custom OAuth app IDs
- Append `oauthAppId` to Pipedream Connect links when a mapping exists
- Pass `x-pd-oauth-app-id` for single-app Pipedream MCP requests and include it in the agent client cache key
- Validate the new metadata shape and cover the flow with focused unit tests

## Testing
- Added unit coverage for metadata validation, OAuth app ID lookup, Connect Link URL generation, MCP header injection, and cache-key behavior
- Validated the affected Pipedream test suites locally