### PR TITLE
Simplify planning prompts and gate native integration setup links by connection state

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -136,6 +136,11 @@ SQLITE_MESSAGES_SNAPSHOT_MAX_RECORDS = 10_000
 MESSAGE_ONLY_TOOL_NAMES_TEXT = (
     "send_email, send_sms, send_chat_message, and send_agent_message"
 )
+SQLITE_EFFICIENCY_WARNING = (
+    "SQLite efficiency warning: you've been reading full __tool_results.result_text blobs one at a time. "
+    "Stop fetching by single result_id; run one shaped query across all needed rows using IN/CTEs/"
+    "json_extract/json_each/aggregation, or create a durable working table first."
+)
 BROWSER_TASK_RESULT_BLOCK_RE = re.compile(
     r"<result>\s*(?P<payload>.*?)\s*</result>",
     re.DOTALL | re.IGNORECASE,
@@ -1378,8 +1383,7 @@ def _render_prompt_context_once(
         (
             "Request credentials only when you'll use them immediately: use domain-scoped credentials for `http_request`, "
             "login credentials for `spawn_web_task`, and `secret_type='env_var'` for custom tools, `python_exec`, `run_command`, "
-            "or MCP servers that read secrets from `os.environ`. Avoid 2FA/MFA unless the user explicitly asks for it, "
-            "because those flows may hit system limitations; prefer non-2FA paths when available."
+            "or MCP servers that read secrets from `os.environ`."
         ),
         weight=1,
         non_shrinkable=True
@@ -3054,22 +3058,14 @@ def _build_sqlite_retry_warning(
     summary = summarize_sqlite_tool_result_sql(sql_values)
     if not result_id_counts:
         if summary.direct_result_text_fetches >= 2 or summary.duplicate_direct_fetches:
-            return (
-                "SQLite efficiency warning: you've been reading full __tool_results.result_text blobs one at a time. "
-                "Stop fetching by single result_id; run one shaped query across all needed rows using IN/CTEs/"
-                "json_extract/json_each/aggregation, or create a durable working table first."
-            )
+            return SQLITE_EFFICIENCY_WARNING
         return ""
 
     result_id, call_count = result_id_counts.most_common(1)[0]
     empty_count = empty_counts[result_id]
     if call_count < 4 or empty_count < 2:
         if summary.direct_result_text_fetches >= 2 or summary.duplicate_direct_fetches:
-            return (
-                "SQLite efficiency warning: you've been reading full __tool_results.result_text blobs one at a time. "
-                "Stop fetching by single result_id; run one shaped query across all needed rows using IN/CTEs/"
-                "json_extract/json_each/aggregation, or create a durable working table first."
-            )
+            return SQLITE_EFFICIENCY_WARNING
         return ""
 
     return (

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -88,6 +88,7 @@ from .step_compaction import llm_summarise_steps
 from ..files.filesystem_prompt import MAX_RECENT_FILES_IN_PROMPT, format_agent_filesystem_prompt
 from ..tools.agent_variables import format_variables_for_prompt
 from ..tools.attachment_guidance import SYSTEM_ATTACHMENT_PREFLIGHT_GUIDANCE
+from ..tools.plan import format_current_plan_for_prompt
 from ..tools.spawn_web_task import get_browser_daily_task_limit
 from ..tools.static_tools import get_static_tool_definitions
 from ..tools.sqlite_state import (
@@ -1287,6 +1288,13 @@ def _render_prompt_context_once(
             weight=2,
             non_shrinkable=True,
         )
+
+    important_group.section_text(
+        "current_plan",
+        format_current_plan_for_prompt(agent),
+        weight=3,
+        non_shrinkable=True,
+    )
 
     # Schedule block
     schedule_str = agent.schedule if agent.schedule else "No schedule configured"
@@ -3623,7 +3631,11 @@ def _get_system_instruction(
         "Respect one-off preferences like 'stand by' or 'don't follow up unless I ask' in the current conversation without mutating config. When in doubt, leave config unchanged, deliver the result, and stop.\n\n"
 
         "## Plan Discipline (CRITICAL)\n\n"
-        "update_plan is for real multi-step work that benefits from a user-visible plan. Do not create/update one for quick lookups, simple research answers, scheduled briefings, one-shot charts, or simple latest/current reports. For deep work, use at most one initial plan update; update it again only to finish an existing visible plan before stopping.\n\n"
+        "Use `update_plan` only for substantial multi-step work where a visible plan helps. "
+        "Keep plans short, current, and verifiable; each call replaces the full active plan. "
+        "Do not create/update one for quick lookups, simple research answers, scheduled briefings, one-shot charts, or simple latest/current reports. "
+        "For deep work, use at most one initial plan update; update it again only to finish an existing visible plan before stopping. "
+        "Send the final user-facing report before any final completion update.\n\n"
 
         "## Silent Work (CRITICAL)\n\n"
         "Do not announce what you're about to do. Make tool calls with no text until findings, blocker, needed human question, or final answer. Text is for results, not narration; tools execute silently.\n\n"

--- a/api/agent/system_skills/defaults.py
+++ b/api/agent/system_skills/defaults.py
@@ -64,7 +64,7 @@ def _hubspot_native_prompt_context(agent) -> str:
 def _google_sheets_native_prompt_instructions(agent) -> str:
     integrations_url = _app_integrations_url()
     setup_text = (
-        "If setup is needed, tell the user to open `" + integrations_url + "`, connect Google Drive, "
+        f"If setup is needed, tell the user to open `{integrations_url}`, connect Google Drive, "
         "then choose the spreadsheet(s) the agent should be allowed to access.\n"
         if not _native_integration_connected(agent, "google_drive")
         else ""
@@ -109,7 +109,7 @@ def _google_sheets_native_prompt_instructions(agent) -> str:
 def _apollo_native_prompt_instructions(agent) -> str:
     integrations_url = _app_integrations_url()
     setup_text = (
-        "If setup is needed, tell the user to open `" + integrations_url + "` and connect Apollo. "
+        f"If setup is needed, tell the user to open `{integrations_url}` and connect Apollo. "
         if not _native_integration_connected(agent, "apollo")
         else ""
     )

--- a/api/agent/system_skills/defaults.py
+++ b/api/agent/system_skills/defaults.py
@@ -14,44 +14,6 @@ APOLLO_NATIVE_SYSTEM_SKILL_KEY = "apollo_native"
 HUBSPOT_NATIVE_SYSTEM_SKILL_KEY = "hubspot_native"
 
 
-def _format_runtime_planning_context(agent) -> str:
-    from api.models import PersistentAgentKanbanCard
-
-    cards = list(
-        PersistentAgentKanbanCard.objects.filter(assigned_agent=agent)
-        .only("title", "status", "priority", "created_at")
-        .order_by("-priority", "created_at")
-    )
-    if not cards:
-        return "Current plan: none"
-
-    groups = {
-        PersistentAgentKanbanCard.Status.DOING: [],
-        PersistentAgentKanbanCard.Status.TODO: [],
-        PersistentAgentKanbanCard.Status.DONE: [],
-    }
-    for card in cards:
-        if card.status in groups:
-            groups[card.status].append(card.title)
-
-    lines = [
-        "Current plan:",
-        f"- Doing: {len(groups[PersistentAgentKanbanCard.Status.DOING])}",
-        f"- Todo: {len(groups[PersistentAgentKanbanCard.Status.TODO])}",
-        f"- Done: {len(groups[PersistentAgentKanbanCard.Status.DONE])}",
-    ]
-    for label, status in (
-        ("Doing", PersistentAgentKanbanCard.Status.DOING),
-        ("Todo", PersistentAgentKanbanCard.Status.TODO),
-        ("Done", PersistentAgentKanbanCard.Status.DONE),
-    ):
-        titles = groups[status]
-        if titles:
-            lines.append(f"{label}:")
-            lines.extend(f"- {title}" for title in titles[:20])
-    return "\n".join(lines)
-
-
 def _custom_tool_development_prompt_available(agent) -> bool:
     from api.agent.system_skills.service import get_available_system_skill_tool_names
 
@@ -79,6 +41,14 @@ def _native_integration_prompt_context(agent, provider_key: str) -> str:
     return format_native_integration_permission_prompt(provider_key, owner_user, owner_org)
 
 
+def _native_integration_connected(agent, provider_key: str) -> bool:
+    from api.services.native_integrations import native_integration_is_connected
+    from api.services.persistent_agent_secrets import resolve_global_secret_owner_for_agent
+
+    owner_user, owner_org = resolve_global_secret_owner_for_agent(agent)
+    return native_integration_is_connected(provider_key, owner_user, owner_org)
+
+
 def _google_sheets_native_prompt_context(agent) -> str:
     return _native_integration_prompt_context(agent, "google_drive")
 
@@ -93,6 +63,16 @@ def _hubspot_native_prompt_context(agent) -> str:
 
 def _google_sheets_native_prompt_instructions(agent) -> str:
     integrations_url = _app_integrations_url()
+    setup_text = (
+        "If setup is needed, tell the user to open `" + integrations_url + "`, connect Google Drive, "
+        "then choose the spreadsheet(s) the agent should be allowed to access.\n"
+        if not _native_integration_connected(agent, "google_drive")
+        else ""
+    )
+    missing_file_text = (
+        "If the requested spreadsheet is not listed, ask the user to choose it through the Google Drive native "
+        "integration before making Sheets API calls for that file."
+    )
     return (
         "Use `http_request` for Google Sheets and Drive API calls. Native Google Drive OAuth is applied "
         "automatically for `https://sheets.googleapis.com/` and `https://www.googleapis.com/drive/` requests.\n"
@@ -102,8 +82,7 @@ def _google_sheets_native_prompt_instructions(agent) -> str:
         "uses Google `drive.file`, so missing spreadsheets may need to be selected in Google Picker first.\n"
         "When the user asks to find or search for one of their sheets by name, use Drive file discovery over "
         "connected files. Do not use web search or public `docs.google.com` results to choose a private sheet.\n"
-        "If setup is needed, tell the user to open `" + integrations_url + "`, connect Google Drive, "
-        "then choose the spreadsheet(s) the agent should be allowed to access.\n"
+        f"{setup_text}"
         "For Drive spreadsheet discovery, first build the complete `q` string in your reasoning, then URL-encode it "
         "and call `http_request`. The canonical base query is exactly "
         "`mimeType = 'application/vnd.google-apps.spreadsheet' and trashed = false`; add "
@@ -123,18 +102,22 @@ def _google_sheets_native_prompt_instructions(agent) -> str:
         "{url_encoded_range}?valueInputOption=USER_ENTERED with JSON body {\"values\": [[...]]}\n"
         "- Append rows: POST https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values/"
         "{url_encoded_range}:append?valueInputOption=USER_ENTERED with JSON body {\"values\": [[...]]}\n"
-        "If the requested spreadsheet is not listed, ask the user to choose it through the Google Drive native "
-        "integration at `" + integrations_url + "` before making Sheets API calls for that file."
+        f"{missing_file_text}"
     )
 
 
 def _apollo_native_prompt_instructions(agent) -> str:
     integrations_url = _app_integrations_url()
+    setup_text = (
+        "If setup is needed, tell the user to open `" + integrations_url + "` and connect Apollo. "
+        if not _native_integration_connected(agent, "apollo")
+        else ""
+    )
     return (
         "Use `http_request` for Apollo REST API calls. Native Apollo OAuth is applied automatically for "
         "`https://api.apollo.io/` requests and the Apollo profile endpoint "
         "`https://app.apollo.io/api/v1/users/api_profile`.\n"
-        "If setup is needed, tell the user to open `" + integrations_url + "` and connect Apollo. Use "
+        f"{setup_text}Use "
         "`https://api.apollo.io/api/v1/...` for Apollo API work unless a documented OAuth metadata endpoint "
         "specifically uses `https://app.apollo.io/api/v1/...`.\n"
         "Use bounded requests with explicit filters plus `page` and `per_page`; avoid broad unbounded exports or "
@@ -155,10 +138,15 @@ def _apollo_native_prompt_instructions(agent) -> str:
 
 def _hubspot_native_prompt_instructions(agent) -> str:
     integrations_url = _app_integrations_url()
+    setup_text = (
+        f"If setup is needed, tell the user to open `{integrations_url}` and connect HubSpot.\n"
+        if not _native_integration_connected(agent, "hubspot")
+        else ""
+    )
     return (
         "Use `http_request` for HubSpot REST API calls. Native HubSpot OAuth is applied automatically for "
         "`https://api.hubapi.com/` requests.\n"
-        f"If setup is needed, tell the user to open `{integrations_url}` and connect HubSpot.\n"
+        f"{setup_text}"
         "Use HubSpot CRM v3 endpoints for core CRM work. Keep requests bounded with explicit filters, "
         "`limit`, and `after` pagination where applicable; report when more pages remain.\n"
         "Representative calls:\n"
@@ -176,36 +164,6 @@ def _hubspot_native_prompt_instructions(agent) -> str:
         "Do not use Pipedream HubSpot tools, browser automation, web search, or manually supplied private-app "
         "tokens when the connected native HubSpot API can do the work."
     )
-
-
-RUNTIME_PLANNING_SYSTEM_SKILL = SystemSkillDefinition(
-    skill_key="runtime_planning",
-    name="Runtime Planning",
-    search_summary="Track multi-step runtime work with visible plan steps and deliverables.",
-    tool_names=("update_plan",),
-    enables=(
-        "visible task plans",
-        "runtime step tracking",
-        "file and message deliverable references",
-    ),
-    use_when=(
-        "work is non-trivial and requires multiple actions",
-        "work has logical phases or dependencies",
-        "work has ambiguity that benefits from outlining goals",
-        "intermediate checkpoints would help",
-        "the user asked for multiple things",
-        "the user explicitly asked for TODOs or a plan",
-        "extra steps are discovered before yielding",
-    ),
-    query_aliases=("plan", "planning", "todo", "todos", "update plan", "task steps"),
-    prompt_instructions=(
-        "Use `update_plan` only for substantial multi-step work where a visible plan helps. "
-        "Keep plans short, current, and verifiable; each call replaces the full active plan. "
-        "Send the final user-facing report before any final completion update."
-    ),
-    prompt_context_renderer=_format_runtime_planning_context,
-    default_enabled=True,
-)
 
 
 CUSTOM_TOOL_DEVELOPMENT_SYSTEM_SKILL = SystemSkillDefinition(
@@ -770,7 +728,6 @@ META_GOBII_SYSTEM_SKILL = SystemSkillDefinition(
 
 
 DEFAULT_SYSTEM_SKILL_DEFINITIONS = {
-    RUNTIME_PLANNING_SYSTEM_SKILL.skill_key: RUNTIME_PLANNING_SYSTEM_SKILL,
     CUSTOM_TOOL_DEVELOPMENT_SYSTEM_SKILL.skill_key: CUSTOM_TOOL_DEVELOPMENT_SYSTEM_SKILL,
     GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL.skill_key: GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL,
     APOLLO_NATIVE_SYSTEM_SKILL.skill_key: APOLLO_NATIVE_SYSTEM_SKILL,

--- a/api/agent/tools/plan.py
+++ b/api/agent/tools/plan.py
@@ -468,6 +468,28 @@ def build_plan_snapshot(agent) -> PlanSnapshot:
     )
 
 
+def format_current_plan_for_prompt(agent) -> str:
+    snapshot = build_plan_snapshot(agent)
+    if not (snapshot.todo_count or snapshot.doing_count or snapshot.done_count):
+        return "Current plan: none"
+
+    lines = [
+        "Current plan:",
+        f"- Doing: {snapshot.doing_count}",
+        f"- Todo: {snapshot.todo_count}",
+        f"- Done: {snapshot.done_count}",
+    ]
+    for label, titles in (
+        ("Doing", snapshot.doing_titles),
+        ("Todo", snapshot.todo_titles),
+        ("Done", snapshot.done_titles),
+    ):
+        if titles:
+            lines.append(f"{label}:")
+            lines.extend(f"- {title}" for title in titles[:20])
+    return "\n".join(lines)
+
+
 def _validate_update_plan_params(agent, params: dict[str, Any]) -> dict[str, Any]:
     errors: list[str] = []
     raw_plan = params.get("plan")

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -8,9 +8,8 @@ from django.test import SimpleTestCase, TestCase, tag
 import api.evals.loader  # noqa: F401 - registers scenarios and suites
 from api.agent.core.event_processing import _get_completed_process_run_count
 from api.agent.core.event_processing import _looks_like_blocking_human_input_request
-from api.agent.core.prompt_context import build_prompt_context_preview
+from api.agent.core.prompt_context import _get_system_instruction, build_prompt_context_preview
 from api.agent.core.tool_results import _wrap_as_sqlite_result
-from api.agent.system_skills.defaults import RUNTIME_PLANNING_SYSTEM_SKILL
 from api.agent.tools.create_chart import get_create_chart_tool
 from api.agent.tools.eval_synthetic_tools import EVAL_SYNTHETIC_TOOL_DEFINITIONS
 from api.agent.tools.plan import get_update_plan_tool
@@ -281,8 +280,24 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertIn("Do not use for quick lookups", description)
         self.assertIn("one-shot chart requests", description)
 
-    def test_runtime_planning_skill_excludes_bounded_current_research(self):
-        instructions = RUNTIME_PLANNING_SYSTEM_SKILL.prompt_instructions
+    def test_plan_discipline_excludes_bounded_current_research(self):
+        class NoPeerLinks:
+            def filter(self, *_args, **_kwargs):
+                return self
+
+            def exists(self):
+                return False
+
+        agent = SimpleNamespace(
+            id="effort-plan-discipline-agent",
+            planning_state=PersistentAgent.PlanningState.SKIPPED,
+            organization_id=None,
+        )
+        with patch("api.agent.core.prompt_context.AgentPeerLink.objects.filter", return_value=NoPeerLinks()), patch(
+            "api.agent.core.prompt_context.CommsAllowlistEntry.objects.filter",
+            return_value=NoPeerLinks(),
+        ):
+            instructions = _get_system_instruction(agent, system_directive_block="")
 
         self.assertIn("Use `update_plan` only for substantial multi-step work", instructions)
         self.assertIn("where a visible plan helps", instructions)

--- a/api/services/native_integrations.py
+++ b/api/services/native_integrations.py
@@ -640,12 +640,7 @@ def native_integration_is_connected(
 ) -> bool:
     provider = get_native_integration_provider(provider_key)
     secret = get_native_integration_secret(provider.key, owner_user, owner_org)
-    if secret is None:
-        return False
-    try:
-        return load_native_integration_credentials(secret) is not None
-    except NativeIntegrationAuthError:
-        return False
+    return secret is not None
 
 
 def preflight_native_integration_capability(

--- a/api/services/native_integrations.py
+++ b/api/services/native_integrations.py
@@ -633,6 +633,21 @@ def format_native_integration_permission_prompt(
     return "\n".join(lines)
 
 
+def native_integration_is_connected(
+    provider_key: str,
+    owner_user,
+    owner_org,
+) -> bool:
+    provider = get_native_integration_provider(provider_key)
+    secret = get_native_integration_secret(provider.key, owner_user, owner_org)
+    if secret is None:
+        return False
+    try:
+        return load_native_integration_credentials(secret) is not None
+    except NativeIntegrationAuthError:
+        return False
+
+
 def preflight_native_integration_capability(
     agent: PersistentAgent,
     provider_key: str,

--- a/tests/unit/test_agent_skills.py
+++ b/tests/unit/test_agent_skills.py
@@ -416,7 +416,7 @@ class AgentSkillsPersistenceTests(TestCase):
         self.assertLess(block.index("Skill: skill-2 (v1)"), block.index("Skill: skill-3 (v1)"))
         self.assertIn("Omitted skills due to prompt limit:", block)
         self.assertIn("- skill-0", block)
-        self.assertIn("- System Skill: Runtime Planning (runtime_planning)", block)
+        self.assertNotIn("System Skill: Runtime Planning", block)
         self.assertIn("Use `search_tools` with an exact omitted skill name or key", block)
         self.assertIn("instructions for skill 3", block)
 
@@ -450,18 +450,12 @@ class AgentSkillsPersistenceTests(TestCase):
         self.assertIn("Skill: Daily Brief (v1)", block)
         self.assertIn("Skill: Daily-Brief (v1)", block)
 
-    def test_prompt_block_includes_default_runtime_planning_system_skill(self):
+    def test_prompt_block_does_not_include_runtime_planning_system_skill(self):
+        self.assertNotIn("runtime_planning", default_enabled_system_skill_keys())
+
         block = format_recent_skills_for_prompt(self.agent, limit=1)
 
-        self.assertIn("<skill_runtime_planning>", block)
-        self.assertIn("System Skill: Runtime Planning", block)
-        self.assertIn("Tools: update_plan", block)
-        self.assertIn("Use `update_plan` only for substantial multi-step work", block)
-        self.assertIn("Keep plans short, current, and verifiable", block)
-        self.assertIn("each call replaces the full active plan", block)
-        self.assertIn("Send the final user-facing report before any final completion update", block)
-        self.assertIn("Current plan: none", block)
-        self.assertIn("</skill_runtime_planning>", block)
+        self.assertEqual(block, "")
 
     def test_custom_tool_development_system_skill_is_not_default_enabled(self):
         self.assertNotIn(CUSTOM_TOOL_DEVELOPMENT_SYSTEM_SKILL_KEY, default_enabled_system_skill_keys())
@@ -585,26 +579,19 @@ class AgentSkillsPersistenceTests(TestCase):
             tools=["sqlite_batch"],
             instructions="Use sqlite.",
         )
-        format_recent_skills_for_prompt(self.agent, limit=1)
-        system_state = PersistentAgentSystemSkillState.objects.get(
-            agent=self.agent,
-            skill_key="runtime_planning",
-        )
-
         refresh_skills_for_tool(self.agent, "sqlite_batch")
         saved.refresh_from_db()
-        system_state.refresh_from_db()
 
         self.assertIsNotNone(saved.last_used_at)
         self.assertEqual(saved.usage_count, 1)
-        self.assertIsNone(system_state.last_used_at)
-        self.assertEqual(system_state.usage_count, 0)
 
-        refresh_skills_for_tool(self.agent, "update_plan")
-        system_state.refresh_from_db()
-
-        self.assertIsNotNone(system_state.last_used_at)
-        self.assertEqual(system_state.usage_count, 1)
+        self.assertEqual(refresh_skills_for_tool(self.agent, "update_plan"), [])
+        self.assertFalse(
+            PersistentAgentSystemSkillState.objects.filter(
+                agent=self.agent,
+                skill_key="runtime_planning",
+            ).exists()
+        )
 
     def test_prompt_block_reports_required_pending_and_missing_secrets(self):
         global_secret = GlobalSecret(

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -332,11 +332,13 @@ class PromptContextBuilderTests(TestCase):
         self.assertIn("Omitted skills due to prompt limit:", content)
         self.assertIn("- prompt-skill-1", content)
         self.assertIn("- prompt-skill-0", content)
-        self.assertIn("- System Skill: Runtime Planning (runtime_planning)", content)
+        self.assertNotIn("- System Skill: Runtime Planning (runtime_planning)", content)
+        self.assertIn("<current_plan>", content)
+        self.assertIn("Current plan: none", content)
 
-    def test_prompt_includes_default_runtime_planning_system_skill_when_limit_allows(self):
+    def test_prompt_includes_current_plan_independent_of_skill_limit(self):
         config, _ = PromptConfig.objects.get_or_create(singleton_id=1)
-        config.standard_skill_prompt_limit = 1
+        config.standard_skill_prompt_limit = 0
         config.save()
         invalidate_prompt_settings_cache()
 
@@ -349,13 +351,20 @@ class PromptContextBuilderTests(TestCase):
         self.assertIsNotNone(user_message)
         content = user_message["content"]
 
-        self.assertIn("<agent_skills>", content)
-        self.assertIn("<skill_runtime_planning>", content)
-        self.assertIn("System Skill: Runtime Planning", content)
-        self.assertIn("Use `update_plan` only for substantial multi-step work", content)
-        self.assertIn("</skill_runtime_planning>", content)
+        self.assertNotIn("<agent_skills>", content)
+        self.assertIn("<current_plan>", content)
+        self.assertIn("Current plan: none", content)
+        self.assertIn("</current_plan>", content)
+        system_message = next((m for m in context if m["role"] == "system"), None)
+        self.assertIsNotNone(system_message)
+        assert system_message is not None
+        system_content = system_message["content"]
+        self.assertIn("Use `update_plan` only for substantial multi-step work", system_content)
+        self.assertIn("Keep plans short, current, and verifiable", system_content)
+        self.assertIn("each call replaces the full active plan", system_content)
+        self.assertIn("Send the final user-facing report before any final completion update", system_content)
 
-    def test_update_plan_tool_execution_refreshes_runtime_planning_system_skill(self):
+    def test_update_plan_tool_execution_does_not_refresh_runtime_planning_system_skill(self):
         prepared = _PreparedToolExecution(
             idx=0,
             tool_name="update_plan",
@@ -379,12 +388,23 @@ class PromptContextBuilderTests(TestCase):
         )
 
         self.assertEqual(outcome.result["status"], "ok")
-        state = PersistentAgentSystemSkillState.objects.get(
-            agent=self.agent,
-            skill_key="runtime_planning",
+        self.assertFalse(
+            PersistentAgentSystemSkillState.objects.filter(
+                agent=self.agent,
+                skill_key="runtime_planning",
+            ).exists()
         )
-        self.assertIsNotNone(state.last_used_at)
-        self.assertEqual(state.usage_count, 1)
+
+        with patch("api.agent.core.prompt_context.ensure_steps_compacted"), \
+             patch("api.agent.core.prompt_context.ensure_comms_compacted"):
+            context, _, _ = build_prompt_context(self.agent)
+
+        user_message = next((m for m in context if m["role"] == "user"), None)
+        self.assertIsNotNone(user_message)
+        content = user_message["content"]
+        self.assertIn("<current_plan>", content)
+        self.assertIn("- Doing: 1", content)
+        self.assertIn("Doing:\n- Check source", content)
 
     def test_prompt_omits_skill_section_when_skill_prompt_limit_is_zero(self):
         config, _ = PromptConfig.objects.get_or_create(singleton_id=1)

--- a/tests/unit/test_native_integrations.py
+++ b/tests/unit/test_native_integrations.py
@@ -27,6 +27,7 @@ from api.models import (
     OrganizationMembership,
     PersistentAgent,
     PersistentAgentEnabledTool,
+    PersistentAgentSystemSkillState,
 )
 from api.services.native_integrations import (
     APOLLO_PROVIDER,
@@ -1035,8 +1036,30 @@ class NativeIntegrationTests(TestCase):
         self.assertEqual(block.count("Read selected Google Sheets metadata and values"), 1)
         self.assertNotIn("connected with access for", block)
         self.assertIn("Granted scopes", block)
+        self.assertNotIn("/app/integrations", block)
         self.assertNotIn("native_google_drive", block)
         self.assertIn("</skill_google_sheets_native>", block)
+
+    @override_settings(PUBLIC_SITE_URL="https://app.example.test")
+    def test_native_system_skill_prompts_include_setup_link_only_when_disconnected(self):
+        cases = (
+            (GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY, "Google Drive"),
+            (APOLLO_NATIVE_SYSTEM_SKILL_KEY, "Apollo"),
+            (HUBSPOT_NATIVE_SYSTEM_SKILL_KEY, "HubSpot"),
+        )
+
+        for skill_key, provider_name in cases:
+            with self.subTest(skill_key=skill_key):
+                PersistentAgentEnabledTool.objects.filter(agent=self.agent, tool_full_name="http_request").delete()
+                PersistentAgentSystemSkillState.objects.filter(agent=self.agent, skill_key=skill_key).delete()
+
+                result = enable_system_skills(self.agent, [skill_key])
+                self.assertEqual(result["invalid"], [])
+
+                block = format_recent_skills_for_prompt(self.agent, limit=3)
+
+                self.assertIn(f"{provider_name} is not connected", block)
+                self.assertIn("https://app.example.test/app/integrations", block)
 
     @override_settings(PUBLIC_SITE_URL="https://app.example.test")
     def test_apollo_prompt_tells_agent_how_to_use_native_rest_api(self):
@@ -1054,7 +1077,7 @@ class NativeIntegrationTests(TestCase):
         self.assertIn("per_page", block)
         self.assertIn("credit-sensitive", block)
         self.assertIn("Never invent webhook URLs", block)
-        self.assertIn("/app/integrations", block)
+        self.assertNotIn("/app/integrations", block)
         self.assertIn("mixed_people/api_search", block)
         self.assertIn("do not use `/mixed_people/search`", block)
         self.assertIn("mixed_companies/search", block)
@@ -1082,7 +1105,7 @@ class NativeIntegrationTests(TestCase):
         self.assertIn("/crm/v3/owners/", block)
         self.assertIn("properties", block)
         self.assertIn("side-effecting operations", block)
-        self.assertIn("/app/integrations", block)
+        self.assertNotIn("/app/integrations", block)
         self.assertIn("Native integration permissions", block)
         self.assertIn("Search and read HubSpot contacts", block)
         self.assertIn("Granted scopes", block)

--- a/tests/unit/test_native_integrations.py
+++ b/tests/unit/test_native_integrations.py
@@ -37,6 +37,7 @@ from api.services.native_integrations import (
     build_native_integration_permission_summary,
     get_native_integration_provider,
     list_native_integration_capabilities,
+    native_integration_is_connected,
     parse_native_integration_scopes,
     preflight_native_integration_capability,
 )
@@ -338,6 +339,15 @@ class NativeIntegrationTests(TestCase):
         self.assertTrue(full["connected"])
         self.assertEqual(full["missing_scopes"], [])
         self.assertIn("Create or update HubSpot deals", [item["label"] for item in full["available_capabilities"]])
+
+    def test_native_integration_is_connected_uses_secret_existence_without_decrypting(self):
+        self._create_integration_secret(owner_user=self.user, provider=APOLLO_PROVIDER)
+
+        with patch(
+            "api.services.native_integrations.load_native_integration_credentials",
+            side_effect=AssertionError("should not decrypt"),
+        ):
+            self.assertTrue(native_integration_is_connected("apollo", self.user, None))
 
     def test_provider_registry_accepts_google_sheets_alias(self):
         provider = get_native_integration_provider("google_sheets")


### PR DESCRIPTION
## Summary
- Removed `runtime_planning` as a code-defined system skill and moved the live current-plan snapshot into the main prompt context as `<current_plan>`.
- Kept `update_plan` as a static tool, and expanded the system prompt’s Plan Discipline guidance so the usage policy still lives in the core prompt.
- Updated native integration skill instructions so `/app/integrations` only appears when the integration is disconnected.

## Testing
- Passed targeted unit coverage for native integrations, agent skills, prompt/event processing, and `update_plan`.
- Passed the focused eval unit test that now verifies the consolidated Plan Discipline prompt text.