### PR TITLE
Route read_file image context through vision-capable multimodal requests

### DIFF
--- a/api/agent/core/endpoint_config_utils.py
+++ b/api/agent/core/endpoint_config_utils.py
@@ -8,6 +8,8 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
+from cryptography.exceptions import InvalidTag
+
 from api.encryption import SecretsEncryption
 from api.llm.utils import normalize_model_name
 from api.openrouter import get_attribution_headers
@@ -25,13 +27,12 @@ def resolve_provider_api_key(provider) -> Optional[str]:
     if encrypted:
         try:
             api_key = SecretsEncryption.decrypt_value(encrypted)
-        except Exception as exc:
+        except (InvalidTag, TypeError, UnicodeDecodeError, ValueError) as exc:
             logger.warning(
-                "Failed to decrypt API key for provider %s: %s",
+                "Failed to decrypt API key for provider %s; falling back to env var if configured: %s",
                 getattr(provider, "key", "unknown"),
                 exc,
             )
-            return None
 
     if not api_key:
         env_var = getattr(provider, "env_var_name", None)

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -4159,6 +4159,42 @@ def _completion_with_failover(
     raise RuntimeError("No LLM provider available")
 
 
+def _prepare_multimodal_read_file_completion_request(
+    *,
+    agent: PersistentAgent,
+    history: List[dict],
+    failover_configs: List[Tuple[str, str, dict]],
+    image_attachments: list,
+    fitted_token_count: int,
+    is_first_run: bool,
+    routing_profile: Any,
+    prefer_low_latency: Optional[bool],
+) -> tuple[List[dict], List[Tuple[str, str, dict]], bool]:
+    candidate_failover_configs = failover_configs
+    if not any(bool((params or {}).get("supports_vision")) for _, _, params in failover_configs):
+        try:
+            candidate_failover_configs = get_llm_config_with_failover(
+                agent_id=str(agent.id),
+                token_count=fitted_token_count,
+                agent=agent,
+                is_first_loop=is_first_run,
+                routing_profile=routing_profile,
+                prefer_low_latency=prefer_low_latency,
+                ignore_agent_tier_cap=True,
+            )
+        except LLMNotConfiguredError:
+            candidate_failover_configs = failover_configs
+
+    request_history, request_failover_configs, multimodal_attached = prepare_multimodal_read_file_request(
+        history,
+        candidate_failover_configs,
+        image_attachments,
+    )
+    if not multimodal_attached:
+        request_failover_configs = failover_configs
+    return request_history, request_failover_configs, multimodal_attached
+
+
 def _get_completed_process_run_count(agent: Optional[PersistentAgent]) -> int:
     """Return how many PROCESS_EVENTS loops completed for the agent."""
     if agent is None:
@@ -5912,28 +5948,19 @@ def _run_agent_loop(
                     fresh_tool_call_step_ids,
                 )
                 if image_attachments:
-                    candidate_failover_configs = failover_configs
-                    if not any(bool((params or {}).get("supports_vision")) for _, _, params in failover_configs):
-                        try:
-                            candidate_failover_configs = get_llm_config_with_failover(
-                                agent_id=str(agent.id),
-                                token_count=fitted_token_count,
-                                agent=agent,
-                                is_first_loop=is_first_run,
-                                routing_profile=routing_profile,
-                                prefer_low_latency=prefer_low_latency,
-                                ignore_agent_tier_cap=True,
-                            )
-                        except LLMNotConfiguredError:
-                            candidate_failover_configs = failover_configs
                     (
                         request_history,
                         request_failover_configs,
                         multimodal_attached,
-                    ) = prepare_multimodal_read_file_request(
-                        history,
-                        candidate_failover_configs,
-                        image_attachments,
+                    ) = _prepare_multimodal_read_file_completion_request(
+                        agent=agent,
+                        history=history,
+                        failover_configs=failover_configs,
+                        image_attachments=image_attachments,
+                        fitted_token_count=fitted_token_count,
+                        is_first_run=is_first_run,
+                        routing_profile=routing_profile,
+                        prefer_low_latency=prefer_low_latency,
                     )
                     if multimodal_attached:
                         logger.info(

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -69,6 +69,10 @@ from .llm_utils import (
     raise_if_invalid_litellm_response,
     run_completion,
 )
+from .multimodal_context import (
+    collect_fresh_read_file_image_attachments,
+    prepare_multimodal_read_file_request,
+)
 from .llm_streaming import StreamAccumulator
 from .token_usage import (
     completion_kwargs_from_usage,
@@ -5900,6 +5904,48 @@ def _run_agent_loop(
                         failover_configs,
                         agent_id=str(agent.id),
                     )
+                request_history = history
+                request_failover_configs = failover_configs
+                fresh_tool_call_step_ids = prompt_metadata.get("fresh_tool_call_step_ids") or []
+                image_attachments = collect_fresh_read_file_image_attachments(
+                    agent,
+                    fresh_tool_call_step_ids,
+                )
+                if image_attachments:
+                    candidate_failover_configs = failover_configs
+                    if not any(bool((params or {}).get("supports_vision")) for _, _, params in failover_configs):
+                        try:
+                            candidate_failover_configs = get_llm_config_with_failover(
+                                agent_id=str(agent.id),
+                                token_count=fitted_token_count,
+                                agent=agent,
+                                is_first_loop=is_first_run,
+                                routing_profile=routing_profile,
+                                prefer_low_latency=prefer_low_latency,
+                                ignore_agent_tier_cap=True,
+                            )
+                        except LLMNotConfiguredError:
+                            candidate_failover_configs = failover_configs
+                    (
+                        request_history,
+                        request_failover_configs,
+                        multimodal_attached,
+                    ) = prepare_multimodal_read_file_request(
+                        history,
+                        candidate_failover_configs,
+                        image_attachments,
+                    )
+                    if multimodal_attached:
+                        logger.info(
+                            "Agent %s: attached %d read_file image(s) to multimodal orchestrator request",
+                            agent.id,
+                            len(image_attachments),
+                        )
+                    else:
+                        logger.info(
+                            "Agent %s: read_file image context available but no vision-capable orchestrator endpoint found",
+                            agent.id,
+                        )
                 stream_broadcaster = None
                 try:
                     stream_target = resolve_web_stream_target(agent)
@@ -5910,9 +5956,9 @@ def _run_agent_loop(
 
                 try:
                     response, token_usage = _completion_with_failover(
-                        messages=history,
+                        messages=request_history,
                         tools=iteration_tools,
-                        failover_configs=failover_configs,
+                        failover_configs=request_failover_configs,
                         agent_id=str(agent.id),
                         safety_identifier=agent.user.id if agent.user else None,
                         preferred_config=preferred_config,

--- a/api/agent/core/file_handler_config.py
+++ b/api/agent/core/file_handler_config.py
@@ -1,13 +1,25 @@
-import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from django.db.models import Prefetch
 
 from api.agent.core.endpoint_config_utils import resolve_endpoint_model_and_params
+from api.agent.core.llm_config import (
+    _get_failover_configs_from_profile,
+    _resolve_active_routing_profile,
+)
 from api.models import FileHandlerLLMTier, FileHandlerTierEndpoint
 
-logger = logging.getLogger(__name__)
+_ROUTING_HINT_PARAM_KEYS = {
+    "allow_implied_send",
+    "low_latency",
+    "reasoning_effort",
+    "supports_reasoning",
+    "supports_temperature",
+    "supports_tool_choice",
+    "supports_vision",
+    "use_parallel_tool_calls",
+}
 
 
 @dataclass
@@ -18,7 +30,60 @@ class FileHandlerLLMConfig:
     endpoint_key: str
 
 
-def get_file_handler_llm_config() -> Optional[FileHandlerLLMConfig]:
+def _get_current_eval_routing_profile() -> Any | None:
+    try:
+        from api.evals.execution import get_current_eval_routing_profile
+    except ImportError:
+        return None
+    return get_current_eval_routing_profile()
+
+
+def _resolve_routing_profile(routing_profile: Any | None) -> Any | None:
+    if routing_profile is not None:
+        return routing_profile
+    eval_profile = _get_current_eval_routing_profile()
+    if eval_profile is not None:
+        return eval_profile
+    return _resolve_active_routing_profile(None, purpose="file handler")
+
+
+def _strip_routing_hints(params: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in params.items() if key not in _ROUTING_HINT_PARAM_KEYS}
+
+
+def _config_from_profile(profile: Any | None) -> Optional[FileHandlerLLMConfig]:
+    if profile is None:
+        return None
+
+    configs = _get_failover_configs_from_profile(
+        token_count=0,
+        agent_id=None,
+        agent=None,
+        is_first_loop=None,
+        routing_profile=profile,
+        prefer_low_latency=False,
+        ignore_agent_tier_cap=True,
+    )
+    for endpoint_key, model_name, params in configs:
+        if not params.get("supports_vision", False):
+            continue
+        return FileHandlerLLMConfig(
+            model=model_name,
+            params=_strip_routing_hints(params),
+            supports_vision=True,
+            endpoint_key=endpoint_key,
+        )
+    return None
+
+
+def get_file_handler_llm_config(
+    routing_profile: Any | None = None,
+) -> Optional[FileHandlerLLMConfig]:
+    profile = _resolve_routing_profile(routing_profile)
+    profile_config = _config_from_profile(profile)
+    if profile_config is not None:
+        return profile_config
+
     tier_prefetch = Prefetch(
         "tier_endpoints",
         queryset=FileHandlerTierEndpoint.objects.select_related("endpoint__provider").order_by("-weight"),

--- a/api/agent/core/llm_config.py
+++ b/api/agent/core/llm_config.py
@@ -1040,6 +1040,7 @@ def get_llm_config_with_failover(
     is_first_loop: bool | None = None,
     routing_profile: Any | None = None,
     prefer_low_latency: Optional[bool] = None,
+    ignore_agent_tier_cap: bool = False,
 ) -> List[Tuple[str, str, dict]]:
     """
     Get LLM configurations for tiered failover with token-based tier selection.
@@ -1058,6 +1059,9 @@ def get_llm_config_with_failover(
             this profile's configuration instead of the active profile or legacy config.
         prefer_low_latency: When true, prioritize low-latency endpoints within a tier.
             When None, automatically prefers low latency for active web sessions.
+        ignore_agent_tier_cap: When true, include all configured intelligence tiers
+            for special-purpose routing that may need a capability absent from the
+            agent's normal tier.
 
     Returns:
         List of (provider_name, model_name, litellm_params) tuples in failover order
@@ -1075,6 +1079,7 @@ def get_llm_config_with_failover(
         is_first_loop=is_first_loop,
         routing_profile=routing_profile,
         prefer_low_latency=prefer_low_latency,
+        ignore_agent_tier_cap=ignore_agent_tier_cap,
     )
     if configs:
         _cache_bootstrap_status(False)
@@ -1087,6 +1092,7 @@ def get_llm_config_with_failover(
         agent=agent,
         is_first_loop=is_first_loop,
         prefer_low_latency=prefer_low_latency,
+        ignore_agent_tier_cap=ignore_agent_tier_cap,
     )
     if configs:
         _cache_bootstrap_status(False)
@@ -1110,6 +1116,7 @@ def _get_failover_configs_from_profile(
     is_first_loop: bool | None,
     routing_profile: Any | None,
     prefer_low_latency: bool,
+    ignore_agent_tier_cap: bool,
 ) -> List[Tuple[str, str, dict]]:
     """Get failover configs from an LLMRoutingProfile.
 
@@ -1186,13 +1193,11 @@ def _get_failover_configs_from_profile(
             )
 
         profile_name = getattr(profile, 'name', 'unknown')
-        allowed_rank = get_allowed_tier_rank(agent_tier)
-        tiers = (
-            ProfilePersistentTier.objects
-            .filter(token_range=token_range, intelligence_tier__rank__lte=allowed_rank)
-            .select_related("intelligence_tier")
-            .order_by("-intelligence_tier__rank", "order")
-        )
+        tiers = ProfilePersistentTier.objects.filter(token_range=token_range)
+        if not ignore_agent_tier_cap:
+            allowed_rank = get_allowed_tier_rank(agent_tier)
+            tiers = tiers.filter(intelligence_tier__rank__lte=allowed_rank)
+        tiers = tiers.select_related("intelligence_tier").order_by("-intelligence_tier__rank", "order")
         return _collect_failover_configs(
             tiers,
             token_range_name=f"{profile_name}:{token_range.name}",
@@ -1211,6 +1216,7 @@ def _get_failover_configs_from_legacy(
     agent: Any | None,
     is_first_loop: bool | None,
     prefer_low_latency: bool,
+    ignore_agent_tier_cap: bool,
 ) -> List[Tuple[str, str, dict]]:
     """Get failover configs from legacy PersistentTokenRange/PersistentLLMTier tables."""
     try:
@@ -1271,13 +1277,11 @@ def _get_failover_configs_from_legacy(
             is_first_loop=is_first_loop,
         )
 
-    allowed_rank = get_allowed_tier_rank(agent_tier)
-    tiers = (
-        PersistentLLMTier.objects
-        .filter(token_range=token_range, intelligence_tier__rank__lte=allowed_rank)
-        .select_related("intelligence_tier")
-        .order_by("-intelligence_tier__rank", "order")
-    )
+    tiers = PersistentLLMTier.objects.filter(token_range=token_range)
+    if not ignore_agent_tier_cap:
+        allowed_rank = get_allowed_tier_rank(agent_tier)
+        tiers = tiers.filter(intelligence_tier__rank__lte=allowed_rank)
+    tiers = tiers.select_related("intelligence_tier").order_by("-intelligence_tier__rank", "order")
     return _collect_failover_configs(
         tiers,
         token_range_name=token_range.name,

--- a/api/agent/core/llm_config.py
+++ b/api/agent/core/llm_config.py
@@ -22,6 +22,7 @@ from django.db.models import Q
 from django.db.utils import DatabaseError
 from django.conf import settings
 
+from api.agent.core.endpoint_config_utils import resolve_provider_api_key
 from api.openrouter import get_attribution_headers
 from api.llm.utils import normalize_model_name
 from api.services.web_sessions import has_active_web_session
@@ -873,20 +874,11 @@ def _build_weighted_failover_configs(
         params: Dict[str, Any] = {}
         if supports_temperature:
             params["temperature"] = 0.1
-        try:
-            effective_key = None
-            if provider.api_key_encrypted:
-                from api.encryption import SecretsEncryption
-                effective_key = SecretsEncryption.decrypt_value(provider.api_key_encrypted)
-            if not effective_key and provider.env_var_name:
-                effective_key = os.getenv(provider.env_var_name)
-            if effective_key:
-                params["api_key"] = effective_key
-            else:
-                if endpoint.litellm_model.startswith("openai/") and getattr(endpoint, "api_base", None):
-                    params["api_key"] = "sk-noauth"
-        except Exception:
-            logger.debug("Unable to determine API key for endpoint %s", endpoint.key, exc_info=True)
+        effective_key = resolve_provider_api_key(provider)
+        if effective_key:
+            params["api_key"] = effective_key
+        elif endpoint.litellm_model.startswith("openai/") and getattr(endpoint, "api_base", None):
+            params["api_key"] = "sk-noauth"
         if supports_temperature and endpoint.temperature_override is not None:
             params["temperature"] = float(endpoint.temperature_override)
         if "google" in provider.key:

--- a/api/agent/core/multimodal_context.py
+++ b/api/agent/core/multimodal_context.py
@@ -1,0 +1,271 @@
+import base64
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from django.db import DatabaseError
+
+from api.agent.files.filespace_service import get_or_create_default_filespace
+from api.models import (
+    AgentFileSpaceAccess,
+    AgentFsNode,
+    PersistentAgent,
+    PersistentAgentCompletion,
+    PersistentAgentToolCall,
+)
+from api.services.system_settings import get_max_file_size
+
+logger = logging.getLogger(__name__)
+
+MAX_MULTIMODAL_READ_FILE_IMAGES = 3
+
+SUPPORTED_READ_FILE_IMAGE_MIME_TYPES = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "image/gif",
+    }
+)
+SUPPORTED_READ_FILE_IMAGE_EXTENSIONS = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
+
+@dataclass(frozen=True)
+class ReadFileImageAttachment:
+    path: str
+    mime_type: str
+    data_url: str
+
+
+def _resolve_read_file_path(params: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(params, Mapping):
+        return None
+    for key in ("path", "file_path", "filename"):
+        value = params.get(key)
+        if not isinstance(value, str):
+            continue
+        cleaned = value.strip()
+        if cleaned.startswith("$[") and cleaned.endswith("]"):
+            cleaned = cleaned[2:-1].strip()
+        if cleaned:
+            return cleaned
+    return None
+
+
+def _is_successful_read_file_result(result_text: str) -> bool:
+    if not result_text:
+        return False
+    try:
+        result = json.loads(result_text)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(result, dict) and result.get("status") == "ok"
+
+
+def _supported_image_mime_type(node: AgentFsNode) -> str | None:
+    mime_type = (node.mime_type or "").split(";", 1)[0].strip().lower()
+    if mime_type in SUPPORTED_READ_FILE_IMAGE_MIME_TYPES:
+        return mime_type
+
+    extension = os.path.splitext(node.name or "")[1].lower()
+    extension_mime_type = SUPPORTED_READ_FILE_IMAGE_EXTENSIONS.get(extension)
+    if extension_mime_type and mime_type in {"", "application/octet-stream"}:
+        return extension_mime_type
+    return None
+
+
+def _node_size_bytes(node: AgentFsNode) -> int | None:
+    if node.size_bytes is not None:
+        return int(node.size_bytes)
+    content = getattr(node, "content", None)
+    if content is None:
+        return None
+    try:
+        return int(content.size)
+    except (OSError, TypeError, ValueError):
+        return None
+
+
+def _read_node_bytes(node: AgentFsNode, *, max_size: int | None) -> bytes:
+    content = getattr(node, "content", None)
+    if content is None or not getattr(content, "name", None):
+        raise ValueError("Node has no stored content.")
+
+    chunks: list[bytes] = []
+    total_bytes = 0
+    with content.storage.open(content.name, "rb") as src:
+        for chunk in iter(lambda: src.read(64 * 1024), b""):
+            total_bytes += len(chunk)
+            if max_size and total_bytes > max_size:
+                raise ValueError("File exceeds maximum allowed size.")
+            chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def collect_fresh_read_file_image_attachments(
+    agent: PersistentAgent,
+    fresh_tool_call_step_ids: Sequence[str] | set[str] | None,
+    *,
+    max_images: int = MAX_MULTIMODAL_READ_FILE_IMAGES,
+) -> list[ReadFileImageAttachment]:
+    if not fresh_tool_call_step_ids or max_images <= 0:
+        return []
+
+    step_ids = [str(step_id) for step_id in fresh_tool_call_step_ids if step_id]
+    if not step_ids:
+        return []
+
+    calls = list(
+        PersistentAgentToolCall.objects.filter(
+            step_id__in=step_ids,
+            tool_name="read_file",
+            status="complete",
+        )
+        .select_related("step", "step__completion")
+        .order_by("step__created_at", "step_id")
+    )
+    if not calls:
+        return []
+
+    latest_completion = (
+        PersistentAgentCompletion.objects.filter(
+            agent=agent,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+        )
+        .only("id")
+        .order_by("-created_at")
+        .first()
+    )
+    latest_completion_id = str(latest_completion.id) if latest_completion is not None else None
+
+    requested_paths: list[str] = []
+    seen_paths: set[str] = set()
+    for call in calls:
+        call_completion_id = str(call.step.completion_id) if call.step.completion_id else None
+        if call_completion_id and latest_completion_id and call_completion_id != latest_completion_id:
+            continue
+        if not _is_successful_read_file_result(call.result or ""):
+            continue
+        path = _resolve_read_file_path(call.tool_params)
+        if not path or path in seen_paths:
+            continue
+        requested_paths.append(path)
+        seen_paths.add(path)
+        if len(requested_paths) >= max_images:
+            break
+
+    if not requested_paths:
+        return []
+
+    try:
+        filespace = get_or_create_default_filespace(agent)
+    except (DatabaseError, ValueError):
+        logger.debug("Unable to resolve filespace for multimodal read_file context", exc_info=True)
+        return []
+
+    if not AgentFileSpaceAccess.objects.filter(agent=agent, filespace=filespace).exists():
+        return []
+
+    nodes = (
+        AgentFsNode.objects.alive()
+        .filter(
+            filespace=filespace,
+            path__in=requested_paths,
+            node_type=AgentFsNode.NodeType.FILE,
+        )
+    )
+    nodes_by_path = {node.path: node for node in nodes}
+    max_size = get_max_file_size()
+
+    attachments: list[ReadFileImageAttachment] = []
+    for path in requested_paths:
+        node = nodes_by_path.get(path)
+        if node is None:
+            continue
+        mime_type = _supported_image_mime_type(node)
+        if not mime_type:
+            continue
+        size_bytes = _node_size_bytes(node)
+        if max_size and size_bytes and size_bytes > max_size:
+            continue
+        try:
+            image_bytes = _read_node_bytes(node, max_size=max_size)
+        except (OSError, ValueError):
+            logger.debug("Unable to read image bytes for multimodal context: %s", path, exc_info=True)
+            continue
+        encoded = base64.b64encode(image_bytes).decode("ascii")
+        attachments.append(
+            ReadFileImageAttachment(
+                path=path,
+                mime_type=mime_type,
+                data_url=f"data:{mime_type};base64,{encoded}",
+            )
+        )
+    return attachments
+
+
+def filter_vision_capable_failover_configs(
+    failover_configs: Sequence[tuple[str, str, dict]] | None,
+) -> list[tuple[str, str, dict]]:
+    return [
+        config
+        for config in failover_configs or []
+        if len(config) >= 3 and bool((config[2] or {}).get("supports_vision"))
+    ]
+
+
+def attach_read_file_images_to_messages(
+    messages: Sequence[dict[str, Any]],
+    attachments: Sequence[ReadFileImageAttachment],
+) -> list[dict[str, Any]]:
+    if not attachments:
+        return list(messages)
+
+    updated_messages = [dict(message) for message in messages]
+    target_index = next(
+        (idx for idx in range(len(updated_messages) - 1, -1, -1) if updated_messages[idx].get("role") == "user"),
+        None,
+    )
+    if target_index is None:
+        updated_messages.append({"role": "user", "content": []})
+        target_index = len(updated_messages) - 1
+
+    target = dict(updated_messages[target_index])
+    content = target.get("content", "")
+    if isinstance(content, list):
+        parts = list(content)
+    elif isinstance(content, str):
+        parts = [{"type": "text", "text": content}]
+    else:
+        parts = [{"type": "text", "text": str(content)}]
+
+    for attachment in attachments:
+        parts.append({"type": "text", "text": f"Image from read_file: {attachment.path}"})
+        parts.append({"type": "image_url", "image_url": {"url": attachment.data_url}})
+
+    target["content"] = parts
+    updated_messages[target_index] = target
+    return updated_messages
+
+
+def prepare_multimodal_read_file_request(
+    messages: Sequence[dict[str, Any]],
+    failover_configs: Sequence[tuple[str, str, dict]] | None,
+    attachments: Sequence[ReadFileImageAttachment],
+) -> tuple[list[dict[str, Any]], list[tuple[str, str, dict]], bool]:
+    if not attachments:
+        return list(messages), list(failover_configs or []), False
+
+    vision_configs = filter_vision_capable_failover_configs(failover_configs)
+    if not vision_configs:
+        return list(messages), list(failover_configs or []), False
+
+    return attach_read_file_images_to_messages(messages, attachments), vision_configs, True

--- a/api/agent/core/multimodal_context.py
+++ b/api/agent/core/multimodal_context.py
@@ -56,6 +56,8 @@ def _resolve_read_file_path(params: Mapping[str, Any] | None) -> str | None:
         if cleaned.startswith("$[") and cleaned.endswith("]"):
             cleaned = cleaned[2:-1].strip()
         if cleaned:
+            if not cleaned.startswith("/"):
+                cleaned = f"/{cleaned}"
             return cleaned
     return None
 

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1527,7 +1527,7 @@ def _render_prompt_context_once(
 
     # Unified history follows the important context (order within user prompt: important -> unified_history -> critical)
     unified_history_group = prompt.group("unified_history", weight=3)
-    _get_unified_history_prompt(agent, unified_history_group, config_authority)
+    fresh_tool_call_step_ids = _get_unified_history_prompt(agent, unified_history_group, config_authority)
 
     # Variable priority sections (weight=4) - can be heavily shrunk with smart truncation
     variable_group = prompt.group("variable", weight=4)
@@ -1777,6 +1777,7 @@ def _render_prompt_context_once(
             "prompt_render_signature": _prompt_render_signature_from_failover_configs(
                 prompt_failover_configs
             ),
+            "fresh_tool_call_step_ids": sorted(fresh_tool_call_step_ids),
         },
     )
 
@@ -4175,7 +4176,7 @@ def _get_unified_history_prompt(
     agent: PersistentAgent,
     history_group,
     config_authority: _ConfigAuthorityResolver,
-) -> None:
+) -> Set[str]:
     """Add summaries + interleaved recent steps & messages to the provided promptree group."""
     epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
     unified_limit, unified_hysteresis = _get_unified_history_limits(agent)
@@ -4659,6 +4660,8 @@ def _get_unified_history_prompt(
                     weight=component_weight,
                     shrinker=shrinker
                 )
+
+    return fresh_tool_call_step_ids
 
 
 def get_agent_tools(agent: PersistentAgent = None) -> List[dict]:

--- a/tests/unit/test_file_handler_config.py
+++ b/tests/unit/test_file_handler_config.py
@@ -1,0 +1,210 @@
+import os
+import uuid
+from unittest import mock
+
+from django.apps import apps
+from django.test import TestCase, tag
+
+from api.agent.core.file_handler_config import get_file_handler_llm_config
+from api.evals.execution import (
+    get_current_eval_routing_profile,
+    set_current_eval_routing_profile,
+)
+from tests.utils.llm_seed import clear_llm_db, get_intelligence_tier
+
+
+@tag("batch_agent_tools")
+class FileHandlerConfigTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        clear_llm_db()
+        self._clear_file_handler_config()
+
+    def tearDown(self):
+        self._clear_file_handler_config()
+        clear_llm_db()
+        super().tearDown()
+
+    def _clear_file_handler_config(self):
+        FileHandlerTierEndpoint = apps.get_model("api", "FileHandlerTierEndpoint")
+        FileHandlerLLMTier = apps.get_model("api", "FileHandlerLLMTier")
+        FileHandlerModelEndpoint = apps.get_model("api", "FileHandlerModelEndpoint")
+        FileHandlerTierEndpoint.objects.all().delete()
+        FileHandlerLLMTier.objects.all().delete()
+        FileHandlerModelEndpoint.objects.all().delete()
+
+    def _make_provider(self):
+        LLMProvider = apps.get_model("api", "LLMProvider")
+        return LLMProvider.objects.create(
+            key=f"openrouter-{uuid.uuid4().hex[:8]}",
+            display_name="OpenRouter",
+            enabled=True,
+            env_var_name="OPENROUTER_API_KEY",
+            browser_backend="OPENAI",
+        )
+
+    def _make_profile(self):
+        LLMRoutingProfile = apps.get_model("api", "LLMRoutingProfile")
+        return LLMRoutingProfile.objects.create(
+            name=f"profile-{uuid.uuid4().hex[:8]}",
+            display_name="Profile",
+            is_active=False,
+        )
+
+    def _make_persistent_endpoint(self, provider, *, key: str, model: str, supports_vision: bool):
+        PersistentModelEndpoint = apps.get_model("api", "PersistentModelEndpoint")
+        return PersistentModelEndpoint.objects.create(
+            key=key,
+            provider=provider,
+            enabled=True,
+            litellm_model=model,
+            supports_vision=supports_vision,
+        )
+
+    def _make_global_file_handler_endpoint(self, provider):
+        FileHandlerModelEndpoint = apps.get_model("api", "FileHandlerModelEndpoint")
+        FileHandlerLLMTier = apps.get_model("api", "FileHandlerLLMTier")
+        FileHandlerTierEndpoint = apps.get_model("api", "FileHandlerTierEndpoint")
+        endpoint = FileHandlerModelEndpoint.objects.create(
+            key="global-file-handler",
+            provider=provider,
+            enabled=True,
+            litellm_model="openrouter/global-file-handler",
+            supports_vision=True,
+        )
+        tier = FileHandlerLLMTier.objects.create(order=1)
+        FileHandlerTierEndpoint.objects.create(tier=tier, endpoint=endpoint, weight=1.0)
+        return endpoint
+
+    def _add_profile_tier_endpoint(self, profile, endpoint, *, tier_key: str = "standard"):
+        ProfileTokenRange = apps.get_model("api", "ProfileTokenRange")
+        ProfilePersistentTier = apps.get_model("api", "ProfilePersistentTier")
+        ProfilePersistentTierEndpoint = apps.get_model("api", "ProfilePersistentTierEndpoint")
+        token_range, _created = ProfileTokenRange.objects.get_or_create(
+            profile=profile,
+            name="default",
+            defaults={
+                "min_tokens": 0,
+                "max_tokens": None,
+            },
+        )
+        tier = ProfilePersistentTier.objects.create(
+            token_range=token_range,
+            order=1,
+            intelligence_tier=get_intelligence_tier(tier_key),
+        )
+        ProfilePersistentTierEndpoint.objects.create(tier=tier, endpoint=endpoint, weight=1.0)
+
+    def test_profile_vision_endpoint_wins_over_global_file_handler_tier(self):
+        provider = self._make_provider()
+        profile_endpoint = self._make_persistent_endpoint(
+            provider,
+            key="profile-tier-vision",
+            model="openrouter/profile-tier-vision",
+            supports_vision=True,
+        )
+        profile = self._make_profile()
+        self._add_profile_tier_endpoint(profile, profile_endpoint)
+        self._make_global_file_handler_endpoint(provider)
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-openrouter"}, clear=True):
+            config = get_file_handler_llm_config(routing_profile=profile)
+
+        self.assertIsNotNone(config)
+        self.assertEqual(config.endpoint_key, "profile-tier-vision")
+        self.assertEqual(config.model, "openrouter/profile-tier-vision")
+        self.assertTrue(config.supports_vision)
+
+    def test_profile_without_vision_endpoint_falls_back_to_global_file_handler_tier(self):
+        provider = self._make_provider()
+        text_endpoint = self._make_persistent_endpoint(
+            provider,
+            key="profile-text-only",
+            model="openrouter/text-only",
+            supports_vision=False,
+        )
+        profile = self._make_profile()
+        self._add_profile_tier_endpoint(profile, text_endpoint)
+        self._make_global_file_handler_endpoint(provider)
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-openrouter"}, clear=True):
+            config = get_file_handler_llm_config(routing_profile=profile)
+
+        self.assertIsNotNone(config)
+        self.assertEqual(config.endpoint_key, "global-file-handler")
+        self.assertEqual(config.model, "openrouter/global-file-handler")
+        self.assertTrue(config.supports_vision)
+
+    def test_profile_failover_can_use_higher_tier_vision_endpoint(self):
+        provider = self._make_provider()
+        standard_endpoint = self._make_persistent_endpoint(
+            provider,
+            key="profile-standard-text-only",
+            model="openrouter/standard-text-only",
+            supports_vision=False,
+        )
+        higher_vision_endpoint = self._make_persistent_endpoint(
+            provider,
+            key="profile-ultra-vision",
+            model="openrouter/profile-ultra-vision",
+            supports_vision=True,
+        )
+        profile = self._make_profile()
+        self._add_profile_tier_endpoint(profile, standard_endpoint, tier_key="standard")
+        self._add_profile_tier_endpoint(profile, higher_vision_endpoint, tier_key="ultra")
+        self._make_global_file_handler_endpoint(provider)
+
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-openrouter"}, clear=True):
+            config = get_file_handler_llm_config(routing_profile=profile)
+
+        self.assertIsNotNone(config)
+        self.assertEqual(config.endpoint_key, "profile-ultra-vision")
+        self.assertEqual(config.model, "openrouter/profile-ultra-vision")
+        self.assertTrue(config.supports_vision)
+
+    def test_profile_failover_falls_back_to_env_key_when_encrypted_key_is_bad(self):
+        provider = self._make_provider()
+        provider.api_key_encrypted = b"not-valid-ciphertext"
+        provider.save(update_fields=["api_key_encrypted", "updated_at"])
+        vision_endpoint = self._make_persistent_endpoint(
+            provider,
+            key="profile-tier-vision",
+            model="openrouter/profile-tier-vision",
+            supports_vision=True,
+        )
+        profile = self._make_profile()
+        self._add_profile_tier_endpoint(profile, vision_endpoint)
+
+        with (
+            mock.patch("api.encryption.SecretsEncryption.decrypt_value", side_effect=ValueError("bad key")),
+            mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-openrouter"}, clear=True),
+        ):
+            config = get_file_handler_llm_config(routing_profile=profile)
+
+        self.assertIsNotNone(config)
+        self.assertEqual(config.endpoint_key, "profile-tier-vision")
+        self.assertEqual(config.params["api_key"], "sk-openrouter")
+
+    def test_eval_routing_profile_is_used_without_explicit_argument(self):
+        provider = self._make_provider()
+        vision_endpoint = self._make_persistent_endpoint(
+            provider,
+            key="eval-profile-tier-vision",
+            model="openrouter/eval-profile-tier-vision",
+            supports_vision=True,
+        )
+        profile = self._make_profile()
+        self._add_profile_tier_endpoint(profile, vision_endpoint)
+        self._make_global_file_handler_endpoint(provider)
+        previous_profile = get_current_eval_routing_profile()
+
+        try:
+            set_current_eval_routing_profile(profile)
+            with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-openrouter"}, clear=True):
+                config = get_file_handler_llm_config()
+        finally:
+            set_current_eval_routing_profile(previous_profile)
+
+        self.assertIsNotNone(config)
+        self.assertEqual(config.endpoint_key, "eval-profile-tier-vision")
+        self.assertEqual(config.model, "openrouter/eval-profile-tier-vision")

--- a/tests/unit/test_llm_failover.py
+++ b/tests/unit/test_llm_failover.py
@@ -541,6 +541,65 @@ class TestLLMFailover(TestCase):
         self.assertEqual(endpoint_order, ["openai_max", "openai_premium", "openai_standard"])
 
     @override_settings(GOBII_PROPRIETARY_MODE=True)
+    def test_ignore_agent_tier_cap_includes_higher_vision_tier(self):
+        clear_llm_db()
+        LLMProvider = apps.get_model('api', 'LLMProvider')
+        PersistentModelEndpoint = apps.get_model('api', 'PersistentModelEndpoint')
+        PersistentTokenRange = apps.get_model('api', 'PersistentTokenRange')
+        PersistentLLMTier = apps.get_model('api', 'PersistentLLMTier')
+        PersistentTierEndpoint = apps.get_model('api', 'PersistentTierEndpoint')
+
+        provider = LLMProvider.objects.create(
+            key='openai',
+            display_name='OpenAI',
+            enabled=True,
+            env_var_name='OPENAI_API_KEY',
+            browser_backend='OPENAI',
+        )
+        standard_endpoint = PersistentModelEndpoint.objects.create(
+            key='openai_standard_text',
+            provider=provider,
+            enabled=True,
+            litellm_model='openai/gpt-4o-mini',
+            supports_tool_choice=True,
+            supports_vision=False,
+        )
+        ultra_endpoint = PersistentModelEndpoint.objects.create(
+            key='openai_ultra_vision',
+            provider=provider,
+            enabled=True,
+            litellm_model='openai/gpt-4.1',
+            supports_tool_choice=True,
+            supports_vision=True,
+        )
+
+        token_range = PersistentTokenRange.objects.create(name='default', min_tokens=0, max_tokens=None)
+        standard_tier = PersistentLLMTier.objects.create(
+            token_range=token_range,
+            order=1,
+            intelligence_tier=get_intelligence_tier("standard"),
+        )
+        ultra_tier = PersistentLLMTier.objects.create(
+            token_range=token_range,
+            order=1,
+            intelligence_tier=get_intelligence_tier("ultra_max"),
+        )
+        PersistentTierEndpoint.objects.create(tier=standard_tier, endpoint=standard_endpoint, weight=1.0)
+        PersistentTierEndpoint.objects.create(tier=ultra_tier, endpoint=ultra_endpoint, weight=1.0)
+
+        with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
+            with mock.patch("api.agent.core.llm_config.get_agent_llm_tier", return_value=AgentLLMTier.STANDARD):
+                capped_configs = get_llm_config_with_failover(token_count=0)
+                uncapped_configs = get_llm_config_with_failover(
+                    token_count=0,
+                    ignore_agent_tier_cap=True,
+                )
+
+        self.assertEqual([cfg[0] for cfg in capped_configs], ["openai_standard_text"])
+        self.assertEqual([cfg[0] for cfg in uncapped_configs], ["openai_ultra_vision", "openai_standard_text"])
+        self.assertTrue(uncapped_configs[0][2]["supports_vision"])
+
+    @override_settings(GOBII_PROPRIETARY_MODE=True)
     def test_premium_tiers_preferred_for_paid_plan(self):
         clear_llm_db()
         seeded = self._seed_premium_setup(include_premium=True)

--- a/tests/unit/test_multimodal_read_file_context.py
+++ b/tests/unit/test_multimodal_read_file_context.py
@@ -1,0 +1,259 @@
+import json
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, tag
+
+from api.agent.core.multimodal_context import (
+    attach_read_file_images_to_messages,
+    collect_fresh_read_file_image_attachments,
+    filter_vision_capable_failover_configs,
+    prepare_multimodal_read_file_request,
+)
+from api.agent.core.prompt_context import build_prompt_context
+from api.agent.files.filespace_service import write_bytes_to_dir
+from api.models import (
+    BrowserUseAgent,
+    PersistentAgent,
+    PersistentAgentCompletion,
+    PersistentAgentStep,
+    PersistentAgentToolCall,
+)
+
+
+@tag("batch_event_llm")
+class MultimodalReadFileContextTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user = get_user_model().objects.create_user(
+            username="multimodal-read-file@example.com",
+            email="multimodal-read-file@example.com",
+            password="secret",
+        )
+        browser_agent = BrowserUseAgent.objects.create(user=user, name="Multimodal Browser")
+        cls.agent = PersistentAgent.objects.create(
+            user=user,
+            name="Multimodal Agent",
+            charter="Inspect files.",
+            browser_use_agent=browser_agent,
+        )
+
+    def _write_file(self, *, path: str, content: bytes, mime_type: str) -> None:
+        result = write_bytes_to_dir(
+            agent=self.agent,
+            content_bytes=content,
+            path=path,
+            mime_type=mime_type,
+            overwrite=True,
+        )
+        self.assertEqual(result.get("status"), "ok")
+
+    def _create_read_file_step(
+        self,
+        *,
+        path: str,
+        result_status: str = "ok",
+        tool_status: str = "complete",
+        completion: PersistentAgentCompletion | None = None,
+    ) -> PersistentAgentStep:
+        if completion is None:
+            completion = PersistentAgentCompletion.objects.create(agent=self.agent)
+        step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            completion=completion,
+            description=f"Tool read_file called for {path}",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="read_file",
+            tool_params={"path": path},
+            result=json.dumps({"status": result_status, "format": "markdown", "markdown": "converted"}),
+            status=tool_status,
+        )
+        return step
+
+    def test_collects_only_fresh_successful_supported_images(self):
+        self._write_file(path="/images/photo.png", content=b"\x89PNG\r\nimage", mime_type="image/png")
+        self._write_file(path="/images/note.txt", content=b"hello", mime_type="text/plain")
+        completion = PersistentAgentCompletion.objects.create(agent=self.agent)
+        image_step = self._create_read_file_step(path="/images/photo.png", completion=completion)
+        text_step = self._create_read_file_step(path="/images/note.txt", completion=completion)
+        failed_step = self._create_read_file_step(
+            path="/images/photo.png",
+            result_status="error",
+            completion=completion,
+        )
+
+        attachments = collect_fresh_read_file_image_attachments(
+            self.agent,
+            {str(image_step.id), str(text_step.id), str(failed_step.id)},
+        )
+
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0].path, "/images/photo.png")
+        self.assertEqual(attachments[0].mime_type, "image/png")
+        self.assertTrue(attachments[0].data_url.startswith("data:image/png;base64,"))
+
+    def test_collects_multiple_fresh_images_with_cap(self):
+        steps = []
+        completion = PersistentAgentCompletion.objects.create(agent=self.agent)
+        for idx in range(4):
+            path = f"/images/photo-{idx}.png"
+            self._write_file(path=path, content=f"png-{idx}".encode("utf-8"), mime_type="image/png")
+            steps.append(self._create_read_file_step(path=path, completion=completion))
+
+        attachments = collect_fresh_read_file_image_attachments(
+            self.agent,
+            {str(step.id) for step in steps},
+            max_images=2,
+        )
+
+        self.assertEqual(len(attachments), 2)
+
+    @patch("api.agent.core.multimodal_context.get_max_file_size", return_value=4)
+    def test_collect_skips_oversized_image(self, _mock_max_size):
+        self._write_file(path="/images/large.png", content=b"too-large", mime_type="image/png")
+        step = self._create_read_file_step(path="/images/large.png")
+
+        attachments = collect_fresh_read_file_image_attachments(self.agent, {str(step.id)})
+
+        self.assertEqual(attachments, [])
+
+    def test_collect_skips_read_file_image_after_newer_orchestrator_completion(self):
+        self._write_file(path="/images/old.png", content=b"png", mime_type="image/png")
+        step = self._create_read_file_step(path="/images/old.png")
+        PersistentAgentCompletion.objects.create(agent=self.agent)
+
+        attachments = collect_fresh_read_file_image_attachments(self.agent, {str(step.id)})
+
+        self.assertEqual(attachments, [])
+
+    def test_filter_vision_capable_failover_configs_preserves_order(self):
+        configs = [
+            ("text-primary", "model-a", {"supports_vision": False}),
+            ("vision-primary", "model-b", {"supports_vision": True}),
+            ("vision-fallback", "model-c", {"supports_vision": True}),
+        ]
+
+        filtered = filter_vision_capable_failover_configs(configs)
+
+        self.assertEqual(
+            filtered,
+            [
+                ("vision-primary", "model-b", {"supports_vision": True}),
+                ("vision-fallback", "model-c", {"supports_vision": True}),
+            ],
+        )
+
+    def test_prepare_multimodal_request_attaches_images_only_with_vision_config(self):
+        self._write_file(path="/images/photo.webp", content=b"webp", mime_type="image/webp")
+        step = self._create_read_file_step(path="/images/photo.webp")
+        attachments = collect_fresh_read_file_image_attachments(self.agent, {str(step.id)})
+        messages = [{"role": "system", "content": "sys"}, {"role": "user", "content": "Inspect it."}]
+        configs = [
+            ("text-primary", "model-a", {"supports_vision": False}),
+            ("vision-primary", "model-b", {"supports_vision": True}),
+        ]
+
+        updated_messages, updated_configs, attached = prepare_multimodal_read_file_request(
+            messages,
+            configs,
+            attachments,
+        )
+
+        self.assertTrue(attached)
+        self.assertEqual(updated_configs, [("vision-primary", "model-b", {"supports_vision": True})])
+        user_content = updated_messages[-1]["content"]
+        self.assertEqual(user_content[0], {"type": "text", "text": "Inspect it."})
+        self.assertEqual(user_content[1], {"type": "text", "text": "Image from read_file: /images/photo.webp"})
+        self.assertEqual(user_content[2]["type"], "image_url")
+        self.assertTrue(user_content[2]["image_url"]["url"].startswith("data:image/webp;base64,"))
+
+    def test_prepare_multimodal_request_keeps_text_only_when_no_vision_config(self):
+        self._write_file(path="/images/photo.gif", content=b"gif", mime_type="image/gif")
+        step = self._create_read_file_step(path="/images/photo.gif")
+        attachments = collect_fresh_read_file_image_attachments(self.agent, {str(step.id)})
+        messages = [{"role": "user", "content": "Inspect it."}]
+        configs = [("text-primary", "model-a", {"supports_vision": False})]
+
+        updated_messages, updated_configs, attached = prepare_multimodal_read_file_request(
+            messages,
+            configs,
+            attachments,
+        )
+
+        self.assertFalse(attached)
+        self.assertEqual(updated_messages, messages)
+        self.assertEqual(updated_configs, configs)
+
+    @patch("api.agent.core.event_processing.get_llm_config_with_failover")
+    def test_orchestrator_can_fetch_uncapped_vision_configs_for_image_context(self, mock_get_configs):
+        from api.agent.core import event_processing
+
+        self._write_file(path="/images/photo.png", content=b"png", mime_type="image/png")
+        step = self._create_read_file_step(path="/images/photo.png")
+        attachments = collect_fresh_read_file_image_attachments(self.agent, {str(step.id)})
+        capped_configs = [("standard-text", "model-a", {"supports_vision": False})]
+        uncapped_configs = [
+            ("ultra-vision", "model-b", {"supports_vision": True}),
+            ("standard-text", "model-a", {"supports_vision": False}),
+        ]
+        mock_get_configs.return_value = uncapped_configs
+
+        candidate_configs = capped_configs
+        if not any(bool((params or {}).get("supports_vision")) for _, _, params in capped_configs):
+            candidate_configs = event_processing.get_llm_config_with_failover(
+                agent_id=str(self.agent.id),
+                token_count=123,
+                agent=self.agent,
+                is_first_loop=False,
+                routing_profile=None,
+                prefer_low_latency=False,
+                ignore_agent_tier_cap=True,
+            )
+        updated_messages, updated_configs, attached = prepare_multimodal_read_file_request(
+            [{"role": "user", "content": "Inspect it."}],
+            candidate_configs,
+            attachments,
+        )
+
+        self.assertTrue(attached)
+        self.assertEqual(updated_configs, [("ultra-vision", "model-b", {"supports_vision": True})])
+        self.assertEqual(updated_messages[0]["content"][2]["type"], "image_url")
+        mock_get_configs.assert_called_once_with(
+            agent_id=str(self.agent.id),
+            token_count=123,
+            agent=self.agent,
+            is_first_loop=False,
+            routing_profile=None,
+            prefer_low_latency=False,
+            ignore_agent_tier_cap=True,
+        )
+
+    def test_attach_read_file_images_to_messages_preserves_existing_list_content(self):
+        self._write_file(path="/images/photo.jpg", content=b"jpeg", mime_type="image/jpeg")
+        step = self._create_read_file_step(path="/images/photo.jpg")
+        attachments = collect_fresh_read_file_image_attachments(self.agent, {str(step.id)})
+        messages = [{"role": "user", "content": [{"type": "text", "text": "Existing"}]}]
+
+        updated_messages = attach_read_file_images_to_messages(messages, attachments)
+
+        self.assertEqual(updated_messages[0]["content"][0], {"type": "text", "text": "Existing"})
+        self.assertEqual(updated_messages[0]["content"][1]["text"], "Image from read_file: /images/photo.jpg")
+        self.assertEqual(updated_messages[0]["content"][2]["type"], "image_url")
+
+    def test_prompt_metadata_exposes_fresh_tool_call_step_ids(self):
+        step = self._create_read_file_step(path="/images/photo.png")
+
+        with patch("api.agent.core.prompt_context.ensure_steps_compacted"), patch(
+            "api.agent.core.prompt_context.ensure_comms_compacted"
+        ), patch(
+            "api.agent.core.prompt_context.get_llm_config_with_failover",
+            return_value=[("endpoint", "openai/gpt-4o-mini", {"allow_implied_send": True})],
+        ):
+            _context, _tokens, _archive_id, metadata = build_prompt_context(
+                self.agent,
+                include_metadata=True,
+            )
+
+        self.assertIn(str(step.id), metadata["fresh_tool_call_step_ids"])

--- a/tests/unit/test_multimodal_read_file_context.py
+++ b/tests/unit/test_multimodal_read_file_context.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 
+from api.agent.core.event_processing import _prepare_multimodal_read_file_completion_request
 from api.agent.core.multimodal_context import (
+    ReadFileImageAttachment,
     attach_read_file_images_to_messages,
     collect_fresh_read_file_image_attachments,
     filter_vision_capable_failover_configs,
@@ -93,6 +95,15 @@ class MultimodalReadFileContextTests(TestCase):
         self.assertEqual(attachments[0].path, "/images/photo.png")
         self.assertEqual(attachments[0].mime_type, "image/png")
         self.assertTrue(attachments[0].data_url.startswith("data:image/png;base64,"))
+
+    def test_collect_normalizes_unprefixed_read_file_paths(self):
+        self._write_file(path="/images/no-prefix.png", content=b"png", mime_type="image/png")
+        step = self._create_read_file_step(path="images/no-prefix.png")
+
+        attachments = collect_fresh_read_file_image_attachments(self.agent, {str(step.id)})
+
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0].path, "/images/no-prefix.png")
 
     def test_collects_multiple_fresh_images_with_cap(self):
         steps = []
@@ -188,8 +199,6 @@ class MultimodalReadFileContextTests(TestCase):
 
     @patch("api.agent.core.event_processing.get_llm_config_with_failover")
     def test_orchestrator_can_fetch_uncapped_vision_configs_for_image_context(self, mock_get_configs):
-        from api.agent.core import event_processing
-
         self._write_file(path="/images/photo.png", content=b"png", mime_type="image/png")
         step = self._create_read_file_step(path="/images/photo.png")
         attachments = collect_fresh_read_file_image_attachments(self.agent, {str(step.id)})
@@ -200,21 +209,15 @@ class MultimodalReadFileContextTests(TestCase):
         ]
         mock_get_configs.return_value = uncapped_configs
 
-        candidate_configs = capped_configs
-        if not any(bool((params or {}).get("supports_vision")) for _, _, params in capped_configs):
-            candidate_configs = event_processing.get_llm_config_with_failover(
-                agent_id=str(self.agent.id),
-                token_count=123,
-                agent=self.agent,
-                is_first_loop=False,
-                routing_profile=None,
-                prefer_low_latency=False,
-                ignore_agent_tier_cap=True,
-            )
-        updated_messages, updated_configs, attached = prepare_multimodal_read_file_request(
-            [{"role": "user", "content": "Inspect it."}],
-            candidate_configs,
-            attachments,
+        updated_messages, updated_configs, attached = _prepare_multimodal_read_file_completion_request(
+            agent=self.agent,
+            history=[{"role": "user", "content": "Inspect it."}],
+            failover_configs=capped_configs,
+            image_attachments=attachments,
+            fitted_token_count=123,
+            is_first_run=False,
+            routing_profile=None,
+            prefer_low_latency=False,
         )
 
         self.assertTrue(attached)
@@ -229,6 +232,34 @@ class MultimodalReadFileContextTests(TestCase):
             prefer_low_latency=False,
             ignore_agent_tier_cap=True,
         )
+
+    @patch("api.agent.core.event_processing.get_llm_config_with_failover")
+    def test_orchestrator_keeps_capped_configs_when_uncapped_search_has_no_vision(self, mock_get_configs):
+        capped_configs = [("standard-text", "model-a", {"supports_vision": False})]
+        mock_get_configs.return_value = [("ultra-text", "model-b", {"supports_vision": False})]
+        attachments = [
+            ReadFileImageAttachment(
+                path="/images/photo.png",
+                mime_type="image/png",
+                data_url="data:image/png;base64,cG5n",
+            )
+        ]
+        history = [{"role": "user", "content": "Inspect it."}]
+
+        updated_messages, updated_configs, attached = _prepare_multimodal_read_file_completion_request(
+            agent=self.agent,
+            history=history,
+            failover_configs=capped_configs,
+            image_attachments=attachments,
+            fitted_token_count=123,
+            is_first_run=False,
+            routing_profile=None,
+            prefer_low_latency=False,
+        )
+
+        self.assertFalse(attached)
+        self.assertEqual(updated_messages, history)
+        self.assertEqual(updated_configs, capped_configs)
 
     def test_attach_read_file_images_to_messages_preserves_existing_list_content(self):
         self._write_file(path="/images/photo.jpg", content=b"jpeg", mime_type="image/jpeg")


### PR DESCRIPTION
## Summary
- Detect fresh `read_file` image outputs and attach them to the next orchestrator request as multimodal context
- Allow special-purpose failover selection to bypass the agent tier cap when a vision-capable endpoint is needed
- Add prompt-context plumbing so fresh tool-call step IDs flow into request preparation
- Cover image collection, multimodal request shaping, and tier-cap override behavior with unit tests

## Testing
- Added focused unit coverage for multimodal `read_file` attachment collection and request preparation
- Added unit coverage for uncapped failover selection including a higher-tier vision endpoint
- Not run (not requested)