### PR TITLE
Stop inferring owner names from email when first name is unset

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1285,12 +1285,12 @@ def _build_owner_identity_prompt(user: Any) -> str:
         return (
             f"The owner's name is {first_name}. "
             "Use their name occasionally to build rapport—not every message, but naturally. "
-            "Good: 'Hey {name}, found it!' or 'Here's your update, {name}.' "
+            f"Good: 'Hey {first_name}, found it!' or 'Here's your update, {first_name}.' "
             "Bad: Using their name in every sentence (forced, robotic). "
             "Use it for: greetings, celebrating wins, checking in after a while, or when it feels warm and natural. "
             "In shared chats, address the most recent inbound sender from unified history/recent contacts; "
             "do not assume every inbound message came from the owner."
-        ).format(name=first_name)
+        )
 
     return (
         "The owner's name is unknown. Do not infer a first name, last name, or preferred form of address from "

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1278,6 +1278,28 @@ def _build_agent_email_settings_section(agent: PersistentAgent) -> str:
     ]
     return "Agent email settings:\n- " + "\n- ".join(lines)
 
+
+def _build_owner_identity_prompt(user: Any) -> str:
+    first_name = (getattr(user, "first_name", "") or "").strip()
+    if first_name:
+        return (
+            f"The owner's name is {first_name}. "
+            "Use their name occasionally to build rapport—not every message, but naturally. "
+            "Good: 'Hey {name}, found it!' or 'Here's your update, {name}.' "
+            "Bad: Using their name in every sentence (forced, robotic). "
+            "Use it for: greetings, celebrating wins, checking in after a while, or when it feels warm and natural. "
+            "In shared chats, address the most recent inbound sender from unified history/recent contacts; "
+            "do not assume every inbound message came from the owner."
+        ).format(name=first_name)
+
+    return (
+        "The owner's name is unknown. Do not infer a first name, last name, or preferred form of address from "
+        "their email address, username, or other account identifiers. Use a generic greeting unless the user "
+        "provides a preferred name. In shared chats, address the most recent inbound sender from unified "
+        "history/recent contacts; do not assume every inbound message came from the owner."
+    )
+
+
 def _render_prompt_context_once(
     agent: PersistentAgent,
     current_iteration: int = 1,
@@ -1352,26 +1374,10 @@ def _render_prompt_context_once(
         non_shrinkable=True,
     )
 
-    # User's name for personalization
-    user_display_name = None
     if agent.user:
-        user_display_name = (
-            agent.user.first_name.strip()
-            if agent.user.first_name
-            else None
-        )
-    if user_display_name:
         important_group.section_text(
             "user_identity",
-            (
-                f"The owner's name is {user_display_name}. "
-                "Use their name occasionally to build rapport—not every message, but naturally. "
-                "Good: 'Hey {name}, found it!' or 'Here's your update, {name}.' "
-                "Bad: Using their name in every sentence (forced, robotic). "
-                "Use it for: greetings, celebrating wins, checking in after a while, or when it feels warm and natural. "
-                "In shared chats, address the most recent inbound sender from unified history/recent contacts; "
-                "do not assume every inbound message came from the owner."
-            ).format(name=user_display_name),
+            _build_owner_identity_prompt(agent.user),
             weight=2,
             non_shrinkable=True,
         )

--- a/tests/unit/test_prompt_capabilities.py
+++ b/tests/unit/test_prompt_capabilities.py
@@ -36,6 +36,78 @@ class AgentCapabilitiesPromptTests(TestCase):
             browser_use_agent=browser_agent,
         )
 
+    def _build_prompt_text_for_owner(
+        self,
+        *,
+        email: str = "owner@example.com",
+        first_name: str = "",
+        last_name: str = "",
+    ) -> str:
+        User = get_user_model()
+        suffix = User.objects.count()
+        user = User.objects.create_user(
+            username=f"identity-owner-{suffix}",
+            email=email,
+            password="pass1234",
+            first_name=first_name,
+            last_name=last_name,
+        )
+        browser_agent = BrowserUseAgent.objects.create(
+            user=user,
+            name=f"Identity Browser Agent {suffix}",
+        )
+        agent = PersistentAgent.objects.create(
+            user=user,
+            name=f"Identity Agent {suffix}",
+            browser_use_agent=browser_agent,
+        )
+
+        with patch("api.agent.core.prompt_context.ensure_steps_compacted"), patch(
+            "api.agent.core.prompt_context.ensure_comms_compacted"
+        ):
+            context, _, _ = build_prompt_context(agent)
+        return "\n".join(message["content"] for message in context)
+
+    def test_owner_identity_prompt_uses_profile_first_name(self):
+        contents = self._build_prompt_text_for_owner(
+            email="mattworkpro@example.com",
+            first_name="Ada",
+            last_name="Lovelace",
+        )
+
+        self.assertIn("The owner's name is Ada.", contents)
+        self.assertIn("Use their name occasionally to build rapport", contents)
+        self.assertNotIn("profile name is not set", contents)
+        self.assertNotIn("owner's name is unknown", contents)
+
+    def test_owner_identity_prompt_marks_missing_profile_name_unknown(self):
+        for email in [
+            "jane@example.com",
+            "jane.doe@example.com",
+            "jane_doe@example.com",
+            "jane-doe@example.com",
+            "mattworkpro@example.com",
+            "jane123@example.com",
+            "support@example.com",
+            "hello+test@example.com",
+            "",
+        ]:
+            with self.subTest(email=email):
+                contents = self._build_prompt_text_for_owner(email=email)
+
+                self.assertIn("The owner's name is unknown.", contents)
+                self.assertIn("Do not infer a first name, last name, or preferred form of address", contents)
+
+    def test_owner_identity_prompt_does_not_use_last_name_as_call_name(self):
+        contents = self._build_prompt_text_for_owner(
+            email="jane.doe@example.com",
+            last_name="Lovelace",
+        )
+
+        self.assertIn("The owner's name is unknown.", contents)
+        self.assertIn("Do not infer a first name, last name, or preferred form of address", contents)
+        self.assertNotIn("The owner's name is Lovelace", contents)
+
     @override_settings(PUBLIC_SITE_URL="https://app.test")
     @patch("api.agent.core.prompt_context.DedicatedProxyService.allocated_count", return_value=2)
     @patch("api.agent.core.prompt_context.AddonEntitlementService.get_uplift")

--- a/tests/unit/test_prompt_capabilities.py
+++ b/tests/unit/test_prompt_capabilities.py
@@ -80,6 +80,16 @@ class AgentCapabilitiesPromptTests(TestCase):
         self.assertNotIn("profile name is not set", contents)
         self.assertNotIn("owner's name is unknown", contents)
 
+    def test_owner_identity_prompt_handles_braces_in_profile_first_name(self):
+        contents = self._build_prompt_text_for_owner(
+            email="braces@example.com",
+            first_name="{Ada}",
+        )
+
+        self.assertIn("The owner's name is {Ada}.", contents)
+        self.assertIn("Hey {Ada}, found it!", contents)
+        self.assertNotIn("owner's name is unknown", contents)
+
     def test_owner_identity_prompt_marks_missing_profile_name_unknown(self):
         for email in [
             "jane@example.com",


### PR DESCRIPTION
## Summary
- Keep the existing first-name hint when the owner profile has a `first_name`.
- When no first name is set, tell the model the owner’s name is unknown and not to infer one from email, username, or other identifiers.
- Add focused unit coverage for the profile-name and unknown-name prompt paths.

## Testing
- Added `batch_promptree` unit tests covering profile first-name usage, missing-name fallback, and last-name-only behavior.
- Verified locally with `tests.unit.test_prompt_capabilities.AgentCapabilitiesPromptTests`.