### PR TITLE
Add ephemeral __contacts SQLite snapshot for effective contact authority

### DIFF
--- a/api/agent/core/contact_results.py
+++ b/api/agent/core/contact_results.py
@@ -1,0 +1,120 @@
+import logging
+import sqlite3
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from ..tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
+from ..tools.sqlite_state import CONTACTS_TABLE, get_sqlite_db_path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ContactSQLiteRecord:
+    contact_id: str
+    channel: str
+    address: str
+    normalized_address: str
+    display_name: str
+    source: str
+    status: str
+    allow_inbound: bool
+    allow_outbound: bool
+    can_configure: bool
+    requested_at: Optional[str]
+    responded_at: Optional[str]
+    updated_at: Optional[str]
+
+
+def store_contacts_for_prompt(records: Sequence[ContactSQLiteRecord]) -> None:
+    """Store a per-cycle contact authority snapshot in SQLite for agent querying."""
+    db_path = get_sqlite_db_path()
+    if not db_path:
+        logger.warning("SQLite DB path unavailable; contacts snapshot not stored.")
+        return
+
+    conn = None
+    try:
+        conn = open_guarded_sqlite_connection(db_path)
+        _recreate_contacts_table(conn)
+        rows = []
+        for record in records:
+            rows.append(
+                (
+                    record.contact_id,
+                    record.channel,
+                    record.address or "",
+                    record.normalized_address or "",
+                    record.display_name or "",
+                    record.source,
+                    record.status,
+                    1 if record.allow_inbound else 0,
+                    1 if record.allow_outbound else 0,
+                    1 if record.can_configure else 0,
+                    record.requested_at,
+                    record.responded_at,
+                    record.updated_at,
+                )
+            )
+        if rows:
+            conn.executemany(
+                f"""
+                INSERT INTO "{CONTACTS_TABLE}" (
+                    contact_id,
+                    channel,
+                    address,
+                    normalized_address,
+                    display_name,
+                    source,
+                    status,
+                    allow_inbound,
+                    allow_outbound,
+                    can_configure,
+                    requested_at,
+                    responded_at,
+                    updated_at
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+                """,
+                rows,
+            )
+        conn.commit()
+    except (OSError, sqlite3.Error):
+        logger.exception("Failed to store contacts in SQLite.")
+    finally:
+        if conn is not None:
+            clear_guarded_connection(conn)
+            try:
+                conn.close()
+            except sqlite3.Error:
+                logger.warning("Failed to close SQLite connection during cleanup.", exc_info=True)
+
+
+def _recreate_contacts_table(conn) -> None:
+    conn.execute(f'DROP TABLE IF EXISTS "{CONTACTS_TABLE}";')
+    conn.execute(
+        f"""
+        CREATE TABLE "{CONTACTS_TABLE}" (
+            contact_id TEXT,
+            channel TEXT,
+            address TEXT,
+            normalized_address TEXT,
+            display_name TEXT,
+            source TEXT,
+            status TEXT,
+            allow_inbound INTEGER,
+            allow_outbound INTEGER,
+            can_configure INTEGER,
+            requested_at TEXT,
+            responded_at TEXT,
+            updated_at TEXT
+        );
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE INDEX "{CONTACTS_TABLE}_channel_address_idx"
+        ON "{CONTACTS_TABLE}" (channel, normalized_address);
+        """
+    )

--- a/api/agent/core/contact_snapshot.py
+++ b/api/agent/core/contact_snapshot.py
@@ -1,0 +1,241 @@
+from email.utils import parseaddr
+from typing import Callable, List
+
+from api.services.email_verification import has_verified_email
+from api.services.organization_permissions import ORG_AGENT_CONFIG_AUTHORITY_ROLES
+
+from ...models import (
+    AgentCollaborator,
+    CommsAllowlistEntry,
+    CommsAllowlistRequest,
+    CommsChannel,
+    OrganizationMembership,
+    PersistentAgent,
+    UserPhoneNumber,
+)
+from .contact_results import ContactSQLiteRecord
+
+DisplayNameFn = Callable[[object], str | None]
+CanConfigureFn = Callable[[int | None], bool]
+
+
+def normalize_contact_address(channel: str, address: str) -> str:
+    raw = (address or "").strip()
+    if channel == CommsChannel.EMAIL:
+        return (parseaddr(raw)[1] or raw).strip().lower()
+    return raw
+
+
+def build_contacts_snapshot_records(
+    agent: PersistentAgent,
+    *,
+    display_name_for_user: DisplayNameFn,
+    user_can_configure: CanConfigureFn,
+) -> List[ContactSQLiteRecord]:
+    allowed_records: dict[tuple[str, str], ContactSQLiteRecord] = {}
+    owner_email_verified = has_verified_email(agent.user) if agent.user else False
+
+    def add_allowed(record: ContactSQLiteRecord) -> None:
+        if record.normalized_address:
+            allowed_records[(record.channel, record.normalized_address)] = record
+
+    if owner_email_verified and agent.user and agent.user.email:
+        add_allowed(
+            _contact_record(
+                contact_id=f"owner:email:{agent.user_id}",
+                channel=CommsChannel.EMAIL,
+                address=agent.user.email,
+                display_name=display_name_for_user(agent.user) or "",
+                source="owner",
+                status="allowed",
+                allow_inbound=True,
+                allow_outbound=True,
+                can_configure=user_can_configure(agent.user_id),
+            )
+        )
+        owner_phones = UserPhoneNumber.objects.filter(
+            user=agent.user,
+            is_verified=True,
+        ).order_by("phone_number")
+        for phone in owner_phones:
+            add_allowed(
+                _contact_record(
+                    contact_id=f"owner:sms:{phone.id}",
+                    channel=CommsChannel.SMS,
+                    address=phone.phone_number,
+                    display_name=display_name_for_user(agent.user) or "",
+                    source="owner",
+                    status="allowed",
+                    allow_inbound=True,
+                    allow_outbound=True,
+                    can_configure=user_can_configure(agent.user_id),
+                )
+            )
+
+    if owner_email_verified and agent.organization_id:
+        org_user_ids: list[int] = []
+        memberships = (
+            OrganizationMembership.objects.filter(
+                org_id=agent.organization_id,
+                status=OrganizationMembership.OrgStatus.ACTIVE,
+                user__email__isnull=False,
+            )
+            .exclude(user__email="")
+            .select_related("user")
+            .order_by("user__email")
+        )
+        for membership in memberships:
+            org_user_ids.append(membership.user_id)
+            add_allowed(
+                _contact_record(
+                    contact_id=f"org_member:email:{membership.id}",
+                    channel=CommsChannel.EMAIL,
+                    address=membership.user.email,
+                    display_name=display_name_for_user(membership.user) or "",
+                    source="org_member",
+                    status="allowed",
+                    allow_inbound=True,
+                    allow_outbound=True,
+                    can_configure=membership.role in ORG_AGENT_CONFIG_AUTHORITY_ROLES,
+                )
+            )
+
+        org_phones = (
+            UserPhoneNumber.objects.filter(
+                user_id__in=org_user_ids,
+                is_verified=True,
+            )
+            .select_related("user")
+            .order_by("phone_number")
+        )
+        for phone in org_phones:
+            add_allowed(
+                _contact_record(
+                    contact_id=f"org_member:sms:{phone.id}",
+                    channel=CommsChannel.SMS,
+                    address=phone.phone_number,
+                    display_name=display_name_for_user(phone.user) or "",
+                    source="org_member",
+                    status="allowed",
+                    allow_inbound=True,
+                    allow_outbound=False,
+                    can_configure=user_can_configure(phone.user_id),
+                )
+            )
+
+    if owner_email_verified:
+        collaborators = (
+            AgentCollaborator.objects.filter(agent=agent, user__email__isnull=False)
+            .exclude(user__email="")
+            .select_related("user")
+            .order_by("user__email")
+        )
+        for collaborator in collaborators:
+            add_allowed(
+                _contact_record(
+                    contact_id=f"collaborator:email:{collaborator.id}",
+                    channel=CommsChannel.EMAIL,
+                    address=collaborator.user.email,
+                    display_name=display_name_for_user(collaborator.user) or "",
+                    source="collaborator",
+                    status="allowed",
+                    allow_inbound=True,
+                    allow_outbound=True,
+                    can_configure=user_can_configure(collaborator.user_id),
+                    updated_at=collaborator.created_at.isoformat() if collaborator.created_at else None,
+                )
+            )
+
+        allowlist_entries = (
+            CommsAllowlistEntry.objects.filter(agent=agent, is_active=True)
+            .order_by("channel", "address")
+        )
+        for entry in allowlist_entries:
+            add_allowed(
+                _contact_record(
+                    contact_id=f"allowlist_entry:{entry.id}",
+                    channel=entry.channel,
+                    address=entry.address,
+                    source="allowlist_entry",
+                    status="allowed",
+                    allow_inbound=entry.allow_inbound,
+                    allow_outbound=entry.allow_outbound,
+                    can_configure=entry.can_configure,
+                    updated_at=entry.updated_at.isoformat() if entry.updated_at else None,
+                )
+            )
+
+    records = dict(allowed_records)
+    contact_requests = (
+        CommsAllowlistRequest.objects.filter(agent=agent)
+        .order_by("-requested_at")
+    )
+    for request in contact_requests:
+        request_record = _contact_record(
+            contact_id=f"contact_request:{request.id}",
+            channel=request.channel,
+            address=request.address,
+            display_name=request.name or "",
+            source="contact_request",
+            status=_contact_request_status(request),
+            allow_inbound=False,
+            allow_outbound=False,
+            can_configure=False,
+            requested_at=request.requested_at.isoformat() if request.requested_at else None,
+            responded_at=request.responded_at.isoformat() if request.responded_at else None,
+            updated_at=request.responded_at.isoformat() if request.responded_at else (
+                request.requested_at.isoformat() if request.requested_at else None
+            ),
+        )
+        key = (request_record.channel, request_record.normalized_address)
+        if request_record.normalized_address and key not in allowed_records and key not in records:
+            records[key] = request_record
+
+    return sorted(
+        records.values(),
+        key=lambda record: (record.channel, record.normalized_address, record.source),
+    )
+
+
+def _contact_record(
+    *,
+    contact_id: str,
+    channel: str,
+    address: str,
+    display_name: str = "",
+    source: str,
+    status: str,
+    allow_inbound: bool,
+    allow_outbound: bool,
+    can_configure: bool = False,
+    requested_at: str | None = None,
+    responded_at: str | None = None,
+    updated_at: str | None = None,
+) -> ContactSQLiteRecord:
+    return ContactSQLiteRecord(
+        contact_id=contact_id,
+        channel=channel,
+        address=(address or "").strip(),
+        normalized_address=normalize_contact_address(channel, address),
+        display_name=display_name or "",
+        source=source,
+        status=status,
+        allow_inbound=allow_inbound,
+        allow_outbound=allow_outbound,
+        can_configure=can_configure,
+        requested_at=requested_at,
+        responded_at=responded_at,
+        updated_at=updated_at,
+    )
+
+
+def _contact_request_status(request: CommsAllowlistRequest) -> str:
+    if request.status == CommsAllowlistRequest.RequestStatus.PENDING:
+        return "expired_request" if request.is_expired() else "pending_request"
+    if request.status == CommsAllowlistRequest.RequestStatus.REJECTED:
+        return "rejected_request"
+    if request.status == CommsAllowlistRequest.RequestStatus.EXPIRED:
+        return "expired_request"
+    if request.status == CommsAllowlistRequest.RequestStatus.APPROVED:
+        return "approved_missing_allowlist"
+    return f"{request.status}_request"

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -48,7 +48,9 @@ from ...models import (
     BrowserUseAgentTaskStep,
     build_web_user_address,
     parse_web_user_address,
+    AgentCollaborator,
     CommsAllowlistEntry,
+    CommsAllowlistRequest,
     CommsChannel,
     PersistentAgent,
     PersistentAgentCommsEndpoint,
@@ -94,6 +96,7 @@ from ..tools.static_tools import get_static_tool_definitions
 from ..tools.sqlite_state import (
     AGENT_CONFIG_TABLE,
     AGENT_SKILLS_TABLE,
+    CONTACTS_TABLE,
     FILES_TABLE,
     get_sqlite_digest_prompt,
     get_sqlite_schema_prompt,
@@ -113,6 +116,7 @@ from .tool_results import (
     prepare_tool_results_for_prompt,
 )
 from .daily_limit_mode import is_daily_hard_limit_message_only_mode
+from .contact_results import ContactSQLiteRecord, store_contacts_for_prompt
 from .file_results import FileSQLiteRecord, store_files_for_prompt
 from .message_results import MessageSQLiteRecord, store_messages_for_prompt
 from api.services.email_verification import has_verified_email
@@ -133,6 +137,8 @@ SIGNED_FILES_URL_RE = re.compile(
 )
 SQLITE_MESSAGES_SNAPSHOT_MAX_BYTES = 5_000_000
 SQLITE_MESSAGES_SNAPSHOT_MAX_RECORDS = 10_000
+CONTACT_PROMPT_INLINE_LIMIT = 25
+CONTACT_PROMPT_SAMPLE_LIMIT = 10
 MESSAGE_ONLY_TOOL_NAMES_TEXT = (
     "send_email, send_sms, send_chat_message, and send_agent_message"
 )
@@ -615,6 +621,8 @@ columns: result_id, tool_name, created_at, result_json, result_text, analysis_js
 columns include message_id, seq, timestamp, channel, is_outbound, from_address, to_address, subject, body, body_bytes, body_is_truncated, attachment_paths_json, attachment_count, rejected_attachments_json, latest_status, latest_sent_at, latest_delivered_at, latest_error_message. message_id is the internal Gobii id accepted by send_email.reply_to_message_id. attachments → SELECT message_id, value AS path FROM __messages, json_each(attachment_paths_json). Use __messages only for structured analysis/history, not freshness checks.
 # __files (special table; metadata only)
 columns: node_id, filespace_id, path, name, parent_path, mime_type, size_bytes, checksum_sha256, created_at, updated_at. recent_files → SELECT * FROM __files ORDER BY updated_at DESC LIMIT 30. metadata only; read_file gets contents.
+# __contacts (special table)
+columns: contact_id, channel, address, normalized_address, display_name, source, status, allow_inbound, allow_outbound, can_configure, requested_at, responded_at, updated_at. Safe outbound recipients require status='allowed' AND allow_outbound=1. Bulk outreach join example: lower(leads.email)=__contacts.normalized_address AND __contacts.channel='email' AND __contacts.status='allowed' AND __contacts.allow_outbound=1. Do not infer approval from local lead status or an empty pending request queue.
 # JSON: path from hint, field from hint
 hint PATH $.data.items → json_each(result_json, '$.data.items'). hint FIELDS name,url → json_extract(r.value, '$.name'), json_extract(r.value, '$.url'). hint absent → inspect result_text/result_json first.
 ## CSV Parsing
@@ -1433,6 +1441,7 @@ def _render_prompt_context_once(
 
     # Contacts block - use promptree natively
     recent_contacts_text = _build_contacts_block(agent, important_group, span, config_authority)
+    store_contacts_for_prompt(_build_sqlite_contacts_snapshot_records(agent, config_authority))
     _build_webhooks_block(agent, important_group, span)
     _build_mcp_servers_block(agent, important_group, span)
 
@@ -1573,11 +1582,14 @@ def _render_prompt_context_once(
 
     sqlite_note = (
         "SQLite is always available. Snapshots: __tool_results for prior outputs, "
-        f"__messages for recent comms, {FILES_TABLE} for file metadata. "
+        f"__messages for recent comms, {FILES_TABLE} for file metadata, "
+        f"{CONTACTS_TABLE} for effective contacts/contact requests. "
         "Use sqlite_batch for filtering, joins, aggregation, charts, large/truncated data, or durable tables. "
         "Multiple prior outputs: query rows together with IN/CTEs/json_each or CREATE TABLE AS SELECT; do not read one result_text blob per source. "
         "Use __messages for structured history only, not freshness checks. "
-        "Use read_file for contents of known filespace paths; use sqlite_batch on __tool_results or __files only for prior tool outputs or file metadata."
+        f"For bulk or exact recipient checks, join against {CONTACTS_TABLE} where status='allowed' and allow_outbound=1; "
+        "do not infer approval from local lead status or an empty pending contact queue. "
+        "Use read_file for contents of known filespace paths; use sqlite_batch on __tool_results, __files, or __contacts only for prior outputs, file metadata, or contact authority."
     )
     variable_group.section_text(
         "sqlite_note",
@@ -2089,6 +2101,267 @@ class _ConfigAuthorityResolver:
         return can_configure
 
 
+def _normalize_contact_address(channel: str, address: str) -> str:
+    raw = (address or "").strip()
+    if channel == CommsChannel.EMAIL:
+        return (parseaddr(raw)[1] or raw).strip().lower()
+    return raw
+
+
+def _contact_record_key(record: ContactSQLiteRecord) -> tuple[str, str]:
+    return record.channel, record.normalized_address
+
+
+def _contact_record_priority(record: ContactSQLiteRecord) -> int:
+    if record.status == "allowed":
+        if record.source == "owner":
+            return 100
+        if record.source == "org_member":
+            return 90
+        if record.source == "collaborator":
+            return 80
+        return 70
+    if record.status == "approved_request_no_active_entry":
+        return 40
+    if record.status == "pending_request":
+        return 30
+    if record.status == "rejected_request":
+        return 20
+    if record.status == "expired_request":
+        return 10
+    if record.status == "inactive":
+        return 5
+    return 0
+
+
+def _put_contact_record(
+    records_by_key: dict[tuple[str, str], ContactSQLiteRecord],
+    record: ContactSQLiteRecord,
+) -> None:
+    key = _contact_record_key(record)
+    if not key[1]:
+        return
+    existing = records_by_key.get(key)
+    if existing is None or _contact_record_priority(record) > _contact_record_priority(existing):
+        records_by_key[key] = record
+
+
+def _contact_record(
+    *,
+    contact_id: str,
+    channel: str,
+    address: str,
+    display_name: str = "",
+    source: str,
+    status: str,
+    allow_inbound: bool,
+    allow_outbound: bool,
+    can_configure: bool = False,
+    requested_at: Optional[str] = None,
+    responded_at: Optional[str] = None,
+    updated_at: Optional[str] = None,
+) -> ContactSQLiteRecord:
+    return ContactSQLiteRecord(
+        contact_id=contact_id,
+        channel=channel,
+        address=(address or "").strip(),
+        normalized_address=_normalize_contact_address(channel, address),
+        display_name=display_name or "",
+        source=source,
+        status=status,
+        allow_inbound=allow_inbound,
+        allow_outbound=allow_outbound,
+        can_configure=can_configure,
+        requested_at=requested_at,
+        responded_at=responded_at,
+        updated_at=updated_at,
+    )
+
+
+def _contact_request_status(request: CommsAllowlistRequest) -> str:
+    if request.status == CommsAllowlistRequest.RequestStatus.PENDING:
+        return "expired_request" if request.is_expired() else "pending_request"
+    if request.status == CommsAllowlistRequest.RequestStatus.REJECTED:
+        return "rejected_request"
+    if request.status == CommsAllowlistRequest.RequestStatus.EXPIRED:
+        return "expired_request"
+    if request.status == CommsAllowlistRequest.RequestStatus.APPROVED:
+        return "approved_request_no_active_entry"
+    return f"{request.status}_request"
+
+
+def _build_sqlite_contacts_snapshot_records(
+    agent: PersistentAgent,
+    config_authority: _ConfigAuthorityResolver,
+) -> List[ContactSQLiteRecord]:
+    records_by_key: dict[tuple[str, str], ContactSQLiteRecord] = {}
+    owner_email_verified = has_verified_email(agent.user) if agent.user else False
+
+    if owner_email_verified and agent.user and agent.user.email:
+        _put_contact_record(
+            records_by_key,
+            _contact_record(
+                contact_id=f"owner:email:{agent.user_id}",
+                channel=CommsChannel.EMAIL,
+                address=agent.user.email,
+                display_name=_build_user_display_name(agent.user) or "",
+                source="owner",
+                status="allowed",
+                allow_inbound=True,
+                allow_outbound=True,
+                can_configure=config_authority.user_can_configure(agent.user_id),
+            ),
+        )
+        owner_phones = UserPhoneNumber.objects.filter(
+            user=agent.user,
+            is_verified=True,
+        ).order_by("phone_number")
+        for phone in owner_phones:
+            _put_contact_record(
+                records_by_key,
+                _contact_record(
+                    contact_id=f"owner:sms:{phone.id}",
+                    channel=CommsChannel.SMS,
+                    address=phone.phone_number,
+                    display_name=_build_user_display_name(agent.user) or "",
+                    source="owner",
+                    status="allowed",
+                    allow_inbound=True,
+                    allow_outbound=True,
+                    can_configure=config_authority.user_can_configure(agent.user_id),
+                ),
+            )
+
+    if owner_email_verified and agent.organization_id:
+        memberships = (
+            OrganizationMembership.objects.filter(
+                org_id=agent.organization_id,
+                status=OrganizationMembership.OrgStatus.ACTIVE,
+                user__email__isnull=False,
+            )
+            .exclude(user__email="")
+            .select_related("user")
+            .order_by("user__email")
+        )
+        org_user_ids: list[int] = []
+        for membership in memberships:
+            org_user_ids.append(membership.user_id)
+            role_can_configure = membership.role in ORG_AGENT_CONFIG_AUTHORITY_ROLES
+            _put_contact_record(
+                records_by_key,
+                _contact_record(
+                    contact_id=f"org_member:email:{membership.id}",
+                    channel=CommsChannel.EMAIL,
+                    address=membership.user.email,
+                    display_name=_build_user_display_name(membership.user) or "",
+                    source="org_member",
+                    status="allowed",
+                    allow_inbound=True,
+                    allow_outbound=True,
+                    can_configure=role_can_configure,
+                ),
+            )
+
+        org_phones = (
+            UserPhoneNumber.objects.filter(
+                user_id__in=org_user_ids,
+                is_verified=True,
+            )
+            .select_related("user")
+            .order_by("phone_number")
+        )
+        for phone in org_phones:
+            _put_contact_record(
+                records_by_key,
+                _contact_record(
+                    contact_id=f"org_member:sms:{phone.id}",
+                    channel=CommsChannel.SMS,
+                    address=phone.phone_number,
+                    display_name=_build_user_display_name(phone.user) or "",
+                    source="org_member",
+                    status="allowed",
+                    allow_inbound=True,
+                    allow_outbound=False,
+                    can_configure=config_authority.user_can_configure(phone.user_id),
+                ),
+            )
+
+    if owner_email_verified:
+        collaborators = (
+            AgentCollaborator.objects.filter(agent=agent, user__email__isnull=False)
+            .exclude(user__email="")
+            .select_related("user")
+            .order_by("user__email")
+        )
+        for collaborator in collaborators:
+            _put_contact_record(
+                records_by_key,
+                _contact_record(
+                    contact_id=f"collaborator:email:{collaborator.id}",
+                    channel=CommsChannel.EMAIL,
+                    address=collaborator.user.email,
+                    display_name=_build_user_display_name(collaborator.user) or "",
+                    source="collaborator",
+                    status="allowed",
+                    allow_inbound=True,
+                    allow_outbound=True,
+                    can_configure=config_authority.user_can_configure(collaborator.user_id),
+                    updated_at=collaborator.created_at.isoformat() if collaborator.created_at else None,
+                ),
+            )
+
+        allowlist_entries = (
+            CommsAllowlistEntry.objects.filter(agent=agent)
+            .order_by("-is_active", "channel", "address")
+        )
+        for entry in allowlist_entries:
+            status = "allowed" if entry.is_active else "inactive"
+            _put_contact_record(
+                records_by_key,
+                _contact_record(
+                    contact_id=f"allowlist_entry:{entry.id}",
+                    channel=entry.channel,
+                    address=entry.address,
+                    source="allowlist_entry",
+                    status=status,
+                    allow_inbound=entry.allow_inbound if entry.is_active else False,
+                    allow_outbound=entry.allow_outbound if entry.is_active else False,
+                    can_configure=entry.can_configure if entry.is_active else False,
+                    updated_at=entry.updated_at.isoformat() if entry.updated_at else None,
+                ),
+            )
+
+    contact_requests = (
+        CommsAllowlistRequest.objects.filter(agent=agent)
+        .order_by("-requested_at")
+    )
+    for request in contact_requests:
+        _put_contact_record(
+            records_by_key,
+            _contact_record(
+                contact_id=f"contact_request:{request.id}",
+                channel=request.channel,
+                address=request.address,
+                display_name=request.name or "",
+                source="contact_request",
+                status=_contact_request_status(request),
+                allow_inbound=False,
+                allow_outbound=False,
+                can_configure=False,
+                requested_at=request.requested_at.isoformat() if request.requested_at else None,
+                responded_at=request.responded_at.isoformat() if request.responded_at else None,
+                updated_at=request.responded_at.isoformat() if request.responded_at else (
+                    request.requested_at.isoformat() if request.requested_at else None
+                ),
+            ),
+        )
+
+    return sorted(
+        records_by_key.values(),
+        key=lambda record: (record.channel, record.normalized_address, record.source),
+    )
+
+
 def _get_interacted_web_user_info_by_endpoint(
     agent: PersistentAgent,
     endpoints: Sequence[PersistentAgentCommsEndpoint],
@@ -2469,9 +2742,8 @@ def _build_contacts_block(
         )
 
     # Add explicitly allowed contacts from CommsAllowlistEntry (only if verified)
-    from api.models import AgentCollaborator
     if owner_email_verified:
-        allowed_contacts = (
+        allowed_contacts = list(
             CommsAllowlistEntry.objects.filter(
                 agent=agent,
                 is_active=True,
@@ -2480,7 +2752,14 @@ def _build_contacts_block(
         )
         if allowed_contacts:
             allowed_lines.append("Additional allowed contacts (inbound = can receive from them; outbound = can send to them):")
-            for entry in allowed_contacts:
+            display_contacts = allowed_contacts
+            if len(allowed_contacts) > CONTACT_PROMPT_INLINE_LIMIT:
+                allowed_lines.append(
+                    f"- {len(allowed_contacts)} active contacts are available; query {CONTACTS_TABLE} for the complete exact list."
+                )
+                display_contacts = allowed_contacts[:CONTACT_PROMPT_SAMPLE_LIMIT]
+                allowed_lines.append(f"Sample active contacts (first {len(display_contacts)}):")
+            for entry in display_contacts:
                 name_str = f" ({entry.name})" if hasattr(entry, "name") and entry.name else ""
                 config_marker = " [can configure]" if entry.can_configure else ""
                 perms = ("inbound" if entry.allow_inbound else "") + ("/" if entry.allow_inbound and entry.allow_outbound else "") + ("outbound" if entry.allow_outbound else "")
@@ -2499,6 +2778,9 @@ def _build_contacts_block(
 
     if owner_email_verified:
         allowed_lines.append("Only contact people listed here or in recent conversations.")
+        allowed_lines.append(
+            f"For bulk or exact recipient checks, query {CONTACTS_TABLE}; safe outbound recipients have status='allowed' AND allow_outbound=1. Do not infer approval from local lead status or an empty pending contacts queue."
+        )
         allowed_lines.append("To reach someone new, use request_contact_permission—it returns a link to share with the user.")
         allowed_lines.append(
             "If the user asks you to email or text a specific new address or phone number, request contact permission before reading files, searching, drafting, tool search, or asking non-blocking follow-up questions."

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -50,7 +50,6 @@ from ...models import (
     parse_web_user_address,
     AgentCollaborator,
     CommsAllowlistEntry,
-    CommsAllowlistRequest,
     CommsChannel,
     PersistentAgent,
     PersistentAgentCommsEndpoint,
@@ -116,7 +115,8 @@ from .tool_results import (
     prepare_tool_results_for_prompt,
 )
 from .daily_limit_mode import is_daily_hard_limit_message_only_mode
-from .contact_results import ContactSQLiteRecord, store_contacts_for_prompt
+from .contact_results import store_contacts_for_prompt
+from .contact_snapshot import build_contacts_snapshot_records
 from .file_results import FileSQLiteRecord, store_files_for_prompt
 from .message_results import MessageSQLiteRecord, store_messages_for_prompt
 from api.services.email_verification import has_verified_email
@@ -1441,7 +1441,13 @@ def _render_prompt_context_once(
 
     # Contacts block - use promptree natively
     recent_contacts_text = _build_contacts_block(agent, important_group, span, config_authority)
-    store_contacts_for_prompt(_build_sqlite_contacts_snapshot_records(agent, config_authority))
+    store_contacts_for_prompt(
+        build_contacts_snapshot_records(
+            agent,
+            display_name_for_user=_build_user_display_name,
+            user_can_configure=config_authority.user_can_configure,
+        )
+    )
     _build_webhooks_block(agent, important_group, span)
     _build_mcp_servers_block(agent, important_group, span)
 
@@ -2099,267 +2105,6 @@ class _ConfigAuthorityResolver:
         can_configure = self.address_can_configure(endpoint.channel, endpoint.address)
         self.endpoint_cache[endpoint.id] = can_configure
         return can_configure
-
-
-def _normalize_contact_address(channel: str, address: str) -> str:
-    raw = (address or "").strip()
-    if channel == CommsChannel.EMAIL:
-        return (parseaddr(raw)[1] or raw).strip().lower()
-    return raw
-
-
-def _contact_record_key(record: ContactSQLiteRecord) -> tuple[str, str]:
-    return record.channel, record.normalized_address
-
-
-def _contact_record_priority(record: ContactSQLiteRecord) -> int:
-    if record.status == "allowed":
-        if record.source == "owner":
-            return 100
-        if record.source == "org_member":
-            return 90
-        if record.source == "collaborator":
-            return 80
-        return 70
-    if record.status == "approved_request_no_active_entry":
-        return 40
-    if record.status == "pending_request":
-        return 30
-    if record.status == "rejected_request":
-        return 20
-    if record.status == "expired_request":
-        return 10
-    if record.status == "inactive":
-        return 5
-    return 0
-
-
-def _put_contact_record(
-    records_by_key: dict[tuple[str, str], ContactSQLiteRecord],
-    record: ContactSQLiteRecord,
-) -> None:
-    key = _contact_record_key(record)
-    if not key[1]:
-        return
-    existing = records_by_key.get(key)
-    if existing is None or _contact_record_priority(record) > _contact_record_priority(existing):
-        records_by_key[key] = record
-
-
-def _contact_record(
-    *,
-    contact_id: str,
-    channel: str,
-    address: str,
-    display_name: str = "",
-    source: str,
-    status: str,
-    allow_inbound: bool,
-    allow_outbound: bool,
-    can_configure: bool = False,
-    requested_at: Optional[str] = None,
-    responded_at: Optional[str] = None,
-    updated_at: Optional[str] = None,
-) -> ContactSQLiteRecord:
-    return ContactSQLiteRecord(
-        contact_id=contact_id,
-        channel=channel,
-        address=(address or "").strip(),
-        normalized_address=_normalize_contact_address(channel, address),
-        display_name=display_name or "",
-        source=source,
-        status=status,
-        allow_inbound=allow_inbound,
-        allow_outbound=allow_outbound,
-        can_configure=can_configure,
-        requested_at=requested_at,
-        responded_at=responded_at,
-        updated_at=updated_at,
-    )
-
-
-def _contact_request_status(request: CommsAllowlistRequest) -> str:
-    if request.status == CommsAllowlistRequest.RequestStatus.PENDING:
-        return "expired_request" if request.is_expired() else "pending_request"
-    if request.status == CommsAllowlistRequest.RequestStatus.REJECTED:
-        return "rejected_request"
-    if request.status == CommsAllowlistRequest.RequestStatus.EXPIRED:
-        return "expired_request"
-    if request.status == CommsAllowlistRequest.RequestStatus.APPROVED:
-        return "approved_request_no_active_entry"
-    return f"{request.status}_request"
-
-
-def _build_sqlite_contacts_snapshot_records(
-    agent: PersistentAgent,
-    config_authority: _ConfigAuthorityResolver,
-) -> List[ContactSQLiteRecord]:
-    records_by_key: dict[tuple[str, str], ContactSQLiteRecord] = {}
-    owner_email_verified = has_verified_email(agent.user) if agent.user else False
-
-    if owner_email_verified and agent.user and agent.user.email:
-        _put_contact_record(
-            records_by_key,
-            _contact_record(
-                contact_id=f"owner:email:{agent.user_id}",
-                channel=CommsChannel.EMAIL,
-                address=agent.user.email,
-                display_name=_build_user_display_name(agent.user) or "",
-                source="owner",
-                status="allowed",
-                allow_inbound=True,
-                allow_outbound=True,
-                can_configure=config_authority.user_can_configure(agent.user_id),
-            ),
-        )
-        owner_phones = UserPhoneNumber.objects.filter(
-            user=agent.user,
-            is_verified=True,
-        ).order_by("phone_number")
-        for phone in owner_phones:
-            _put_contact_record(
-                records_by_key,
-                _contact_record(
-                    contact_id=f"owner:sms:{phone.id}",
-                    channel=CommsChannel.SMS,
-                    address=phone.phone_number,
-                    display_name=_build_user_display_name(agent.user) or "",
-                    source="owner",
-                    status="allowed",
-                    allow_inbound=True,
-                    allow_outbound=True,
-                    can_configure=config_authority.user_can_configure(agent.user_id),
-                ),
-            )
-
-    if owner_email_verified and agent.organization_id:
-        memberships = (
-            OrganizationMembership.objects.filter(
-                org_id=agent.organization_id,
-                status=OrganizationMembership.OrgStatus.ACTIVE,
-                user__email__isnull=False,
-            )
-            .exclude(user__email="")
-            .select_related("user")
-            .order_by("user__email")
-        )
-        org_user_ids: list[int] = []
-        for membership in memberships:
-            org_user_ids.append(membership.user_id)
-            role_can_configure = membership.role in ORG_AGENT_CONFIG_AUTHORITY_ROLES
-            _put_contact_record(
-                records_by_key,
-                _contact_record(
-                    contact_id=f"org_member:email:{membership.id}",
-                    channel=CommsChannel.EMAIL,
-                    address=membership.user.email,
-                    display_name=_build_user_display_name(membership.user) or "",
-                    source="org_member",
-                    status="allowed",
-                    allow_inbound=True,
-                    allow_outbound=True,
-                    can_configure=role_can_configure,
-                ),
-            )
-
-        org_phones = (
-            UserPhoneNumber.objects.filter(
-                user_id__in=org_user_ids,
-                is_verified=True,
-            )
-            .select_related("user")
-            .order_by("phone_number")
-        )
-        for phone in org_phones:
-            _put_contact_record(
-                records_by_key,
-                _contact_record(
-                    contact_id=f"org_member:sms:{phone.id}",
-                    channel=CommsChannel.SMS,
-                    address=phone.phone_number,
-                    display_name=_build_user_display_name(phone.user) or "",
-                    source="org_member",
-                    status="allowed",
-                    allow_inbound=True,
-                    allow_outbound=False,
-                    can_configure=config_authority.user_can_configure(phone.user_id),
-                ),
-            )
-
-    if owner_email_verified:
-        collaborators = (
-            AgentCollaborator.objects.filter(agent=agent, user__email__isnull=False)
-            .exclude(user__email="")
-            .select_related("user")
-            .order_by("user__email")
-        )
-        for collaborator in collaborators:
-            _put_contact_record(
-                records_by_key,
-                _contact_record(
-                    contact_id=f"collaborator:email:{collaborator.id}",
-                    channel=CommsChannel.EMAIL,
-                    address=collaborator.user.email,
-                    display_name=_build_user_display_name(collaborator.user) or "",
-                    source="collaborator",
-                    status="allowed",
-                    allow_inbound=True,
-                    allow_outbound=True,
-                    can_configure=config_authority.user_can_configure(collaborator.user_id),
-                    updated_at=collaborator.created_at.isoformat() if collaborator.created_at else None,
-                ),
-            )
-
-        allowlist_entries = (
-            CommsAllowlistEntry.objects.filter(agent=agent)
-            .order_by("-is_active", "channel", "address")
-        )
-        for entry in allowlist_entries:
-            status = "allowed" if entry.is_active else "inactive"
-            _put_contact_record(
-                records_by_key,
-                _contact_record(
-                    contact_id=f"allowlist_entry:{entry.id}",
-                    channel=entry.channel,
-                    address=entry.address,
-                    source="allowlist_entry",
-                    status=status,
-                    allow_inbound=entry.allow_inbound if entry.is_active else False,
-                    allow_outbound=entry.allow_outbound if entry.is_active else False,
-                    can_configure=entry.can_configure if entry.is_active else False,
-                    updated_at=entry.updated_at.isoformat() if entry.updated_at else None,
-                ),
-            )
-
-    contact_requests = (
-        CommsAllowlistRequest.objects.filter(agent=agent)
-        .order_by("-requested_at")
-    )
-    for request in contact_requests:
-        _put_contact_record(
-            records_by_key,
-            _contact_record(
-                contact_id=f"contact_request:{request.id}",
-                channel=request.channel,
-                address=request.address,
-                display_name=request.name or "",
-                source="contact_request",
-                status=_contact_request_status(request),
-                allow_inbound=False,
-                allow_outbound=False,
-                can_configure=False,
-                requested_at=request.requested_at.isoformat() if request.requested_at else None,
-                responded_at=request.responded_at.isoformat() if request.responded_at else None,
-                updated_at=request.responded_at.isoformat() if request.responded_at else (
-                    request.requested_at.isoformat() if request.requested_at else None
-                ),
-            ),
-        )
-
-    return sorted(
-        records_by_key.values(),
-        key=lambda record: (record.channel, record.normalized_address, record.source),
-    )
 
 
 def _get_interacted_web_user_info_by_endpoint(

--- a/api/agent/tools/sqlite_state.py
+++ b/api/agent/tools/sqlite_state.py
@@ -37,6 +37,7 @@ AGENT_CONFIG_TABLE = "__agent_config"
 LEGACY_PLAN_TABLE = "__kanban_cards"
 MESSAGES_TABLE = "__messages"
 FILES_TABLE = "__files"
+CONTACTS_TABLE = "__contacts"
 AGENT_SKILLS_TABLE = "__agent_skills"
 EPHEMERAL_TABLES = {
     TOOL_RESULTS_TABLE,
@@ -44,6 +45,7 @@ EPHEMERAL_TABLES = {
     LEGACY_PLAN_TABLE,
     MESSAGES_TABLE,
     FILES_TABLE,
+    CONTACTS_TABLE,
     AGENT_SKILLS_TABLE,
 }
 BUILTIN_TABLE_NOTES = {
@@ -51,6 +53,7 @@ BUILTIN_TABLE_NOTES = {
     AGENT_CONFIG_TABLE: "built-in, ephemeral (reset every LLM call; charter/schedule updates)",
     MESSAGES_TABLE: "built-in, ephemeral (recent messages snapshot for this cycle)",
     FILES_TABLE: "built-in, ephemeral (recent file index for this cycle; metadata only)",
+    CONTACTS_TABLE: "built-in, ephemeral (effective contacts and contact request state for this cycle)",
     AGENT_SKILLS_TABLE: "built-in, ephemeral (versioned skill mirror synced to persistent storage after tool execution)",
 }
 

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -1283,7 +1283,7 @@ class PromptContextBuilderTests(TestCase):
         content = user_message["content"]
 
         self.assertIn(
-            "Use read_file for contents of known filespace paths; use sqlite_batch on __tool_results or __files only for prior tool outputs or file metadata.",
+            "Use read_file for contents of known filespace paths; use sqlite_batch on __tool_results, __files, or __contacts only for prior outputs, file metadata, or contact authority.",
             content,
         )
         self.assertNotIn("Query __tool_results and __files with sqlite_batch (not read_file).", content)

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -1,6 +1,9 @@
-from django.test import SimpleTestCase, tag
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase, tag
 
 from api.agent.core import prompt_context
+from api.models import BrowserUseAgent, CommsAllowlistEntry, CommsChannel, PersistentAgent
 
 
 @tag("batch_promptree")
@@ -41,6 +44,13 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
         self.assertIn("# __files (special table; metadata only)", examples)
         self.assertIn("recent_files", examples)
         self.assertIn("metadata only", examples)
+
+    def test_examples_include_contacts_table_schema(self):
+        examples = prompt_context._get_sqlite_examples()
+        self.assertIn("# __contacts (special table)", examples)
+        self.assertIn("normalized_address", examples)
+        self.assertIn("status='allowed' AND allow_outbound=1", examples)
+        self.assertIn("empty pending request queue", examples)
 
     def test_examples_discourage_browser_task_completion_polling(self):
         examples = prompt_context._get_sqlite_examples()
@@ -93,6 +103,76 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
 
         self.assertIn("SQLite efficiency warning", warning)
         self.assertIn("one shaped query", warning)
+
+
+class _PromptSectionCollector:
+    def __init__(self):
+        self.sections = {}
+
+    def section_text(self, name, text, **_kwargs):
+        self.sections[name] = text
+
+
+class _NoopSpan:
+    def set_attribute(self, *_args, **_kwargs):
+        return None
+
+
+@tag("batch_promptree")
+class PromptContextContactsGuidanceTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="owner",
+            email="owner@example.com",
+        )
+        EmailAddress.objects.create(
+            user=self.user,
+            email=self.user.email,
+            verified=True,
+            primary=True,
+        )
+        self.browser_agent = BrowserUseAgent.objects.create(
+            user=self.user,
+            name="Prompt Contacts Browser",
+        )
+        self.agent = PersistentAgent.objects.create(
+            user=self.user,
+            name="Prompt Contacts Agent",
+            charter="Test contacts guidance.",
+            browser_use_agent=self.browser_agent,
+        )
+
+    def test_large_allowed_contacts_are_compacted_in_prompt(self):
+        CommsAllowlistEntry.objects.bulk_create(
+            [
+                CommsAllowlistEntry(
+                    agent=self.agent,
+                    channel=CommsChannel.EMAIL,
+                    address=f"person-{idx:02d}@example.com",
+                    is_active=True,
+                    allow_inbound=True,
+                    allow_outbound=True,
+                )
+                for idx in range(prompt_context.CONTACT_PROMPT_INLINE_LIMIT + 5)
+            ]
+        )
+        collector = _PromptSectionCollector()
+
+        prompt_context._build_contacts_block(
+            self.agent,
+            collector,
+            _NoopSpan(),
+            prompt_context._ConfigAuthorityResolver(self.agent),
+        )
+
+        allowed_contacts = collector.sections["allowed_contacts"]
+        self.assertIn("__contacts", allowed_contacts)
+        self.assertIn("active contacts are available", allowed_contacts)
+        self.assertIn("Sample active contacts", allowed_contacts)
+        self.assertIn("person-00@example.com", allowed_contacts)
+        self.assertNotIn("person-29@example.com", allowed_contacts)
+        self.assertIn("status='allowed' AND allow_outbound=1", allowed_contacts)
 
     def test_examples_prefer_patch_and_retry_for_named_missing_parameters(self):
         examples = prompt_context._get_sqlite_examples()

--- a/tests/unit/test_sqlite_contacts_table.py
+++ b/tests/unit/test_sqlite_contacts_table.py
@@ -1,0 +1,323 @@
+import os
+import sqlite3
+import tempfile
+from datetime import timedelta
+
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase, tag
+from django.utils import timezone
+from unittest.mock import patch
+
+from api.agent.core.contact_results import ContactSQLiteRecord, store_contacts_for_prompt
+from api.agent.core.prompt_context import (
+    _ConfigAuthorityResolver,
+    _build_sqlite_contacts_snapshot_records,
+)
+from api.agent.tools.sqlite_state import reset_sqlite_db_path, set_sqlite_db_path
+from api.models import (
+    AgentCollaborator,
+    BrowserUseAgent,
+    CommsAllowlistEntry,
+    CommsAllowlistRequest,
+    CommsChannel,
+    Organization,
+    OrganizationMembership,
+    PersistentAgent,
+    UserPhoneNumber,
+)
+
+
+@tag("batch_sqlite")
+class SqliteContactsTableStorageTests(SimpleTestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.tmp.name, "state.db")
+        self.token = set_sqlite_db_path(self.db_path)
+
+    def tearDown(self):
+        reset_sqlite_db_path(self.token)
+        self.tmp.cleanup()
+
+    def test_store_contacts_for_prompt_creates_and_populates_table(self):
+        records = [
+            ContactSQLiteRecord(
+                contact_id="allowlist_entry:1",
+                channel="email",
+                address="User@Example.COM",
+                normalized_address="user@example.com",
+                display_name="User Example",
+                source="allowlist_entry",
+                status="allowed",
+                allow_inbound=True,
+                allow_outbound=False,
+                can_configure=True,
+                requested_at=None,
+                responded_at=None,
+                updated_at="2026-01-01T00:00:00+00:00",
+            )
+        ]
+
+        store_contacts_for_prompt(records)
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.cursor()
+            cur.execute('SELECT COUNT(*) FROM "__contacts";')
+            self.assertEqual(cur.fetchone()[0], 1)
+            cur.execute(
+                """
+                SELECT contact_id, channel, address, normalized_address, display_name,
+                       source, status, allow_inbound, allow_outbound, can_configure,
+                       requested_at, responded_at, updated_at
+                FROM "__contacts"
+                WHERE normalized_address='user@example.com';
+                """
+            )
+            row = cur.fetchone()
+            self.assertIsNotNone(row)
+            assert row is not None
+            self.assertEqual(row[0], "allowlist_entry:1")
+            self.assertEqual(row[1], "email")
+            self.assertEqual(row[2], "User@Example.COM")
+            self.assertEqual(row[3], "user@example.com")
+            self.assertEqual(row[4], "User Example")
+            self.assertEqual(row[5], "allowlist_entry")
+            self.assertEqual(row[6], "allowed")
+            self.assertEqual(row[7], 1)
+            self.assertEqual(row[8], 0)
+            self.assertEqual(row[9], 1)
+            self.assertIsNone(row[10])
+            self.assertIsNone(row[11])
+            self.assertEqual(row[12], "2026-01-01T00:00:00+00:00")
+        finally:
+            conn.close()
+
+    def test_store_contacts_for_prompt_replaces_previous_snapshot(self):
+        first = ContactSQLiteRecord(
+            contact_id="contact_request:old",
+            channel="email",
+            address="old@example.com",
+            normalized_address="old@example.com",
+            display_name="Old",
+            source="contact_request",
+            status="pending_request",
+            allow_inbound=False,
+            allow_outbound=False,
+            can_configure=False,
+            requested_at="2026-01-01T00:00:00+00:00",
+            responded_at=None,
+            updated_at=None,
+        )
+        second = ContactSQLiteRecord(
+            contact_id="contact_request:new",
+            channel="email",
+            address="new@example.com",
+            normalized_address="new@example.com",
+            display_name="New",
+            source="contact_request",
+            status="rejected_request",
+            allow_inbound=False,
+            allow_outbound=False,
+            can_configure=False,
+            requested_at="2026-01-02T00:00:00+00:00",
+            responded_at="2026-01-02T01:00:00+00:00",
+            updated_at="2026-01-02T01:00:00+00:00",
+        )
+
+        store_contacts_for_prompt([first])
+        store_contacts_for_prompt([second])
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.cursor()
+            cur.execute('SELECT COUNT(*) FROM "__contacts";')
+            self.assertEqual(cur.fetchone()[0], 1)
+            cur.execute('SELECT contact_id FROM "__contacts";')
+            self.assertEqual(cur.fetchone()[0], "contact_request:new")
+        finally:
+            conn.close()
+
+
+@tag("batch_sqlite")
+class SqliteContactsSnapshotBuilderTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.owner = User.objects.create_user(
+            username="owner",
+            email="Owner@Example.COM",
+            first_name="Owner",
+            last_name="User",
+        )
+        EmailAddress.objects.create(
+            user=self.owner,
+            email=self.owner.email,
+            verified=True,
+            primary=True,
+        )
+        self.browser_agent = BrowserUseAgent.objects.create(
+            user=self.owner,
+            name="Contacts Browser Agent",
+        )
+        self.agent = PersistentAgent.objects.create(
+            user=self.owner,
+            name="Contacts Agent",
+            charter="Test contacts snapshot.",
+            browser_use_agent=self.browser_agent,
+        )
+        self.config_authority = _ConfigAuthorityResolver(self.agent)
+
+    def _records_by_address(self):
+        records = _build_sqlite_contacts_snapshot_records(self.agent, self.config_authority)
+        return {(record.channel, record.normalized_address): record for record in records}
+
+    def test_owner_implicit_contact_appears_allowed(self):
+        records = self._records_by_address()
+
+        record = records[(CommsChannel.EMAIL, "owner@example.com")]
+        self.assertEqual(record.source, "owner")
+        self.assertEqual(record.status, "allowed")
+        self.assertTrue(record.allow_inbound)
+        self.assertTrue(record.allow_outbound)
+        self.assertTrue(record.can_configure)
+
+    def test_active_allowlist_entry_uses_direction_flags(self):
+        CommsAllowlistEntry.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="Friend@Example.COM",
+            is_active=True,
+            allow_inbound=True,
+            allow_outbound=False,
+            can_configure=True,
+        )
+
+        records = self._records_by_address()
+
+        record = records[(CommsChannel.EMAIL, "friend@example.com")]
+        self.assertEqual(record.source, "allowlist_entry")
+        self.assertEqual(record.status, "allowed")
+        self.assertTrue(record.allow_inbound)
+        self.assertFalse(record.allow_outbound)
+        self.assertTrue(record.can_configure)
+
+    def test_contact_requests_are_non_sendable_diagnostics(self):
+        pending = CommsAllowlistRequest.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="pending@example.com",
+            name="Pending Person",
+            reason="Coordinate launch.",
+            purpose="Launch coordination",
+            expires_at=timezone.now() + timedelta(days=1),
+        )
+        rejected = CommsAllowlistRequest.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="rejected@example.com",
+            name="Rejected Person",
+            reason="Coordinate launch.",
+            purpose="Launch coordination",
+            status=CommsAllowlistRequest.RequestStatus.REJECTED,
+            responded_at=timezone.now(),
+        )
+
+        records = self._records_by_address()
+
+        pending_record = records[(CommsChannel.EMAIL, pending.address)]
+        self.assertEqual(pending_record.status, "pending_request")
+        self.assertFalse(pending_record.allow_outbound)
+        rejected_record = records[(CommsChannel.EMAIL, rejected.address)]
+        self.assertEqual(rejected_record.status, "rejected_request")
+        self.assertFalse(rejected_record.allow_outbound)
+
+    def test_approved_request_without_active_allowlist_is_not_sendable(self):
+        CommsAllowlistRequest.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="approved-but-missing@example.com",
+            name="Approved Missing",
+            reason="Coordinate launch.",
+            purpose="Launch coordination",
+            status=CommsAllowlistRequest.RequestStatus.APPROVED,
+            responded_at=timezone.now(),
+        )
+
+        records = self._records_by_address()
+
+        record = records[(CommsChannel.EMAIL, "approved-but-missing@example.com")]
+        self.assertEqual(record.status, "approved_request_no_active_entry")
+        self.assertFalse(record.allow_outbound)
+
+    def test_allowed_row_overrides_request_for_same_address(self):
+        CommsAllowlistEntry.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="allowed@example.com",
+            is_active=True,
+            allow_inbound=True,
+            allow_outbound=True,
+        )
+        CommsAllowlistRequest.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="allowed@example.com",
+            name="Allowed Person",
+            reason="Coordinate launch.",
+            purpose="Launch coordination",
+            status=CommsAllowlistRequest.RequestStatus.APPROVED,
+            responded_at=timezone.now(),
+        )
+
+        records = self._records_by_address()
+
+        record = records[(CommsChannel.EMAIL, "allowed@example.com")]
+        self.assertEqual(record.source, "allowlist_entry")
+        self.assertEqual(record.status, "allowed")
+        self.assertTrue(record.allow_outbound)
+
+    def test_org_members_and_collaborators_are_effective_contacts(self):
+        User = get_user_model()
+        org = Organization.objects.create(name="Org", slug="contacts-org", created_by=self.owner)
+        with patch.object(PersistentAgent, "_validate_org_seats", return_value=None):
+            self.agent.organization = org
+            self.agent.save(update_fields=["organization"])
+        org_member = User.objects.create_user(
+            username="org-member",
+            email="member@example.com",
+            first_name="Org",
+            last_name="Member",
+        )
+        OrganizationMembership.objects.create(
+            org=org,
+            user=org_member,
+            role=OrganizationMembership.OrgRole.ADMIN,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+        UserPhoneNumber.objects.create(
+            user=org_member,
+            phone_number="+15555550123",
+            is_verified=True,
+        )
+        collaborator = User.objects.create_user(
+            username="collaborator",
+            email="collab@example.com",
+            first_name="Collab",
+            last_name="User",
+        )
+        AgentCollaborator.objects.create(agent=self.agent, user=collaborator)
+        self.config_authority = _ConfigAuthorityResolver(self.agent)
+
+        records = self._records_by_address()
+
+        org_email = records[(CommsChannel.EMAIL, "member@example.com")]
+        self.assertEqual(org_email.source, "org_member")
+        self.assertTrue(org_email.allow_outbound)
+        self.assertTrue(org_email.can_configure)
+        org_sms = records[(CommsChannel.SMS, "+15555550123")]
+        self.assertEqual(org_sms.source, "org_member")
+        self.assertTrue(org_sms.allow_inbound)
+        self.assertFalse(org_sms.allow_outbound)
+        collaborator_record = records[(CommsChannel.EMAIL, "collab@example.com")]
+        self.assertEqual(collaborator_record.source, "collaborator")
+        self.assertTrue(collaborator_record.allow_outbound)

--- a/tests/unit/test_sqlite_contacts_table.py
+++ b/tests/unit/test_sqlite_contacts_table.py
@@ -10,9 +10,8 @@ from django.utils import timezone
 from unittest.mock import patch
 
 from api.agent.core.contact_results import ContactSQLiteRecord, store_contacts_for_prompt
-from api.agent.core.prompt_context import (
-    _ConfigAuthorityResolver,
-    _build_sqlite_contacts_snapshot_records,
+from api.agent.core.contact_snapshot import (
+    build_contacts_snapshot_records,
 )
 from api.agent.tools.sqlite_state import reset_sqlite_db_path, set_sqlite_db_path
 from api.models import (
@@ -165,10 +164,20 @@ class SqliteContactsSnapshotBuilderTests(TestCase):
             charter="Test contacts snapshot.",
             browser_use_agent=self.browser_agent,
         )
-        self.config_authority = _ConfigAuthorityResolver(self.agent)
+        self.configure_user_ids = {self.owner.id}
+
+    def _display_name_for_user(self, user):
+        return (user.get_full_name() or "").strip() or None
+
+    def _user_can_configure(self, user_id):
+        return user_id in self.configure_user_ids
 
     def _records_by_address(self):
-        records = _build_sqlite_contacts_snapshot_records(self.agent, self.config_authority)
+        records = build_contacts_snapshot_records(
+            self.agent,
+            display_name_for_user=self._display_name_for_user,
+            user_can_configure=self._user_can_configure,
+        )
         return {(record.channel, record.normalized_address): record for record in records}
 
     def test_owner_implicit_contact_appears_allowed(self):
@@ -246,7 +255,7 @@ class SqliteContactsSnapshotBuilderTests(TestCase):
         records = self._records_by_address()
 
         record = records[(CommsChannel.EMAIL, "approved-but-missing@example.com")]
-        self.assertEqual(record.status, "approved_request_no_active_entry")
+        self.assertEqual(record.status, "approved_missing_allowlist")
         self.assertFalse(record.allow_outbound)
 
     def test_allowed_row_overrides_request_for_same_address(self):
@@ -294,6 +303,7 @@ class SqliteContactsSnapshotBuilderTests(TestCase):
             role=OrganizationMembership.OrgRole.ADMIN,
             status=OrganizationMembership.OrgStatus.ACTIVE,
         )
+        self.configure_user_ids.add(org_member.id)
         UserPhoneNumber.objects.create(
             user=org_member,
             phone_number="+15555550123",
@@ -306,7 +316,6 @@ class SqliteContactsSnapshotBuilderTests(TestCase):
             last_name="User",
         )
         AgentCollaborator.objects.create(agent=self.agent, user=collaborator)
-        self.config_authority = _ConfigAuthorityResolver(self.agent)
 
         records = self._records_by_address()
 


### PR DESCRIPTION
## Summary
- Added a per-cycle `__contacts` SQLite snapshot for agents to query effective contact authority instead of inferring approval from lead status or prose.
- Populated the snapshot from owner, org member, collaborator, allowlist entry, and contact request state, with safe outbound recipients defined by `status='allowed'` and `allow_outbound=1`.
- Updated prompt guidance so large contact sets are compacted in prose and exact/bulk recipient checks are directed to `__contacts`.
- Added targeted unit coverage for snapshot storage, effective contact resolution, and prompt guidance.

## Testing
- `uv run python manage.py test tests.unit.test_event_processing.PromptContextBuilderTests.test_prompt_describes_sqlite_snapshots_without_banning_read_file tests.unit.test_sqlite_contacts_table tests.unit.test_prompt_context_sqlite_guidance --settings=config.test_settings`
- `uv run python -m compileall -q api/agent/core/contact_results.py api/agent/core/prompt_context.py tests/unit/test_sqlite_contacts_table.py tests/unit/test_prompt_context_sqlite_guidance.py`