### PR TITLE
Google Integration Fixes

### DIFF
--- a/api/services/native_integrations.py
+++ b/api/services/native_integrations.py
@@ -114,7 +114,7 @@ GOOGLE_DRIVE_PROVIDER = NativeIntegrationProvider(
     icon="google_drive",
     authorization_params={
         "access_type": "offline",
-        "include_granted_scopes": "true",
+        "include_granted_scopes": "false",
         "prompt": "consent",
     },
 )

--- a/frontend/src/api/agentChat.test.ts
+++ b/frontend/src/api/agentChat.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveSpawnRequest } from './agentChat'
+import { jsonRequest } from './http'
 
 describe('resolveSpawnRequest', () => {
   beforeEach(() => {
@@ -34,5 +35,26 @@ describe('resolveSpawnRequest', () => {
     const headers = new Headers(init?.headers)
     expect(headers.get('Content-Type')).toBe('application/json')
     expect(headers.get('X-CSRFToken')).toBe('test-token')
+  })
+
+  it('prefers an explicit CSRF token over the cookie token', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await jsonRequest('/example/', {
+      method: 'POST',
+      includeCsrf: true,
+      csrfToken: 'fresh-token',
+      json: {},
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const headers = new Headers(init?.headers)
+    expect(headers.get('X-CSRFToken')).toBe('fresh-token')
   })
 })

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -191,16 +191,17 @@ export function getCsrfToken(): string {
 type JsonRequestInit = RequestInit & {
   json?: unknown
   includeCsrf?: boolean
+  csrfToken?: string
 }
 
 export async function jsonRequest<T>(input: RequestInfo | URL, init: JsonRequestInit = {}): Promise<T> {
-  const { json, includeCsrf = false, headers, ...rest } = init
+  const { json, includeCsrf = false, csrfToken = '', headers, ...rest } = init
   const finalHeaders = new Headers(headers ?? undefined)
   if (json !== undefined) {
     finalHeaders.set('Content-Type', 'application/json')
   }
   if (includeCsrf) {
-    finalHeaders.set('X-CSRFToken', getCsrfToken())
+    finalHeaders.set('X-CSRFToken', csrfToken || getCsrfToken())
   }
 
   const body = json !== undefined ? JSON.stringify(json) : rest.body

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -48,11 +48,12 @@ function applyConsoleContextHeaders(headers: Headers): boolean {
   return applied
 }
 
-function buildLoginUrl(): string {
+export function buildLoginUrl(nextUrl?: string): string {
   if (typeof window === 'undefined') {
-    return '/accounts/login/'
+    const params = nextUrl ? `?next=${encodeURIComponent(nextUrl)}` : ''
+    return `/accounts/login/${params}`
   }
-  const next = `${window.location.pathname}${window.location.search}${window.location.hash}` || '/'
+  const next = nextUrl || `${window.location.pathname}${window.location.search}${window.location.hash}` || '/'
   return `/accounts/login/?next=${encodeURIComponent(next)}`
 }
 
@@ -65,7 +66,7 @@ function isLoginPath(url: string): boolean {
   }
 }
 
-export function scheduleLoginRedirect(): void {
+export function scheduleLoginRedirect(nextUrl?: string): void {
   if (typeof window === 'undefined') {
     return
   }
@@ -76,7 +77,7 @@ export function scheduleLoginRedirect(): void {
     return
   }
   loginRedirectScheduled = true
-  window.location.assign(buildLoginUrl())
+  window.location.assign(buildLoginUrl(nextUrl))
 }
 
 function maybeRedirectToLogin(response: Response): void {

--- a/frontend/src/api/nativeIntegrations.ts
+++ b/frontend/src/api/nativeIntegrations.ts
@@ -133,10 +133,14 @@ export async function fetchNativeIntegrations(listUrl: string): Promise<NativeIn
   }
 }
 
-export async function startNativeIntegrationConnect(connectUrl: string): Promise<NativeIntegrationConnectResponse> {
+export async function startNativeIntegrationConnect(
+  connectUrl: string,
+  csrfToken?: string,
+): Promise<NativeIntegrationConnectResponse> {
   const payload = await jsonRequest<NativeIntegrationConnectResponseDTO>(connectUrl, {
     method: 'POST',
     includeCsrf: true,
+    csrfToken,
     json: {},
   })
   return {
@@ -168,10 +172,11 @@ export async function fetchNativeIntegrationFiles(filesUrl: string): Promise<Nat
   }
 }
 
-export async function revokeNativeIntegration(revokeUrl: string): Promise<{ revoked: boolean }> {
+export async function revokeNativeIntegration(revokeUrl: string, csrfToken?: string): Promise<{ revoked: boolean }> {
   return jsonRequest<{ revoked: boolean }>(revokeUrl, {
     method: 'POST',
     includeCsrf: true,
+    csrfToken,
     json: {},
   })
 }

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.test.ts
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildLoginUrl } from '../../api/http'
+import { buildHomepageNativeIntegrationLoginReturnUrl } from './HomepageIntegrationsModal'
+
+describe('homepage native integration login redirects', () => {
+  it('builds a homepage return URL that reopens the integrations modal for the provider', () => {
+    const returnUrl = buildHomepageNativeIntegrationLoginReturnUrl(
+      {
+        displayName: 'Google Drive',
+        providerKey: 'google_drive',
+      },
+      'https://gobii.test/?utm_source=homepage#apps',
+    )
+
+    expect(returnUrl).toBe('/?utm_source=homepage&integration_search=Google+Drive#apps')
+  })
+
+  it('preserves the modal return URL as the login next parameter', () => {
+    expect(buildLoginUrl('/?integration_search=Google+Drive#apps')).toBe(
+      '/accounts/login/?next=%2F%3Fintegration_search%3DGoogle%2BDrive%23apps',
+    )
+  })
+})

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.test.ts
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.test.ts
@@ -1,7 +1,98 @@
-import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { buildLoginUrl } from '../../api/http'
-import { buildHomepageNativeIntegrationLoginReturnUrl } from './HomepageIntegrationsModal'
+import type {
+  NativeIntegrationPickerTokenResponse,
+  NativeIntegrationProviderDTO,
+} from '../../api/nativeIntegrations'
+import {
+  buildHomepageNativeIntegrationLoginReturnUrl,
+  HomepageIntegrationsModal,
+} from './HomepageIntegrationsModal'
+
+const mocks = vi.hoisted(() => ({
+  fetchNativeIntegrationPickerToken: vi.fn(),
+  openGoogleDrivePicker: vi.fn(),
+}))
+
+vi.mock('../../api/nativeIntegrations', async () => {
+  const actual = await vi.importActual<typeof import('../../api/nativeIntegrations')>('../../api/nativeIntegrations')
+  return {
+    ...actual,
+    fetchNativeIntegrationPickerToken: mocks.fetchNativeIntegrationPickerToken,
+  }
+})
+
+vi.mock('../mcp/NativeIntegrationShared', async () => {
+  const actual = await vi.importActual<typeof import('../mcp/NativeIntegrationShared')>('../mcp/NativeIntegrationShared')
+  return {
+    ...actual,
+    openGoogleDrivePicker: mocks.openGoogleDrivePicker,
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  document.body.innerHTML = ''
+})
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, reject, resolve }
+}
+
+const googleDriveProvider: NativeIntegrationProviderDTO = {
+  provider_key: 'google_drive',
+  display_name: 'Google Drive',
+  description: 'Grant file access for Google Sheets and Google Docs.',
+  auth_type: 'oauth2',
+  icon: 'google_drive',
+  api_hosts: ['googleapis.com'],
+  scopes: ['https://www.googleapis.com/auth/drive.file'],
+  connected: true,
+  scope: 'user',
+  expires_at: null,
+  connect_url: '/console/api/native-integrations/google_drive/connect/',
+  files_url: '/console/api/native-integrations/google_drive/files/',
+  picker_token_url: '/console/api/native-integrations/google_drive/picker-token/',
+  revoke_url: '/console/api/native-integrations/google_drive/revoke/',
+}
+
+function renderHomepageIntegrationsModal() {
+  document.body.innerHTML = '<div id="selected-fields"></div>'
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+  return render(
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(HomepageIntegrationsModal, {
+        builtins: [],
+        initialSearchTerm: '',
+        initialSelectedAppSlugs: [],
+        nativeIntegrationsUrl: '',
+        nativeProviders: [googleDriveProvider],
+        isAuthenticated: true,
+        searchUrl: '/console/api/pipedream-apps/search/',
+        selectedFieldsContainerId: 'selected-fields',
+        initialOpen: true,
+      }),
+    ),
+  )
+}
 
 describe('homepage native integration login redirects', () => {
   it('builds a homepage return URL that reopens the integrations modal for the provider', () => {
@@ -20,5 +111,42 @@ describe('homepage native integration login redirects', () => {
     expect(buildLoginUrl('/?integration_search=Google+Drive#apps')).toBe(
       '/accounts/login/?next=%2F%3Fintegration_search%3DGoogle%2BDrive%23apps',
     )
+  })
+
+  it('keeps the homepage modal mounted while Google Picker is active and restores scroll afterward', async () => {
+    const tokenDeferred = createDeferred<NativeIntegrationPickerTokenResponse>()
+    const pickerDeferred = createDeferred<number>()
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    Object.defineProperty(window, 'scrollX', { configurable: true, value: 12 })
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 640 })
+    mocks.fetchNativeIntegrationPickerToken.mockReturnValue(tokenDeferred.promise)
+    mocks.openGoogleDrivePicker.mockReturnValue(pickerDeferred.promise)
+
+    renderHomepageIntegrationsModal()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select Files' }))
+
+    await waitFor(() => {
+      expect(scrollTo).toHaveBeenCalledWith(0, 0)
+    })
+    expect(screen.getByRole('dialog', { name: 'Manage integrations' })).toBeInTheDocument()
+
+    tokenDeferred.resolve({
+      accessToken: 'access-token',
+      developerKey: 'developer-key',
+      appId: 'app-id',
+      scope: 'user',
+      expiresAt: null,
+    })
+    await waitFor(() => {
+      expect(mocks.openGoogleDrivePicker).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByRole('dialog', { name: 'Manage integrations' })).toBeInTheDocument()
+
+    pickerDeferred.resolve(1)
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Manage integrations' })).toBeInTheDocument()
+    })
+    expect(scrollTo).toHaveBeenLastCalledWith(12, 640)
   })
 })

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
@@ -58,6 +58,12 @@ function fallbackAppForSlug(slug: string): PipedreamAppSummary {
   }
 }
 
+function scrollPageToTop() {
+  window.scrollTo(0, 0)
+  document.documentElement.scrollTop = 0
+  document.body.scrollTop = 0
+}
+
 async function ensureHomepageCsrf(): Promise<string> {
   const response = await fetch('/api/homepage/csrf-token/', {
     credentials: 'same-origin',
@@ -231,9 +237,16 @@ export function HomepageIntegrationsModal({
 
   const nativePickerMutation = useMutation({
     mutationFn: async (provider: NativeIntegrationProvider) => {
-      const token = await fetchNativeIntegrationPickerToken(provider.pickerTokenUrl)
-      const selectedCount = await openGoogleDrivePicker(token)
-      return { provider, selectedCount }
+      const previousScrollX = window.scrollX
+      const previousScrollY = window.scrollY
+      try {
+        scrollPageToTop()
+        const token = await fetchNativeIntegrationPickerToken(provider.pickerTokenUrl)
+        const selectedCount = await openGoogleDrivePicker(token)
+        return { provider, selectedCount }
+      } finally {
+        window.scrollTo(previousScrollX, previousScrollY)
+      }
     },
     onMutate: (provider) => {
       setPendingNativeAction({ providerKey: provider.providerKey, kind: 'picker' })
@@ -562,6 +575,7 @@ export function HomepageIntegrationsModal({
           icon={Sparkles}
           iconBgClass="bg-blue-100"
           iconColorClass="text-blue-700"
+          dismissible={!nativePickerMutation.isPending}
         >
           {body}
         </Modal>

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
@@ -65,6 +65,15 @@ async function ensureHomepageCsrf(): Promise<void> {
   })
 }
 
+export function buildHomepageNativeIntegrationLoginReturnUrl(
+  provider: Pick<NativeIntegrationProvider, 'displayName' | 'providerKey'>,
+  currentHref = typeof window === 'undefined' ? '/' : window.location.href,
+): string {
+  const url = new URL(currentHref, typeof window === 'undefined' ? 'http://localhost' : window.location.origin)
+  url.searchParams.set('integration_search', provider.displayName || provider.providerKey)
+  return `${url.pathname}${url.search}${url.hash}`
+}
+
 export function HomepageIntegrationsModal({
   builtins,
   initialSearchTerm,
@@ -333,7 +342,7 @@ export function HomepageIntegrationsModal({
                 disabled={nativeConnectMutation.isPending || nativeDisconnectMutation.isPending || nativePickerMutation.isPending}
                 onConnect={() => {
                   if (!isAuthenticated) {
-                    scheduleLoginRedirect()
+                    scheduleLoginRedirect(buildHomepageNativeIntegrationLoginReturnUrl(provider))
                     return
                   }
                   nativeConnectMutation.mutate({ provider, popup: openNativeOAuthPopup(provider) })

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
@@ -58,11 +58,16 @@ function fallbackAppForSlug(slug: string): PipedreamAppSummary {
   }
 }
 
-async function ensureHomepageCsrf(): Promise<void> {
-  await fetch('/api/homepage/csrf-token/', {
+async function ensureHomepageCsrf(): Promise<string> {
+  const response = await fetch('/api/homepage/csrf-token/', {
     credentials: 'same-origin',
     headers: { Accept: 'application/json' },
   })
+  if (!response.ok) {
+    throw new Error('Unable to refresh the CSRF token.')
+  }
+  const payload = await response.json() as { csrfToken?: unknown }
+  return typeof payload.csrfToken === 'string' ? payload.csrfToken : ''
 }
 
 export function buildHomepageNativeIntegrationLoginReturnUrl(
@@ -177,8 +182,8 @@ export function HomepageIntegrationsModal({
 
   const nativeConnectMutation = useMutation({
     mutationFn: async ({ provider }: { provider: NativeIntegrationProvider; popup: Window | null }) => {
-      await ensureHomepageCsrf()
-      return startNativeIntegrationConnect(provider.connectUrl)
+      const csrfToken = await ensureHomepageCsrf()
+      return startNativeIntegrationConnect(provider.connectUrl, csrfToken)
     },
     onMutate: ({ provider }) => {
       setPendingNativeAction({ providerKey: provider.providerKey, kind: 'connect' })
@@ -208,8 +213,8 @@ export function HomepageIntegrationsModal({
 
   const nativeDisconnectMutation = useMutation({
     mutationFn: async (provider: NativeIntegrationProvider) => {
-      await ensureHomepageCsrf()
-      return revokeNativeIntegration(provider.revokeUrl).then(() => provider)
+      const csrfToken = await ensureHomepageCsrf()
+      return revokeNativeIntegration(provider.revokeUrl, csrfToken).then(() => provider)
     },
     onMutate: (provider) => {
       setPendingNativeAction({ providerKey: provider.providerKey, kind: 'disconnect' })

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
@@ -72,8 +72,8 @@ async function ensureHomepageCsrf(): Promise<string> {
   if (!response.ok) {
     throw new Error('Unable to refresh the CSRF token.')
   }
-  const payload = await response.json() as { csrfToken?: unknown }
-  return typeof payload.csrfToken === 'string' ? payload.csrfToken : ''
+  const payload = await response.json() as { csrfToken?: unknown } | null
+  return typeof payload?.csrfToken === 'string' ? payload.csrfToken : ''
 }
 
 export function buildHomepageNativeIntegrationLoginReturnUrl(

--- a/static/js/native_integration_oauth_callback.js
+++ b/static/js/native_integration_oauth_callback.js
@@ -33,7 +33,7 @@ async function refreshCsrfToken() {
     throw new Error("Unable to refresh the CSRF token.");
   }
   const payload = await response.json();
-  return typeof payload.csrfToken === "string" ? payload.csrfToken : getCsrfToken();
+  return payload && typeof payload.csrfToken === "string" ? payload.csrfToken : getCsrfToken();
 }
 
 function getPendingSession(state) {

--- a/static/js/native_integration_oauth_callback.js
+++ b/static/js/native_integration_oauth_callback.js
@@ -24,6 +24,18 @@ function getCsrfToken() {
   return match ? decodeURIComponent(match[1]) : "";
 }
 
+async function refreshCsrfToken() {
+  const response = await fetch("/api/homepage/csrf-token/", {
+    credentials: "same-origin",
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error("Unable to refresh the CSRF token.");
+  }
+  const payload = await response.json();
+  return typeof payload.csrfToken === "string" ? payload.csrfToken : getCsrfToken();
+}
+
 function getPendingSession(state) {
   const raw = localStorage.getItem(`gobii:native_oauth_state:${state}`);
   if (!raw) {
@@ -37,10 +49,10 @@ function getPendingSession(state) {
   }
 }
 
-function buildCallbackHeaders(sessionData) {
+function buildCallbackHeaders(sessionData, csrfToken) {
   const headers = {
     "Content-Type": "application/json",
-    "X-CSRFToken": getCsrfToken(),
+    "X-CSRFToken": csrfToken || getCsrfToken(),
   };
   const context = sessionData && sessionData.context;
   if (context && typeof context === "object" && context.type && context.id) {
@@ -163,9 +175,11 @@ async function completeOAuth() {
   setStatus("Securely storing integration...");
 
   try {
+    const csrfToken = await refreshCsrfToken();
     const response = await fetch(`/console/api/native-integrations/${encodeURIComponent(sessionData.providerKey)}/callback/`, {
       method: "POST",
-      headers: buildCallbackHeaders(sessionData),
+      credentials: "same-origin",
+      headers: buildCallbackHeaders(sessionData, csrfToken),
       body: JSON.stringify({
         authorization_code: code,
         state,


### PR DESCRIPTION
## Summary
- Preserve the homepage integrations modal return path after anonymous Google integration login
- Refresh and pass CSRF tokens through native integration connect and callback flows
- Fix Google Picker behavior so the integrations UI stays stable while files are selected
- Add focused tests for login redirect handling, CSRF overrides, and picker lifecycle behavior

## Testing
- `HomepageIntegrationsModal.test.ts` and `agentChat.test.ts` passed
- Local frontend build passed
- Added unit coverage for Google Picker callback behavior and homepage modal flow