### PR TITLE
Add custom tool child failure budget and judge source context

### DIFF
--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -14,7 +14,12 @@ from django.db import DatabaseError, IntegrityError, transaction
 from django.utils import timezone
 from waffle import get_waffle_flag_model
 
-from api.agent.core.llm_config import INPUT_TOKEN_HEADROOM, LLMNotConfiguredError, get_agent_judge_llm_config, get_agent_llm_tier
+from api.agent.core.llm_config import (
+    INPUT_TOKEN_HEADROOM,
+    LLMNotConfiguredError,
+    get_agent_judge_llm_config,
+    get_agent_llm_tier,
+)
 from api.agent.core.llm_utils import run_completion
 from api.agent.core.prompt_context import _create_token_estimator
 from api.agent.core.promptree import Prompt
@@ -128,13 +133,19 @@ def maybe_run_agent_judge(
     *,
     tools: list[dict[str, Any]] | None = None,
     extra_trigger_reasons: list[str] | None = None,
+    trigger_context: dict[str, Any] | None = None,
 ) -> None:
     """Run the internal judge when heuristics indicate the agent may need guidance."""
 
     try:
         if not is_agent_judge_enabled_for_agent(agent):
             return
-        trigger = build_judge_trigger(agent, tools=tools, extra_trigger_reasons=extra_trigger_reasons)
+        trigger = build_judge_trigger(
+            agent,
+            tools=tools,
+            extra_trigger_reasons=extra_trigger_reasons,
+            trigger_context=trigger_context,
+        )
         if trigger is None:
             return
         _run_judge(agent, trigger)
@@ -251,6 +262,7 @@ def build_judge_trigger(
     *,
     tools: list[dict[str, Any]] | None = None,
     extra_trigger_reasons: list[str] | None = None,
+    trigger_context: dict[str, Any] | None = None,
 ) -> JudgeTrigger | None:
     if not is_agent_judge_enabled_for_agent(agent):
         return None
@@ -291,12 +303,14 @@ def build_judge_trigger(
         trigger_reasons=reasons,
         non_judge_step_count=non_judge_step_count,
         prompt_limits=prompt_limits,
+        trigger_context=trigger_context,
     )
     evidence_hash = _hash_payload(
         {
             "agent_id": str(agent.id),
             "step_count": non_judge_step_count,
             "reasons": reasons,
+            "trigger_context": trigger_context or {},
             "message_ids": [str(message.id) for message in recent_messages],
             "tool_step_ids": [str(call.step_id) for call in recent_tool_calls],
         }
@@ -792,6 +806,7 @@ def _build_trajectory_packet(
     non_judge_step_count: int,
     prompt_limits: JudgePromptLimits,
     report_context: dict[str, Any] | None = None,
+    trigger_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     tier = get_agent_llm_tier(agent)
     recent_steps = list(
@@ -828,8 +843,13 @@ def _build_trajectory_packet(
                 "solely because ordinary tool calls appear near or after a custom_* tool call; require direct "
                 "evidence from timing, parameters, results, messages, or steps."
             ),
+            (
+                "When trigger_context.custom_tool_sources is present, inspect that source as direct evidence "
+                "for the custom tool behavior involved in the trigger."
+            ),
         ],
         "trigger_reasons": trigger_reasons,
+        "trigger_context": trigger_context or {},
         "user_report": report_context or {},
         "non_judge_step_count": non_judge_step_count,
         "policy_excerpts": [
@@ -1134,16 +1154,54 @@ def _build_judge_user_prompt(
 
     high_priority = prompt.group("high_priority", weight=8)
     if trajectory.get("user_report"):
-        high_priority.section_text("user_report", _json_section(trajectory.get("user_report") or {}), weight=9)
-    high_priority.section_text("messages", _json_section(recent_trajectory.get("messages") or []), weight=8)
-    high_priority.section_text("system_directives", _json_section(recent_trajectory.get("system_directives") or []), weight=5)
-    high_priority.section_text("plan_snapshot", _json_section(recent_trajectory.get("plan_snapshot") or {}), weight=4)
-    high_priority.section_text("steps", _json_section(recent_trajectory.get("steps") or []), weight=4)
+        high_priority.section_text(
+            "user_report",
+            _json_section(trajectory.get("user_report") or {}),
+            weight=9,
+        )
+    if trajectory.get("trigger_context"):
+        high_priority.section_text(
+            "trigger_context",
+            _json_section(trajectory.get("trigger_context") or {}),
+            weight=9,
+        )
+    high_priority.section_text(
+        "messages",
+        _json_section(recent_trajectory.get("messages") or []),
+        weight=8,
+    )
+    high_priority.section_text(
+        "system_directives",
+        _json_section(recent_trajectory.get("system_directives") or []),
+        weight=5,
+    )
+    high_priority.section_text(
+        "plan_snapshot",
+        _json_section(recent_trajectory.get("plan_snapshot") or {}),
+        weight=4,
+    )
+    high_priority.section_text(
+        "steps",
+        _json_section(recent_trajectory.get("steps") or []),
+        weight=4,
+    )
 
     medium_priority = prompt.group("medium_priority", weight=5)
-    medium_priority.section_text("tool_calls", _json_section(recent_trajectory.get("tool_calls") or []), weight=6)
-    medium_priority.section_text("skills", _json_section((current_context.get("skills") or {})), weight=3)
-    medium_priority.section_text("capability_manifest", _json_section(trajectory.get("capability_manifest") or []), weight=2)
+    medium_priority.section_text(
+        "tool_calls",
+        _json_section(recent_trajectory.get("tool_calls") or []),
+        weight=6,
+    )
+    medium_priority.section_text(
+        "skills",
+        _json_section((current_context.get("skills") or {})),
+        weight=3,
+    )
+    medium_priority.section_text(
+        "capability_manifest",
+        _json_section(trajectory.get("capability_manifest") or []),
+        weight=2,
+    )
 
     low_priority = prompt.group("low_priority", weight=2)
     low_priority.section_text("sqlite", _json_section(current_context.get("sqlite") or {}), weight=2)

--- a/api/agent/tools/custom_tools.py
+++ b/api/agent/tools/custom_tools.py
@@ -165,9 +165,12 @@ _GOBII_CTX_MODULE = textwrap.dedent(
             body = json.dumps(payload).encode("utf-8")
             raw = self._call_tool_via_curl(body)
             try:
-                return json.loads(raw or "{{}}")
+                result = json.loads(raw or "{{}}")
             except json.JSONDecodeError as exc:
                 raise RuntimeError(f"Tool bridge returned invalid JSON: {{raw[:500]}}") from exc
+            if isinstance(result, dict) and result.get("custom_tool_abort") is True:
+                raise RuntimeError(result.get("message") or "Custom tool stopped by bridge.")
+            return result
 
         @contextlib.contextmanager
         def sqlite(self):
@@ -385,6 +388,10 @@ def _read_source_text(agent: PersistentAgent, source_path: str) -> tuple[Optiona
         return raw.decode("utf-8"), None
     except UnicodeDecodeError:
         return None, "Custom tool source must be UTF-8 text."
+
+
+def read_custom_tool_source_text(agent: PersistentAgent, source_path: str) -> tuple[Optional[str], Optional[str]]:
+    return _read_source_text(agent, source_path)
 
 
 def _sync_workspace_source(agent: PersistentAgent, source_path: str) -> Optional[Dict[str, Any]]:

--- a/api/custom_tool_bridge.py
+++ b/api/custom_tool_bridge.py
@@ -1,16 +1,32 @@
+import hashlib
 import json
 import logging
 
+from django.conf import settings
+from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from api.agent.tools.custom_tools import load_custom_tool_bridge_payload
+from api.agent.core.agent_judge import maybe_run_agent_judge
+from api.agent.tools.custom_tools import (
+    CUSTOM_TOOL_BRIDGE_TTL_SECONDS,
+    load_custom_tool_bridge_payload,
+    read_custom_tool_source_text,
+)
 from api.agent.tools.tracked_runtime import execute_tracked_runtime_tool_call
-from api.models import PersistentAgent, PersistentAgentCustomTool, PersistentAgentStep
+from api.models import (
+    PersistentAgent,
+    PersistentAgentCustomTool,
+    PersistentAgentStep,
+    PersistentAgentSystemStep,
+)
 
 logger = logging.getLogger(__name__)
+
+CUSTOM_TOOL_CHILD_FAILURE_TRIGGER_REASON = "custom_tool_child_failure_budget_exceeded"
+CUSTOM_TOOL_ABORT_MESSAGE_TEMPLATE = "Custom tool stopped after {threshold} failed child tool calls."
 
 
 def _json_safe(value):
@@ -24,6 +40,118 @@ def _extract_bearer_token(request) -> str:
     if not header.lower().startswith("bearer "):
         return ""
     return header[7:].strip()
+
+
+def _child_failure_limit() -> int:
+    return max(1, int(settings.CUSTOM_TOOL_CHILD_FAILURE_LIMIT))
+
+
+def _execution_cache_key(token: str, payload: dict) -> str:
+    parent_step_id = payload.get("parent_step_id")
+    if isinstance(parent_step_id, str) and parent_step_id.strip():
+        execution_id = f"parent:{parent_step_id.strip()}"
+    else:
+        token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()[:32]
+        execution_id = f"token:{token_hash}"
+    return (
+        "custom-tool-bridge:child-failure-budget:"
+        f"{payload.get('agent_id')}:{payload.get('tool_id')}:{execution_id}"
+    )
+
+
+def _abort_payload(state: dict | None = None) -> dict:
+    threshold = _child_failure_limit()
+    failure_count = threshold
+    if isinstance(state, dict):
+        threshold = int(state.get("threshold") or threshold)
+        failure_count = int(state.get("failure_count") or threshold)
+    return {
+        "status": "error",
+        "message": CUSTOM_TOOL_ABORT_MESSAGE_TEMPLATE.format(threshold=threshold),
+        "custom_tool_abort": True,
+        "failure_count": failure_count,
+        "threshold": threshold,
+    }
+
+
+def _is_error_result(result) -> bool:
+    return isinstance(result, dict) and str(result.get("status") or "").lower() == "error"
+
+
+def _get_budget_state(cache_key: str) -> dict:
+    state = cache.get(cache_key)
+    if isinstance(state, dict):
+        return state
+    return {
+        "failure_count": 0,
+        "aborted": False,
+        "threshold": _child_failure_limit(),
+        "first_failed_tool": "",
+        "last_failed_tool": "",
+    }
+
+
+def _record_budget_abort(agent: PersistentAgent, custom_tool: PersistentAgentCustomTool, state: dict) -> None:
+    description = (
+        f"Custom tool `{custom_tool.tool_name}` stopped after "
+        f"{state.get('failure_count')} failed child tool calls."
+    )
+    step = PersistentAgentStep.objects.create(agent=agent, description=description)
+    PersistentAgentSystemStep.objects.create(
+        step=step,
+        code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+        notes=CUSTOM_TOOL_CHILD_FAILURE_TRIGGER_REASON,
+    )
+    maybe_run_agent_judge(
+        agent,
+        extra_trigger_reasons=[CUSTOM_TOOL_CHILD_FAILURE_TRIGGER_REASON],
+        trigger_context=_custom_tool_judge_trigger_context(agent, custom_tool),
+    )
+
+
+def _custom_tool_judge_trigger_context(agent: PersistentAgent, custom_tool: PersistentAgentCustomTool) -> dict:
+    source_text, source_error = read_custom_tool_source_text(agent, custom_tool.source_path)
+    source_context = {
+        "source_type": "custom_tool_source",
+        "tool_name": custom_tool.tool_name,
+        "name": custom_tool.name or "",
+        "source_path": custom_tool.source_path,
+    }
+    if source_error:
+        source_context["source_error"] = source_error
+    else:
+        source_context["source_code"] = source_text or ""
+    return {
+        "custom_tool_sources": [source_context],
+    }
+
+
+def _record_child_tool_failure(
+    *,
+    cache_key: str,
+    agent: PersistentAgent,
+    custom_tool: PersistentAgentCustomTool,
+    failed_tool_name: str,
+) -> dict | None:
+    state = _get_budget_state(cache_key)
+    if state.get("aborted"):
+        return _abort_payload(state)
+
+    failure_count = int(state.get("failure_count") or 0) + 1
+    state["failure_count"] = failure_count
+    state["threshold"] = _child_failure_limit()
+    if not state.get("first_failed_tool"):
+        state["first_failed_tool"] = failed_tool_name
+    state["last_failed_tool"] = failed_tool_name
+
+    if failure_count >= int(state["threshold"]):
+        state["aborted"] = True
+        cache.set(cache_key, state, timeout=CUSTOM_TOOL_BRIDGE_TTL_SECONDS)
+        _record_budget_abort(agent, custom_tool, state)
+        return _abort_payload(state)
+
+    cache.set(cache_key, state, timeout=CUSTOM_TOOL_BRIDGE_TTL_SECONDS)
+    return None
 
 
 @csrf_exempt
@@ -46,6 +174,11 @@ def custom_tool_bridge_execute(request):
     if custom_tool is None:
         return JsonResponse({"status": "error", "message": "Custom tool not found."}, status=403)
 
+    budget_cache_key = _execution_cache_key(token, payload)
+    budget_state = _get_budget_state(budget_cache_key)
+    if budget_state.get("aborted"):
+        return JsonResponse(_abort_payload(budget_state))
+
     try:
         body = json.loads(request.body.decode("utf-8") or "{}")
     except (UnicodeDecodeError, json.JSONDecodeError):
@@ -63,12 +196,17 @@ def custom_tool_bridge_execute(request):
         return JsonResponse({"status": "error", "message": "params must be a JSON object."}, status=400)
 
     if tool_name == custom_tool.tool_name:
-        return JsonResponse(
-            {
-                "status": "error",
-                "message": "Custom tools cannot call themselves recursively.",
-            }
+        result = {
+            "status": "error",
+            "message": "Custom tools cannot call themselves recursively.",
+        }
+        abort = _record_child_tool_failure(
+            cache_key=budget_cache_key,
+            agent=agent,
+            custom_tool=custom_tool,
+            failed_tool_name=tool_name,
         )
+        return JsonResponse(abort or result)
 
     parent_step = None
     parent_step_id = payload.get("parent_step_id")
@@ -84,4 +222,13 @@ def custom_tool_bridge_execute(request):
         exec_params=params,
         parent_step=parent_step,
     )
+    if _is_error_result(result):
+        abort = _record_child_tool_failure(
+            cache_key=budget_cache_key,
+            agent=agent,
+            custom_tool=custom_tool,
+            failed_tool_name=tool_name,
+        )
+        if abort is not None:
+            return JsonResponse(abort)
     return JsonResponse(_json_safe(result), safe=isinstance(result, dict))

--- a/config/settings.py
+++ b/config/settings.py
@@ -192,6 +192,7 @@ MCP_STDIO_REQUEST_TIMEOUT_SECONDS = env.float(
 )
 # Maximum number of safe tool calls executed concurrently in one batch.
 MAX_PARALLEL_TOOL_CALLS = env.int("MAX_PARALLEL_TOOL_CALLS", default=4)
+CUSTOM_TOOL_CHILD_FAILURE_LIMIT = env.int("CUSTOM_TOOL_CHILD_FAILURE_LIMIT", default=3)
 # Retry configuration for transient LiteLLM failures
 LITELLM_MAX_RETRIES = env.int("LITELLM_MAX_RETRIES", default=2)
 LITELLM_RETRY_BACKOFF_SECONDS = env.float("LITELLM_RETRY_BACKOFF_SECONDS", default=1.0)

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -288,6 +288,54 @@ class AgentJudgeTests(TestCase):
         self.assertIsNotNone(trigger)
         self.assertEqual(trigger.reasons, ["burn_rate_throttled"])
 
+    def test_custom_tool_failure_trigger_context_reaches_judge_prompt(self):
+        self._add_steps(1)
+        source_code = (
+            "from _gobii_ctx import main\n\n"
+            "def run(params, ctx):\n"
+            "    return ctx.call_tool('send_email', params)\n\n"
+            "if __name__ == '__main__': main(run)\n"
+        )
+
+        trigger = build_judge_trigger(
+            self.agent,
+            tools=[],
+            extra_trigger_reasons=["custom_tool_child_failure_budget_exceeded"],
+            trigger_context={
+                "custom_tool_sources": [
+                    {
+                        "source_type": "custom_tool_source",
+                        "tool_name": "custom_outreach_sender",
+                        "name": "Outreach Sender",
+                        "source_path": "/tools/outreach_sender.py",
+                        "source_code": source_code,
+                    }
+                ],
+            },
+        )
+
+        self.assertIsNotNone(trigger)
+        self.assertEqual(
+            trigger.trajectory["trigger_context"]["custom_tool_sources"][0]["source_code"],
+            source_code,
+        )
+
+        limits = JudgePromptLimits(
+            prompt_token_budget=2000,
+            message_history_limit=2,
+            tool_call_history_limit=2,
+            skill_prompt_limit=1,
+            enabled_tool_limit=1,
+        )
+        with patch("api.agent.core.agent_judge._create_token_estimator", return_value=lambda text: len(text.split())):
+            messages = _build_judge_messages(trigger.trajectory, model="test-model", prompt_limits=limits)
+
+        user_content = messages[1]["content"]
+        self.assertIn("<trigger_context>", user_content)
+        self.assertIn("custom_tool_sources", user_content)
+        self.assertIn("/tools/outreach_sender.py", user_content)
+        self.assertIn("ctx.call_tool('send_email', params)", user_content)
+
     def test_judge_tool_does_not_offer_request_human_input_suggestion(self):
         tool = _judge_tool_definition()
 

--- a/tests/unit/test_custom_tools.py
+++ b/tests/unit/test_custom_tools.py
@@ -1,9 +1,13 @@
 import base64
+import contextlib
 import hashlib
+import io
 import json
 import os
 import sqlite3
+import sys
 import tempfile
+import types
 import uuid
 import zipfile
 from decimal import Decimal
@@ -13,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings, tag
 from django.urls import reverse
@@ -22,6 +27,7 @@ from api.agent.files.filespace_service import write_bytes_to_dir
 from api.agent.system_skills.defaults import CUSTOM_TOOL_DEVELOPMENT_SYSTEM_SKILL
 from api.agent.tools.custom_tools import (
     CUSTOM_TOOL_RESULT_MARKER,
+    _GOBII_CTX_MODULE,
     _sync_workspace_source,
     build_custom_tool_bridge_token,
     execute_create_custom_tool,
@@ -59,6 +65,7 @@ from api.models import (
     PersistentAgentEnabledTool,
     PersistentAgentSecret,
     PersistentAgentStep,
+    PersistentAgentSystemStep,
     PersistentAgentSystemSkillState,
     SystemSkillProfile,
     TaskCredit,
@@ -136,6 +143,23 @@ class CustomToolsTests(TestCase):
         sections.append("    main(run)")
         sections.append("")
         return "\n".join(sections)
+
+    @staticmethod
+    def _run_bootstrap_snippet(source: str) -> str:
+        module = types.ModuleType("_gobii_ctx")
+        exec(_GOBII_CTX_MODULE, module.__dict__)
+        prior_module = sys.modules.get("_gobii_ctx")
+        sys.modules["_gobii_ctx"] = module
+        stdout = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout):
+                exec(source, {})
+        finally:
+            if prior_module is None:
+                sys.modules.pop("_gobii_ctx", None)
+            else:
+                sys.modules["_gobii_ctx"] = prior_module
+        return stdout.getvalue()
 
     @staticmethod
     def _write_local_wheel(wheel_path: str) -> None:
@@ -2058,6 +2082,225 @@ def run(params, ctx):
             exec_params={"value": 1},
             parent_step=None,
         )
+
+    def _create_bridge_custom_tool(
+        self,
+        *,
+        tool_name: str = "custom_wrapper",
+    ) -> PersistentAgentCustomTool:
+        return PersistentAgentCustomTool.objects.create(
+            agent=self.agent,
+            name="Wrapper",
+            tool_name=tool_name,
+            description="Calls nested tools.",
+            source_path="/tools/wrapper.py",
+            parameters_schema={"type": "object", "properties": {}},
+        )
+
+    def _post_bridge_tool_call(
+        self,
+        token: str,
+        *,
+        tool_name: str = "send_email",
+        params: dict | None = None,
+    ):
+        return self.client.post(
+            reverse("api:custom-tool-bridge-execute"),
+            data=json.dumps({"tool_name": tool_name, "params": params or {"value": 1}}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+    @override_settings(CUSTOM_TOOL_CHILD_FAILURE_LIMIT=3)
+    @patch("api.custom_tool_bridge.maybe_run_agent_judge")
+    @patch("api.custom_tool_bridge.execute_tracked_runtime_tool_call")
+    def test_custom_tool_bridge_aborts_after_three_child_failures(
+        self,
+        mock_execute_tracked_runtime,
+        mock_maybe_run_agent_judge,
+    ):
+        cache.clear()
+        custom_tool = self._create_bridge_custom_tool()
+        source_code = self._build_runnable_tool_source(
+            "def run(params, ctx):\n"
+            "    return ctx.call_tool('send_email', params)\n"
+        )
+        write_result = write_bytes_to_dir(
+            agent=self.agent,
+            content_bytes=source_code.encode("utf-8"),
+            extension=".py",
+            mime_type="text/x-python",
+            path=custom_tool.source_path,
+            overwrite=True,
+        )
+        self.assertEqual(write_result.get("status"), "ok")
+        parent_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Outer custom tool step",
+        )
+        token = build_custom_tool_bridge_token(
+            self.agent,
+            custom_tool,
+            parent_step_id=str(parent_step.id),
+        )
+        child_error = {"status": "error", "message": "Child failed.", "retryable": True}
+        mock_execute_tracked_runtime.return_value = (child_error, None)
+
+        first = self._post_bridge_tool_call(token)
+        second = self._post_bridge_tool_call(token)
+        third = self._post_bridge_tool_call(token)
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(third.status_code, 200)
+        self.assertEqual(first.json(), child_error)
+        self.assertEqual(second.json(), child_error)
+        third_payload = third.json()
+        self.assertEqual(third_payload["status"], "error")
+        self.assertTrue(third_payload["custom_tool_abort"])
+        self.assertEqual(third_payload["failure_count"], 3)
+        self.assertEqual(third_payload["threshold"], 3)
+        self.assertEqual(
+            third_payload["message"],
+            "Custom tool stopped after 3 failed child tool calls.",
+        )
+
+        system_step = PersistentAgentSystemStep.objects.get(
+            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+            notes="custom_tool_child_failure_budget_exceeded",
+        )
+        self.assertEqual(system_step.step.agent_id, self.agent.id)
+        mock_maybe_run_agent_judge.assert_called_once_with(
+            self.agent,
+            extra_trigger_reasons=["custom_tool_child_failure_budget_exceeded"],
+            trigger_context={
+                "custom_tool_sources": [
+                    {
+                        "source_type": "custom_tool_source",
+                        "tool_name": custom_tool.tool_name,
+                        "name": custom_tool.name,
+                        "source_path": custom_tool.source_path,
+                        "source_code": source_code,
+                    }
+                ],
+            },
+        )
+        self.assertEqual(mock_execute_tracked_runtime.call_count, 3)
+
+        fourth = self._post_bridge_tool_call(token)
+        self.assertEqual(fourth.status_code, 200)
+        self.assertTrue(fourth.json()["custom_tool_abort"])
+        self.assertEqual(mock_execute_tracked_runtime.call_count, 3)
+
+    @override_settings(CUSTOM_TOOL_CHILD_FAILURE_LIMIT=3)
+    @patch("api.custom_tool_bridge.maybe_run_agent_judge")
+    @patch("api.custom_tool_bridge.execute_tracked_runtime_tool_call")
+    def test_custom_tool_bridge_successes_do_not_increment_failure_budget(
+        self,
+        mock_execute_tracked_runtime,
+        mock_maybe_run_agent_judge,
+    ):
+        cache.clear()
+        custom_tool = self._create_bridge_custom_tool()
+        token = build_custom_tool_bridge_token(self.agent, custom_tool)
+        mock_execute_tracked_runtime.side_effect = [
+            ({"status": "error", "message": "first"}, None),
+            ({"status": "ok", "result": {"sent": 1}}, None),
+            ({"status": "error", "message": "second"}, None),
+        ]
+
+        first = self._post_bridge_tool_call(token)
+        second = self._post_bridge_tool_call(token)
+        third = self._post_bridge_tool_call(token)
+
+        self.assertFalse(first.json().get("custom_tool_abort", False))
+        self.assertEqual(second.json()["status"], "ok")
+        self.assertFalse(third.json().get("custom_tool_abort", False))
+        mock_maybe_run_agent_judge.assert_not_called()
+        self.assertFalse(
+            PersistentAgentSystemStep.objects.filter(
+                notes="custom_tool_child_failure_budget_exceeded",
+            ).exists()
+        )
+
+    @override_settings(CUSTOM_TOOL_CHILD_FAILURE_LIMIT=3)
+    @patch("api.custom_tool_bridge.maybe_run_agent_judge")
+    @patch("api.custom_tool_bridge.execute_tracked_runtime_tool_call")
+    def test_custom_tool_bridge_failure_budget_is_scoped_to_parent_step(
+        self,
+        mock_execute_tracked_runtime,
+        mock_maybe_run_agent_judge,
+    ):
+        cache.clear()
+        custom_tool = self._create_bridge_custom_tool()
+        parent_one = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Parent one",
+        )
+        parent_two = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Parent two",
+        )
+        token_one = build_custom_tool_bridge_token(
+            self.agent,
+            custom_tool,
+            parent_step_id=str(parent_one.id),
+        )
+        token_two = build_custom_tool_bridge_token(
+            self.agent,
+            custom_tool,
+            parent_step_id=str(parent_two.id),
+        )
+        mock_execute_tracked_runtime.return_value = ({"status": "error", "message": "failed"}, None)
+
+        self._post_bridge_tool_call(token_one)
+        self._post_bridge_tool_call(token_one)
+        response = self._post_bridge_tool_call(token_two)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json().get("custom_tool_abort", False))
+        mock_maybe_run_agent_judge.assert_not_called()
+        self.assertEqual(mock_execute_tracked_runtime.call_count, 3)
+
+    @override_settings(CUSTOM_TOOL_CHILD_FAILURE_LIMIT=3)
+    @patch("api.custom_tool_bridge.maybe_run_agent_judge")
+    def test_custom_tool_bridge_counts_recursive_child_denials(
+        self,
+        mock_maybe_run_agent_judge,
+    ):
+        cache.clear()
+        custom_tool = self._create_bridge_custom_tool()
+        token = build_custom_tool_bridge_token(self.agent, custom_tool)
+
+        first = self._post_bridge_tool_call(token, tool_name=custom_tool.tool_name)
+        second = self._post_bridge_tool_call(token, tool_name=custom_tool.tool_name)
+        third = self._post_bridge_tool_call(token, tool_name=custom_tool.tool_name)
+
+        self.assertEqual(
+            first.json()["message"],
+            "Custom tools cannot call themselves recursively.",
+        )
+        self.assertEqual(
+            second.json()["message"],
+            "Custom tools cannot call themselves recursively.",
+        )
+        self.assertTrue(third.json()["custom_tool_abort"])
+        mock_maybe_run_agent_judge.assert_called_once()
+
+    def test_custom_tool_context_raises_on_bridge_abort_response(self):
+        source = (
+            "import _gobii_ctx\n"
+            "ctx = _gobii_ctx.ToolContext()\n"
+            "ctx._call_tool_via_curl = lambda body: "
+            "'{\"status\":\"error\",\"custom_tool_abort\":true,\"message\":\"stopped\"}'\n"
+            "try:\n"
+            "    ctx.call_tool('send_email', {})\n"
+            "except RuntimeError as exc:\n"
+            "    print(str(exc))\n"
+        )
+
+        result = self._run_bootstrap_snippet(source)
+        self.assertIn("stopped", result)
 
     @patch("api.agent.tools.meta_ads.requests.get")
     @patch("api.agent.core.event_processing._ensure_credit_for_tool")


### PR DESCRIPTION
## Summary
- Add a per-custom-tool execution failure budget that aborts after 3 child tool errors and short-circuits subsequent bridge calls.
- Trigger the existing throttled judge path on abort and include the custom tool `.py` source in the judge trigger context.
- Raise from the custom tool runtime when the bridge returns a terminal abort payload so the custom tool exits cleanly.

## Testing
- `uv run python manage.py test tests.unit.test_custom_tools tests.unit.test_agent_llm_judge --settings=config.test_settings`
- Added unit coverage for failure counting, scoped execution state, recursive child denials, bridge abort behavior, and judge prompt context