### PR TITLE
Add message tools to no-charge-on-error credit allowlist

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1137,6 +1137,9 @@ TOOL_CREDIT_COSTS = {
 # error. Names are normalized case-insensitively by the credit helpers.
 TOOL_CREDIT_NO_CHARGE_ON_ERROR_TOOLS = {
     "create_video",
+    "send_chat_message",
+    "send_email",
+    "send_sms",
 }
 
 # Analytics


### PR DESCRIPTION
**Summary**
- Add `send_email`, `send_sms`, and `send_chat_message` to `TOOL_CREDIT_NO_CHARGE_ON_ERROR_TOOLS` in `config/settings.py`.
- This prevents errored message sends from consuming task credits.

**Testing**
- Ran focused unit coverage for tool credit behavior; tests passed.