### PR TITLE
Avoid sending parallel_tool_calls without tools in LiteLLM requests

### DIFF
--- a/api/agent/core/llm_utils.py
+++ b/api/agent/core/llm_utils.py
@@ -421,14 +421,12 @@ def run_completion(
     - Removes internal hints (``supports_temperature``, ``supports_tool_choice``, ``use_parallel_tool_calls``, ``allow_implied_send``, ``supports_vision``, and ``supports_reasoning``).
     - Allows ``reasoning_effort`` through LiteLLM's OpenAI parameter filter when reasoning is supported.
     - Adds ``tool_choice`` when tools are provided and supported.
-    - Propagates ``parallel_tool_calls`` when tools are provided *or* the endpoint
-      supplied an explicit hint.
+    - Propagates ``parallel_tool_calls`` only when tools are provided.
     - Allows callers to control ``drop_params`` while keeping consistent defaults.
     - Enforces non-empty responses when not streaming.
     """
     params = dict(params or {})
 
-    parallel_hint_provided = "use_parallel_tool_calls" in params
     hints: dict[str, Any] = {key: params.pop(key, None) for key in _HINT_KEYS}
 
     supports_temperature_hint = hints.get("supports_temperature")
@@ -482,9 +480,7 @@ def run_completion(
         # Ensure we don't pass tool-choice hints when tools are absent
         kwargs.pop("tool_choice", None)
 
-    if use_parallel_tool_calls is not None and (tools or parallel_hint_provided):
-        # Respect explicit hints even when no tools are provided; some providers
-        # validate the flag independently of tool availability.
+    if tools and use_parallel_tool_calls is not None:
         kwargs["parallel_tool_calls"] = bool(use_parallel_tool_calls)
     else:
         kwargs.pop("parallel_tool_calls", None)

--- a/api/agent/core/llm_utils.py
+++ b/api/agent/core/llm_utils.py
@@ -480,7 +480,7 @@ def run_completion(
         # Ensure we don't pass tool-choice hints when tools are absent
         kwargs.pop("tool_choice", None)
 
-    if tools and use_parallel_tool_calls is not None:
+    if tools:
         kwargs["parallel_tool_calls"] = bool(use_parallel_tool_calls)
     else:
         kwargs.pop("parallel_tool_calls", None)

--- a/tests/unit/test_event_processing_llm_selection.py
+++ b/tests/unit/test_event_processing_llm_selection.py
@@ -75,7 +75,16 @@ class TestEventProcessingLLMSelection(TestCase):
         mock_completion.return_value = mock_response
 
         messages = [{"role": "user", "content": "hello"}]
-        tools = []
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "Lookup information",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
         # Provide endpoint params with our hint
         failover_configs = [
             (

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -146,6 +146,46 @@ class RunCompletionReasoningTests(TestCase):
         )
 
     @tag("batch_event_llm")
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_parallel_tool_calls_omitted_when_tools_absent(self, mock_completion):
+        mock_completion.return_value = make_completion_response(content="ok")
+
+        run_completion(
+            model="mock-model",
+            messages=[],
+            params={"use_parallel_tool_calls": True},
+        )
+
+        _, kwargs = mock_completion.call_args
+        self.assertNotIn("parallel_tool_calls", kwargs)
+        self.assertNotIn("use_parallel_tool_calls", kwargs)
+
+    @tag("batch_event_llm")
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_parallel_tool_calls_forwarded_when_tools_present(self, mock_completion):
+        mock_completion.return_value = make_completion_response(content="ok")
+
+        run_completion(
+            model="mock-model",
+            messages=[],
+            params={"use_parallel_tool_calls": True},
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "description": "Search",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+
+        _, kwargs = mock_completion.call_args
+        self.assertTrue(kwargs["parallel_tool_calls"])
+        self.assertNotIn("use_parallel_tool_calls", kwargs)
+
+    @tag("batch_event_llm")
     @override_settings(LITELLM_TIMEOUT_SECONDS=321)
     @patch("api.agent.core.llm_utils.litellm.completion")
     def test_timeout_defaults_to_settings_value(self, mock_completion):


### PR DESCRIPTION
## Summary
- Stop forwarding `parallel_tool_calls` on tool-less LiteLLM calls so Azure GPT-5.4 requests no longer fail with a BadRequestError
- Keep the parallel tool flag working when actual tools are present
- Add regression coverage for both the no-tools and tools-present paths

## Testing
- Ran focused Django unit tests for the LiteLLM wrapper and event-processing selection path
- Verified the updated tests pass locally