### PR TITLE
Prevent final reports from stopping with unfinished plans

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -127,7 +127,7 @@ from ..tools.sqlite_skills import apply_sqlite_skill_updates, refresh_skills_for
 from ..tools.custom_tools import execute_create_custom_tool
 from ..tools.custom_tool_names import CREATE_CUSTOM_TOOL_NAME
 from ..tools.file_str_replace import execute_file_str_replace
-from ..tools.plan import build_redundant_research_plan_skip_result, execute_update_plan
+from ..tools.plan import build_plan_snapshot, build_redundant_research_plan_skip_result, execute_update_plan
 from ..tools.planning import execute_end_planning
 from ..tools.runtime_execution_context import tool_execution_context
 from ..tools.sqlite_state import agent_sqlite_db, get_sqlite_db_path
@@ -1796,6 +1796,33 @@ class _FinalizedToolBatch:
     human_input_request_ok: bool = False
 
 
+def _plan_has_unfinished_items(agent: PersistentAgent) -> bool:
+    try:
+        snapshot = build_plan_snapshot(agent)
+    except (DatabaseError, LookupError, RuntimeError):
+        logger.debug("Failed to build plan snapshot for terminal-send check.", exc_info=True)
+        return False
+    return snapshot.todo_count > 0 or snapshot.doing_count > 0
+
+
+def _record_terminal_send_unfinished_plan_correction(
+    agent: PersistentAgent,
+    *,
+    attach_completion: Any,
+    attach_prompt_archive: Any,
+) -> None:
+    step_kwargs = {
+        "agent": agent,
+        "description": (
+            "Terminal message delivery requested stop, but the current plan still has unfinished items. "
+            "Call update_plan with the complete current plan state before stopping."
+        ),
+    }
+    attach_completion(step_kwargs)
+    step = PersistentAgentStep.objects.create(**step_kwargs)
+    attach_prompt_archive(step)
+
+
 def _should_skip_stale_planning_mode_after_terminal_delivery(
     agent: PersistentAgent,
     finalized_batch: _FinalizedToolBatch,
@@ -3196,6 +3223,14 @@ def _finalize_tool_batch(
         executed_calls += 1
         if tool_name not in MESSAGE_TOOL_NAMES and tool_name != "sleep_until_next_trigger":
             executed_non_message_action = True
+
+    if terminal_message_delivery_ok and not followup_required and _plan_has_unfinished_items(agent):
+        _record_terminal_send_unfinished_plan_correction(
+            agent,
+            attach_completion=attach_completion,
+            attach_prompt_archive=attach_prompt_archive,
+        )
+        followup_required = True
 
     return _FinalizedToolBatch(
         executed_calls=executed_calls,

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -1799,7 +1799,7 @@ class _FinalizedToolBatch:
 def _plan_has_unfinished_items(agent: PersistentAgent) -> bool:
     try:
         snapshot = build_plan_snapshot(agent)
-    except (DatabaseError, LookupError, RuntimeError):
+    except Exception:
         logger.debug("Failed to build plan snapshot for terminal-send check.", exc_info=True)
         return False
     return snapshot.todo_count > 0 or snapshot.doing_count > 0

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -3224,7 +3224,12 @@ def _finalize_tool_batch(
         if tool_name not in MESSAGE_TOOL_NAMES and tool_name != "sleep_until_next_trigger":
             executed_non_message_action = True
 
-    if terminal_message_delivery_ok and not followup_required and _plan_has_unfinished_items(agent):
+    if (
+        agent.planning_state != PersistentAgent.PlanningState.PLANNING
+        and terminal_message_delivery_ok
+        and not followup_required
+        and _plan_has_unfinished_items(agent)
+    ):
         _record_terminal_send_unfinished_plan_correction(
             agent,
             attach_completion=attach_completion,

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3461,11 +3461,10 @@ def _get_system_instruction(
         "- Need a blocking human answer, another tool result, or a final user-facing report → will_continue_work=true, keep going.\n"
         f"{text_only_guidance}"
         f"{mid_conversation_schedule_examples}"
-        "**CRITICAL termination sequence:** "
-        "1. Send your final report to the user with will_continue_work=false on that final send tool.\n"
-        "2. Preserve reusable workflows/feedback as skills silently when useful.\n"
-        "3. If you still need to mark the plan done after the report is already sent, call update_plan with will_continue_work=false; otherwise sleep.\n"
-        "4. You're done: no extra turn, no announcement or confirmation message.\n\n"
+        "**Plan-aware termination sequence:** "
+        "1. Send the final report with will_continue_work=false only if no current plan items remain todo/doing. "
+        "2. If the report is ready but the plan is unfinished, send with will_continue_work=true, then call update_plan with every finished/deferred item resolved and will_continue_work=false. "
+        "3. After the final send and final plan update, stop with no extra message.\n\n"
         "Recurring or truly multi-phase work may need charter/schedule updates; one-off work usually needs neither.\n"
     )
 
@@ -3624,7 +3623,7 @@ def _get_system_instruction(
         "Respect one-off preferences like 'stand by' or 'don't follow up unless I ask' in the current conversation without mutating config. When in doubt, leave config unchanged, deliver the result, and stop.\n\n"
 
         "## Plan Discipline (CRITICAL)\n\n"
-        "update_plan is for real multi-step work that benefits from a user-visible plan. Do not create/update one for quick lookups, simple research answers, scheduled briefings, one-shot charts, or simple latest/current reports. For deep work, use at most one initial plan update; do not update it again just to mark research done, narrate progress, or prepare the final. After the final message, stop unless an existing plan genuinely needs maintenance.\n\n"
+        "update_plan is for real multi-step work that benefits from a user-visible plan. Do not create/update one for quick lookups, simple research answers, scheduled briefings, one-shot charts, or simple latest/current reports. For deep work, use at most one initial plan update; update it again only to finish an existing visible plan before stopping.\n\n"
 
         "## Silent Work (CRITICAL)\n\n"
         "Do not announce what you're about to do. Make tool calls with no text until findings, blocker, needed human question, or final answer. Text is for results, not narration; tools execute silently.\n\n"

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -23,6 +23,7 @@ from api.agent.core.event_processing import (
     _sanitize_tool_name,
     _should_infer_message_tool_continuation,
     _should_imply_continue,
+    _should_skip_stale_planning_mode_after_terminal_delivery,
     _ToolExecutionOutcome,
     _tool_call_likely_terminal_message,
 )
@@ -250,6 +251,66 @@ class MessageToolExplicitContinuationTests(TestCase):
         self.assertTrue(finalized.followup_required)
         self.assertIs(finalized.last_explicit_continue, False)
         self.assertTrue(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description__contains="current plan still has unfinished items",
+            ).exists()
+        )
+
+    def test_planning_mode_terminal_message_with_unfinished_plan_allows_stale_skip(self):
+        self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
+        self.agent.save(update_fields=["planning_state"])
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Synthesize final report",
+            status=PersistentAgentKanbanCard.Status.TODO,
+            priority=1,
+        )
+        prepared = _PreparedToolExecution(
+            idx=1,
+            tool_name="send_chat_message",
+            tool_params={"body": "Here is the answer.", "will_continue_work": False},
+            exec_params={"body": "Here is the answer.", "will_continue_work": False},
+            pending_step=None,
+            credits_consumed=None,
+            consumed_credit=None,
+            call_id="call_1",
+            explicit_continue=False,
+            inferred_continue=False,
+            parallel_safe=False,
+            parallel_ineligible_reason=None,
+        )
+
+        finalized = _finalize_tool_batch(
+            self.agent,
+            [
+                _ToolExecutionOutcome(
+                    prepared=prepared,
+                    result={
+                        "status": "ok",
+                        "message": "Web chat message sent.",
+                        "message_id": str(uuid4()),
+                        "auto_sleep_ok": True,
+                    },
+                    duration_ms=1,
+                    updated_tools=None,
+                    variable_map={},
+                )
+            ],
+            attach_completion=lambda kwargs: None,
+            attach_prompt_archive=lambda step: None,
+        )
+
+        self.assertTrue(finalized.terminal_message_delivery_ok)
+        self.assertFalse(finalized.followup_required)
+        self.assertTrue(
+            _should_skip_stale_planning_mode_after_terminal_delivery(
+                self.agent,
+                finalized,
+                followup_required=finalized.followup_required,
+            )
+        )
+        self.assertFalse(
             PersistentAgentStep.objects.filter(
                 agent=self.agent,
                 description__contains="current plan still has unfinished items",

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -33,7 +33,14 @@ from api.agent.peer_comm import PeerMessagingError
 from api.agent.tools.peer_dm import execute_send_agent_message
 from api.agent.tools.tool_manager import _normalize_tool_params_unicode_escapes
 from api.agent.tools.web_chat_sender import _looks_like_routine_progress_message
-from api.models import BrowserUseAgent, PersistentAgent, PersistentAgentSystemStep, SmsContactPurpose
+from api.models import (
+    BrowserUseAgent,
+    PersistentAgent,
+    PersistentAgentKanbanCard,
+    PersistentAgentStep,
+    PersistentAgentSystemStep,
+    SmsContactPurpose,
+)
 from util.urls import build_agent_detail_url, build_site_url
 
 
@@ -196,6 +203,58 @@ class MessageToolExplicitContinuationTests(TestCase):
         }
 
         self.assertFalse(_tool_call_likely_terminal_message(call))
+
+    def test_terminal_message_with_unfinished_plan_requires_followup(self):
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Synthesize final report",
+            status=PersistentAgentKanbanCard.Status.TODO,
+            priority=1,
+        )
+        prepared = _PreparedToolExecution(
+            idx=1,
+            tool_name="send_chat_message",
+            tool_params={"body": "Here is the final report.", "will_continue_work": False},
+            exec_params={"body": "Here is the final report.", "will_continue_work": False},
+            pending_step=None,
+            credits_consumed=None,
+            consumed_credit=None,
+            call_id="call_1",
+            explicit_continue=False,
+            inferred_continue=False,
+            parallel_safe=False,
+            parallel_ineligible_reason=None,
+        )
+
+        finalized = _finalize_tool_batch(
+            self.agent,
+            [
+                _ToolExecutionOutcome(
+                    prepared=prepared,
+                    result={
+                        "status": "ok",
+                        "message": "Web chat message sent.",
+                        "message_id": str(uuid4()),
+                        "auto_sleep_ok": True,
+                    },
+                    duration_ms=1,
+                    updated_tools=None,
+                    variable_map={},
+                )
+            ],
+            attach_completion=lambda kwargs: None,
+            attach_prompt_archive=lambda step: None,
+        )
+
+        self.assertTrue(finalized.terminal_message_delivery_ok)
+        self.assertTrue(finalized.followup_required)
+        self.assertIs(finalized.last_explicit_continue, False)
+        self.assertTrue(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description__contains="current plan still has unfinished items",
+            ).exists()
+        )
 
 
 @tag('batch_event_processing')

--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -214,7 +214,7 @@ def get_send_email_tool() -> Dict[str, Any]:
                     },
                     "will_continue_work": {
                         "type": "boolean",
-                        "description": "REQUIRED. true=another action follows; false=done.",
+                        "description": "REQUIRED. true=another action follows; false=done and no current plan items remain unfinished.",
                     },
                 },
                 "required": ["to_address", "subject", "mobile_first_html", "will_continue_work"],

--- a/api/agent/tools/plan.py
+++ b/api/agent/tools/plan.py
@@ -40,7 +40,7 @@ MESSAGE_DELIVERABLE_GUIDANCE = (
     "lookup, briefing, or one-shot chart. Message deliverables must come from send_email, send_sms, or send_chat_message. "
     "Use the exact returned message_id UUID, or omit messages. If you are sending the final message now and a completion "
     "plan update is still needed, send it first with will_continue_work=true, then call update_plan after the send tool returns. "
-    "For explicit deep or exhaustive research with no file deliverables, send the final answer with will_continue_work=false. "
+    "For explicit deep or exhaustive research with no file deliverables and no unfinished current plan items, send the final answer with will_continue_work=false. "
     "Do not include peer messages from send_agent_message."
 )
 
@@ -168,7 +168,7 @@ def get_update_plan_tool() -> dict[str, Any]:
                     },
                     "will_continue_work": {
                         "type": "boolean",
-                        "description": "REQUIRED. true = continue after this plan update; false = stop because all work is done or deferred.",
+                        "description": "REQUIRED. true = continue after this plan update; false = stop because all work is done or deferred and no current plan items remain unfinished.",
                     },
                 },
                 "required": ["plan", "will_continue_work"],
@@ -364,6 +364,7 @@ def build_redundant_research_plan_skip_result(agent, params: dict[str, Any]) -> 
         return None
 
     incoming_steps: list[str] = []
+    incoming_statuses: list[str] = []
     for item in raw_plan:
         if not isinstance(item, dict):
             return None
@@ -372,8 +373,23 @@ def build_redundant_research_plan_skip_result(agent, params: dict[str, Any]) -> 
         if not step or status not in PLAN_STATUSES:
             return None
         incoming_steps.append(step)
+        incoming_statuses.append(status)
 
     if len(incoming_steps) != len(existing_cards):
+        return None
+
+    existing_statuses_by_key = {
+        _normalize_step_key(card.title): card.status
+        for card in existing_cards
+    }
+    incoming_statuses_by_key = {
+        _normalize_step_key(step): status
+        for step, status in zip(incoming_steps, incoming_statuses)
+    }
+    if (
+        set(existing_statuses_by_key) != set(incoming_statuses_by_key)
+        or any(incoming_statuses_by_key[key] != existing_statuses_by_key[key] for key in incoming_statuses_by_key)
+    ):
         return None
 
     plan_text = " ".join(incoming_steps).casefold()

--- a/api/agent/tools/sms_sender.py
+++ b/api/agent/tools/sms_sender.py
@@ -76,7 +76,7 @@ def get_send_sms_tool() -> Dict[str, Any]:
                     },
                     "will_continue_work": {
                         "type": "boolean",
-                        "description": "REQUIRED. true = you'll take another action, false = you're done. Omitting this stops you for good—choose wisely.",
+                        "description": "REQUIRED. true = you'll take another action, false = you're done and no current plan items remain unfinished.",
                     },
                 },
                 "required": ["to_number", "body", "will_continue_work"],

--- a/api/agent/tools/tests/test_plan.py
+++ b/api/agent/tools/tests/test_plan.py
@@ -91,7 +91,7 @@ class UpdatePlanResearchSuppressionTests(TestCase):
             charter="Test agent.",
         )
 
-    def test_redundant_research_status_update_is_skipped(self):
+    def test_redundant_research_progress_update_is_skipped(self):
         PersistentAgentKanbanCard.objects.create(
             assigned_agent=self.agent,
             title="Research source set",
@@ -109,8 +109,8 @@ class UpdatePlanResearchSuppressionTests(TestCase):
             self.agent,
             {
                 "plan": [
-                    {"step": "Research source set", "status": "done"},
-                    {"step": "Synthesize investment memo", "status": "done"},
+                    {"step": "Research source set", "status": "doing"},
+                    {"step": "Synthesize investment memo", "status": "todo"},
                 ],
                 "will_continue_work": True,
             },
@@ -120,7 +120,7 @@ class UpdatePlanResearchSuppressionTests(TestCase):
         self.assertTrue(result["skipped"])
         self.assertFalse(result["auto_sleep_ok"])
 
-    def test_redundant_research_status_update_with_retitled_steps_is_skipped(self):
+    def test_research_progress_update_with_retitled_steps_is_not_skipped(self):
         PersistentAgentKanbanCard.objects.create(
             assigned_agent=self.agent,
             title="Research the market and competitors",
@@ -139,15 +139,13 @@ class UpdatePlanResearchSuppressionTests(TestCase):
             {
                 "plan": [
                     {"step": "Research source set", "status": "done"},
-                    {"step": "Synthesize investment memo", "status": "done"},
+                    {"step": "Synthesize investment memo", "status": "todo"},
                 ],
                 "will_continue_work": True,
             },
         )
 
-        self.assertIsNotNone(result)
-        self.assertTrue(result["skipped"])
-        self.assertFalse(result["auto_sleep_ok"])
+        self.assertIsNone(result)
 
     def test_old_outbound_message_does_not_turn_redundant_plan_skip_into_sleep(self):
         agent_endpoint = PersistentAgentCommsEndpoint.objects.create(
@@ -196,8 +194,8 @@ class UpdatePlanResearchSuppressionTests(TestCase):
             self.agent,
             {
                 "plan": [
-                    {"step": "Research source set", "status": "done"},
-                    {"step": "Synthesize investment memo", "status": "done"},
+                    {"step": "Research source set", "status": "doing"},
+                    {"step": "Synthesize investment memo", "status": "todo"},
                 ],
                 "will_continue_work": True,
             },
@@ -206,6 +204,33 @@ class UpdatePlanResearchSuppressionTests(TestCase):
         self.assertIsNotNone(result)
         self.assertTrue(result["skipped"])
         self.assertFalse(result["auto_sleep_ok"])
+
+    def test_all_done_update_for_unfinished_research_plan_is_not_skipped(self):
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Research source set",
+            status=PersistentAgentKanbanCard.Status.DOING,
+            priority=2,
+        )
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Synthesize investment memo",
+            status=PersistentAgentKanbanCard.Status.TODO,
+            priority=1,
+        )
+
+        result = build_redundant_research_plan_skip_result(
+            self.agent,
+            {
+                "plan": [
+                    {"step": "Research source set", "status": "done"},
+                    {"step": "Synthesize investment memo", "status": "done"},
+                ],
+                "will_continue_work": False,
+            },
+        )
+
+        self.assertIsNone(result)
 
     def test_changed_research_plan_is_not_skipped(self):
         PersistentAgentKanbanCard.objects.create(

--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -254,7 +254,7 @@ def get_send_chat_tool() -> Dict[str, Any]:
                     },
                     "will_continue_work": {
                         "type": "boolean",
-                        "description": "REQUIRED. true=another immediate tool call follows in this turn; false=current turn is done, even if future scheduled work remains. Never send a message solely to justify continuing work.",
+                        "description": "REQUIRED. true=another immediate tool call follows in this turn; false=current turn is done, even if future scheduled work remains, and no current plan items remain unfinished. Never send a message solely to justify continuing work.",
                     },
                 },
                 "required": ["body", "will_continue_work"],

--- a/api/evals/scenarios/__init__.py
+++ b/api/evals/scenarios/__init__.py
@@ -22,6 +22,7 @@ from .behavior_micro import (
     PlanningFirstTurnAsksBoundedQuestionsScenario,
     PlanningClearTaskEndsPlanningFirstScenario,
     PlanningExecuteRequestStaysInPlanningScenario,
+    PlanningFinalReportCompletesVisiblePlanScenario,
     PlanningNoDirectScheduleOrConfigUpdatesScenario,
     ToolChoiceExactJsonUrlUsesHttpRequestScenario,
     ToolChoiceCsvDeliverableUsesCreateCsvScenario,

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -29,6 +29,7 @@ from api.models import (
     PersistentAgentConversation,
     PersistentAgentEnabledTool,
     PersistentAgentHumanInputRequest,
+    PersistentAgentKanbanCard,
     PersistentAgentMessage,
     PersistentAgentStep,
     PersistentAgentSystemStep,
@@ -43,6 +44,7 @@ PLANNING_EXECUTE_REQUEST_STAYS_IN_PLANNING = "planning_execute_request_stays_in_
 PLANNING_ONE_OFF_RESEARCH_REPORT_ENDS_PLANNING_FIRST = "planning_one_off_research_report_ends_planning_first"
 PLANNING_NO_DIRECT_SCHEDULE_OR_CONFIG_UPDATES = "planning_no_direct_schedule_or_config_updates"
 PLANNING_DISMISS_AFTER_GREETING_DOES_NOT_RESUME = "planning_dismiss_after_greeting_does_not_resume"
+PLANNING_FINAL_REPORT_COMPLETES_VISIBLE_PLAN = "planning_final_report_completes_visible_plan"
 CHARTER_ADDS_DURABLE_PREFERENCE_PRESERVING_EXISTING = "charter_adds_durable_preference_preserving_existing"
 CHARTER_ADDS_INFERRED_PREFERENCE_PRESERVING_EXISTING = "charter_adds_inferred_preference_preserving_existing"
 CHARTER_EXPANDS_SPARSE_CHARTER_WITH_DETAIL = "charter_expands_sparse_charter_with_detail"
@@ -340,6 +342,7 @@ PLANNING_MICRO_SCENARIO_SLUGS = [
     PLANNING_ONE_OFF_RESEARCH_REPORT_ENDS_PLANNING_FIRST,
     PLANNING_NO_DIRECT_SCHEDULE_OR_CONFIG_UPDATES,
     PLANNING_DISMISS_AFTER_GREETING_DOES_NOT_RESUME,
+    PLANNING_FINAL_REPORT_COMPLETES_VISIBLE_PLAN,
 ]
 
 CHARTER_MEMORY_MICRO_SCENARIO_SLUGS = [
@@ -1093,6 +1096,133 @@ class PlanningOneOffResearchReportEndsPlanningFirstScenario(BehaviorMicroScenari
             ),
             artifacts={"step": message_calls_before_end[0].step},
         )
+
+
+@register_scenario
+class PlanningFinalReportCompletesVisiblePlanScenario(BehaviorMicroScenario):
+    slug = PLANNING_FINAL_REPORT_COMPLETES_VISIBLE_PLAN
+    description = "A final report should not leave an existing visible plan with todo/doing items."
+    category = "planning"
+    tags = ("agent_behavior", "micro", "planning", "stop_policy", "update_plan")
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_final_report_sent", assertion_type="manual"),
+        ScenarioTask(name="verify_plan_completed", assertion_type="manual"),
+    ]
+
+    def _seed_unfinished_plan(self, agent_id):
+        steps = [
+            ("Search for QuantaGrid AI and identify key sources.", PersistentAgentKanbanCard.Status.DOING),
+            ("Scrape official website and secondary sources.", PersistentAgentKanbanCard.Status.TODO),
+            ("Synthesize findings into a structured report.", PersistentAgentKanbanCard.Status.TODO),
+            ("Deliver the report in chat.", PersistentAgentKanbanCard.Status.TODO),
+        ]
+        for priority, (title, status) in enumerate(reversed(steps), start=1):
+            PersistentAgentKanbanCard.objects.create(
+                assigned_agent_id=agent_id,
+                title=title,
+                status=status,
+                priority=priority,
+            )
+
+    @staticmethod
+    def _message_call_was_delivered(call):
+        try:
+            payload = json.loads(call.result or "{}")
+        except json.JSONDecodeError:
+            return False
+        return isinstance(payload, dict) and payload.get("status") in {"ok", "sent", "success"}
+
+    def run(self, run_id, agent_id):
+        self._set_planning_state(agent_id, PersistentAgent.PlanningState.COMPLETED)
+        self._seed_prior_processing_run(agent_id)
+        self._enable_builtin_tools(agent_id, ["send_chat_message", "update_plan"])
+        self._seed_unfinished_plan(agent_id)
+
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="inject_prompt")
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            inbound = self.inject_message(
+                agent_id,
+                (
+                    "Use only these facts and send the final QuantaGrid AI report in this chat now. "
+                    "QuantaGrid AI builds capacity-planning copilots for data center operators. "
+                    "Its product predicts rack power saturation, flags cooling risks, and exports weekly risk summaries. "
+                    "Pricing is usage-based, and the best fit is infrastructure teams with fragmented telemetry."
+                ),
+                trigger_processing=True,
+                eval_run_id=run_id,
+                eval_stop_policy={
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": ["send_chat_message", "update_plan", "sleep_until_next_trigger"],
+                    "max_relevant_tool_calls": 6,
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_prompt",
+            observed_summary="Prompt injected and processing completed.",
+            artifacts={"message": inbound},
+        )
+
+        send_calls = [
+            call
+            for call in get_tool_calls_for_run(run_id, after=inbound.timestamp, tool_names={"send_chat_message"})
+            if self._message_call_was_delivered(call)
+        ]
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="verify_final_report_sent")
+        if send_calls:
+            self.record_task_result(
+                run_id,
+                None,
+                EvalRunTask.Status.PASSED,
+                task_name="verify_final_report_sent",
+                observed_summary="Agent delivered a web chat report.",
+                artifacts={"step": send_calls[0].step},
+            )
+        else:
+            self.record_task_result(
+                run_id,
+                None,
+                EvalRunTask.Status.FAILED,
+                task_name="verify_final_report_sent",
+                observed_summary="Expected one delivered send_chat_message call.",
+            )
+
+        unfinished = list(
+            PersistentAgentKanbanCard.objects.filter(
+                assigned_agent_id=agent_id,
+                status__in=[
+                    PersistentAgentKanbanCard.Status.TODO,
+                    PersistentAgentKanbanCard.Status.DOING,
+                ],
+            ).order_by("-priority", "created_at")
+        )
+        update_plan_calls = get_tool_calls_for_run(run_id, after=inbound.timestamp, tool_names={"update_plan"})
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="verify_plan_completed")
+        if send_calls and not unfinished and update_plan_calls:
+            self.record_task_result(
+                run_id,
+                None,
+                EvalRunTask.Status.PASSED,
+                task_name="verify_plan_completed",
+                observed_summary="Final report delivery left no todo/doing plan items.",
+                artifacts={"step": update_plan_calls[-1].step},
+            )
+        else:
+            self.record_task_result(
+                run_id,
+                None,
+                EvalRunTask.Status.FAILED,
+                task_name="verify_plan_completed",
+                observed_summary=(
+                    f"Expected final delivery plus update_plan to leave no unfinished plan items; "
+                    f"send_calls={len(send_calls)}, update_plan_calls={len(update_plan_calls)}, "
+                    f"unfinished={[card.title for card in unfinished]}."
+                ),
+                artifacts={"step": (send_calls[0].step if send_calls else None)},
+            )
 
 
 @register_scenario

--- a/tests/unit/test_event_processing_batch_sleep.py
+++ b/tests/unit/test_event_processing_batch_sleep.py
@@ -418,17 +418,45 @@ class TestBatchToolCallsWithSleep(TestCase):
         resp = MagicMock(); resp.choices = [choice]
         resp.model_extra = {"usage": MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15, prompt_tokens_details=MagicMock(cached_tokens=0))}
 
+        tc_plan = mk_tc(
+            'update_plan',
+            '{"plan": [{"step": "Finish outstanding work", "status": "done"}], "will_continue_work": false}',
+        )
+        followup_msg = MagicMock()
+        followup_msg.tool_calls = [tc_plan]
+        followup_msg.content = None
+        followup_choice = MagicMock(); followup_choice.message = followup_msg
+        followup_resp = MagicMock(); followup_resp.choices = [followup_choice]
+        followup_resp.model_extra = {"usage": MagicMock(prompt_tokens=4, completion_tokens=2, total_tokens=6, prompt_tokens_details=MagicMock(cached_tokens=0))}
+
         mock_completion.side_effect = [
             (resp, {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "model": "m", "provider": "p"}),
+            (followup_resp, {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6, "model": "m", "provider": "p"}),
         ]
 
         from api.agent.core import event_processing as ep
         with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 2):
             ep._run_agent_loop(self.agent, is_first_run=False)
 
-        self.assertEqual(mock_completion.call_count, 1)
-        self.assertEqual(len(notices), 1)
+        self.assertEqual(mock_completion.call_count, 2)
+        self.assertEqual(len(notices), 2)
         self.assertIsNone(notices[0])
+        self.assertIsNone(notices[1])
+        self.assertTrue(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description__contains="current plan still has unfinished items",
+            ).exists()
+        )
+        self.assertFalse(
+            PersistentAgentKanbanCard.objects.filter(
+                assigned_agent=self.agent,
+                status__in=[
+                    PersistentAgentKanbanCard.Status.TODO,
+                    PersistentAgentKanbanCard.Status.DOING,
+                ],
+            ).exists()
+        )
 
     @patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None})
     @patch('api.agent.core.event_processing.execute_send_chat_message', return_value={"status": "ok", "auto_sleep_ok": True})

--- a/tests/unit/test_prompt_capabilities.py
+++ b/tests/unit/test_prompt_capabilities.py
@@ -160,15 +160,22 @@ class AgentCapabilitiesPromptTests(TestCase):
             contents,
         )
         self.assertIn(
-            "Send your final report to the user with will_continue_work=false on that final send tool",
+            "Plan-aware termination sequence",
             contents,
         )
         self.assertIn(
-            "If you still need to mark the plan done after the report is already sent, call update_plan with will_continue_work=false",
+            "Send the final report with will_continue_work=false only if no current plan items remain todo/doing",
+            contents,
+        )
+        self.assertIn(
+            "send with will_continue_work=true, then call update_plan with every finished/deferred item resolved and will_continue_work=false",
+            contents,
+        )
+        self.assertIn(
+            "After the final send and final plan update, stop with no extra message",
             contents,
         )
         self.assertIn("Plain text is invisible and update_plan is not delivery", contents)
-        self.assertIn("no extra turn, no announcement or confirmation message", contents)
         self.assertNotIn(
             "Need to send the user your answer, summary, or final report → will_continue_work=true",
             contents,


### PR DESCRIPTION
**Summary**
- Tighten the plan and message-tool stop rules so a terminal report cannot end the turn while the visible plan still has `todo` or `doing` items.
- Add a small runtime backstop in agent event processing that keeps the agent alive after a terminal send when the current plan is still unfinished, so it can issue the needed `update_plan`.
- Narrow redundant research-plan suppression so real progress updates, including all-done completion updates, are not skipped.
- Add a focused micro-eval for the final-report-with-unfinished-plan case, plus unit coverage for plan suppression and terminal-send continuation behavior.

**Testing**
- Ran targeted unit tests for plan suppression and event-processing continuation behavior.
- Ran the new micro-eval locally; it passed with the seeded plan fully completed after the final report was delivered.