### PR TITLE
Improve Google Sheets workflows and native integration resume signals

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -137,7 +137,6 @@ from ..tools.sqlite_state import agent_sqlite_db, get_sqlite_db_path
 from ..tools.secure_credentials_request import execute_secure_credentials_request
 from ..tools.request_contact_permission import execute_request_contact_permission
 from ..tools.request_human_input import execute_request_human_input
-from ..tools.spawn_agent import execute_spawn_agent
 from ..tools.search_tools import execute_search_tools
 from ..tools.static_tools import planning_mode_disallows_tool
 from ..tools.tool_manager import (
@@ -2370,7 +2369,6 @@ _DIRECT_TOOL_EXECUTORS: Dict[str, _ToolExecutorResolver] = {
     "secure_credentials_request": lambda: execute_secure_credentials_request,
     "request_contact_permission": lambda: execute_request_contact_permission,
     "request_human_input": lambda: execute_request_human_input,
-    "spawn_agent": lambda: execute_spawn_agent,
     "file_str_replace": lambda: execute_file_str_replace,
 }
 

--- a/api/agent/system_skills/defaults.py
+++ b/api/agent/system_skills/defaults.py
@@ -66,7 +66,8 @@ def _google_sheets_native_prompt_instructions(agent) -> str:
     integrations_url = _app_integrations_url()
     setup_text = (
         f"If setup is needed, tell the user to open `{integrations_url}`, connect Google Drive, "
-        "then choose the spreadsheet(s) the agent should be allowed to access.\n"
+        "then choose the spreadsheet(s) the agent should be allowed to access. The native connection and file-selection "
+        "events will wake you once the user finishes.\n"
         if not _native_integration_connected(agent, "google_drive")
         else ""
     )
@@ -98,11 +99,30 @@ def _google_sheets_native_prompt_instructions(agent) -> str:
         "mimeType = 'application/vnd.google-apps.spreadsheet' and trashed = false; add name contains 'text' "
         "when searching by title.\n"
         "- Spreadsheet metadata and sheet tabs: GET https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}\n"
+        "- Create a new spreadsheet: POST https://sheets.googleapis.com/v4/spreadsheets with JSON body "
+        "{\"properties\":{\"title\":\"...\"},\"sheets\":[{\"properties\":{\"title\":\"Sheet1\"}}]}. Do not use "
+        "Drive file creation for Google Sheets.\n"
         "- Read values: GET https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values/{url_encoded_range}\n"
         "- Update values: PUT https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values/"
         "{url_encoded_range}?valueInputOption=USER_ENTERED with JSON body {\"values\": [[...]]}\n"
         "- Append rows: POST https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values/"
         "{url_encoded_range}:append?valueInputOption=USER_ENTERED with JSON body {\"values\": [[...]]}\n"
+        "- Format or chart: POST https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}:batchUpdate with "
+        "valid Sheets `requests`.\n"
+        "When creating a reasonable new spreadsheet and the user has not specified columns, choose safe, obvious "
+        "default columns and proceed instead of blocking on a preference question. For new data sheets, write the "
+        "values first, then apply a polished baseline in the same turn: freeze row 1, bold and color the header, "
+        "auto-resize populated columns, apply sensible number/date formats when column meaning is clear, and add "
+        "alternating row colors with `addBanding` using the exact key `bandedRange`.\n"
+        "Before adding banding to an existing sheet, inspect spreadsheet metadata. If a matching banded range "
+        "already exists, skip `addBanding` or update/delete the existing banded range instead of adding a duplicate. "
+        "Malformed `batchUpdate` requests usually need the request object names fixed, not blind retries.\n"
+        "For charts, bind labels through `basicChart.domains` and numeric values through `basicChart.series`. If "
+        "you add helper columns or rows for numeric data and hide them, set `hiddenDimensionStrategy` to `SHOW_ALL`; "
+        "otherwise the chart may show no series. For `updateChartSpec`, send the complete chart spec and do not "
+        "include a `fields` parameter.\n"
+        "For native API calls, treat a tool result with `status: error` or a non-2xx `status_code` as a failed API "
+        "call. Use the returned guidance and response body to repair the request before telling the user it worked.\n"
         f"{missing_file_text}"
     )
 
@@ -110,7 +130,8 @@ def _google_sheets_native_prompt_instructions(agent) -> str:
 def _apollo_native_prompt_instructions(agent) -> str:
     integrations_url = _app_integrations_url()
     setup_text = (
-        f"If setup is needed, tell the user to open `{integrations_url}` and connect Apollo. "
+        f"If setup is needed, tell the user to open `{integrations_url}` and connect Apollo; "
+        "the native connection event will wake you once the user finishes. "
         if not _native_integration_connected(agent, "apollo")
         else ""
     )
@@ -164,7 +185,8 @@ def _apollo_native_prompt_instructions(agent) -> str:
 def _hubspot_native_prompt_instructions(agent) -> str:
     integrations_url = _app_integrations_url()
     setup_text = (
-        f"If setup is needed, tell the user to open `{integrations_url}` and connect HubSpot.\n"
+        f"If setup is needed, tell the user to open `{integrations_url}` and connect HubSpot; "
+        "the native connection event will wake you once the user finishes.\n"
         if not _native_integration_connected(agent, "hubspot")
         else ""
     )
@@ -285,18 +307,21 @@ CUSTOM_TOOL_DEVELOPMENT_SYSTEM_SKILL = SystemSkillDefinition(
 GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL = SystemSkillDefinition(
     skill_key=GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
     name="Google Sheets",
-    search_summary="Read and update selected Google Sheets through the native Google Drive integration.",
+    search_summary="Create, read, update, format, and chart Google Sheets through the native Google Drive integration.",
     tool_names=("http_request",),
     enables=(
         "read Google Sheets metadata and worksheet names",
+        "create new Google Sheets spreadsheets",
         "read spreadsheet ranges and rows",
         "append rows to selected spreadsheets",
         "update ranges in selected spreadsheets",
+        "format sheets with headers, frozen rows, banding, sizing, and charts",
         "use native Google Drive OAuth with drive.file access",
     ),
     use_when=(
         "the user asks to read a Google Sheet",
         "the user asks to update, append, or write spreadsheet rows",
+        "the user asks to create, format, polish, or chart a Google Sheet",
         "the user asks to find or search for one of their Google Sheets by name",
         "the user asks to inspect worksheets, tabs, ranges, cells, or formulas in Google Sheets",
         "the work references a spreadsheet selected through the native Google Drive integration",

--- a/api/agent/tools/http_request.py
+++ b/api/agent/tools/http_request.py
@@ -24,6 +24,7 @@ from ...services.native_integrations import (
     NativeIntegrationAuthError,
     NativeIntegrationConfigurationError,
     apply_native_integration_auth,
+    find_provider_for_url,
 )
 from ...services.persistent_agent_secrets import global_secrets_queryset_for_agent
 from ..files.attachment_helpers import build_signed_filespace_download_url
@@ -43,6 +44,33 @@ _JSON_PREFIXES = (
     "for(;;);",
     "/*-secure-*/",
 )
+
+
+def _native_http_error_guidance(provider_key: str, status_code: int, content: Any) -> str:
+    if provider_key != "google_drive":
+        return "Check the native integration connection, requested scopes, endpoint, and request body before retrying."
+
+    content_text = json.dumps(content) if isinstance(content, (dict, list)) else str(content or "")
+    content_lower = content_text.lower()
+    if "addbanding" in content_lower or "banding" in content_lower:
+        return (
+            "For Google Sheets formatting, use batchUpdate addBanding.bandedRange and inspect existing bandedRanges "
+            "before adding another alternating-color range."
+        )
+    if "chart" in content_lower or "series" in content_lower:
+        return (
+            "For Google Sheets charts, send a full chart spec with valid domain and series ranges. Do not include "
+            "fields on updateChartSpec, and set hiddenDimensionStrategy to SHOW_ALL when helper data is hidden."
+        )
+    if status_code in {401, 403, 404}:
+        return (
+            "Confirm Google Drive is connected and that the user selected the target spreadsheet or document in "
+            "Google Picker before retrying."
+        )
+    return (
+        "Check the Google Sheets or Drive API request shape, especially batchUpdate request names, ranges, and "
+        "selected-file access."
+    )
 
 
 def _strip_json_prefixes(text: str) -> str:
@@ -428,6 +456,7 @@ def execute_http_request(agent: PersistentAgent, params: Dict[str, Any]) -> Dict
     headers = {k: _replace_placeholders(v) for k, v in headers.items()}
     body = _replace_placeholders(body)
 
+    native_provider = find_provider_for_url(url)
     try:
         headers = apply_native_integration_auth(agent, url, headers, method=method)
     except NativeIntegrationConfigurationError as exc:
@@ -503,11 +532,23 @@ def execute_http_request(agent: PersistentAgent, params: Dict[str, Any]) -> Dict
 
     if download_requested and (resp.status_code < 200 or resp.status_code >= 300):
         resp.close()
-        return {
+        result = {
             "status": "error",
             "message": f"Download failed with status {resp.status_code}.",
             "status_code": resp.status_code,
         }
+        if native_provider is not None:
+            result.update(
+                {
+                    "provider_key": native_provider.key,
+                    "provider_name": native_provider.display_name,
+                    "method": method,
+                    "url": url,
+                    "retryable": resp.status_code >= 500 or resp.status_code == 429,
+                    "guidance": _native_http_error_guidance(native_provider.key, resp.status_code, ""),
+                }
+            )
+        return result
 
     content_length = resp.headers.get("Content-Length")
     try:
@@ -625,6 +666,19 @@ def execute_http_request(agent: PersistentAgent, params: Dict[str, Any]) -> Dict
         "headers": dict(resp.headers),
         "content": content_str,
     }
+    if native_provider is not None and (resp.status_code < 200 or resp.status_code >= 300):
+        response.update(
+            {
+                "status": "error",
+                "message": f"{native_provider.display_name} API request failed with status {resp.status_code}.",
+                "provider_key": native_provider.key,
+                "provider_name": native_provider.display_name,
+                "method": method,
+                "url": url,
+                "retryable": resp.status_code >= 500 or resp.status_code == 429,
+                "guidance": _native_http_error_guidance(native_provider.key, resp.status_code, content_str),
+            }
+        )
     if download_requested:
         content_type_header = resp.headers.get("Content-Type") or ""
         mime_type = content_type_header.split(";", 1)[0].strip().lower() or "application/octet-stream"

--- a/api/agent/tools/spawn_agent.py
+++ b/api/agent/tools/spawn_agent.py
@@ -70,56 +70,6 @@ def _build_urls(agent: PersistentAgent, spawn_request: AgentSpawnRequest) -> tup
     return approval_url, decision_path
 
 
-def get_spawn_agent_tool(
-    agent: PersistentAgent | None = None,
-    *,
-    available_capacity: int | None = None,
-) -> Dict[str, Any]:
-    availability_note = ""
-    if agent:
-        available = available_capacity
-        if available is None:
-            owner = _owner_for_agent(agent)
-            available = AgentService.get_agents_available(owner)
-        availability_note = f" Current owner capacity: {max(int(available), 0)} additional agent(s)."
-
-    return {
-        "type": "function",
-        "function": {
-            "name": "spawn_agent",
-            "description": (
-                "Request creation of a specialist partner agent when work is genuinely outside your charter/scope. "
-                "This does not create the agent immediately: it creates a human approval request (Create/Decline). "
-                "On approval, the new agent is automatically peer-linked and receives your handoff message. "
-                "Use sparingly for clear scope boundaries, not for convenience."
-                f"{availability_note}"
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "charter": {
-                        "type": "string",
-                        "description": "Full charter/instructions for the specialist agent to run with.",
-                    },
-                    "handoff_message": {
-                        "type": "string",
-                        "description": "Initial task handoff sent from you to the spawned agent after approval.",
-                    },
-                    "reason": {
-                        "type": "string",
-                        "description": "Why this work is out-of-scope and requires a specialist agent.",
-                    },
-                    "will_continue_work": {
-                        "type": "boolean",
-                        "description": "REQUIRED. true = you will continue with more work now, false = done after this action.",
-                    },
-                },
-                "required": ["charter", "handoff_message", "will_continue_work"],
-            },
-        },
-    }
-
-
 def execute_spawn_agent(
     agent: PersistentAgent,
     params: Dict[str, Any],

--- a/api/agent/tools/static_tools.py
+++ b/api/agent/tools/static_tools.py
@@ -12,7 +12,6 @@ PLANNING_MODE_DISABLED_TOOL_NAMES = frozenset({
     CREATE_CUSTOM_TOOL_NAME,
     "file_str_replace",
     "request_contact_permission",
-    "spawn_agent",
     "spawn_web_task",
     "update_plan",
 })

--- a/api/agent/tools/tool_runtime.py
+++ b/api/agent/tools/tool_runtime.py
@@ -16,7 +16,6 @@ from .schedule_updater import execute_update_schedule
 from .search_tools import execute_search_tools
 from .secure_credentials_request import execute_secure_credentials_request
 from .sms_sender import execute_send_sms
-from .spawn_agent import execute_spawn_agent
 from .spawn_web_task import execute_spawn_web_task
 from .static_tools import planning_mode_disallows_tool
 from .tool_manager import execute_enabled_tool
@@ -72,8 +71,6 @@ def execute_runtime_tool_call(
         return execute_request_contact_permission(agent, exec_params), updated_tools
     if tool_name == "request_human_input":
         return execute_request_human_input(agent, exec_params), updated_tools
-    if tool_name == "spawn_agent":
-        return execute_spawn_agent(agent, exec_params), updated_tools
     if tool_name == "search_tools":
         result = execute_search_tools(agent, exec_params)
         updated_tools = _refresh_agent_tools(agent)

--- a/api/evals/scenarios/google_sheets_native.py
+++ b/api/evals/scenarios/google_sheets_native.py
@@ -22,6 +22,10 @@ GOOGLE_SHEETS_NATIVE_SEARCH_TEST_BY_NAME = "google_sheets_native_search_test_by_
 GOOGLE_SHEETS_NATIVE_LIST_TABS = "google_sheets_native_list_tabs"
 GOOGLE_SHEETS_NATIVE_READ_RANGE = "google_sheets_native_read_range"
 GOOGLE_SHEETS_NATIVE_APPEND_ROW = "google_sheets_native_append_row"
+GOOGLE_SHEETS_NATIVE_CREATE_DEFAULT_COLUMNS = "google_sheets_native_create_default_columns"
+GOOGLE_SHEETS_NATIVE_CREATE_AND_FORMAT = "google_sheets_native_create_and_format"
+GOOGLE_SHEETS_NATIVE_FORMAT_EXISTING_IDEMPOTENT = "google_sheets_native_format_existing_idempotent"
+GOOGLE_SHEETS_NATIVE_CHART_WITH_HELPER_DATA = "google_sheets_native_chart_with_helper_data"
 GOOGLE_SHEETS_NATIVE_MISSING_SELECTED_FILE = "google_sheets_native_missing_selected_file"
 
 FORBIDDEN_DISCOVERY_TOOL_NAMES = ("search_tools", "enable_system_skills")
@@ -39,6 +43,7 @@ def _http_result(url: str, content: Any, *, status_code: int = 200) -> dict[str,
 DRIVE_SEARCH_URL = "https://www.googleapis.com/drive/v3/files"
 SALES_TRACKER_ID = "sheet-sales-q2"
 GENERIC_TRACKER_ID = "sheet-123"
+LOCAL_LLMS_SHEET_ID = "sheet-local-llms"
 
 
 def _drive_files_result(files: list[dict[str, str]]) -> dict[str, Any]:
@@ -90,6 +95,54 @@ def _generic_tracker_leads_values_rule() -> dict[str, Any]:
                 "values": [
                     ["Company", "Owner", "Priority"],
                     ["Existing Co", "Mina", "Medium"],
+                ],
+            },
+        ),
+    }
+
+
+def _create_local_llms_rule() -> dict[str, Any]:
+    return {
+        "url_contains": "sheets.googleapis.com/v4/spreadsheets",
+        "result": _http_result(
+            "https://sheets.googleapis.com/v4/spreadsheets",
+            {
+                "spreadsheetId": LOCAL_LLMS_SHEET_ID,
+                "spreadsheetUrl": f"https://docs.google.com/spreadsheets/d/{LOCAL_LLMS_SHEET_ID}/edit",
+                "properties": {"title": "Top Local LLM Models"},
+                "sheets": [{"properties": {"sheetId": 0, "title": "Models"}}],
+            },
+        ),
+    }
+
+
+def _local_llms_values_update_rule() -> dict[str, Any]:
+    return {
+        "url_contains": (
+            f"sheets.googleapis.com/v4/spreadsheets/{LOCAL_LLMS_SHEET_ID}/values",
+            "models",
+        ),
+        "result": _http_result(
+            f"https://sheets.googleapis.com/v4/spreadsheets/{LOCAL_LLMS_SHEET_ID}/values/Models!A1:F10",
+            {"spreadsheetId": LOCAL_LLMS_SHEET_ID, "updatedRows": 6, "updatedCells": 30},
+        ),
+    }
+
+
+def _local_llms_format_rule() -> dict[str, Any]:
+    return {
+        "url_contains": (
+            f"sheets.googleapis.com/v4/spreadsheets/{LOCAL_LLMS_SHEET_ID}:batchUpdate",
+        ),
+        "result": _http_result(
+            f"https://sheets.googleapis.com/v4/spreadsheets/{LOCAL_LLMS_SHEET_ID}:batchUpdate",
+            {
+                "spreadsheetId": LOCAL_LLMS_SHEET_ID,
+                "replies": [
+                    {"updateSheetProperties": {}},
+                    {"repeatCell": {}},
+                    {"addBanding": {"bandedRange": {"bandedRangeId": 88}}},
+                    {"autoResizeDimensions": {}},
                 ],
             },
         ),
@@ -284,6 +337,158 @@ GOOGLE_SHEETS_NATIVE_CASES = (
         ),
         response_term_groups=(("row", "appended", "updated"),),
         tags=("values_write",),
+    ),
+    GoogleSheetsNativeCase(
+        slug=GOOGLE_SHEETS_NATIVE_CREATE_DEFAULT_COLUMNS,
+        description="Create a useful spreadsheet with safe default columns instead of asking for preferences.",
+        prompt=(
+            "Create a Google Sheet named Top Local LLM Models with the latest useful local LLM model list. "
+            "Use sensible default columns if I did not specify them."
+        ),
+        http_rules=(
+            _local_llms_values_update_rule(),
+            _local_llms_format_rule(),
+            _create_local_llms_rule(),
+        ),
+        expected_http_requests=(
+            HttpRequestExpectation(
+                name="create_spreadsheet",
+                method="POST",
+                url_terms=("sheets.googleapis.com/v4/spreadsheets",),
+                body_terms=("top local llm models",),
+            ),
+            HttpRequestExpectation(
+                name="write_default_columns",
+                method="PUT",
+                url_terms=(
+                    f"sheets.googleapis.com/v4/spreadsheets/{LOCAL_LLMS_SHEET_ID}/values",
+                    "models",
+                    "valueinputoption=user_entered",
+                ),
+                body_terms=("name", "size", "license", "links"),
+            ),
+        ),
+        response_term_groups=(("Top Local LLM Models", LOCAL_LLMS_SHEET_ID),),
+        tags=("create", "defaults"),
+    ),
+    GoogleSheetsNativeCase(
+        slug=GOOGLE_SHEETS_NATIVE_CREATE_AND_FORMAT,
+        description="Create, populate, and apply baseline formatting to a new spreadsheet.",
+        prompt=(
+            "Make a polished Google Sheet called Top Local LLM Models with columns for name, size, license, links, "
+            "and release date."
+        ),
+        http_rules=(
+            _local_llms_values_update_rule(),
+            _local_llms_format_rule(),
+            _create_local_llms_rule(),
+        ),
+        expected_http_requests=(
+            HttpRequestExpectation(
+                name="create_spreadsheet",
+                method="POST",
+                url_terms=("sheets.googleapis.com/v4/spreadsheets",),
+                body_terms=("top local llm models",),
+            ),
+            HttpRequestExpectation(
+                name="write_values",
+                method="PUT",
+                url_terms=(f"sheets.googleapis.com/v4/spreadsheets/{LOCAL_LLMS_SHEET_ID}/values",),
+                body_terms=("release date", "license", "links"),
+            ),
+            HttpRequestExpectation(
+                name="format_spreadsheet",
+                method="POST",
+                url_terms=(f"sheets.googleapis.com/v4/spreadsheets/{LOCAL_LLMS_SHEET_ID}:batchupdate",),
+                body_terms=("freezerowcount", "repeatcell", "addbanding", "bandedrange", "autoresizedimensions"),
+            ),
+        ),
+        response_term_groups=(("polished", "formatted", "ready"), (LOCAL_LLMS_SHEET_ID,)),
+        tags=("create", "format"),
+    ),
+    GoogleSheetsNativeCase(
+        slug=GOOGLE_SHEETS_NATIVE_FORMAT_EXISTING_IDEMPOTENT,
+        description="Inspect existing formatting before adding banding to avoid duplicate banded ranges.",
+        prompt="Format Google spreadsheet sheet-123 so it looks polished. Avoid breaking existing alternating row colors.",
+        http_rules=(
+            {
+                "url_contains": f"sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}",
+                "result": _http_result(
+                    f"https://sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}",
+                    {
+                        "spreadsheetId": GENERIC_TRACKER_ID,
+                        "properties": {"title": "Ops Tracker"},
+                        "sheets": [
+                            {
+                                "properties": {"sheetId": 0, "title": "Leads"},
+                                "bandedRanges": [{"bandedRangeId": 77, "range": {"sheetId": 0}}],
+                            }
+                        ],
+                    },
+                ),
+            },
+            {
+                "url_contains": f"sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}:batchUpdate",
+                "result": _http_result(
+                    f"https://sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}:batchUpdate",
+                    {"spreadsheetId": GENERIC_TRACKER_ID, "replies": [{"repeatCell": {}}, {"autoResizeDimensions": {}}]},
+                ),
+            },
+        ),
+        expected_http_requests=(
+            HttpRequestExpectation(
+                name="inspect_existing_formatting",
+                url_terms=(f"sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}",),
+            ),
+            HttpRequestExpectation(
+                name="format_without_duplicate_banding",
+                method="POST",
+                url_terms=(f"sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}:batchupdate",),
+                body_terms=("repeatcell", "autoresizedimensions"),
+            ),
+        ),
+        response_term_groups=(("formatted", "polished"),),
+        tags=("format", "idempotent"),
+    ),
+    GoogleSheetsNativeCase(
+        slug=GOOGLE_SHEETS_NATIVE_CHART_WITH_HELPER_DATA,
+        description="Create a chart that binds numeric helper data even when helper columns are hidden.",
+        prompt=(
+            "In Google spreadsheet sheet-123, add a chart visualizing model sizes. If you need a helper numeric "
+            "column, make sure the chart still reads it."
+        ),
+        http_rules=(
+            {
+                "url_contains": f"sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}/values",
+                "result": _http_result(
+                    f"https://sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}/values/Leads!F1:F10",
+                    {"spreadsheetId": GENERIC_TRACKER_ID, "updatedRows": 6, "updatedCells": 6},
+                ),
+            },
+            {
+                "url_contains": f"sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}:batchUpdate",
+                "result": _http_result(
+                    f"https://sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}:batchUpdate",
+                    {"spreadsheetId": GENERIC_TRACKER_ID, "replies": [{"addChart": {"chart": {"chartId": 55}}}]},
+                ),
+            },
+        ),
+        expected_http_requests=(
+            HttpRequestExpectation(
+                name="write_numeric_helper_data",
+                method="PUT",
+                url_terms=(f"sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}/values",),
+                body_terms=("values",),
+            ),
+            HttpRequestExpectation(
+                name="add_bound_chart",
+                method="POST",
+                url_terms=(f"sheets.googleapis.com/v4/spreadsheets/{GENERIC_TRACKER_ID}:batchupdate",),
+                body_terms=("addchart", "basicchart", "domains", "series", "hiddendimensionstrategy", "show_all"),
+            ),
+        ),
+        response_term_groups=(("chart",),),
+        tags=("chart", "helper_data"),
     ),
     GoogleSheetsNativeCase(
         slug=GOOGLE_SHEETS_NATIVE_MISSING_SELECTED_FILE,

--- a/api/evals/tests/test_google_sheets_native.py
+++ b/api/evals/tests/test_google_sheets_native.py
@@ -24,12 +24,12 @@ from api.evals.suites import SuiteRegistry
 
 @tag("eval_sim")
 class GoogleSheetsNativeScenarioTests(SimpleTestCase):
-    def test_google_sheets_native_suite_contains_six_scenarios(self):
+    def test_google_sheets_native_suite_contains_ten_scenarios(self):
         suite = SuiteRegistry.get(GOOGLE_SHEETS_NATIVE_SUITE_SLUG)
 
         self.assertIsNotNone(suite)
         self.assertEqual(tuple(suite.scenario_slugs), GOOGLE_SHEETS_NATIVE_SCENARIO_SLUGS)
-        self.assertEqual(len(suite.scenario_slugs), 6)
+        self.assertEqual(len(suite.scenario_slugs), 10)
 
     def test_generated_scenarios_have_expected_metadata(self):
         registered = ScenarioRegistry.list_all()
@@ -61,7 +61,7 @@ class GoogleSheetsNativeScenarioTests(SimpleTestCase):
             for expectation in case.expected_http_requests:
                 self.assertEqual(expectation.name.startswith("google_sheets-"), False)
                 self.assertTrue(expectation.url_terms)
-                self.assertIn(expectation.method, {"GET", "POST"})
+                self.assertIn(expectation.method, {"GET", "POST", "PUT"})
 
             prompt_and_description = f"{case.prompt} {case.description}"
             self.assertNotIn("google_sheets-", prompt_and_description)

--- a/api/services/native_integration_events.py
+++ b/api/services/native_integration_events.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from typing import Any
 
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -16,6 +17,10 @@ def resolve_native_integration_event_agent(agent_id: str, *, owner_user, owner_o
     normalized_agent_id = str(agent_id or "").strip()
     if not normalized_agent_id:
         raise ValidationError({"agent_id": "agent_id is required."})
+    try:
+        uuid.UUID(normalized_agent_id)
+    except ValueError as exc:
+        raise ValidationError({"agent_id": "Invalid agent_id format."}) from exc
 
     queryset = PersistentAgent.objects.non_eval().alive()
     if owner_org is not None:
@@ -98,11 +103,13 @@ def record_native_integration_agent_event(
         "files": normalized_files,
     }
 
-    step = PersistentAgentStep.objects.create(agent=agent, description=description)
-    PersistentAgentSystemStep.objects.create(
-        step=step,
-        code=PersistentAgentSystemStep.Code.SYSTEM_DIRECTIVE,
-        notes=json.dumps(notes_payload, separators=(",", ":"), sort_keys=True),
-    )
-    transaction.on_commit(lambda: process_agent_events_task.delay(str(agent.id)))
+    with transaction.atomic():
+        step = PersistentAgentStep.objects.create(agent=agent, description=description)
+        PersistentAgentSystemStep.objects.create(
+            step=step,
+            code=PersistentAgentSystemStep.Code.SYSTEM_DIRECTIVE,
+            notes=json.dumps(notes_payload, separators=(",", ":"), sort_keys=True),
+        )
+        agent_id_str = str(agent.id)
+        transaction.on_commit(lambda: process_agent_events_task.delay(agent_id_str))
     return step

--- a/api/services/native_integration_events.py
+++ b/api/services/native_integration_events.py
@@ -1,0 +1,108 @@
+import json
+from typing import Any
+
+from django.core.exceptions import PermissionDenied, ValidationError
+from django.db import transaction
+
+from api.agent.tasks import process_agent_events_task
+from api.models import PersistentAgent, PersistentAgentStep, PersistentAgentSystemStep
+from api.services.native_integrations import NativeIntegrationProvider
+
+NATIVE_INTEGRATION_EVENT_TYPES = {"connected", "files_selected"}
+MAX_NATIVE_INTEGRATION_EVENT_FILES = 50
+
+
+def resolve_native_integration_event_agent(agent_id: str, *, owner_user, owner_org) -> PersistentAgent:
+    normalized_agent_id = str(agent_id or "").strip()
+    if not normalized_agent_id:
+        raise ValidationError({"agent_id": "agent_id is required."})
+
+    queryset = PersistentAgent.objects.non_eval().alive()
+    if owner_org is not None:
+        queryset = queryset.filter(organization=owner_org)
+    else:
+        queryset = queryset.filter(user=owner_user, organization__isnull=True)
+
+    agent = queryset.filter(id=normalized_agent_id).first()
+    if agent is None:
+        raise PermissionDenied("You do not have access to this agent.")
+    return agent
+
+
+def normalize_native_integration_event_files(raw_files: Any) -> list[dict[str, str]]:
+    if raw_files in (None, ""):
+        return []
+    if not isinstance(raw_files, list):
+        raise ValidationError({"files": "files must be a list."})
+    if len(raw_files) > MAX_NATIVE_INTEGRATION_EVENT_FILES:
+        raise ValidationError({"files": f"Select at most {MAX_NATIVE_INTEGRATION_EVENT_FILES} files at a time."})
+
+    files: list[dict[str, str]] = []
+    for index, raw_file in enumerate(raw_files):
+        if not isinstance(raw_file, dict):
+            raise ValidationError({"files": f"File entry {index + 1} must be an object."})
+        external_id = str(raw_file.get("external_id") or raw_file.get("externalId") or "").strip()
+        name = str(raw_file.get("name") or "").strip()
+        mime_type = str(raw_file.get("mime_type") or raw_file.get("mimeType") or "").strip()
+        web_url = str(raw_file.get("web_url") or raw_file.get("webUrl") or "").strip()
+        if not external_id or not name or not mime_type:
+            raise ValidationError({"files": f"File entry {index + 1} requires external_id, name, and mime_type."})
+        files.append(
+            {
+                "external_id": external_id,
+                "name": name,
+                "mime_type": mime_type,
+                "web_url": web_url,
+            }
+        )
+    return files
+
+
+def record_native_integration_agent_event(
+    *,
+    agent: PersistentAgent,
+    provider: NativeIntegrationProvider,
+    event_type: str,
+    files: list[dict[str, str]] | None = None,
+    source: str = "unknown",
+) -> PersistentAgentStep:
+    normalized_event_type = str(event_type or "").strip()
+    if normalized_event_type not in NATIVE_INTEGRATION_EVENT_TYPES:
+        raise ValidationError({"event_type": "event_type must be connected or files_selected."})
+
+    normalized_files = files or []
+    if normalized_event_type == "files_selected" and not normalized_files:
+        raise ValidationError({"files": "files are required for files_selected events."})
+
+    if normalized_event_type == "connected":
+        description = (
+            f"{provider.display_name} was connected by the user. "
+            "Resume any blocked work that was waiting for this native integration."
+        )
+    else:
+        file_names = ", ".join(file["name"] for file in normalized_files[:5])
+        remaining_count = max(0, len(normalized_files) - 5)
+        if remaining_count:
+            file_names = f"{file_names}, and {remaining_count} more"
+        description = (
+            f"The user selected {len(normalized_files)} {provider.display_name} file"
+            f"{'' if len(normalized_files) == 1 else 's'} for this agent: {file_names}. "
+            "Use these selected file IDs for native integration work when relevant."
+        )
+
+    notes_payload = {
+        "source": source,
+        "provider_key": provider.key,
+        "provider_name": provider.display_name,
+        "event_type": normalized_event_type,
+        "files": normalized_files,
+    }
+
+    step = PersistentAgentStep.objects.create(agent=agent, description=description)
+    PersistentAgentSystemStep.objects.create(
+        step=step,
+        code=PersistentAgentSystemStep.Code.SYSTEM_DIRECTIVE,
+        notes=json.dumps(notes_payload, separators=(",", ":"), sort_keys=True),
+    )
+    transaction.on_commit(lambda: process_agent_events_task.delay(str(agent.id)))
+    return step

--- a/api/services/native_integrations.py
+++ b/api/services/native_integrations.py
@@ -261,12 +261,45 @@ NATIVE_INTEGRATION_CAPABILITIES: dict[str, tuple[NativeIntegrationCapability, ..
             provider_key=GOOGLE_DRIVE_PROVIDER.key,
             resource="google_sheets",
             operation="write",
-            label="Update or append rows in selected Google Sheets",
+            label="Update, append, and edit values in selected Google Sheets",
             required_scopes=("https://www.googleapis.com/auth/drive.file",),
             endpoint_hints=(
                 "PUT https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values/{range}",
                 "POST https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}/values/{range}:append",
             ),
+            write_risk="write",
+            setup_guidance="Connect Google Drive and choose the spreadsheet in Google Picker.",
+        ),
+        NativeIntegrationCapability(
+            key="google_sheets_create",
+            provider_key=GOOGLE_DRIVE_PROVIDER.key,
+            resource="google_sheets",
+            operation="create",
+            label="Create new Google Sheets spreadsheets",
+            required_scopes=("https://www.googleapis.com/auth/drive.file",),
+            endpoint_hints=("POST https://sheets.googleapis.com/v4/spreadsheets",),
+            write_risk="write",
+            setup_guidance="Connect Google Drive before creating spreadsheets.",
+        ),
+        NativeIntegrationCapability(
+            key="google_sheets_format",
+            provider_key=GOOGLE_DRIVE_PROVIDER.key,
+            resource="google_sheets",
+            operation="format",
+            label="Format selected Google Sheets with styles, banding, frozen rows, and column sizing",
+            required_scopes=("https://www.googleapis.com/auth/drive.file",),
+            endpoint_hints=("POST https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}:batchUpdate",),
+            write_risk="write",
+            setup_guidance="Connect Google Drive and choose the spreadsheet in Google Picker.",
+        ),
+        NativeIntegrationCapability(
+            key="google_sheets_chart",
+            provider_key=GOOGLE_DRIVE_PROVIDER.key,
+            resource="google_sheets",
+            operation="chart",
+            label="Create and update charts in selected Google Sheets",
+            required_scopes=("https://www.googleapis.com/auth/drive.file",),
+            endpoint_hints=("POST https://sheets.googleapis.com/v4/spreadsheets/{spreadsheetId}:batchUpdate",),
             write_risk="write",
             setup_guidance="Connect Google Drive and choose the spreadsheet in Google Picker.",
         ),
@@ -890,7 +923,11 @@ def native_integration_capability_for_request(
     capability_key = ""
     if provider.key == GOOGLE_DRIVE_PROVIDER.key:
         if host == "sheets.googleapis.com":
-            if normalized_method in {"POST", "PUT", "PATCH", "DELETE"}:
+            if normalized_method == "POST" and path.rstrip("/") == "/v4/spreadsheets":
+                capability_key = "google_sheets_create"
+            elif normalized_method == "POST" and path.endswith(":batchupdate"):
+                capability_key = "google_sheets_format"
+            elif normalized_method in {"POST", "PUT", "PATCH", "DELETE"}:
                 capability_key = "google_sheets_write"
             else:
                 capability_key = "google_sheets_read"

--- a/config/urls.py
+++ b/config/urls.py
@@ -191,6 +191,7 @@ from console.secrets_api_views import (
 )
 from console.native_integrations_api import (
     NativeIntegrationCallbackAPIView,
+    NativeIntegrationAgentEventAPIView,
     NativeIntegrationConnectAPIView,
     NativeIntegrationFilesAPIView,
     NativeIntegrationListAPIView,
@@ -637,6 +638,11 @@ urlpatterns = [
         "console/api/native-integrations/<slug:provider_key>/files/",
         NativeIntegrationFilesAPIView.as_view(),
         name="console-native-integration-files",
+    ),
+    path(
+        "console/api/native-integrations/<slug:provider_key>/agent-events/",
+        NativeIntegrationAgentEventAPIView.as_view(),
+        name="console-native-integration-agent-events",
     ),
     path(
         "console/api/native-integrations/<slug:provider_key>/revoke/",

--- a/console/agent_chat/pending_actions.py
+++ b/console/agent_chat/pending_actions.py
@@ -1,3 +1,4 @@
+from django.db.models import Count, Q
 from django.urls import reverse
 from django.utils import timezone
 
@@ -9,6 +10,7 @@ from api.models import (
     AgentSpawnRequest,
     CommsAllowlistRequest,
     PersistentAgent,
+    PersistentAgentHumanInputRequest,
     PersistentAgentSecret,
 )
 
@@ -75,6 +77,64 @@ def _serialize_contact_request(request_obj: CommsAllowlistRequest) -> dict:
 
 def serialize_contact_request(request_obj: CommsAllowlistRequest) -> dict:
     return _serialize_contact_request(request_obj)
+
+
+def _add_pending_counts(counts: dict[str, int], queryset) -> None:
+    for row in queryset.values("agent_id").annotate(total=Count("id")):
+        counts[str(row["agent_id"])] = counts.get(str(row["agent_id"]), 0) + int(row["total"] or 0)
+
+
+def count_pending_action_requests_for_agents(agents: list[PersistentAgent], viewer_user) -> dict[str, int]:
+    agent_ids = [agent.id for agent in agents]
+    counts = {str(agent_id): 0 for agent_id in agent_ids}
+    if not agent_ids:
+        return counts
+
+    now = timezone.now()
+    active_expiry_filter = Q(expires_at__isnull=True) | Q(expires_at__gt=now)
+    _add_pending_counts(
+        counts,
+        PersistentAgentHumanInputRequest.objects.filter(
+            agent_id__in=agent_ids,
+            status=PersistentAgentHumanInputRequest.Status.PENDING,
+        ).filter(active_expiry_filter),
+    )
+
+    manageable_agent_ids = [
+        agent.id
+        for agent in agents
+        if viewer_user is not None and user_can_manage_agent_settings(
+            viewer_user,
+            agent,
+            allow_delinquent_personal_chat=True,
+        )
+    ]
+    if not manageable_agent_ids:
+        return counts
+
+    _add_pending_counts(
+        counts,
+        AgentSpawnRequest.objects.filter(
+            agent_id__in=manageable_agent_ids,
+            status=AgentSpawnRequest.RequestStatus.PENDING,
+        ).filter(active_expiry_filter),
+    )
+    _add_pending_counts(
+        counts,
+        PersistentAgentSecret.objects.filter(
+            agent_id__in=manageable_agent_ids,
+            requested=True,
+        ),
+    )
+    _add_pending_counts(
+        counts,
+        CommsAllowlistRequest.objects.filter(
+            agent_id__in=manageable_agent_ids,
+            status=CommsAllowlistRequest.RequestStatus.PENDING,
+        ).filter(active_expiry_filter),
+    )
+
+    return counts
 
 
 def _serialize_spawn_request(agent: PersistentAgent, spawn_request: AgentSpawnRequest) -> dict:

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -198,6 +198,7 @@ from console.agent_chat.access import (
     user_is_collaborator,
 )
 from console.agent_chat.pending_actions import (
+    count_pending_action_requests_for_agents,
     expire_pending_action_requests,
     get_legacy_pending_human_input_requests,
     list_pending_action_requests,
@@ -3198,12 +3199,13 @@ class AgentChatRosterAPIView(LoginRequiredMixin, View):
         collaborators_by_agent_id = {agent.id for agent in shared_agents}
         agents += shared_agents
         enrich_agents_for_card_surface(agents, owner)
+        user = request.user
         processing_activity_by_agent_id = build_processing_activity_map(agents)
+        pending_action_counts_by_agent_id = count_pending_action_requests_for_agents(agents, user)
         message_read_state_by_agent_id = build_latest_agent_message_read_state(
             (agent.id for agent in agents),
             request.user,
         )
-        user = request.user
         org_memberships = OrganizationMembership.objects.filter(
             user=user,
             status=OrganizationMembership.OrgStatus.ACTIVE,
@@ -3291,6 +3293,7 @@ class AgentChatRosterAPIView(LoginRequiredMixin, View):
                     "last_interaction_at": agent.last_interaction_at.isoformat() if agent.last_interaction_at else None,
                     "signup_preview_state": agent.signup_preview_state,
                     "planning_state": agent.planning_state,
+                    "pending_action_request_count": pending_action_counts_by_agent_id.get(str(agent.id), 0),
                     "enabled_system_skills": [
                         state.skill_key
                         for state in getattr(agent, "enabled_system_skill_states_for_roster", [])

--- a/console/native_integrations_api.py
+++ b/console/native_integrations_api.py
@@ -228,6 +228,8 @@ class NativeIntegrationCallbackAPIView(LoginRequiredMixin, View):
             payload = json.loads(body or "{}")
         except json.JSONDecodeError:
             return HttpResponseBadRequest("Invalid JSON body")
+        if not isinstance(payload, dict):
+            return HttpResponseBadRequest("Invalid JSON payload: expected an object")
 
         code = str(payload.get("authorization_code") or "").strip()
         state = str(payload.get("state") or "").strip()
@@ -243,7 +245,8 @@ class NativeIntegrationCallbackAPIView(LoginRequiredMixin, View):
             owner_scope, owner_user, owner_org = _resolve_native_integration_owner(request)
             _validate_oauth_state(request, provider.key, state, owner_scope, owner_user, owner_org)
         except ValidationError as exc:
-            return JsonResponse({"errors": exc.message_dict}, status=400)
+            errors = exc.message_dict if hasattr(exc, "message_dict") else {"non_field_errors": exc.messages}
+            return JsonResponse({"errors": errors}, status=400)
         except PermissionDenied as exc:
             return _permission_denied_response(exc)
 
@@ -418,6 +421,8 @@ class NativeIntegrationAgentEventAPIView(LoginRequiredMixin, View):
             payload = json.loads(body or "{}")
         except json.JSONDecodeError:
             return HttpResponseBadRequest("Invalid JSON body")
+        if not isinstance(payload, dict):
+            return HttpResponseBadRequest("Invalid JSON payload: expected an object")
 
         try:
             provider = get_native_integration_provider(provider_key)

--- a/console/native_integrations_api.py
+++ b/console/native_integrations_api.py
@@ -50,6 +50,11 @@ def _permission_denied_response(exc: PermissionDenied) -> JsonResponse:
     return JsonResponse({"error": message}, status=403)
 
 
+def _validation_error_response(exc: ValidationError, *, status: int = 400) -> JsonResponse:
+    errors = exc.message_dict if hasattr(exc, "message_dict") else {"non_field_errors": exc.messages}
+    return JsonResponse({"errors": errors}, status=status)
+
+
 def _resolve_native_integration_owner(request: HttpRequest):
     context = build_console_context(request)
     if context.current_context.type == "organization":
@@ -245,8 +250,7 @@ class NativeIntegrationCallbackAPIView(LoginRequiredMixin, View):
             owner_scope, owner_user, owner_org = _resolve_native_integration_owner(request)
             _validate_oauth_state(request, provider.key, state, owner_scope, owner_user, owner_org)
         except ValidationError as exc:
-            errors = exc.message_dict if hasattr(exc, "message_dict") else {"non_field_errors": exc.messages}
-            return JsonResponse({"errors": errors}, status=400)
+            return _validation_error_response(exc)
         except PermissionDenied as exc:
             return _permission_denied_response(exc)
 
@@ -293,7 +297,7 @@ class NativeIntegrationCallbackAPIView(LoginRequiredMixin, View):
                 existing_credentials=existing_credentials,
             )
         except ValidationError as exc:
-            return JsonResponse({"errors": exc.message_dict}, status=502)
+            return _validation_error_response(exc, status=502)
 
         with transaction.atomic():
             secret = save_native_integration_credentials(provider, owner_user, owner_org, credentials)
@@ -445,7 +449,7 @@ class NativeIntegrationAgentEventAPIView(LoginRequiredMixin, View):
                 source="console.native_integrations_api.NativeIntegrationAgentEventAPIView",
             )
         except ValidationError as exc:
-            return JsonResponse({"errors": exc.message_dict}, status=400)
+            return _validation_error_response(exc)
         except PermissionDenied as exc:
             return _permission_denied_response(exc)
 

--- a/console/native_integrations_api.py
+++ b/console/native_integrations_api.py
@@ -33,6 +33,11 @@ from api.services.native_integrations import (
     request_oauth_token,
     save_native_integration_credentials,
 )
+from api.services.native_integration_events import (
+    normalize_native_integration_event_files,
+    record_native_integration_agent_event,
+    resolve_native_integration_event_agent,
+)
 from console.context_helpers import build_console_context
 
 NATIVE_INTEGRATION_STATE_SALT = "gobii.native_integrations.oauth_state"
@@ -96,6 +101,7 @@ def _serialize_provider(provider, owner_user, owner_org) -> dict[str, Any]:
         "connect_url": reverse("console-native-integration-connect", args=[provider.key]),
         "files_url": reverse("console-native-integration-files", args=[provider.key]),
         "picker_token_url": reverse("console-native-integration-picker-token", args=[provider.key]),
+        "agent_event_url": reverse("console-native-integration-agent-events", args=[provider.key]),
         "revoke_url": reverse("console-native-integration-revoke", args=[provider.key]),
     }
 
@@ -397,3 +403,53 @@ class NativeIntegrationFilesAPIView(LoginRequiredMixin, View):
         response = JsonResponse({"provider_key": provider.key, "files": [file.to_dict() for file in files]})
         response["Cache-Control"] = "no-store"
         return response
+
+
+class NativeIntegrationAgentEventAPIView(LoginRequiredMixin, View):
+    http_method_names = ["post"]
+
+    def post(self, request: HttpRequest, provider_key: str, *args: Any, **kwargs: Any):
+        try:
+            body = request.body.decode("utf-8")
+        except UnicodeDecodeError:
+            return HttpResponseBadRequest("Invalid request body")
+
+        try:
+            payload = json.loads(body or "{}")
+        except json.JSONDecodeError:
+            return HttpResponseBadRequest("Invalid JSON body")
+
+        try:
+            provider = get_native_integration_provider(provider_key)
+        except KeyError:
+            return JsonResponse({"error": "Unknown native integration provider."}, status=404)
+
+        try:
+            _, owner_user, owner_org = _resolve_native_integration_owner(request)
+            agent = resolve_native_integration_event_agent(
+                str(payload.get("agent_id") or "").strip(),
+                owner_user=owner_user,
+                owner_org=owner_org,
+            )
+            files = normalize_native_integration_event_files(payload.get("files"))
+            step = record_native_integration_agent_event(
+                agent=agent,
+                provider=provider,
+                event_type=str(payload.get("event_type") or "").strip(),
+                files=files,
+                source="console.native_integrations_api.NativeIntegrationAgentEventAPIView",
+            )
+        except ValidationError as exc:
+            return JsonResponse({"errors": exc.message_dict}, status=400)
+        except PermissionDenied as exc:
+            return _permission_denied_response(exc)
+
+        return JsonResponse(
+            {
+                "recorded": True,
+                "provider_key": provider.key,
+                "agent_id": str(agent.id),
+                "step_id": str(step.id),
+            },
+            status=201,
+        )

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -63,6 +63,7 @@ type AgentRosterPayload = {
     last_interaction_at: string | null
     signup_preview_state?: SignupPreviewState | null
     planning_state?: PlanningState | null
+    pending_action_request_count?: number
     has_unread_agent_message?: boolean
     latest_agent_message_id?: string | null
     latest_agent_message_at?: string | null
@@ -117,6 +118,7 @@ export async function fetchAgentRoster(
     lastInteractionAt: agent.last_interaction_at,
     signupPreviewState: agent.signup_preview_state ?? null,
     planningState: agent.planning_state ?? null,
+    pendingActionRequestCount: Math.max(0, Number(agent.pending_action_request_count ?? 0) || 0),
     hasUnreadAgentMessage: Boolean(agent.has_unread_agent_message),
     latestAgentMessageId: agent.latest_agent_message_id ?? null,
     latestAgentMessageAt: agent.latest_agent_message_at ?? null,

--- a/frontend/src/api/nativeIntegrations.ts
+++ b/frontend/src/api/nativeIntegrations.ts
@@ -14,6 +14,7 @@ export type NativeIntegrationProviderDTO = {
   connect_url: string
   files_url: string
   picker_token_url: string
+  agent_event_url: string
   revoke_url: string
 }
 
@@ -64,6 +65,7 @@ export type NativeIntegrationProvider = {
   connectUrl: string
   filesUrl: string
   pickerTokenUrl: string
+  agentEventUrl: string
   revokeUrl: string
 }
 
@@ -114,6 +116,7 @@ export const mapNativeIntegrationProvider = (provider: NativeIntegrationProvider
   connectUrl: provider.connect_url,
   filesUrl: provider.files_url,
   pickerTokenUrl: provider.picker_token_url,
+  agentEventUrl: provider.agent_event_url,
   revokeUrl: provider.revoke_url,
 })
 
@@ -179,4 +182,38 @@ export async function revokeNativeIntegration(revokeUrl: string, csrfToken?: str
     csrfToken,
     json: {},
   })
+}
+
+export async function recordNativeIntegrationAgentEvent({
+  agentEventUrl,
+  agentId,
+  eventType,
+  files = [],
+  csrfToken,
+}: {
+  agentEventUrl: string
+  agentId: string
+  eventType: 'connected' | 'files_selected'
+  files?: NativeIntegrationAccessibleFile[]
+  csrfToken?: string
+}): Promise<{ recorded: boolean; stepId: string }> {
+  const payload = await jsonRequest<{ recorded: boolean; step_id: string }>(agentEventUrl, {
+    method: 'POST',
+    includeCsrf: true,
+    csrfToken,
+    json: {
+      agent_id: agentId,
+      event_type: eventType,
+      files: files.map((file) => ({
+        external_id: file.externalId,
+        name: file.name,
+        mime_type: file.mimeType,
+        web_url: file.webUrl,
+      })),
+    },
+  })
+  return {
+    recorded: Boolean(payload.recorded),
+    stepId: payload.step_id,
+  }
 }

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -1893,6 +1893,7 @@ export function AgentChatLayout({
               apolloNativeTabEnabled={apolloNativeTabEnabled}
               hubspotNativeTabEnabled={hubspotNativeTabEnabled}
               discordNativeTabEnabled={discordNativeTabEnabled}
+              compact={sidebarMode === 'gallery'}
             />
           )}
           </div>

--- a/frontend/src/components/agentChat/AgentComposer.test.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.test.tsx
@@ -352,7 +352,7 @@ describe('AgentComposer pending action insights panel', () => {
     })
   })
 
-  it('returns to the normal composer when paging from free text input to a non-human request', async () => {
+  it('shows the approval footer when paging from free text input to a credential request', () => {
     const handleSubmit = vi.fn(async () => undefined)
     const handleRespondHumanInput = vi.fn(async () => undefined)
 
@@ -369,25 +369,24 @@ describe('AgentComposer pending action insights panel', () => {
 
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText(/^Type your answer/)).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/^Message/)).not.toBeInTheDocument()
+    expect(screen.getByText('Reviewing this request')).toBeInTheDocument()
+    expect(screen.getByText('Add this credential to let the agent continue.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
 
-    const messageComposer = screen.getByPlaceholderText(/^Message/)
-    expect(messageComposer).toHaveValue('')
-    fireEvent.change(messageComposer, { target: { value: 'normal message' } })
-    fireEvent.submit(messageComposer.closest('form') as HTMLFormElement)
-
-    await waitFor(() => {
-      expect(handleSubmit).toHaveBeenCalledWith('normal message', [])
-    })
+    expect(handleSubmit).not.toHaveBeenCalled()
     expect(handleRespondHumanInput).not.toHaveBeenCalled()
   })
 
-  it('keeps the normal message composer available for non-human pending actions', () => {
+  it('replaces the normal message composer for credential pending actions', () => {
     renderAgentComposer({
       pendingActionRequests: [makeRequestedSecretsAction()],
     })
 
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText(/^Message/)).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/^Message/)).not.toBeInTheDocument()
+    expect(screen.getByText('Reviewing this request')).toBeInTheDocument()
   })
 
   it('shows skip planning beside the active planning status instead of a planning strip', () => {

--- a/frontend/src/components/agentChat/AgentComposer.test.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.test.tsx
@@ -352,7 +352,7 @@ describe('AgentComposer pending action insights panel', () => {
     })
   })
 
-  it('shows the approval footer when paging from free text input to a credential request', () => {
+  it('returns to the normal composer when paging from free text input to a credential request', async () => {
     const handleSubmit = vi.fn(async () => undefined)
     const handleRespondHumanInput = vi.fn(async () => undefined)
 
@@ -369,24 +369,27 @@ describe('AgentComposer pending action insights panel', () => {
 
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText(/^Type your answer/)).not.toBeInTheDocument()
-    expect(screen.queryByPlaceholderText(/^Message/)).not.toBeInTheDocument()
-    expect(screen.getByText('Reviewing this request')).toBeInTheDocument()
-    expect(screen.getByText('Add this credential to let the agent continue.')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
 
-    expect(handleSubmit).not.toHaveBeenCalled()
+    const messageComposer = screen.getByPlaceholderText(/^Message/)
+    expect(messageComposer).toHaveValue('')
+    fireEvent.change(messageComposer, { target: { value: 'normal message' } })
+    fireEvent.submit(messageComposer.closest('form') as HTMLFormElement)
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith('normal message', [])
+    })
     expect(handleRespondHumanInput).not.toHaveBeenCalled()
   })
 
-  it('replaces the normal message composer for credential pending actions', () => {
+  it('keeps the normal message composer available for credential pending actions', () => {
     renderAgentComposer({
       pendingActionRequests: [makeRequestedSecretsAction()],
     })
 
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
-    expect(screen.queryByPlaceholderText(/^Message/)).not.toBeInTheDocument()
-    expect(screen.getByText('Reviewing this request')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/^Message/)).toBeInTheDocument()
   })
 
   it('shows skip planning beside the active planning status instead of a planning strip', () => {

--- a/frontend/src/components/agentChat/AgentComposer.test.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.test.tsx
@@ -149,6 +149,39 @@ function makeSecondRequestedSecretsAction(): PendingActionRequest {
   }
 }
 
+function makeContactRequestsAction(): PendingActionRequest {
+  return {
+    id: 'contact-action',
+    kind: 'contact_requests',
+    count: 1,
+    requests: [
+      {
+        id: 'contact-1',
+        channel: 'email',
+        address: 'customer@example.com',
+        name: 'Customer',
+        reason: 'Needs a status update.',
+        purpose: 'Support',
+        allowInbound: true,
+        allowOutbound: true,
+        canConfigure: false,
+      },
+    ],
+  }
+}
+
+function makeSpawnRequestAction(): PendingActionRequest {
+  return {
+    id: 'spawn-action',
+    kind: 'spawn_request',
+    requestId: 'spawn-request-1',
+    requestedCharter: 'Handle follow-up research.',
+    handoffMessage: 'Continue from the current task.',
+    requestReason: 'Parallel research would help.',
+    decisionApiUrl: '/console/api/spawn-request/1/',
+  }
+}
+
 function makeInsight(): InsightEvent {
   return {
     insightId: 'insight-1',
@@ -202,6 +235,7 @@ describe('AgentComposer pending action insights panel', () => {
 
     expect(screen.getByText('Needs your input')).toBeInTheDocument()
     expect(screen.getByText('1 request')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'View 1 pending credentials request' })).toBeInTheDocument()
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
   })
 
@@ -233,7 +267,7 @@ describe('AgentComposer pending action insights panel', () => {
     })
   })
 
-  it('renders pending requests before regular insight content', () => {
+  it('renders pending request tabs alongside regular insight tabs', () => {
     renderAgentComposer({
       pendingActionRequests: [makeRequestedSecretsAction()],
       insights: [makeInsight()],
@@ -243,6 +277,18 @@ describe('AgentComposer pending action insights panel', () => {
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
     expect(screen.queryByTestId('insight-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('google-drive-panel')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'View burn rate insight' }))
+
+    expect(screen.getByTestId('insight-card')).toHaveTextContent('Usage')
+
+    fireEvent.click(screen.getByRole('button', { name: 'View Google Drive files' }))
+
+    expect(screen.getByTestId('google-drive-panel')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'View 1 pending credentials request' }))
+
+    expect(screen.getByText('Stripe API key')).toBeInTheDocument()
   })
 
   it('keeps the normal message composer hidden for human input requests', () => {
@@ -254,20 +300,36 @@ describe('AgentComposer pending action insights panel', () => {
     expect(screen.queryByPlaceholderText(/^Message/)).not.toBeInTheDocument()
   })
 
-  it('uses the regular composer for free text human input and keeps it visible when collapsed', () => {
+  it('uses the regular composer for free text human input only while expanded', () => {
     renderAgentComposer({
       pendingActionRequests: [makeFreeTextHumanInputAction()],
     })
 
     expect(screen.getByText('Could you provide a quick final word?')).toBeInTheDocument()
     expect(screen.getByPlaceholderText(/^Type your answer/)).toBeInTheDocument()
+    expect(screen.getByText('Dismiss')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText(/^Message/)).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByText('Needs your input').closest('.composer-working-header-row') as HTMLElement)
 
     expect(screen.queryByText('Could you provide a quick final word?')).not.toBeInTheDocument()
-    expect(screen.getByPlaceholderText(/^Type your answer/)).toBeInTheDocument()
-    expect(screen.queryByPlaceholderText(/^Message/)).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText(/^Type your answer/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Dismiss')).not.toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/^Message/)).toBeInTheDocument()
+  })
+
+  it('hides pending request navigation when the panel is collapsed', () => {
+    renderAgentComposer({
+      pendingActionRequests: [makeHumanInputAction()],
+    })
+
+    expect(screen.getByRole('button', { name: 'Next pending request' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Needs your input').closest('.composer-working-header-row') as HTMLElement)
+
+    expect(screen.queryByRole('button', { name: 'Next pending request' })).not.toBeInTheDocument()
+    expect(screen.queryByText('1 of 2')).not.toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/^Message/)).toBeInTheDocument()
   })
 
   it('submits free text human input from the regular composer', async () => {
@@ -303,7 +365,7 @@ describe('AgentComposer pending action insights panel', () => {
     const freeTextComposer = screen.getByPlaceholderText(/^Type your answer/)
     fireEvent.change(freeTextComposer, { target: { value: 'human input draft' } })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Next pending request' }))
+    fireEvent.click(screen.getByRole('button', { name: 'View 1 pending credentials request' }))
 
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText(/^Type your answer/)).not.toBeInTheDocument()
@@ -386,7 +448,7 @@ describe('AgentComposer pending action insights panel', () => {
     expect(handleSkipPlanning).toHaveBeenCalledTimes(1)
   })
 
-  it('pages through all pending requests, not only the active human input batch', () => {
+  it('pages through pending requests within the active tab category', () => {
     renderAgentComposer({
       pendingActionRequests: [
         makeHumanInputAction(),
@@ -396,23 +458,113 @@ describe('AgentComposer pending action insights panel', () => {
     })
 
     expect(screen.getByRole('button', { name: 'Next pending request' }).closest('.composer-working-header-row')).not.toBeNull()
-    expect(screen.getByText('1 of 4')).toBeInTheDocument()
+    expect(screen.getByText('1 of 2')).toBeInTheDocument()
     expect(screen.getByText('Which account should I use?')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Next pending request' }))
 
-    expect(screen.getByText('2 of 4')).toBeInTheDocument()
+    expect(screen.getByText('2 of 2')).toBeInTheDocument()
     expect(screen.getByText('Which region should I use?')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Next pending request' }))
+    fireEvent.click(screen.getByRole('button', { name: 'View 2 pending credentials requests' }))
 
-    expect(screen.getByText('3 of 4')).toBeInTheDocument()
+    expect(screen.getByText('1 of 2')).toBeInTheDocument()
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Next pending request' }))
 
-    expect(screen.getByText('4 of 4')).toBeInTheDocument()
+    expect(screen.getByText('2 of 2')).toBeInTheDocument()
     expect(screen.getByText('Database password')).toBeInTheDocument()
+  })
+
+  it('auto-selects a new pending tab from a regular insight tab', async () => {
+    const { rerender } = renderAgentComposer({
+      insights: [makeInsight()],
+    })
+
+    expect(screen.getByTestId('insight-card')).toHaveTextContent('Usage')
+
+    rerender(
+      <AgentComposer
+        agentId="agent-1"
+        agentName="Test Agent"
+        agentFirstName="Test"
+        onSubmit={vi.fn(async () => undefined)}
+        currentInsightIndex={0}
+        pendingActionRequests={[makeContactRequestsAction()]}
+        insights={[makeInsight()]}
+        insightsLoading={false}
+        isProcessing={false}
+        processingTasks={[]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Customer')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('insight-card')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    {
+      name: 'Questions',
+      initialActions: [makeHumanInputAction()],
+      nextActions: [makeHumanInputAction(), makeRequestedSecretsAction()],
+      expectedText: 'Which account should I use?',
+      unexpectedText: 'Stripe API key',
+    },
+    {
+      name: 'Credentials',
+      initialActions: [makeRequestedSecretsAction()],
+      nextActions: [makeRequestedSecretsAction(), makeContactRequestsAction()],
+      expectedText: 'Stripe API key',
+      unexpectedText: 'Customer',
+    },
+    {
+      name: 'Contacts',
+      initialActions: [makeContactRequestsAction()],
+      nextActions: [makeContactRequestsAction(), makeRequestedSecretsAction()],
+      expectedText: 'Customer',
+      unexpectedText: 'Stripe API key',
+    },
+    {
+      name: 'Agents',
+      initialActions: [makeSpawnRequestAction()],
+      nextActions: [makeSpawnRequestAction(), makeContactRequestsAction()],
+      expectedText: 'Handle follow-up research.',
+      unexpectedText: 'Customer',
+    },
+  ])('does not auto-switch away from the active $name pending tab', async ({
+    initialActions,
+    nextActions,
+    expectedText,
+    unexpectedText,
+  }) => {
+    const { rerender } = renderAgentComposer({
+      pendingActionRequests: initialActions,
+    })
+
+    expect(screen.getByText(expectedText)).toBeInTheDocument()
+
+    rerender(
+      <AgentComposer
+        agentId="agent-1"
+        agentName="Test Agent"
+        agentFirstName="Test"
+        onSubmit={vi.fn(async () => undefined)}
+        currentInsightIndex={0}
+        pendingActionRequests={nextActions}
+        insights={[]}
+        insightsLoading={false}
+        isProcessing={false}
+        processingTasks={[]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(expectedText)).toBeInTheDocument()
+    })
+    expect(screen.queryByText(unexpectedText)).not.toBeInTheDocument()
   })
 
   const nativeTabCases = [

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, ClipboardEvent, FormEvent, KeyboardEvent } from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components'
-import { ArrowUp, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Gauge, KeyRound, Loader2, Mail, MessageSquare, MessageSquareQuote, OctagonAlert, Paperclip, Plus, Rocket, ShieldCheck, Sparkles, TriangleAlert, Zap, X } from 'lucide-react'
+import { ArrowUp, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Gauge, KeyRound, Loader2, Mail, MessageSquare, MessageSquareQuote, OctagonAlert, Paperclip, Plus, Rocket, Sparkles, TriangleAlert, Zap, X } from 'lucide-react'
 
 import { InsightEventCard } from './insights'
 import { ApolloInsightPanel } from './insights/ApolloInsightPanel'
@@ -475,6 +475,7 @@ type AgentComposerProps = {
   apolloNativeTabEnabled?: boolean
   hubspotNativeTabEnabled?: boolean
   discordNativeTabEnabled?: boolean
+  compact?: boolean
 }
 
 export const AgentComposer = memo(function AgentComposer({
@@ -534,6 +535,7 @@ export const AgentComposer = memo(function AgentComposer({
   apolloNativeTabEnabled = false,
   hubspotNativeTabEnabled = false,
   discordNativeTabEnabled = false,
+  compact = false,
 }: AgentComposerProps) {
   const [body, setBody] = useState('')
   const [attachments, setAttachments] = useState<File[]>([])
@@ -551,7 +553,6 @@ export const AgentComposer = memo(function AgentComposer({
   const [appsModal, showAppsModal] = useModal()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const shellRef = useRef<HTMLDivElement | null>(null)
-  const [approvalActionsElement, setApprovalActionsElement] = useState<HTMLDivElement | null>(null)
   const focusScrollTimeoutRef = useRef<number | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const dragCounter = useRef(0)
@@ -1669,17 +1670,8 @@ export const AgentComposer = memo(function AgentComposer({
   const taskCount = processingTasks.length
   const skipPlanningDisabled = !canManageAgent || !onSkipPlanning || skipPlanningBusy
   const showHumanInputActionPanel = activePendingAction?.kind === 'human_input' && resolvedWorkingExpanded && !activeHumanInputUsesMainComposer
-  const showApprovalComposerReplacement = Boolean(
-    resolvedWorkingExpanded
-    && activePendingActionTab
-    && (activePendingAction?.kind === 'requested_secrets' || activePendingAction?.kind === 'contact_requests'),
-  )
-  const approvalComposerCopy = activePendingAction?.kind === 'contact_requests'
-    ? "You're reviewing whether this contact can message your organization."
-    : 'Add this credential to let the agent continue.'
-  const hasComposerReplacement = showHumanInputActionPanel || showApprovalComposerReplacement
   const composerSurfaceClassName = `composer-surface${
-    hasComposerReplacement
+    showHumanInputActionPanel
       ? showWorkingPanel
         ? ' overflow-hidden rounded-b-[1.25rem]'
         : ' overflow-hidden rounded-[1.25rem]'
@@ -1876,9 +1868,11 @@ export const AgentComposer = memo(function AgentComposer({
                   ) : (
                     <MessageSquareQuote className="composer-working-indicator" aria-hidden="true" />
                   )}
-                  <span className="composer-working-status">
-                    <strong>Needs your input</strong>
-                  </span>
+                  {!compact ? (
+                    <span className="composer-working-status">
+                      <strong>Needs your input</strong>
+                    </span>
+                  ) : null}
                   <span className="composer-working-tasks-badge">
                     {pendingActionCount} {pendingActionCount === 1 ? 'request' : 'requests'}
                   </span>
@@ -2044,8 +2038,7 @@ export const AgentComposer = memo(function AgentComposer({
                       onRemoveRequestedSecrets={onRemoveRequestedSecrets}
                       onResolveContactRequests={onResolveContactRequests}
                       onViewAllContactRequests={onViewAllContactRequests}
-                      approvalActionsContainer={showApprovalComposerReplacement ? approvalActionsElement : null}
-                      suppressInlineApprovalActions={showApprovalComposerReplacement}
+                      compact={compact}
                     />
                   </div>
                 ) : (
@@ -2084,26 +2077,8 @@ export const AgentComposer = memo(function AgentComposer({
           </div>
         ) : null}
 
-        {showApprovalComposerReplacement ? (
-          <div className="flex flex-col gap-3 rounded-b-[1.25rem] border-x border-b border-t border-slate-200/60 bg-white px-4 py-3 transition sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex min-w-0 items-center gap-3">
-              <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
-                <ShieldCheck className="h-4 w-4" aria-hidden="true" />
-              </span>
-              <div className="min-w-0">
-                <p className="text-sm font-semibold text-slate-900">Reviewing this request</p>
-                <p className="text-sm text-slate-600">{approvalComposerCopy}</p>
-              </div>
-            </div>
-            <div
-              ref={setApprovalActionsElement}
-              className="shrink-0 sm:min-w-[16.5rem]"
-            />
-          </div>
-        ) : null}
-
         {/* Main input form */}
-        {!showHumanInputActionPanel && !showApprovalComposerReplacement ? (
+        {!showHumanInputActionPanel ? (
           <form className="flex flex-col" onSubmit={handleSubmit}>
             {isDragActive ? (
               <div className="agent-chat-drop-overlay" aria-hidden="true">

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, ClipboardEvent, FormEvent, KeyboardEvent } from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components'
-import { ArrowUp, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Gauge, KeyRound, Loader2, Mail, MessageSquare, MessageSquareQuote, OctagonAlert, Paperclip, Plus, Rocket, Sparkles, TriangleAlert, Zap, X } from 'lucide-react'
+import { ArrowUp, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Gauge, KeyRound, Loader2, Mail, MessageSquare, MessageSquareQuote, OctagonAlert, Paperclip, Plus, Rocket, ShieldCheck, Sparkles, TriangleAlert, Zap, X } from 'lucide-react'
 
 import { InsightEventCard } from './insights'
 import { ApolloInsightPanel } from './insights/ApolloInsightPanel'
@@ -551,6 +551,7 @@ export const AgentComposer = memo(function AgentComposer({
   const [appsModal, showAppsModal] = useModal()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const shellRef = useRef<HTMLDivElement | null>(null)
+  const [approvalActionsElement, setApprovalActionsElement] = useState<HTMLDivElement | null>(null)
   const focusScrollTimeoutRef = useRef<number | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const dragCounter = useRef(0)
@@ -1668,8 +1669,17 @@ export const AgentComposer = memo(function AgentComposer({
   const taskCount = processingTasks.length
   const skipPlanningDisabled = !canManageAgent || !onSkipPlanning || skipPlanningBusy
   const showHumanInputActionPanel = activePendingAction?.kind === 'human_input' && resolvedWorkingExpanded && !activeHumanInputUsesMainComposer
+  const showApprovalComposerReplacement = Boolean(
+    resolvedWorkingExpanded
+    && activePendingActionTab
+    && (activePendingAction?.kind === 'requested_secrets' || activePendingAction?.kind === 'contact_requests'),
+  )
+  const approvalComposerCopy = activePendingAction?.kind === 'contact_requests'
+    ? "You're reviewing whether this contact can message your organization."
+    : 'Add this credential to let the agent continue.'
+  const hasComposerReplacement = showHumanInputActionPanel || showApprovalComposerReplacement
   const composerSurfaceClassName = `composer-surface${
-    showHumanInputActionPanel
+    hasComposerReplacement
       ? showWorkingPanel
         ? ' overflow-hidden rounded-b-[1.25rem]'
         : ' overflow-hidden rounded-[1.25rem]'
@@ -2034,6 +2044,8 @@ export const AgentComposer = memo(function AgentComposer({
                       onRemoveRequestedSecrets={onRemoveRequestedSecrets}
                       onResolveContactRequests={onResolveContactRequests}
                       onViewAllContactRequests={onViewAllContactRequests}
+                      approvalActionsContainer={showApprovalComposerReplacement ? approvalActionsElement : null}
+                      suppressInlineApprovalActions={showApprovalComposerReplacement}
                     />
                   </div>
                 ) : (
@@ -2072,8 +2084,26 @@ export const AgentComposer = memo(function AgentComposer({
           </div>
         ) : null}
 
+        {showApprovalComposerReplacement ? (
+          <div className="flex flex-col gap-3 rounded-b-[1.25rem] border-x border-b border-t border-slate-200/60 bg-white px-4 py-3 transition sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
+                <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-slate-900">Reviewing this request</p>
+                <p className="text-sm text-slate-600">{approvalComposerCopy}</p>
+              </div>
+            </div>
+            <div
+              ref={setApprovalActionsElement}
+              className="shrink-0 sm:min-w-[16.5rem]"
+            />
+          </div>
+        ) : null}
+
         {/* Main input form */}
-        {!showHumanInputActionPanel ? (
+        {!showHumanInputActionPanel && !showApprovalComposerReplacement ? (
           <form className="flex flex-col" onSubmit={handleSubmit}>
             {isDragActive ? (
               <div className="agent-chat-drop-overlay" aria-hidden="true">

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -157,14 +157,14 @@ function getPendingActionSignature(action: PendingActionRequest): string {
   }
 }
 
-function getPendingWorkingTabLabel(tab: Extract<WorkingPanelTab, { kind: 'pending_action' }>): string {
+function getPendingWorkingTabLabel(tab: PendingWorkingPanelTab): string {
   if (tab.pendingKind === 'questions') {
     return `${tab.count} ${tab.count === 1 ? 'Question' : 'Questions'}`
   }
   return PENDING_WORKING_TAB_CONFIG[tab.pendingKind].title
 }
 
-function getPendingWorkingTabAriaLabel(tab: Extract<WorkingPanelTab, { kind: 'pending_action' }>): string {
+function getPendingWorkingTabAriaLabel(tab: PendingWorkingPanelTab): string {
   const label = PENDING_WORKING_TAB_CONFIG[tab.pendingKind].title.toLowerCase()
   return `View ${tab.count} pending ${label} ${tab.count === 1 ? 'request' : 'requests'}`
 }
@@ -188,13 +188,19 @@ type HumanInputComposerBatchResponse = {
   responses: HumanInputComposerResponse[]
 }
 
-type WorkingPanelTab =
-  | { id: string; kind: 'insight'; insight: InsightEvent; insightIndex: number }
-  | { id: string; kind: 'pending_action'; pendingKind: PendingWorkingTabKind; actions: PendingActionRequest[]; count: number }
-  | { id: NativeWorkingTabKind; kind: NativeWorkingTabKind }
-
 type NativeWorkingTabKind = 'google_drive' | 'apollo' | 'hubspot' | 'discord'
 type PendingWorkingTabKind = 'questions' | 'credentials' | 'contacts' | 'agents'
+type PendingWorkingPanelTab = {
+  id: `pending:${PendingWorkingTabKind}`
+  kind: 'pending_action'
+  pendingKind: PendingWorkingTabKind
+  actions: PendingActionRequest[]
+  count: number
+}
+type WorkingPanelTab =
+  | { id: string; kind: 'insight'; insight: InsightEvent; insightIndex: number }
+  | PendingWorkingPanelTab
+  | { id: NativeWorkingTabKind; kind: NativeWorkingTabKind }
 
 const PENDING_WORKING_TAB_ORDER: PendingWorkingTabKind[] = ['questions', 'credentials', 'contacts', 'agents']
 
@@ -662,14 +668,14 @@ export const AgentComposer = memo(function AgentComposer({
     ] as const,
     [apolloTabAvailable, discordTabAvailable, googleDriveTabAvailable, hubspotTabAvailable],
   )
-  const pendingActionTabs = useMemo(() => {
+  const pendingActionTabs = useMemo<PendingWorkingPanelTab[]>(() => {
     const actionsByTabKind = new Map<PendingWorkingTabKind, PendingActionRequest[]>()
     pendingActionRequests.forEach((action) => {
       const tabKind = getPendingWorkingTabKind(action)
       actionsByTabKind.set(tabKind, [...(actionsByTabKind.get(tabKind) ?? []), action])
     })
     return PENDING_WORKING_TAB_ORDER
-      .map((pendingKind): WorkingPanelTab | null => {
+      .map((pendingKind): PendingWorkingPanelTab | null => {
         const actions = actionsByTabKind.get(pendingKind) ?? []
         if (!actions.length) {
           return null
@@ -682,17 +688,11 @@ export const AgentComposer = memo(function AgentComposer({
           count: actions.reduce((total, action) => total + getPendingActionRequestCount(action), 0),
         }
       })
-      .filter((tab): tab is WorkingPanelTab => Boolean(tab))
+      .filter((tab): tab is PendingWorkingPanelTab => Boolean(tab))
   }, [pendingActionRequests])
   const pendingActionTabSignature = useMemo(() => (
     pendingActionTabs
-      .map((tab) => {
-        if (tab.kind !== 'pending_action') {
-          return ''
-        }
-        return `${tab.id}=${tab.actions.map(getPendingActionSignature).join('|')}`
-      })
-      .filter(Boolean)
+      .map((tab) => `${tab.id}=${tab.actions.map(getPendingActionSignature).join('|')}`)
       .join(';')
   ), [pendingActionTabs])
   const currentInsightTabId = currentInsight ? `insight:${currentInsight.insightId}` : null
@@ -777,8 +777,7 @@ export const AgentComposer = memo(function AgentComposer({
         }),
     )
     const changedPendingTab = pendingActionTabs.find((tab) => (
-      tab.kind === 'pending_action'
-      && previousSignaturesByTab.get(tab.id) !== tab.actions.map(getPendingActionSignature).join('|')
+      previousSignaturesByTab.get(tab.id) !== tab.actions.map(getPendingActionSignature).join('|')
     ))
     const hasPendingSignatureChanged = previousState.key !== key || previousSignature !== pendingActionTabSignature
 

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, ClipboardEvent, FormEvent, KeyboardEvent } from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components'
-import { ArrowUp, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Gauge, Loader2, MessageSquare, MessageSquareQuote, OctagonAlert, Paperclip, Plus, Rocket, Sparkles, TriangleAlert, Zap, X } from 'lucide-react'
+import { ArrowUp, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Gauge, KeyRound, Loader2, Mail, MessageSquare, MessageSquareQuote, OctagonAlert, Paperclip, Plus, Rocket, Sparkles, TriangleAlert, Zap, X } from 'lucide-react'
 
 import { InsightEventCard } from './insights'
 import { ApolloInsightPanel } from './insights/ApolloInsightPanel'
@@ -127,6 +127,52 @@ function getPendingActionRequestCount(action: PendingActionRequest): number {
   }
 }
 
+function getPendingWorkingTabKind(action: PendingActionRequest): PendingWorkingTabKind {
+  switch (action.kind) {
+    case 'human_input':
+      return 'questions'
+    case 'requested_secrets':
+      return 'credentials'
+    case 'contact_requests':
+      return 'contacts'
+    case 'spawn_request':
+      return 'agents'
+    default:
+      return 'questions'
+  }
+}
+
+function getPendingActionSignature(action: PendingActionRequest): string {
+  switch (action.kind) {
+    case 'human_input':
+      return `${action.id}:${action.requests.map((request) => request.id).join(',')}`
+    case 'requested_secrets':
+      return `${action.id}:${action.secrets.map((secret) => secret.id).join(',')}`
+    case 'contact_requests':
+      return `${action.id}:${action.requests.map((request) => request.id).join(',')}`
+    case 'spawn_request':
+      return `${action.id}:${action.requestId}`
+    default:
+      return ''
+  }
+}
+
+function getPendingWorkingTabLabel(tab: Extract<WorkingPanelTab, { kind: 'pending_action' }>): string {
+  if (tab.pendingKind === 'questions') {
+    return `${tab.count} ${tab.count === 1 ? 'Question' : 'Questions'}`
+  }
+  return PENDING_WORKING_TAB_CONFIG[tab.pendingKind].title
+}
+
+function getPendingWorkingTabAriaLabel(tab: Extract<WorkingPanelTab, { kind: 'pending_action' }>): string {
+  const label = PENDING_WORKING_TAB_CONFIG[tab.pendingKind].title.toLowerCase()
+  return `View ${tab.count} pending ${label} ${tab.count === 1 ? 'request' : 'requests'}`
+}
+
+function isPendingWorkingTabId(tabId: string | null): boolean {
+  return Boolean(tabId?.startsWith('pending:'))
+}
+
 type PendingActionNavigationItem =
   | { actionId: string; kind: 'human_input'; requestId: string }
   | { actionId: string; kind: 'action' }
@@ -144,9 +190,36 @@ type HumanInputComposerBatchResponse = {
 
 type WorkingPanelTab =
   | { id: string; kind: 'insight'; insight: InsightEvent; insightIndex: number }
+  | { id: string; kind: 'pending_action'; pendingKind: PendingWorkingTabKind; actions: PendingActionRequest[]; count: number }
   | { id: NativeWorkingTabKind; kind: NativeWorkingTabKind }
 
 type NativeWorkingTabKind = 'google_drive' | 'apollo' | 'hubspot' | 'discord'
+type PendingWorkingTabKind = 'questions' | 'credentials' | 'contacts' | 'agents'
+
+const PENDING_WORKING_TAB_ORDER: PendingWorkingTabKind[] = ['questions', 'credentials', 'contacts', 'agents']
+
+const PENDING_WORKING_TAB_CONFIG = {
+  questions: {
+    title: 'Questions',
+    color: '#0284c7',
+    icon: <MessageSquareQuote size={11} strokeWidth={2.2} />,
+  },
+  credentials: {
+    title: 'Credentials',
+    color: '#7c3aed',
+    icon: <KeyRound size={11} strokeWidth={2.2} />,
+  },
+  contacts: {
+    title: 'Contacts',
+    color: '#d97706',
+    icon: <Mail size={11} strokeWidth={2.2} />,
+  },
+  agents: {
+    title: 'Agents',
+    color: '#ea580c',
+    icon: <Zap size={11} strokeWidth={2.2} />,
+  },
+} as const
 
 const NATIVE_WORKING_TAB_CONFIG = {
   google_drive: {
@@ -486,6 +559,10 @@ export const AgentComposer = memo(function AgentComposer({
     key: string
     previousEnabled: boolean
   }>>>({})
+  const pendingActionAutoSwitchStateRef = useRef<{
+    key: string
+    signature: string
+  }>({ key: '', signature: '' })
 
   // Countdown timer state for auto-rotation indicator
   const [countdownProgress, setCountdownProgress] = useState(0)
@@ -583,6 +660,39 @@ export const AgentComposer = memo(function AgentComposer({
     ] as const,
     [apolloTabAvailable, discordTabAvailable, googleDriveTabAvailable, hubspotTabAvailable],
   )
+  const pendingActionTabs = useMemo(() => {
+    const actionsByTabKind = new Map<PendingWorkingTabKind, PendingActionRequest[]>()
+    pendingActionRequests.forEach((action) => {
+      const tabKind = getPendingWorkingTabKind(action)
+      actionsByTabKind.set(tabKind, [...(actionsByTabKind.get(tabKind) ?? []), action])
+    })
+    return PENDING_WORKING_TAB_ORDER
+      .map((pendingKind): WorkingPanelTab | null => {
+        const actions = actionsByTabKind.get(pendingKind) ?? []
+        if (!actions.length) {
+          return null
+        }
+        return {
+          id: `pending:${pendingKind}`,
+          kind: 'pending_action',
+          pendingKind,
+          actions,
+          count: actions.reduce((total, action) => total + getPendingActionRequestCount(action), 0),
+        }
+      })
+      .filter((tab): tab is WorkingPanelTab => Boolean(tab))
+  }, [pendingActionRequests])
+  const pendingActionTabSignature = useMemo(() => (
+    pendingActionTabs
+      .map((tab) => {
+        if (tab.kind !== 'pending_action') {
+          return ''
+        }
+        return `${tab.id}=${tab.actions.map(getPendingActionSignature).join('|')}`
+      })
+      .filter(Boolean)
+      .join(';')
+  ), [pendingActionTabs])
   const currentInsightTabId = currentInsight ? `insight:${currentInsight.insightId}` : null
   const workingTabs = useMemo<WorkingPanelTab[]>(() => {
     const insightTabs = insights.map((insight, index): WorkingPanelTab => ({
@@ -595,21 +705,25 @@ export const AgentComposer = memo(function AgentComposer({
       .filter(({ available }) => available)
       .map(({ kind }): WorkingPanelTab => ({ id: kind, kind }))
     return [
+      ...pendingActionTabs,
       ...insightTabs,
       ...nativeTabs,
     ]
-  }, [insights, nativeTabAvailability])
+  }, [insights, nativeTabAvailability, pendingActionTabs])
   const workingTabIds = useMemo(() => new Set(workingTabs.map((tab) => tab.id)), [workingTabs])
   const effectiveWorkingTabId = (
     activeWorkingTabId && workingTabIds.has(activeWorkingTabId)
       ? activeWorkingTabId
-      : currentInsightTabId && workingTabIds.has(currentInsightTabId)
-        ? currentInsightTabId
-        : workingTabs[0]?.id ?? null
+      : pendingActionTabs[0]?.id && workingTabIds.has(pendingActionTabs[0].id)
+        ? pendingActionTabs[0].id
+        : currentInsightTabId && workingTabIds.has(currentInsightTabId)
+          ? currentInsightTabId
+          : workingTabs[0]?.id ?? null
   )
   const activeWorkingTab = workingTabs.find((tab) => tab.id === effectiveWorkingTabId) ?? null
   const activeInsightTab = activeWorkingTab?.kind === 'insight' ? activeWorkingTab : null
-  const ActiveNativePanel = activeWorkingTab && activeWorkingTab.kind !== 'insight'
+  const activePendingActionTab = activeWorkingTab?.kind === 'pending_action' ? activeWorkingTab : null
+  const ActiveNativePanel = activeWorkingTab && activeWorkingTab.kind !== 'insight' && activeWorkingTab.kind !== 'pending_action'
     ? NATIVE_WORKING_TAB_CONFIG[activeWorkingTab.kind].panel
     : null
   const visibleInsight = activeInsightTab?.insight ?? null
@@ -647,6 +761,64 @@ export const AgentComposer = memo(function AgentComposer({
 
   useEffect(() => {
     const key = agentId ?? focusKey ?? 'new-agent'
+    const previousState = pendingActionAutoSwitchStateRef.current
+    const previousSignature = previousState.key === key ? previousState.signature : ''
+    const previousSignaturesByTab = new Map(
+      previousSignature
+        .split(';')
+        .filter(Boolean)
+        .map((entry) => {
+          const separatorIndex = entry.indexOf('=')
+          return separatorIndex >= 0
+            ? [entry.slice(0, separatorIndex), entry.slice(separatorIndex + 1)] as const
+            : [entry, ''] as const
+        }),
+    )
+    const changedPendingTab = pendingActionTabs.find((tab) => (
+      tab.kind === 'pending_action'
+      && previousSignaturesByTab.get(tab.id) !== tab.actions.map(getPendingActionSignature).join('|')
+    ))
+    const hasPendingSignatureChanged = previousState.key !== key || previousSignature !== pendingActionTabSignature
+
+    pendingActionAutoSwitchStateRef.current = {
+      key,
+      signature: pendingActionTabSignature,
+    }
+
+    if (!pendingActionTabs.length || !hasPendingSignatureChanged) {
+      return
+    }
+
+    setPendingActionsForceExpanded(true)
+
+    const activePendingTabStillOpen = Boolean(
+      activeWorkingTabId
+      && workingTabIds.has(activeWorkingTabId)
+      && isPendingWorkingTabId(activeWorkingTabId),
+    )
+    if (activePendingTabStillOpen) {
+      return
+    }
+
+    const nextPendingTabId = changedPendingTab?.id ?? pendingActionTabs[0]?.id
+    if (nextPendingTabId) {
+      selectWorkingTab(nextPendingTabId)
+    }
+  }, [
+    activeWorkingTabId,
+    agentId,
+    focusKey,
+    pendingActionTabSignature,
+    pendingActionTabs,
+    selectWorkingTab,
+    workingTabIds,
+  ])
+
+  useEffect(() => {
+    if (pendingActionTabs.length > 0 || isPendingWorkingTabId(activeWorkingTabId)) {
+      return
+    }
+    const key = agentId ?? focusKey ?? 'new-agent'
     let nextAutoSelectedTab: NativeWorkingTabKind | null = null
     for (const { kind, available } of nativeTabAvailability) {
       const previousState = nativeAutoSwitchStateRef.current[kind]
@@ -661,7 +833,7 @@ export const AgentComposer = memo(function AgentComposer({
     if (nextAutoSelectedTab) {
       selectWorkingTab(nextAutoSelectedTab)
     }
-  }, [agentId, focusKey, nativeTabAvailability, selectWorkingTab])
+  }, [activeWorkingTabId, agentId, focusKey, nativeTabAvailability, pendingActionTabs.length, selectWorkingTab])
 
   // Handle tab click - select that insight, expand panel if collapsed, and pause auto-rotation
   const handleTabClick = useCallback((tab: WorkingPanelTab) => {
@@ -678,6 +850,16 @@ export const AgentComposer = memo(function AgentComposer({
         title: tab.insight.title,
         tabIndex: tab.insightIndex,
         totalInsights: insights.length,
+      })
+    } else if (tab.kind === 'pending_action') {
+      const title = PENDING_WORKING_TAB_CONFIG[tab.pendingKind].title
+      track(AnalyticsEvent.INSIGHT_TAB_CLICKED + " - " + title, {
+        insightType: tab.pendingKind,
+        insightId: tab.id,
+        title,
+        tabIndex: workingTabs.findIndex((candidate) => candidate.id === tab.id),
+        totalInsights: insights.length,
+        pendingRequestCount: tab.count,
       })
     } else {
       const title = NATIVE_WORKING_TAB_CONFIG[tab.kind].title
@@ -937,19 +1119,22 @@ export const AgentComposer = memo(function AgentComposer({
     }
   }, [])
 
+  const activePendingActions = activePendingActionTab?.actions ?? []
   const activePendingAction =
-    pendingActionRequests.find((request) => request.id === activePendingActionId)
-    ?? pendingActionRequests[0]
+    activePendingActions.find((request) => request.id === activePendingActionId)
+    ?? activePendingActions[0]
     ?? null
   const activeHumanInputRequest =
     activePendingAction?.kind === 'human_input'
       ? (
-        pendingHumanInputRequests.find((request) => request.id === activeHumanInputRequestId)
-        ?? activePendingAction.requests[0]
+        orderHumanInputRequests(activePendingAction.requests).find((request) => request.id === activeHumanInputRequestId)
+        ?? orderHumanInputRequests(activePendingAction.requests)[0]
         ?? null
       )
       : null
   const activeHumanInputUsesMainComposer = Boolean(
+    resolvedWorkingExpanded
+    &&
     activeHumanInputRequest
     && (
       activeHumanInputRequest.inputMode === 'free_text_only'
@@ -964,6 +1149,15 @@ export const AgentComposer = memo(function AgentComposer({
     activeHumanInputUsesMainComposer ? 'Type your answer' : 'Message',
     submitShortcutHint,
   ].filter(Boolean).join(' · ')
+
+  const wasUsingMainComposerHumanInputRef = useRef(false)
+  useEffect(() => {
+    if (wasUsingMainComposerHumanInputRef.current && !activeHumanInputUsesMainComposer) {
+      setBody('')
+      requestAnimationFrame(() => adjustTextareaHeight(true))
+    }
+    wasUsingMainComposerHumanInputRef.current = activeHumanInputUsesMainComposer
+  }, [activeHumanInputUsesMainComposer, adjustTextareaHeight])
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -1449,7 +1643,7 @@ export const AgentComposer = memo(function AgentComposer({
 
   const pendingActionCount = pendingActionRequests.reduce((total, action) => total + getPendingActionRequestCount(action), 0)
   const pendingActionNavigationItems = useMemo<PendingActionNavigationItem[]>(() => (
-    pendingActionRequests.reduce<PendingActionNavigationItem[]>((items, action) => {
+    activePendingActions.reduce<PendingActionNavigationItem[]>((items, action) => {
       if (action.kind !== 'human_input') {
         items.push({ actionId: action.id, kind: 'action' })
         return items
@@ -1461,7 +1655,7 @@ export const AgentComposer = memo(function AgentComposer({
       }))
       return items
     }, [])
-  ), [pendingActionRequests])
+  ), [activePendingActions])
   const activePendingActionItemIndex = Math.max(0, pendingActionNavigationItems.findIndex((item) => (
     activePendingAction?.kind === 'human_input'
       ? item.kind === 'human_input'
@@ -1679,42 +1873,6 @@ export const AgentComposer = memo(function AgentComposer({
                     {pendingActionCount} {pendingActionCount === 1 ? 'request' : 'requests'}
                   </span>
                   {isPlanningMode ? renderSkipPlanningButton() : null}
-                  {pendingActionNavigationItems.length > 1 ? (
-                    <div
-                      className="composer-pending-action-nav"
-                      onClick={(event) => event.stopPropagation()}
-                      onKeyDown={(event) => event.stopPropagation()}
-                    >
-                      <button
-                        type="button"
-                        className="composer-pending-action-nav__button"
-                        onClick={() => handlePendingActionNavigationItemChange(
-                          pendingActionNavigationItems[Math.max(0, activePendingActionItemIndex - 1)],
-                        )}
-                        disabled={disabled || activePendingActionItemIndex === 0}
-                        aria-label="Previous pending request"
-                      >
-                        <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                      </button>
-                      <span className="composer-pending-action-nav__count">
-                        {activePendingActionItemIndex + 1} of {pendingActionNavigationItems.length}
-                      </span>
-                      <button
-                        type="button"
-                        className="composer-pending-action-nav__button"
-                        onClick={() => handlePendingActionNavigationItemChange(
-                          pendingActionNavigationItems[Math.min(
-                            pendingActionNavigationItems.length - 1,
-                            activePendingActionItemIndex + 1,
-                          )],
-                        )}
-                        disabled={disabled || activePendingActionItemIndex >= pendingActionNavigationItems.length - 1}
-                        aria-label="Next pending request"
-                      >
-                        <ChevronRight className="h-4 w-4" aria-hidden="true" />
-                      </button>
-                    </div>
-                  ) : null}
                 </>
               ) : isProcessing || isPlanningMode ? (
                 <>
@@ -1741,7 +1899,7 @@ export const AgentComposer = memo(function AgentComposer({
               )}
 
               {/* Colored pill tabs in header */}
-              {!hasPendingActions && hasWorkingTabs ? (
+              {hasWorkingTabs ? (
                 <div
                   className="composer-insight-tabs"
                   onClick={(e) => e.stopPropagation()}
@@ -1750,17 +1908,27 @@ export const AgentComposer = memo(function AgentComposer({
                   <div className="composer-insight-tabs-scroll">
                     {workingTabs.map((tab) => {
                       const isActive = tab.id === effectiveWorkingTabId
-                      const nativeTabConfig = tab.kind === 'insight' ? null : NATIVE_WORKING_TAB_CONFIG[tab.kind]
-                      const color = tab.kind === 'insight' ? getInsightTabColor(tab.insight) : DEFAULT_INSIGHT_TAB_COLOR
-                      const label = nativeTabConfig?.label ?? (tab.kind === 'insight' ? getInsightTabLabel(tab.insight) : '')
-                      const ariaLabel = nativeTabConfig?.ariaLabel
-                        ?? (tab.kind === 'insight' ? `View ${tab.insight.insightType.replace('_', ' ')} insight` : undefined)
+                      const nativeTabConfig = tab.kind !== 'insight' && tab.kind !== 'pending_action'
+                        ? NATIVE_WORKING_TAB_CONFIG[tab.kind]
+                        : null
+                      const pendingTabConfig = tab.kind === 'pending_action' ? PENDING_WORKING_TAB_CONFIG[tab.pendingKind] : null
+                      const color = tab.kind === 'insight'
+                        ? getInsightTabColor(tab.insight)
+                        : pendingTabConfig?.color ?? DEFAULT_INSIGHT_TAB_COLOR
+                      const label = tab.kind === 'pending_action'
+                        ? getPendingWorkingTabLabel(tab)
+                        : nativeTabConfig?.label ?? (tab.kind === 'insight' ? getInsightTabLabel(tab.insight) : '')
+                      const ariaLabel = tab.kind === 'pending_action'
+                        ? getPendingWorkingTabAriaLabel(tab)
+                        : nativeTabConfig?.ariaLabel
+                          ?? (tab.kind === 'insight' ? `View ${tab.insight.insightType.replace('_', ' ')} insight` : undefined)
                       return (
                         <button
                           key={tab.id}
                           type="button"
                           className="composer-insight-tab"
                           data-active={isActive ? 'true' : 'false'}
+                          data-priority={tab.kind === 'pending_action' ? 'true' : 'false'}
                           onClick={() => handleTabClick(tab)}
                           aria-label={ariaLabel}
                           style={{
@@ -1770,9 +1938,12 @@ export const AgentComposer = memo(function AgentComposer({
                         >
                           <span className="composer-insight-tab-inner" />
                           <span className="composer-insight-tab-icon" aria-hidden="true">
-                            {nativeTabConfig?.icon ?? (tab.kind === 'insight' ? getInsightTabIcon(tab.insight) : null)}
+                            {pendingTabConfig?.icon ?? nativeTabConfig?.icon ?? (tab.kind === 'insight' ? getInsightTabIcon(tab.insight) : null)}
                           </span>
                           <span className="composer-insight-tab-label">{label}</span>
+                          {tab.kind === 'pending_action' && tab.pendingKind !== 'questions' ? (
+                            <span className="composer-insight-tab-count">{tab.count}</span>
+                          ) : null}
                           {tab.kind === 'insight' && isActive && !isInsightsPaused && isProcessing && (
                             <span className="composer-insight-tab-progress" />
                           )}
@@ -1781,13 +1952,50 @@ export const AgentComposer = memo(function AgentComposer({
                     })}
                   </div>
                 </div>
-              ) : !hasPendingActions && insightsLoading ? (
+              ) : insightsLoading ? (
                 <div className="composer-insight-tabs composer-insight-tabs--loading" aria-hidden="true">
                   <div className="composer-insight-tabs-scroll">
                     <span className="composer-insight-tab-placeholder composer-insight-tab-placeholder--active" />
                     <span className="composer-insight-tab-placeholder" />
                     <span className="composer-insight-tab-placeholder composer-insight-tab-placeholder--short" />
                   </div>
+                </div>
+              ) : null}
+
+              {resolvedWorkingExpanded && activePendingActionTab && pendingActionNavigationItems.length > 1 ? (
+                <div
+                  className="composer-pending-action-nav"
+                  onClick={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => event.stopPropagation()}
+                >
+                  <button
+                    type="button"
+                    className="composer-pending-action-nav__button"
+                    onClick={() => handlePendingActionNavigationItemChange(
+                      pendingActionNavigationItems[Math.max(0, activePendingActionItemIndex - 1)],
+                    )}
+                    disabled={disabled || activePendingActionItemIndex === 0}
+                    aria-label="Previous pending request"
+                  >
+                    <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                  <span className="composer-pending-action-nav__count">
+                    {activePendingActionItemIndex + 1} of {pendingActionNavigationItems.length}
+                  </span>
+                  <button
+                    type="button"
+                    className="composer-pending-action-nav__button"
+                    onClick={() => handlePendingActionNavigationItemChange(
+                      pendingActionNavigationItems[Math.min(
+                        pendingActionNavigationItems.length - 1,
+                        activePendingActionItemIndex + 1,
+                      )],
+                    )}
+                    disabled={disabled || activePendingActionItemIndex >= pendingActionNavigationItems.length - 1}
+                    aria-label="Next pending request"
+                  >
+                    <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                  </button>
                 </div>
               ) : null}
 
@@ -1801,16 +2009,16 @@ export const AgentComposer = memo(function AgentComposer({
             </div>
 
             {/* Expanded content */}
-            {resolvedWorkingExpanded && (hasPendingActions || hasWorkingTabs || insightsLoading) ? (
+            {resolvedWorkingExpanded && (hasWorkingTabs || insightsLoading) ? (
               <div
                 className="composer-working-content"
                 onMouseEnter={handleInsightMouseEnter}
                 onMouseLeave={handleInsightMouseLeave}
               >
-                {hasPendingActions ? (
+                {activePendingActionTab ? (
                   <div className="composer-working-pending-actions">
                     <PendingActionComposerPanel
-                      actions={pendingActionRequests}
+                      actions={activePendingActionTab.actions}
                       agentName={agentName ?? agentFirstName}
                       activeActionId={activePendingActionId}
                       disabled={disabled || isSending}

--- a/frontend/src/components/agentChat/ChatSidebarGallery.tsx
+++ b/frontend/src/components/agentChat/ChatSidebarGallery.tsx
@@ -104,6 +104,7 @@ function GalleryCard({
   const showEmailAction = Boolean(agent.email) && !isSignupPreviewAgent
   const showConfigureAction = Boolean(agent.canManageAgent && (onConfigureAgent || agent.detailUrl)) && !isSignupPreviewAgent
   const miniDescription = (agent.miniDescription || '').trim()
+  const pendingRequestCount = Math.max(0, agent.pendingActionRequestCount ?? 0)
   const showChatAction = Boolean(onSelectAgent)
 
   return (
@@ -145,7 +146,11 @@ function GalleryCard({
           />
           <div className={styles.heroMetaClass}>
             <span className={styles.nameClass}>{agent.name || 'Agent'}</span>
-            {miniDescription ? (
+            {pendingRequestCount > 0 ? (
+              <span className="agent-roster-pending-pill">
+                {pendingRequestCount} {pendingRequestCount === 1 ? 'request' : 'requests'}
+              </span>
+            ) : miniDescription ? (
               <span className={styles.miniClass}>{miniDescription}</span>
             ) : null}
           </div>

--- a/frontend/src/components/agentChat/ChatSidebarParts.tsx
+++ b/frontend/src/components/agentChat/ChatSidebarParts.tsx
@@ -219,6 +219,8 @@ export function AgentListItem({
     : undefined
   const showMeta = variant === 'drawer' || !collapsed
   const miniDescription = (agent.miniDescription || '').trim()
+  const pendingRequestCount = Math.max(0, agent.pendingActionRequestCount ?? 0)
+  const hasPendingRequests = pendingRequestCount > 0
   const longDescription = (agent.shortDescription || '').trim()
   const hoverDescription = longDescription && longDescription !== miniDescription ? longDescription : undefined
   const showFavoriteButton = Boolean(onToggleFavorite) && (variant === 'drawer' || !collapsed) && showFavoriteToggle
@@ -295,7 +297,11 @@ export function AgentListItem({
       {showMeta ? (
         <span className={styles.metaClass}>
           <span className={styles.nameClass}>{agent.name || 'Agent'}</span>
-          {isWorking ? (
+          {hasPendingRequests ? (
+            <span className="agent-roster-pending-pill">
+              {pendingRequestCount} {pendingRequestCount === 1 ? 'request' : 'requests'}
+            </span>
+          ) : isWorking ? (
             <span className={styles.descClass}>
               <AgentWorkingIndicator />
             </span>

--- a/frontend/src/components/agentChat/PendingActionComposerPanel.tsx
+++ b/frontend/src/components/agentChat/PendingActionComposerPanel.tsx
@@ -42,6 +42,8 @@ type PendingActionComposerPanelProps = {
     }>
   ) => Promise<void>
   onViewAllContactRequests?: () => void
+  approvalActionsContainer?: Element | null
+  suppressInlineApprovalActions?: boolean
 }
 
 function parseInlineError(error: unknown): string {
@@ -128,6 +130,8 @@ export function PendingActionComposerPanel({
   onRemoveRequestedSecrets,
   onResolveContactRequests,
   onViewAllContactRequests,
+  approvalActionsContainer = null,
+  suppressInlineApprovalActions = false,
 }: PendingActionComposerPanelProps) {
   const [busySpawnDecision, setBusySpawnDecision] = useState<'approve' | 'decline' | null>(null)
   const [spawnError, setSpawnError] = useState<string | null>(null)
@@ -293,95 +297,105 @@ export function PendingActionComposerPanel({
     || activeAction.kind === 'spawn_request'
     || activeAction.kind === 'requested_secrets'
     || activeAction.kind === 'contact_requests'
+  const useApprovalInfoCard = activeAction.kind === 'requested_secrets' || activeAction.kind === 'contact_requests'
 
   return (
-    <section className="bg-white px-3 py-3 text-slate-800" aria-label="Pending action request">
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 items-start gap-3">
-          <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl bg-sky-100 text-sky-700">
-            <ActiveIcon className="h-4 w-4" aria-hidden="true" />
-          </span>
-          <div className={`min-w-0 ${activeActionMeta ? '' : 'flex min-h-9 items-center'}`}>
-            <p className="min-w-0 text-[0.95rem] font-semibold leading-6 tracking-[-0.02em] text-slate-900">
-              {activeActionHeading}
-            </p>
-            {activeActionMeta ? (
-              <p className="text-xs text-slate-600">
-                {activeActionMeta}
+    <section
+      className={`${useApprovalInfoCard ? 'bg-transparent' : 'bg-white'} px-4 py-3 text-slate-800 sm:px-5`}
+      aria-label="Pending action request"
+    >
+      <div className={useApprovalInfoCard ? 'rounded-xl border border-slate-200/70 bg-white px-3 py-3' : undefined}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-2.5">
+            <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-sky-100 text-sky-700">
+              <ActiveIcon className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <div className={`min-w-0 ${activeActionMeta ? '' : 'flex min-h-8 items-center'}`}>
+              <p className="min-w-0 text-sm font-semibold leading-5 text-slate-900">
+                {activeActionHeading}
               </p>
+              {activeActionMeta ? (
+                <p className="mt-0.5 truncate text-xs text-slate-600">
+                  {activeActionMeta}
+                </p>
+              ) : null}
+            </div>
+          </div>
+          {activeAction.kind === 'contact_requests' && onViewAllContactRequests ? (
+            <button
+              type="button"
+              onClick={onViewAllContactRequests}
+              className="shrink-0 rounded-lg px-2 py-1 text-xs font-semibold text-slate-600 transition hover:bg-white/55 hover:text-slate-900"
+            >
+              View all
+            </button>
+          ) : null}
+        </div>
+
+        {hasActionBody ? (
+          <div className={`mt-3 ${activeAction.kind === 'requested_secrets' || activeAction.kind === 'contact_requests' ? 'sm:ml-10' : ''}`}>
+            {showHumanInputComposer && activeAction.kind === 'human_input' ? (
+              <HumanInputComposerPanel
+                requests={activeAction.requests}
+                agentName={agentName}
+                activeRequestId={activeHumanInputRequestId}
+                draftResponses={draftHumanInputResponses}
+                disabled={disabled}
+                busyRequestId={busyHumanInputRequestId}
+                onSelectOption={onSelectHumanInputOption}
+                onDraftFreeTextChange={onDraftHumanInputFreeTextChange}
+                onSubmitRequest={onSubmitHumanInputRequest}
+                onDismissRequest={onDismissHumanInputRequest}
+              />
+            ) : null}
+
+            {activeAction.kind === 'spawn_request' ? (
+              <PendingSpawnRequestPanel
+                action={activeAction}
+                disabled={disabled || !onResolveSpawnRequest}
+                busyDecision={busySpawnDecision}
+                error={spawnError}
+                onResolve={handleResolveSpawn}
+              />
+            ) : null}
+
+            {activeAction.kind === 'requested_secrets' ? (
+              <PendingRequestedSecretsPanel
+                action={activeAction}
+                disabled={disabled || (!onFulfillRequestedSecrets && !onRemoveRequestedSecrets)}
+                busyAction={busySecretsAction}
+                error={secretError}
+                secretValues={secretValues}
+                makeGlobal={makeGlobal}
+                onSecretValueChange={(secretId, value) => {
+                  setSecretValues((current) => ({ ...current, [secretId]: value }))
+                }}
+                onMakeGlobalChange={setMakeGlobal}
+                onSave={handleSaveSecrets}
+                onRemove={handleRemoveSecrets}
+                actionsContainer={approvalActionsContainer}
+                suppressInlineActions={suppressInlineApprovalActions}
+              />
+            ) : null}
+
+            {activeAction.kind === 'contact_requests' ? (
+              <PendingContactRequestsPanel
+                action={activeAction}
+                disabled={disabled || !onResolveContactRequests}
+                busy={busyContacts}
+                error={contactError}
+                contactDrafts={contactDrafts}
+                onContactDraftChange={(requestId, nextDraft) => {
+                  setContactDrafts((current) => ({ ...current, [requestId]: nextDraft }))
+                }}
+                onSubmit={handleResolveContacts}
+                actionsContainer={approvalActionsContainer}
+                suppressInlineActions={suppressInlineApprovalActions}
+              />
             ) : null}
           </div>
-        </div>
-        {activeAction.kind === 'contact_requests' && onViewAllContactRequests ? (
-          <button
-            type="button"
-            onClick={onViewAllContactRequests}
-            className="mt-1 shrink-0 text-sm font-semibold text-slate-600 transition hover:text-slate-900"
-          >
-            View all
-          </button>
         ) : null}
       </div>
-
-      {hasActionBody ? (
-        <div className="mt-3">
-          {showHumanInputComposer && activeAction.kind === 'human_input' ? (
-            <HumanInputComposerPanel
-              requests={activeAction.requests}
-              agentName={agentName}
-              activeRequestId={activeHumanInputRequestId}
-              draftResponses={draftHumanInputResponses}
-              disabled={disabled}
-              busyRequestId={busyHumanInputRequestId}
-              onSelectOption={onSelectHumanInputOption}
-              onDraftFreeTextChange={onDraftHumanInputFreeTextChange}
-              onSubmitRequest={onSubmitHumanInputRequest}
-              onDismissRequest={onDismissHumanInputRequest}
-            />
-          ) : null}
-
-          {activeAction.kind === 'spawn_request' ? (
-            <PendingSpawnRequestPanel
-              action={activeAction}
-              disabled={disabled || !onResolveSpawnRequest}
-              busyDecision={busySpawnDecision}
-              error={spawnError}
-              onResolve={handleResolveSpawn}
-            />
-          ) : null}
-
-          {activeAction.kind === 'requested_secrets' ? (
-            <PendingRequestedSecretsPanel
-              action={activeAction}
-              disabled={disabled || (!onFulfillRequestedSecrets && !onRemoveRequestedSecrets)}
-              busyAction={busySecretsAction}
-              error={secretError}
-              secretValues={secretValues}
-              makeGlobal={makeGlobal}
-              onSecretValueChange={(secretId, value) => {
-                setSecretValues((current) => ({ ...current, [secretId]: value }))
-              }}
-              onMakeGlobalChange={setMakeGlobal}
-              onSave={handleSaveSecrets}
-              onRemove={handleRemoveSecrets}
-            />
-          ) : null}
-
-          {activeAction.kind === 'contact_requests' ? (
-            <PendingContactRequestsPanel
-              action={activeAction}
-              disabled={disabled || !onResolveContactRequests}
-              busy={busyContacts}
-              error={contactError}
-              contactDrafts={contactDrafts}
-              onContactDraftChange={(requestId, nextDraft) => {
-                setContactDrafts((current) => ({ ...current, [requestId]: nextDraft }))
-              }}
-              onSubmit={handleResolveContacts}
-            />
-          ) : null}
-        </div>
-      ) : null}
     </section>
   )
 }

--- a/frontend/src/components/agentChat/PendingActionComposerPanel.tsx
+++ b/frontend/src/components/agentChat/PendingActionComposerPanel.tsx
@@ -42,8 +42,7 @@ type PendingActionComposerPanelProps = {
     }>
   ) => Promise<void>
   onViewAllContactRequests?: () => void
-  approvalActionsContainer?: Element | null
-  suppressInlineApprovalActions?: boolean
+  compact?: boolean
 }
 
 function parseInlineError(error: unknown): string {
@@ -130,8 +129,7 @@ export function PendingActionComposerPanel({
   onRemoveRequestedSecrets,
   onResolveContactRequests,
   onViewAllContactRequests,
-  approvalActionsContainer = null,
-  suppressInlineApprovalActions = false,
+  compact = false,
 }: PendingActionComposerPanelProps) {
   const [busySpawnDecision, setBusySpawnDecision] = useState<'approve' | 'decline' | null>(null)
   const [spawnError, setSpawnError] = useState<string | null>(null)
@@ -367,14 +365,13 @@ export function PendingActionComposerPanel({
                 error={secretError}
                 secretValues={secretValues}
                 makeGlobal={makeGlobal}
+                showReviewSummary={!compact}
                 onSecretValueChange={(secretId, value) => {
                   setSecretValues((current) => ({ ...current, [secretId]: value }))
                 }}
                 onMakeGlobalChange={setMakeGlobal}
                 onSave={handleSaveSecrets}
                 onRemove={handleRemoveSecrets}
-                actionsContainer={approvalActionsContainer}
-                suppressInlineActions={suppressInlineApprovalActions}
               />
             ) : null}
 
@@ -385,12 +382,11 @@ export function PendingActionComposerPanel({
                 busy={busyContacts}
                 error={contactError}
                 contactDrafts={contactDrafts}
+                showReviewSummary={!compact}
                 onContactDraftChange={(requestId, nextDraft) => {
                   setContactDrafts((current) => ({ ...current, [requestId]: nextDraft }))
                 }}
                 onSubmit={handleResolveContacts}
-                actionsContainer={approvalActionsContainer}
-                suppressInlineActions={suppressInlineApprovalActions}
               />
             ) : null}
           </div>

--- a/frontend/src/components/agentChat/PendingContactRequestsPanel.tsx
+++ b/frontend/src/components/agentChat/PendingContactRequestsPanel.tsx
@@ -1,4 +1,4 @@
-import { createPortal } from 'react-dom'
+import { Inbox, Send, ShieldCheck } from 'lucide-react'
 
 import type { PendingContactRequestsAction } from '../../types/agentChat'
 
@@ -14,10 +14,9 @@ type PendingContactRequestsPanelProps = {
   busy?: boolean
   error?: string | null
   contactDrafts: Record<string, PendingContactDraft>
+  showReviewSummary?: boolean
   onContactDraftChange: (requestId: string, nextDraft: PendingContactDraft) => void
   onSubmit: (decision: 'approve' | 'decline', requestId: string) => Promise<void> | void
-  actionsContainer?: Element | null
-  suppressInlineActions?: boolean
 }
 
 export function PendingContactRequestsPanel({
@@ -26,10 +25,9 @@ export function PendingContactRequestsPanel({
   busy = false,
   error = null,
   contactDrafts,
+  showReviewSummary = true,
   onContactDraftChange,
   onSubmit,
-  actionsContainer = null,
-  suppressInlineActions = false,
 }: PendingContactRequestsPanelProps) {
   const activeRequest = action.requests[0] ?? null
 
@@ -49,23 +47,36 @@ export function PendingContactRequestsPanel({
 
   const actionRow = (
     <div className="space-y-2">
-      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-start">
-        <button
-          type="button"
-          disabled={disabled || busy}
-          className="inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
-          onClick={() => void onSubmit('decline', activeRequest.id)}
-        >
-          {busy ? 'Saving...' : 'Deny'}
-        </button>
-        <button
-          type="button"
-          disabled={disabled || busy || smsApprovalBlocked}
-          className="inline-flex w-full items-center justify-center rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
-          onClick={() => void onSubmit('approve', activeRequest.id)}
-        >
-          {busy ? 'Saving...' : 'Approve'}
-        </button>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {showReviewSummary ? (
+          <div className="hidden min-w-0 items-center gap-3 sm:flex">
+            <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
+              <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-slate-900">Reviewing this request</p>
+              <p className="text-sm text-slate-600">You're allowing this contact to message your organization.</p>
+            </div>
+          </div>
+        ) : null}
+        <div className="flex flex-col-reverse gap-2 sm:ml-auto sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            disabled={disabled || busy}
+            className="inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
+            onClick={() => void onSubmit('decline', activeRequest.id)}
+          >
+            {busy ? 'Saving...' : 'Deny'}
+          </button>
+          <button
+            type="button"
+            disabled={disabled || busy || smsApprovalBlocked}
+            className="inline-flex w-full items-center justify-center rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
+            onClick={() => void onSubmit('approve', activeRequest.id)}
+          >
+            {busy ? 'Saving...' : 'Approve'}
+          </button>
+        </div>
       </div>
       {error ? <p className="text-sm text-rose-600 sm:text-right">{error}</p> : null}
     </div>
@@ -103,10 +114,10 @@ export function PendingContactRequestsPanel({
                   disabled={disabled || busy}
                   className="h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
                 />
-                <span className="truncate font-semibold">Allow inbound messages</span>
-              </span>
-              <span className="hidden shrink-0 rounded-md bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700 sm:inline-flex">
-                Recommended
+                <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-700">
+                  <Inbox className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span className="truncate font-semibold">Allow inbound</span>
               </span>
             </label>
             <label className="flex min-h-12 items-center justify-between gap-3 rounded-lg border border-slate-200/70 bg-white/56 px-3 py-2.5 text-sm text-slate-800">
@@ -118,10 +129,10 @@ export function PendingContactRequestsPanel({
                   disabled={disabled || busy}
                   className="h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
                 />
-                <span className="truncate font-semibold">Allow outbound messages</span>
-              </span>
-              <span className="hidden shrink-0 rounded-md bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700 sm:inline-flex">
-                Recommended
+                <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-700">
+                  <Send className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span className="truncate font-semibold">Allow outbound</span>
               </span>
             </label>
           </div>
@@ -140,7 +151,7 @@ export function PendingContactRequestsPanel({
         </div>
       </div>
 
-      {actionsContainer ? createPortal(actionRow, actionsContainer) : suppressInlineActions ? null : actionRow}
+      {actionRow}
     </div>
   )
 }

--- a/frontend/src/components/agentChat/PendingContactRequestsPanel.tsx
+++ b/frontend/src/components/agentChat/PendingContactRequestsPanel.tsx
@@ -1,5 +1,4 @@
 import type { PendingContactRequestsAction } from '../../types/agentChat'
-import { PendingActionSectionCard } from './PendingActionSectionCard'
 
 export type PendingContactDraft = {
   allowInbound: boolean
@@ -43,81 +42,79 @@ export function PendingContactRequestsPanel({
   )
 
   return (
-    <PendingActionSectionCard toneClass="border-amber-200 bg-amber-50/65">
-      <div className="space-y-3">
-        <div className="rounded-xl bg-white px-3 py-3">
-          <div className="space-y-3">
-            {activeRequest.reason ? (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Reason</p>
-                <p className="mt-1 whitespace-pre-line text-sm text-slate-700">{activeRequest.reason}</p>
-              </div>
-            ) : null}
-            {activeRequest.channel === 'sms' && activeRequest.smsContactPurpose ? (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">SMS purpose</p>
-                <p className="mt-1 text-sm text-slate-700">{activeRequest.smsContactPurpose.replace(/_/g, ' ')}</p>
-                {activeRequest.smsContactPurposeDetails ? (
-                  <p className="mt-1 whitespace-pre-line text-sm text-slate-600">{activeRequest.smsContactPurposeDetails}</p>
-                ) : null}
-              </div>
-            ) : null}
-            <div className="grid gap-2 md:grid-cols-2">
-              <label className="flex items-start gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700">
-                <input
-                  type="checkbox"
-                  checked={draft.allowInbound}
-                  onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, allowInbound: event.currentTarget.checked })}
-                  disabled={disabled || busy}
-                  className="mt-0.5 h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
-                />
-                <span>Inbound</span>
-              </label>
-              <label className="flex items-start gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700">
-                <input
-                  type="checkbox"
-                  checked={draft.allowOutbound}
-                  onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, allowOutbound: event.currentTarget.checked })}
-                  disabled={disabled || busy}
-                  className="mt-0.5 h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
-                />
-                <span>Outbound</span>
-              </label>
+    <div className="space-y-3">
+      <div className="rounded-xl bg-white/78 px-3 py-3">
+        <div className="space-y-3">
+          {activeRequest.reason ? (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Reason</p>
+              <p className="mt-1 whitespace-pre-line text-sm text-slate-700">{activeRequest.reason}</p>
             </div>
-            {activeRequest.channel === 'sms' ? (
-              <label className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50/70 px-3 py-2 text-sm text-slate-700">
-                <input
-                  type="checkbox"
-                  checked={draft.smsContactPermissionAttested}
-                  onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, smsContactPermissionAttested: event.currentTarget.checked })}
-                  disabled={disabled || busy}
-                  className="mt-0.5 h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
-                />
-                <span>I confirm I have permission to contact this number by SMS.</span>
-              </label>
-            ) : null}
+          ) : null}
+          {activeRequest.channel === 'sms' && activeRequest.smsContactPurpose ? (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">SMS purpose</p>
+              <p className="mt-1 text-sm text-slate-700">{activeRequest.smsContactPurpose.replace(/_/g, ' ')}</p>
+              {activeRequest.smsContactPurposeDetails ? (
+                <p className="mt-1 whitespace-pre-line text-sm text-slate-600">{activeRequest.smsContactPurposeDetails}</p>
+              ) : null}
+            </div>
+          ) : null}
+          <div className="grid gap-2 md:grid-cols-2">
+            <label className="flex items-start gap-2 rounded-xl border border-slate-200 bg-white/72 px-3 py-2 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={draft.allowInbound}
+                onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, allowInbound: event.currentTarget.checked })}
+                disabled={disabled || busy}
+                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
+              />
+              <span>Inbound</span>
+            </label>
+            <label className="flex items-start gap-2 rounded-xl border border-slate-200 bg-white/72 px-3 py-2 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={draft.allowOutbound}
+                onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, allowOutbound: event.currentTarget.checked })}
+                disabled={disabled || busy}
+                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
+              />
+              <span>Outbound</span>
+            </label>
           </div>
+          {activeRequest.channel === 'sms' ? (
+            <label className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50/70 px-3 py-2 text-sm text-slate-700">
+              <input
+                type="checkbox"
+                checked={draft.smsContactPermissionAttested}
+                onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, smsContactPermissionAttested: event.currentTarget.checked })}
+                disabled={disabled || busy}
+                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
+              />
+              <span>I confirm I have permission to contact this number by SMS.</span>
+            </label>
+          ) : null}
         </div>
-        <div className="grid grid-cols-2 gap-2">
-          <button
-            type="button"
-            disabled={disabled || busy}
-            className="inline-flex w-full items-center justify-center rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
-            onClick={() => void onSubmit('decline', activeRequest.id)}
-          >
-            {busy ? 'Saving...' : 'Deny'}
-          </button>
-          <button
-            type="button"
-            disabled={disabled || busy || smsApprovalBlocked}
-            className="inline-flex w-full items-center justify-center rounded-xl bg-amber-600 px-3 py-2.5 text-sm font-semibold text-white transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
-            onClick={() => void onSubmit('approve', activeRequest.id)}
-          >
-            {busy ? 'Saving...' : 'Approve'}
-          </button>
-        </div>
-        {error ? <p className="text-sm text-rose-600">{error}</p> : null}
       </div>
-    </PendingActionSectionCard>
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          disabled={disabled || busy}
+          className="inline-flex w-full items-center justify-center rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={() => void onSubmit('decline', activeRequest.id)}
+        >
+          {busy ? 'Saving...' : 'Deny'}
+        </button>
+        <button
+          type="button"
+          disabled={disabled || busy || smsApprovalBlocked}
+          className="inline-flex w-full items-center justify-center rounded-xl bg-amber-600 px-3 py-2.5 text-sm font-semibold text-white transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={() => void onSubmit('approve', activeRequest.id)}
+        >
+          {busy ? 'Saving...' : 'Approve'}
+        </button>
+      </div>
+      {error ? <p className="text-sm text-rose-600">{error}</p> : null}
+    </div>
   )
 }

--- a/frontend/src/components/agentChat/PendingContactRequestsPanel.tsx
+++ b/frontend/src/components/agentChat/PendingContactRequestsPanel.tsx
@@ -1,3 +1,5 @@
+import { createPortal } from 'react-dom'
+
 import type { PendingContactRequestsAction } from '../../types/agentChat'
 
 export type PendingContactDraft = {
@@ -14,6 +16,8 @@ type PendingContactRequestsPanelProps = {
   contactDrafts: Record<string, PendingContactDraft>
   onContactDraftChange: (requestId: string, nextDraft: PendingContactDraft) => void
   onSubmit: (decision: 'approve' | 'decline', requestId: string) => Promise<void> | void
+  actionsContainer?: Element | null
+  suppressInlineActions?: boolean
 }
 
 export function PendingContactRequestsPanel({
@@ -24,6 +28,8 @@ export function PendingContactRequestsPanel({
   contactDrafts,
   onContactDraftChange,
   onSubmit,
+  actionsContainer = null,
+  suppressInlineActions = false,
 }: PendingContactRequestsPanelProps) {
   const activeRequest = action.requests[0] ?? null
 
@@ -41,49 +47,86 @@ export function PendingContactRequestsPanel({
     && !draft.smsContactPermissionAttested
   )
 
+  const actionRow = (
+    <div className="space-y-2">
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-start">
+        <button
+          type="button"
+          disabled={disabled || busy}
+          className="inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
+          onClick={() => void onSubmit('decline', activeRequest.id)}
+        >
+          {busy ? 'Saving...' : 'Deny'}
+        </button>
+        <button
+          type="button"
+          disabled={disabled || busy || smsApprovalBlocked}
+          className="inline-flex w-full items-center justify-center rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
+          onClick={() => void onSubmit('approve', activeRequest.id)}
+        >
+          {busy ? 'Saving...' : 'Approve'}
+        </button>
+      </div>
+      {error ? <p className="text-sm text-rose-600 sm:text-right">{error}</p> : null}
+    </div>
+  )
+
   return (
-    <div className="space-y-3">
-      <div className="rounded-xl bg-white/78 px-3 py-3">
-        <div className="space-y-3">
-          {activeRequest.reason ? (
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">Reason</p>
-              <p className="mt-1 whitespace-pre-line text-sm text-slate-700">{activeRequest.reason}</p>
-            </div>
-          ) : null}
-          {activeRequest.channel === 'sms' && activeRequest.smsContactPurpose ? (
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">SMS purpose</p>
-              <p className="mt-1 text-sm text-slate-700">{activeRequest.smsContactPurpose.replace(/_/g, ' ')}</p>
-              {activeRequest.smsContactPurposeDetails ? (
-                <p className="mt-1 whitespace-pre-line text-sm text-slate-600">{activeRequest.smsContactPurposeDetails}</p>
-              ) : null}
-            </div>
-          ) : null}
-          <div className="grid gap-2 md:grid-cols-2">
-            <label className="flex items-start gap-2 rounded-xl border border-slate-200 bg-white/72 px-3 py-2 text-sm text-slate-700">
-              <input
-                type="checkbox"
-                checked={draft.allowInbound}
-                onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, allowInbound: event.currentTarget.checked })}
-                disabled={disabled || busy}
-                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
-              />
-              <span>Inbound</span>
+    <div className="max-w-3xl space-y-3">
+      <div className="space-y-3">
+        {activeRequest.reason ? (
+          <div>
+            <p className="text-xs font-semibold text-slate-900">Reason</p>
+            <p className="mt-1 whitespace-pre-line text-sm leading-5 text-slate-700">{activeRequest.reason}</p>
+          </div>
+        ) : null}
+
+        {activeRequest.channel === 'sms' && activeRequest.smsContactPurpose ? (
+          <div>
+            <p className="text-xs font-semibold text-slate-900">SMS purpose</p>
+            <p className="mt-1 text-sm leading-5 text-slate-700">{activeRequest.smsContactPurpose.replace(/_/g, ' ')}</p>
+            {activeRequest.smsContactPurposeDetails ? (
+              <p className="mt-1 whitespace-pre-line text-sm leading-5 text-slate-600">{activeRequest.smsContactPurposeDetails}</p>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold text-slate-900">Permissions</p>
+          <div className="max-w-2xl space-y-2">
+            <label className="flex min-h-12 items-center justify-between gap-3 rounded-lg border border-slate-200/70 bg-white/56 px-3 py-2.5 text-sm text-slate-800">
+              <span className="inline-flex min-w-0 items-center gap-3">
+                <input
+                  type="checkbox"
+                  checked={draft.allowInbound}
+                  onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, allowInbound: event.currentTarget.checked })}
+                  disabled={disabled || busy}
+                  className="h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
+                />
+                <span className="truncate font-semibold">Allow inbound messages</span>
+              </span>
+              <span className="hidden shrink-0 rounded-md bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700 sm:inline-flex">
+                Recommended
+              </span>
             </label>
-            <label className="flex items-start gap-2 rounded-xl border border-slate-200 bg-white/72 px-3 py-2 text-sm text-slate-700">
-              <input
-                type="checkbox"
-                checked={draft.allowOutbound}
-                onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, allowOutbound: event.currentTarget.checked })}
-                disabled={disabled || busy}
-                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
-              />
-              <span>Outbound</span>
+            <label className="flex min-h-12 items-center justify-between gap-3 rounded-lg border border-slate-200/70 bg-white/56 px-3 py-2.5 text-sm text-slate-800">
+              <span className="inline-flex min-w-0 items-center gap-3">
+                <input
+                  type="checkbox"
+                  checked={draft.allowOutbound}
+                  onChange={(event) => onContactDraftChange(activeRequest.id, { ...draft, allowOutbound: event.currentTarget.checked })}
+                  disabled={disabled || busy}
+                  className="h-4 w-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500"
+                />
+                <span className="truncate font-semibold">Allow outbound messages</span>
+              </span>
+              <span className="hidden shrink-0 rounded-md bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-700 sm:inline-flex">
+                Recommended
+              </span>
             </label>
           </div>
           {activeRequest.channel === 'sms' ? (
-            <label className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50/70 px-3 py-2 text-sm text-slate-700">
+            <label className="inline-flex max-w-full items-start gap-2 rounded-lg border border-amber-200 bg-amber-50/60 px-2.5 py-1.5 text-sm text-slate-700">
               <input
                 type="checkbox"
                 checked={draft.smsContactPermissionAttested}
@@ -96,25 +139,8 @@ export function PendingContactRequestsPanel({
           ) : null}
         </div>
       </div>
-      <div className="grid grid-cols-2 gap-2">
-        <button
-          type="button"
-          disabled={disabled || busy}
-          className="inline-flex w-full items-center justify-center rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
-          onClick={() => void onSubmit('decline', activeRequest.id)}
-        >
-          {busy ? 'Saving...' : 'Deny'}
-        </button>
-        <button
-          type="button"
-          disabled={disabled || busy || smsApprovalBlocked}
-          className="inline-flex w-full items-center justify-center rounded-xl bg-amber-600 px-3 py-2.5 text-sm font-semibold text-white transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
-          onClick={() => void onSubmit('approve', activeRequest.id)}
-        >
-          {busy ? 'Saving...' : 'Approve'}
-        </button>
-      </div>
-      {error ? <p className="text-sm text-rose-600">{error}</p> : null}
+
+      {actionsContainer ? createPortal(actionRow, actionsContainer) : suppressInlineActions ? null : actionRow}
     </div>
   )
 }

--- a/frontend/src/components/agentChat/PendingRequestedSecretsPanel.tsx
+++ b/frontend/src/components/agentChat/PendingRequestedSecretsPanel.tsx
@@ -1,5 +1,4 @@
-import { createPortal } from 'react-dom'
-import { Globe } from 'lucide-react'
+import { Globe, ShieldCheck } from 'lucide-react'
 
 import type { PendingRequestedSecretsAction } from '../../types/agentChat'
 import { InlineInfoTooltipButton } from './InlineInfoTooltipButton'
@@ -11,12 +10,11 @@ type PendingRequestedSecretsPanelProps = {
   error?: string | null
   secretValues: Record<string, string>
   makeGlobal: boolean
+  showReviewSummary?: boolean
   onSecretValueChange: (secretId: string, value: string) => void
   onMakeGlobalChange: (checked: boolean) => void
   onSave: () => Promise<void> | void
   onRemove: () => Promise<void> | void
-  actionsContainer?: Element | null
-  suppressInlineActions?: boolean
 }
 
 export function PendingRequestedSecretsPanel({
@@ -26,12 +24,11 @@ export function PendingRequestedSecretsPanel({
   error = null,
   secretValues,
   makeGlobal,
+  showReviewSummary = true,
   onSecretValueChange,
   onMakeGlobalChange,
   onSave,
   onRemove,
-  actionsContainer = null,
-  suppressInlineActions = false,
 }: PendingRequestedSecretsPanelProps) {
   const secret = action.secrets[0]
 
@@ -41,30 +38,43 @@ export function PendingRequestedSecretsPanel({
 
   const actionRow = (
     <div className="space-y-2">
-      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-start">
-        <button
-          type="button"
-          disabled={disabled || busyAction !== null}
-          className="inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
-          onClick={() => void onRemove()}
-        >
-          {busyAction === 'remove' ? 'Removing...' : 'Remove'}
-        </button>
-        <button
-          type="button"
-          disabled={disabled || busyAction !== null}
-          className="inline-flex w-full items-center justify-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
-          onClick={() => void onSave()}
-        >
-          {busyAction === 'save' ? 'Saving...' : 'Save'}
-        </button>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {showReviewSummary ? (
+          <div className="hidden min-w-0 items-center gap-3 sm:flex">
+            <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-violet-100 text-violet-700">
+              <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-slate-900">Reviewing this request</p>
+              <p className="text-sm text-slate-600">You're allowing this agent to use this credential.</p>
+            </div>
+          </div>
+        ) : null}
+        <div className="flex flex-col-reverse gap-2 sm:ml-auto sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            disabled={disabled || busyAction !== null}
+            className="inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
+            onClick={() => void onRemove()}
+          >
+            {busyAction === 'remove' ? 'Removing...' : 'Remove'}
+          </button>
+          <button
+            type="button"
+            disabled={disabled || busyAction !== null}
+            className="inline-flex w-full items-center justify-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
+            onClick={() => void onSave()}
+          >
+            {busyAction === 'save' ? 'Saving...' : 'Save'}
+          </button>
+        </div>
       </div>
       {error ? <p className="text-sm text-rose-600 sm:text-right">{error}</p> : null}
     </div>
   )
 
   return (
-    <div className="max-w-2xl space-y-3">
+    <div className="w-full space-y-3">
       <div className="space-y-3">
         {secret.description ? (
           <div>
@@ -110,7 +120,7 @@ export function PendingRequestedSecretsPanel({
         </div>
       </div>
 
-      {actionsContainer ? createPortal(actionRow, actionsContainer) : suppressInlineActions ? null : actionRow}
+      {actionRow}
     </div>
   )
 }

--- a/frontend/src/components/agentChat/PendingRequestedSecretsPanel.tsx
+++ b/frontend/src/components/agentChat/PendingRequestedSecretsPanel.tsx
@@ -2,7 +2,6 @@ import { Globe } from 'lucide-react'
 
 import type { PendingRequestedSecretsAction } from '../../types/agentChat'
 import { InlineInfoTooltipButton } from './InlineInfoTooltipButton'
-import { PendingActionSectionCard } from './PendingActionSectionCard'
 
 type PendingRequestedSecretsPanelProps = {
   action: PendingRequestedSecretsAction
@@ -36,65 +35,63 @@ export function PendingRequestedSecretsPanel({
   }
 
   return (
-    <PendingActionSectionCard toneClass="border-sky-200 bg-sky-50/55">
-      <div className="space-y-3">
-        <div className="rounded-xl bg-white px-3 py-3">
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-sky-700">
-                {secret.secretType === 'env_var' ? 'Env Var' : 'Credential'}
-              </span>
-              {secret.description ? <p className="text-sm text-slate-700">{secret.description}</p> : null}
-            </div>
-            <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+    <div className="space-y-3">
+      <div className="rounded-xl bg-white/78 px-3 py-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-sky-700">
+              {secret.secretType === 'env_var' ? 'Env Var' : 'Credential'}
+            </span>
+            {secret.description ? <p className="text-sm text-slate-700">{secret.description}</p> : null}
+          </div>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+            <input
+              type="password"
+              value={secretValues[secret.id] ?? ''}
+              onChange={(event) => onSecretValueChange(secret.id, event.currentTarget.value)}
+              disabled={disabled || busyAction !== null}
+              className="block w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              placeholder={`Enter value for ${secret.name}`}
+              autoComplete="new-password"
+            />
+            <label className="inline-flex shrink-0 items-center gap-2 rounded-xl border border-slate-200 bg-white/72 px-3 py-2 text-sm text-slate-700">
               <input
-                type="password"
-                value={secretValues[secret.id] ?? ''}
-                onChange={(event) => onSecretValueChange(secret.id, event.currentTarget.value)}
+                type="checkbox"
+                checked={makeGlobal}
+                onChange={(event) => onMakeGlobalChange(event.currentTarget.checked)}
                 disabled={disabled || busyAction !== null}
-                className="block w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
-                placeholder={`Enter value for ${secret.name}`}
-                autoComplete="new-password"
+                className="h-4 w-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500"
               />
-              <label className="inline-flex shrink-0 items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700">
-                <input
-                  type="checkbox"
-                  checked={makeGlobal}
-                  onChange={(event) => onMakeGlobalChange(event.currentTarget.checked)}
-                  disabled={disabled || busyAction !== null}
-                  className="h-4 w-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500"
-                />
-                <Globe className="h-4 w-4 text-sky-600" aria-hidden="true" />
-                <span>Global</span>
-                <InlineInfoTooltipButton
-                  label="What Global does"
-                  description="Makes this value available across agents in the current scope instead of storing it only for this agent."
-                  disabled={disabled || busyAction !== null}
-                />
-              </label>
-            </div>
+              <Globe className="h-4 w-4 text-sky-600" aria-hidden="true" />
+              <span>Global</span>
+              <InlineInfoTooltipButton
+                label="What Global does"
+                description="Makes this value available across agents in the current scope instead of storing it only for this agent."
+                disabled={disabled || busyAction !== null}
+              />
+            </label>
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-2">
-          <button
-            type="button"
-            disabled={disabled || busyAction !== null}
-            className="inline-flex w-full items-center justify-center rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
-            onClick={() => void onRemove()}
-          >
-            {busyAction === 'remove' ? 'Removing...' : 'Remove'}
-          </button>
-          <button
-            type="button"
-            disabled={disabled || busyAction !== null}
-            className="inline-flex w-full items-center justify-center rounded-xl bg-sky-600 px-3 py-2.5 text-sm font-semibold text-white transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-60"
-            onClick={() => void onSave()}
-          >
-            {busyAction === 'save' ? 'Saving...' : 'Save'}
-          </button>
-        </div>
-        {error ? <p className="text-sm text-rose-600">{error}</p> : null}
       </div>
-    </PendingActionSectionCard>
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          disabled={disabled || busyAction !== null}
+          className="inline-flex w-full items-center justify-center rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={() => void onRemove()}
+        >
+          {busyAction === 'remove' ? 'Removing...' : 'Remove'}
+        </button>
+        <button
+          type="button"
+          disabled={disabled || busyAction !== null}
+          className="inline-flex w-full items-center justify-center rounded-xl bg-sky-600 px-3 py-2.5 text-sm font-semibold text-white transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={() => void onSave()}
+        >
+          {busyAction === 'save' ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+      {error ? <p className="text-sm text-rose-600">{error}</p> : null}
+    </div>
   )
 }

--- a/frontend/src/components/agentChat/PendingRequestedSecretsPanel.tsx
+++ b/frontend/src/components/agentChat/PendingRequestedSecretsPanel.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom'
 import { Globe } from 'lucide-react'
 
 import type { PendingRequestedSecretsAction } from '../../types/agentChat'
@@ -14,6 +15,8 @@ type PendingRequestedSecretsPanelProps = {
   onMakeGlobalChange: (checked: boolean) => void
   onSave: () => Promise<void> | void
   onRemove: () => Promise<void> | void
+  actionsContainer?: Element | null
+  suppressInlineActions?: boolean
 }
 
 export function PendingRequestedSecretsPanel({
@@ -27,6 +30,8 @@ export function PendingRequestedSecretsPanel({
   onMakeGlobalChange,
   onSave,
   onRemove,
+  actionsContainer = null,
+  suppressInlineActions = false,
 }: PendingRequestedSecretsPanelProps) {
   const secret = action.secrets[0]
 
@@ -34,27 +39,58 @@ export function PendingRequestedSecretsPanel({
     return null
   }
 
+  const actionRow = (
+    <div className="space-y-2">
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-start">
+        <button
+          type="button"
+          disabled={disabled || busyAction !== null}
+          className="inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
+          onClick={() => void onRemove()}
+        >
+          {busyAction === 'remove' ? 'Removing...' : 'Remove'}
+        </button>
+        <button
+          type="button"
+          disabled={disabled || busyAction !== null}
+          className="inline-flex w-full items-center justify-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-60 sm:w-32"
+          onClick={() => void onSave()}
+        >
+          {busyAction === 'save' ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+      {error ? <p className="text-sm text-rose-600 sm:text-right">{error}</p> : null}
+    </div>
+  )
+
   return (
-    <div className="space-y-3">
-      <div className="rounded-xl bg-white/78 px-3 py-3">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-sky-700">
-              {secret.secretType === 'env_var' ? 'Env Var' : 'Credential'}
-            </span>
-            {secret.description ? <p className="text-sm text-slate-700">{secret.description}</p> : null}
+    <div className="max-w-2xl space-y-3">
+      <div className="space-y-3">
+        {secret.description ? (
+          <div>
+            <p className="text-xs font-semibold text-slate-900">
+              {secret.secretType === 'env_var' ? 'Environment variable' : 'Credential'}
+            </p>
+            <p className="mt-1 text-sm leading-5 text-slate-700">{secret.description}</p>
           </div>
-          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+        ) : null}
+
+        <div className="space-y-2">
+          <label htmlFor={`pending-secret-${secret.id}`} className="text-xs font-semibold text-slate-900">
+            Value
+          </label>
+          <div className="space-y-2">
             <input
+              id={`pending-secret-${secret.id}`}
               type="password"
               value={secretValues[secret.id] ?? ''}
               onChange={(event) => onSecretValueChange(secret.id, event.currentTarget.value)}
               disabled={disabled || busyAction !== null}
-              className="block w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
+              className="block w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
               placeholder={`Enter value for ${secret.name}`}
               autoComplete="new-password"
             />
-            <label className="inline-flex shrink-0 items-center gap-2 rounded-xl border border-slate-200 bg-white/72 px-3 py-2 text-sm text-slate-700">
+            <label className="inline-flex min-h-8 w-fit items-center gap-2 rounded-lg border border-white/70 bg-white/48 px-2.5 py-1.5 text-sm text-slate-700">
               <input
                 type="checkbox"
                 checked={makeGlobal}
@@ -63,7 +99,7 @@ export function PendingRequestedSecretsPanel({
                 className="h-4 w-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500"
               />
               <Globe className="h-4 w-4 text-sky-600" aria-hidden="true" />
-              <span>Global</span>
+              <span>Make global</span>
               <InlineInfoTooltipButton
                 label="What Global does"
                 description="Makes this value available across agents in the current scope instead of storing it only for this agent."
@@ -73,25 +109,8 @@ export function PendingRequestedSecretsPanel({
           </div>
         </div>
       </div>
-      <div className="grid grid-cols-2 gap-2">
-        <button
-          type="button"
-          disabled={disabled || busyAction !== null}
-          className="inline-flex w-full items-center justify-center rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
-          onClick={() => void onRemove()}
-        >
-          {busyAction === 'remove' ? 'Removing...' : 'Remove'}
-        </button>
-        <button
-          type="button"
-          disabled={disabled || busyAction !== null}
-          className="inline-flex w-full items-center justify-center rounded-xl bg-sky-600 px-3 py-2.5 text-sm font-semibold text-white transition hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-60"
-          onClick={() => void onSave()}
-        >
-          {busyAction === 'save' ? 'Saving...' : 'Save'}
-        </button>
-      </div>
-      {error ? <p className="text-sm text-rose-600">{error}</p> : null}
+
+      {actionsContainer ? createPortal(actionRow, actionsContainer) : suppressInlineActions ? null : actionRow}
     </div>
   )
 }

--- a/frontend/src/components/agentChat/insights/ApolloInsightPanel.test.tsx
+++ b/frontend/src/components/agentChat/insights/ApolloInsightPanel.test.tsx
@@ -42,6 +42,7 @@ const apolloProvider = {
   connectUrl: '/console/api/native-integrations/apollo/connect/',
   filesUrl: '',
   pickerTokenUrl: '',
+  agentEventUrl: '/console/api/native-integrations/apollo/agent-events/',
   revokeUrl: '/console/api/native-integrations/apollo/revoke/',
 }
 

--- a/frontend/src/components/agentChat/insights/ApolloInsightPanel.tsx
+++ b/frontend/src/components/agentChat/insights/ApolloInsightPanel.tsx
@@ -18,8 +18,9 @@ const APOLLO_FALLBACK_ICON = (
   </span>
 )
 
-export function ApolloInsightPanel({ nativeIntegrationsUrl = null }: ApolloInsightPanelProps) {
+export function ApolloInsightPanel({ agentId = null, nativeIntegrationsUrl = null }: ApolloInsightPanelProps) {
   const panel = useNativeIntegrationPanelState({
+    agentId,
     nativeIntegrationsUrl,
     providerKey: APOLLO_PROVIDER_KEY,
     providerDisplayName: 'Apollo',

--- a/frontend/src/components/agentChat/insights/DiscordInsightPanel.tsx
+++ b/frontend/src/components/agentChat/insights/DiscordInsightPanel.tsx
@@ -33,6 +33,7 @@ const DISCORD_PROVIDER: NativeIntegrationProvider = {
   connectUrl: '',
   filesUrl: '',
   pickerTokenUrl: '',
+  agentEventUrl: '',
   revokeUrl: '',
 }
 

--- a/frontend/src/components/agentChat/insights/GoogleDriveInsightPanel.test.tsx
+++ b/frontend/src/components/agentChat/insights/GoogleDriveInsightPanel.test.tsx
@@ -6,22 +6,26 @@ import { GoogleDriveInsightPanel } from './GoogleDriveInsightPanel'
 import {
   fetchNativeIntegrationPickerToken,
   fetchNativeIntegrations,
+  recordNativeIntegrationAgentEvent,
   startNativeIntegrationConnect,
 } from '../../../api/nativeIntegrations'
 import {
+  nativeOAuthContextPayload,
   openGoogleDrivePicker,
   openNativeOAuthPopup,
+  storePendingNativeOAuth,
 } from '../../mcp/NativeIntegrationShared'
 
 vi.mock('../../../api/nativeIntegrations', () => ({
   fetchNativeIntegrations: vi.fn(),
   fetchNativeIntegrationPickerToken: vi.fn(),
+  recordNativeIntegrationAgentEvent: vi.fn(),
   startNativeIntegrationConnect: vi.fn(),
 }))
 
 vi.mock('../../mcp/NativeIntegrationShared', () => ({
   NativeProviderIcon: () => <img src="/static/images/integrations/native/google_drive.svg" alt="" />,
-  nativeOAuthContextPayload: () => ({ providerKey: 'google_drive' }),
+  nativeOAuthContextPayload: vi.fn(() => ({ providerKey: 'google_drive' })),
   openGoogleDrivePicker: vi.fn(),
   openNativeOAuthPopup: vi.fn(),
   storePendingNativeOAuth: vi.fn(),
@@ -45,10 +49,11 @@ const googleDriveProvider = {
   connectUrl: '/console/api/native-integrations/google_drive/connect/',
   filesUrl: '/console/api/native-integrations/google_drive/files/',
   pickerTokenUrl: '/console/api/native-integrations/google_drive/picker-token/',
+  agentEventUrl: '/console/api/native-integrations/google_drive/agent-events/',
   revokeUrl: '/console/api/native-integrations/google_drive/revoke/',
 }
 
-function renderPanel() {
+function renderPanel({ agentId = null }: { agentId?: string | null } = {}) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -57,7 +62,7 @@ function renderPanel() {
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <GoogleDriveInsightPanel nativeIntegrationsUrl="/console/api/native-integrations/" />
+      <GoogleDriveInsightPanel agentId={agentId} nativeIntegrationsUrl="/console/api/native-integrations/" />
     </QueryClientProvider>,
   )
 }
@@ -66,9 +71,12 @@ describe('GoogleDriveInsightPanel', () => {
   beforeEach(() => {
     vi.mocked(fetchNativeIntegrations).mockReset()
     vi.mocked(fetchNativeIntegrationPickerToken).mockReset()
+    vi.mocked(recordNativeIntegrationAgentEvent).mockReset()
     vi.mocked(startNativeIntegrationConnect).mockReset()
+    vi.mocked(nativeOAuthContextPayload).mockClear()
     vi.mocked(openGoogleDrivePicker).mockReset()
     vi.mocked(openNativeOAuthPopup).mockReset()
+    vi.mocked(storePendingNativeOAuth).mockClear()
   })
 
   it('starts Google Drive OAuth when disconnected', async () => {
@@ -97,11 +105,49 @@ describe('GoogleDriveInsightPanel', () => {
     await waitFor(() => {
       expect(startNativeIntegrationConnect).toHaveBeenCalledWith(googleDriveProvider.connectUrl)
     })
+    expect(nativeOAuthContextPayload).toHaveBeenCalledWith(googleDriveProvider, 'state-1', popup, null)
+    expect(storePendingNativeOAuth).toHaveBeenCalledWith('state-1', { providerKey: 'google_drive' })
     expect(openNativeOAuthPopup).toHaveBeenCalled()
     expect((popup.location as Location).href).toBe('https://accounts.google.com/oauth')
   })
 
-  it('opens Google Picker when connected', async () => {
+  it('stores agent context for Google Drive OAuth when launched from agent chat', async () => {
+    const popup = {
+      closed: false,
+      focus: vi.fn(),
+      location: { href: '' },
+    } as unknown as Window
+    vi.mocked(fetchNativeIntegrations).mockResolvedValue({
+      ownerScope: 'personal',
+      ownerLabel: 'Personal',
+      providers: [{ ...googleDriveProvider, connected: false }],
+    })
+    vi.mocked(openNativeOAuthPopup).mockReturnValue(popup)
+    vi.mocked(startNativeIntegrationConnect).mockResolvedValue({
+      providerKey: 'google_drive',
+      authorizationUrl: 'https://accounts.google.com/oauth',
+      state: 'state-1',
+      expiresAt: '2026-01-01T00:00:00Z',
+    })
+
+    renderPanel({ agentId: 'agent-123' })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Connect' }))
+
+    await waitFor(() => {
+      expect(nativeOAuthContextPayload).toHaveBeenCalledWith(googleDriveProvider, 'state-1', popup, 'agent-123')
+    })
+  })
+
+  it('opens Google Picker and records selected files when connected', async () => {
+    const selectedFiles = [
+      {
+        externalId: 'sheet-123',
+        name: 'Q2 Sales Tracker',
+        mimeType: 'application/vnd.google-apps.spreadsheet',
+        webUrl: 'https://docs.google.com/spreadsheets/d/sheet-123/edit',
+      },
+    ]
     vi.mocked(fetchNativeIntegrations).mockResolvedValue({
       ownerScope: 'personal',
       ownerLabel: 'Personal',
@@ -114,9 +160,13 @@ describe('GoogleDriveInsightPanel', () => {
       scope: 'https://www.googleapis.com/auth/drive.file',
       expiresAt: null,
     })
-    vi.mocked(openGoogleDrivePicker).mockResolvedValue(1)
+    vi.mocked(openGoogleDrivePicker).mockResolvedValue(selectedFiles)
+    vi.mocked(recordNativeIntegrationAgentEvent).mockResolvedValue({
+      recorded: true,
+      stepId: 'step-123',
+    })
 
-    renderPanel()
+    renderPanel({ agentId: 'agent-123' })
 
     expect(await screen.findByText('Google Drive connected')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Select files' }))
@@ -125,5 +175,13 @@ describe('GoogleDriveInsightPanel', () => {
       expect(fetchNativeIntegrationPickerToken).toHaveBeenCalledWith(googleDriveProvider.pickerTokenUrl)
     })
     expect(openGoogleDrivePicker).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(recordNativeIntegrationAgentEvent).toHaveBeenCalledWith({
+        agentEventUrl: googleDriveProvider.agentEventUrl,
+        agentId: 'agent-123',
+        eventType: 'files_selected',
+        files: selectedFiles,
+      })
+    })
   })
 })

--- a/frontend/src/components/agentChat/insights/GoogleDriveInsightPanel.tsx
+++ b/frontend/src/components/agentChat/insights/GoogleDriveInsightPanel.tsx
@@ -3,6 +3,7 @@ import { FolderOpen, Loader2 } from 'lucide-react'
 
 import {
   fetchNativeIntegrationPickerToken,
+  recordNativeIntegrationAgentEvent,
   type NativeIntegrationProvider,
 } from '../../../api/nativeIntegrations'
 import { safeErrorMessage } from '../../../api/safeErrorMessage'
@@ -28,8 +29,9 @@ const GOOGLE_DRIVE_FALLBACK_ICON = (
   <img src="/static/images/integrations/native/google_drive.svg" alt="" className="h-5 w-5 object-contain" />
 )
 
-export function GoogleDriveInsightPanel({ nativeIntegrationsUrl = null }: GoogleDriveInsightPanelProps) {
+export function GoogleDriveInsightPanel({ agentId = null, nativeIntegrationsUrl = null }: GoogleDriveInsightPanelProps) {
   const panel = useNativeIntegrationPanelState({
+    agentId,
     nativeIntegrationsUrl,
     providerKey: GOOGLE_DRIVE_PROVIDER_KEY,
     providerDisplayName: 'Google',
@@ -38,8 +40,16 @@ export function GoogleDriveInsightPanel({ nativeIntegrationsUrl = null }: Google
   const pickerMutation = useMutation({
     mutationFn: async (provider: NativeIntegrationProvider) => {
       const token = await fetchNativeIntegrationPickerToken(provider.pickerTokenUrl)
-      const selectedCount = await openGoogleDrivePicker(token)
-      return { provider, selectedCount }
+      const selectedFiles = await openGoogleDrivePicker(token)
+      if (agentId && selectedFiles.length > 0) {
+        await recordNativeIntegrationAgentEvent({
+          agentEventUrl: provider.agentEventUrl,
+          agentId,
+          eventType: 'files_selected',
+          files: selectedFiles,
+        })
+      }
+      return { provider, selectedCount: selectedFiles.length }
     },
     onMutate: () => {
       panel.setPendingAction('picker')

--- a/frontend/src/components/agentChat/insights/HubSpotInsightPanel.test.tsx
+++ b/frontend/src/components/agentChat/insights/HubSpotInsightPanel.test.tsx
@@ -42,6 +42,7 @@ const hubspotProvider = {
   connectUrl: '/console/api/native-integrations/hubspot/connect/',
   filesUrl: '',
   pickerTokenUrl: '',
+  agentEventUrl: '/console/api/native-integrations/hubspot/agent-events/',
   revokeUrl: '/console/api/native-integrations/hubspot/revoke/',
 }
 

--- a/frontend/src/components/agentChat/insights/HubSpotInsightPanel.tsx
+++ b/frontend/src/components/agentChat/insights/HubSpotInsightPanel.tsx
@@ -16,8 +16,9 @@ const HUBSPOT_FALLBACK_ICON = (
   <img src="/static/images/integrations/native/hubspot.svg" alt="" className="h-5 w-5 object-contain" />
 )
 
-export function HubSpotInsightPanel({ nativeIntegrationsUrl = null }: HubSpotInsightPanelProps) {
+export function HubSpotInsightPanel({ agentId = null, nativeIntegrationsUrl = null }: HubSpotInsightPanelProps) {
   const panel = useNativeIntegrationPanelState({
+    agentId,
     nativeIntegrationsUrl,
     providerKey: HUBSPOT_PROVIDER_KEY,
     providerDisplayName: 'HubSpot',

--- a/frontend/src/components/agentChat/insights/NativeIntegrationInsightPanel.tsx
+++ b/frontend/src/components/agentChat/insights/NativeIntegrationInsightPanel.tsx
@@ -32,10 +32,12 @@ type NativeIntegrationPanelState = {
 }
 
 export function useNativeIntegrationPanelState({
+  agentId = null,
   nativeIntegrationsUrl,
   providerKey,
   providerDisplayName,
 }: {
+  agentId?: string | null
   nativeIntegrationsUrl?: string | null
   providerKey: string
   providerDisplayName: string
@@ -69,8 +71,8 @@ export function useNativeIntegrationPanelState({
       setPendingAction('connect')
       setStatusMessage(null)
     },
-    onSuccess: (payload, { popup }) => {
-      storePendingNativeOAuth(payload.state, nativeOAuthContextPayload(payload.providerKey, payload.state, popup))
+    onSuccess: (payload, { provider, popup }) => {
+      storePendingNativeOAuth(payload.state, nativeOAuthContextPayload(provider, payload.state, popup, agentId))
       if (popup && !popup.closed) {
         popup.location.href = payload.authorizationUrl
         popup.focus()

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.test.ts
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { buildLoginUrl } from '../../api/http'
 import type {
+  NativeIntegrationAccessibleFile,
   NativeIntegrationPickerTokenResponse,
   NativeIntegrationProviderDTO,
 } from '../../api/nativeIntegrations'
@@ -64,6 +65,7 @@ const googleDriveProvider: NativeIntegrationProviderDTO = {
   connect_url: '/console/api/native-integrations/google_drive/connect/',
   files_url: '/console/api/native-integrations/google_drive/files/',
   picker_token_url: '/console/api/native-integrations/google_drive/picker-token/',
+  agent_event_url: '/console/api/native-integrations/google_drive/agent-events/',
   revoke_url: '/console/api/native-integrations/google_drive/revoke/',
 }
 
@@ -115,7 +117,7 @@ describe('homepage native integration login redirects', () => {
 
   it('keeps the homepage modal mounted while Google Picker is active and restores scroll afterward', async () => {
     const tokenDeferred = createDeferred<NativeIntegrationPickerTokenResponse>()
-    const pickerDeferred = createDeferred<number>()
+    const pickerDeferred = createDeferred<NativeIntegrationAccessibleFile[]>()
     const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
     Object.defineProperty(window, 'scrollX', { configurable: true, value: 12 })
     Object.defineProperty(window, 'scrollY', { configurable: true, value: 640 })
@@ -143,7 +145,14 @@ describe('homepage native integration login redirects', () => {
     })
     expect(screen.getByRole('dialog', { name: 'Manage integrations' })).toBeInTheDocument()
 
-    pickerDeferred.resolve(1)
+    pickerDeferred.resolve([
+      {
+        externalId: 'sheet-123',
+        name: 'Q2 Sales Tracker',
+        mimeType: 'application/vnd.google-apps.spreadsheet',
+        webUrl: 'https://docs.google.com/spreadsheets/d/sheet-123/edit',
+      },
+    ])
     await waitFor(() => {
       expect(screen.getByRole('dialog', { name: 'Manage integrations' })).toBeInTheDocument()
     })

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
@@ -187,8 +187,8 @@ export function HomepageIntegrationsModal({
       setPendingNativeAction({ providerKey: provider.providerKey, kind: 'connect' })
       setNativeErrorMessage(null)
     },
-    onSuccess: (payload, { popup }) => {
-      storePendingNativeOAuth(payload.state, nativeOAuthContextPayload(payload.providerKey, payload.state, popup))
+    onSuccess: (payload, { provider, popup }) => {
+      storePendingNativeOAuth(payload.state, nativeOAuthContextPayload(provider, payload.state, popup))
       if (popup && !popup.closed) {
         popup.location.href = payload.authorizationUrl
         popup.focus()
@@ -234,8 +234,8 @@ export function HomepageIntegrationsModal({
       try {
         scrollPageToTop()
         const token = await fetchNativeIntegrationPickerToken(provider.pickerTokenUrl)
-        const selectedCount = await openGoogleDrivePicker(token)
-        return { provider, selectedCount }
+        const selectedFiles = await openGoogleDrivePicker(token)
+        return { provider, selectedCount: selectedFiles.length }
       } finally {
         window.scrollTo(previousScrollX, previousScrollY)
       }

--- a/frontend/src/components/mcp/AgentPipedreamAppsModal.tsx
+++ b/frontend/src/components/mcp/AgentPipedreamAppsModal.tsx
@@ -185,8 +185,8 @@ export function AgentPipedreamAppsModal({
       setPendingNativeAction({ providerKey: provider.providerKey, kind: 'connect' })
       setStatusMessage(null)
     },
-    onSuccess: (payload, { popup }) => {
-      storePendingNativeOAuth(payload.state, nativeOAuthContextPayload(payload.providerKey, payload.state, popup))
+    onSuccess: (payload, { provider, popup }) => {
+      storePendingNativeOAuth(payload.state, nativeOAuthContextPayload(provider, payload.state, popup))
       if (popup && !popup.closed) {
         popup.location.href = payload.authorizationUrl
         popup.focus()
@@ -225,8 +225,8 @@ export function AgentPipedreamAppsModal({
   const nativePickerMutation = useMutation({
     mutationFn: async (provider: NativeIntegrationProvider) => {
       const token = await fetchNativeIntegrationPickerToken(provider.pickerTokenUrl)
-      const selectedCount = await openGoogleDrivePicker(token)
-      return { provider, selectedCount }
+      const selectedFiles = await openGoogleDrivePicker(token)
+      return { provider, selectedCount: selectedFiles.length }
     },
     onMutate: (provider) => {
       setPendingNativeAction({ providerKey: provider.providerKey, kind: 'picker' })

--- a/frontend/src/components/mcp/DiscordNativeShared.ts
+++ b/frontend/src/components/mcp/DiscordNativeShared.ts
@@ -16,6 +16,7 @@ export const DISCORD_NATIVE_DISPLAY_PROVIDER: NativeIntegrationProvider = {
   connectUrl: '',
   filesUrl: '',
   pickerTokenUrl: '',
+  agentEventUrl: '',
   revokeUrl: '',
 }
 

--- a/frontend/src/components/mcp/NativeIntegrationShared.test.tsx
+++ b/frontend/src/components/mcp/NativeIntegrationShared.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { NativeIntegrationPickerTokenResponse } from '../../api/nativeIntegrations'
+import { openGoogleDrivePicker } from './NativeIntegrationShared'
+
+describe('openGoogleDrivePicker', () => {
+  afterEach(() => {
+    document.querySelectorAll('script[data-google-api-script="true"]').forEach((script) => script.remove())
+    delete (window as typeof window & { gapi?: unknown }).gapi
+    delete (window as typeof window & { google?: unknown }).google
+  })
+
+  it('returns selected Google file metadata', async () => {
+    let callback: ((data: Record<string, unknown>) => void) | null = null
+    const picker = {
+      Action: { PICKED: 'picked', CANCEL: 'cancel' },
+      Document: {
+        ID: 'id',
+        NAME: 'name',
+        MIME_TYPE: 'mimeType',
+        URL: 'url',
+      },
+      Feature: { MULTISELECT_ENABLED: 'multiselect' },
+      Response: { ACTION: 'action', DOCUMENTS: 'docs' },
+      ViewId: { DOCS: 'docs' },
+      DocsView: class {
+        setMimeTypes() {
+          return this
+        }
+      },
+      PickerBuilder: class {
+        addView() {
+          return this
+        }
+        setOAuthToken() {
+          return this
+        }
+        setDeveloperKey() {
+          return this
+        }
+        setAppId() {
+          return this
+        }
+        enableFeature() {
+          return this
+        }
+        setCallback(nextCallback: (data: Record<string, unknown>) => void) {
+          callback = nextCallback
+          return this
+        }
+        build() {
+          return {
+            setVisible: (visible: boolean) => {
+              if (visible) {
+                callback?.({
+                  action: 'picked',
+                  docs: [
+                    {
+                      id: 'sheet-123',
+                      name: 'Q2 Sales Tracker',
+                      mimeType: 'application/vnd.google-apps.spreadsheet',
+                      url: 'https://docs.google.com/spreadsheets/d/sheet-123/edit',
+                    },
+                  ],
+                })
+              }
+            },
+          }
+        }
+      },
+    }
+    ;(window as typeof window & { google: unknown }).google = { picker }
+    ;(window as typeof window & { gapi: unknown }).gapi = {
+      load: vi.fn((_apiName: string, config: { callback: () => void }) => config.callback()),
+    }
+    const token: NativeIntegrationPickerTokenResponse = {
+      accessToken: 'access-token',
+      developerKey: 'developer-key',
+      appId: 'app-id',
+      scope: 'https://www.googleapis.com/auth/drive.file',
+      expiresAt: null,
+    }
+
+    const selectedFilesPromise = openGoogleDrivePicker(token)
+    document.querySelector<HTMLScriptElement>('script[data-google-api-script="true"]')?.dispatchEvent(new Event('load'))
+
+    await expect(selectedFilesPromise).resolves.toEqual([
+      {
+        externalId: 'sheet-123',
+        name: 'Q2 Sales Tracker',
+        mimeType: 'application/vnd.google-apps.spreadsheet',
+        webUrl: 'https://docs.google.com/spreadsheets/d/sheet-123/edit',
+      },
+    ])
+  })
+})

--- a/frontend/src/components/mcp/NativeIntegrationShared.tsx
+++ b/frontend/src/components/mcp/NativeIntegrationShared.tsx
@@ -164,9 +164,16 @@ export function storePendingNativeOAuth(state: string, payload: Record<string, u
   }
 }
 
-export function nativeOAuthContextPayload(providerKey: string, state: string, popup: Window | null) {
+export function nativeOAuthContextPayload(
+  provider: NativeIntegrationProvider,
+  state: string,
+  popup: Window | null,
+  agentId?: string | null,
+) {
   return {
-    providerKey,
+    providerKey: provider.providerKey,
+    agentEventUrl: provider.agentEventUrl,
+    agentId: agentId || null,
     returnUrl: window.location.href,
     createdAt: Date.now(),
     context: readStoredConsoleContext(),
@@ -378,7 +385,7 @@ async function loadGooglePickerApi(): Promise<void> {
   return googlePickerApiPromise
 }
 
-export async function openGoogleDrivePicker(token: NativeIntegrationPickerTokenResponse): Promise<number> {
+export async function openGoogleDrivePicker(token: NativeIntegrationPickerTokenResponse): Promise<NativeIntegrationAccessibleFile[]> {
   await loadGooglePickerApi()
   const picker = window.google?.picker
   if (!picker) {
@@ -387,15 +394,15 @@ export async function openGoogleDrivePicker(token: NativeIntegrationPickerTokenR
 
   return new Promise((resolve) => {
     let settled = false
-    const finish = (selectedCount: number) => {
+    const finish = (selectedFiles: NativeIntegrationAccessibleFile[]) => {
       if (settled) {
         return
       }
       settled = true
       window.clearTimeout(timeoutId)
-      resolve(selectedCount)
+      resolve(selectedFiles)
     }
-    const timeoutId = window.setTimeout(() => finish(0), 5 * 60 * 1000)
+    const timeoutId = window.setTimeout(() => finish([]), 5 * 60 * 1000)
     const view = new picker.DocsView(picker.ViewId.DOCS).setMimeTypes(
       `${GOOGLE_SHEETS_MIME_TYPE},${GOOGLE_DOCS_MIME_TYPE}`,
     )
@@ -409,11 +416,11 @@ export async function openGoogleDrivePicker(token: NativeIntegrationPickerTokenR
         const action = data[picker.Response.ACTION]
         if (action === picker.Action.PICKED) {
           const docs = data[picker.Response.DOCUMENTS]
-          finish(countSelectedPickerDocs(docs, picker))
+          finish(normalizeSelectedPickerDocs(docs, picker))
         } else if (picker.Action.CANCEL && action === picker.Action.CANCEL) {
-          finish(0)
+          finish([])
         } else if (typeof action === 'string' && action) {
-          finish(0)
+          finish([])
         }
       })
       .build()
@@ -422,18 +429,30 @@ export async function openGoogleDrivePicker(token: NativeIntegrationPickerTokenR
   })
 }
 
-function countSelectedPickerDocs(docs: unknown, picker: GooglePickerNamespace): number {
+function normalizeSelectedPickerDocs(
+  docs: unknown,
+  picker: GooglePickerNamespace,
+): NativeIntegrationAccessibleFile[] {
   if (!Array.isArray(docs)) {
-    return 0
+    return []
   }
-  return docs.reduce((count, doc) => {
+  return docs.reduce<NativeIntegrationAccessibleFile[]>((files, doc) => {
     if (!doc || typeof doc !== 'object') {
-      return count
+      return files
     }
     const rawDoc = doc as Record<string, unknown>
     const externalFileId = String(rawDoc[picker.Document.ID] ?? '').trim()
     const name = String(rawDoc[picker.Document.NAME] ?? '').trim()
     const mimeType = String(rawDoc[picker.Document.MIME_TYPE] ?? '').trim()
-    return externalFileId && name && mimeType ? count + 1 : count
-  }, 0)
+    const webUrl = String(rawDoc[picker.Document.URL] ?? '').trim()
+    if (externalFileId && name && mimeType) {
+      files.push({
+        externalId: externalFileId,
+        name,
+        mimeType,
+        webUrl,
+      })
+    }
+    return files
+  }, [])
 }

--- a/frontend/src/components/mcp/PipedreamAppsModal.tsx
+++ b/frontend/src/components/mcp/PipedreamAppsModal.tsx
@@ -332,8 +332,8 @@ export function PipedreamAppsModal({
       setPendingNativeAction({ providerKey: provider.providerKey, kind: 'connect' })
       setStatusMessage(null)
     },
-    onSuccess: (payload, { popup }) => {
-      storePendingNativeOAuth(payload.state, nativeOAuthContextPayload(payload.providerKey, payload.state, popup))
+    onSuccess: (payload, { provider, popup }) => {
+      storePendingNativeOAuth(payload.state, nativeOAuthContextPayload(provider, payload.state, popup))
       if (popup && !popup.closed) {
         popup.location.href = payload.authorizationUrl
         popup.focus()
@@ -393,8 +393,8 @@ export function PipedreamAppsModal({
   const nativePickerMutation = useMutation({
     mutationFn: async (provider: NativeIntegrationProvider) => {
       const token = await fetchNativeIntegrationPickerToken(provider.pickerTokenUrl)
-      const selectedCount = await openGoogleDrivePicker(token)
-      return { provider, selectedCount }
+      const selectedFiles = await openGoogleDrivePicker(token)
+      return { provider, selectedCount: selectedFiles.length }
     },
     onMutate: (provider) => {
       setPendingNativeAction({ providerKey: provider.providerKey, kind: 'picker' })

--- a/frontend/src/components/tooling/toolMetadata.ts
+++ b/frontend/src/components/tooling/toolMetadata.ts
@@ -771,43 +771,6 @@ export const TOOL_METADATA_CONFIGS: ToolMetadataConfig[] = [
     },
   },
   {
-    name: 'spawn_agent',
-    label: 'Create agent',
-    icon: BotMessageSquare,
-    iconBgClass: 'bg-emerald-100',
-    iconColorClass: 'text-emerald-700',
-    detailKind: 'spawnAgent',
-    derive(entry, parameters) {
-      const result = parseResultObject(entry.result)
-      const statusRaw =
-        (result ? coerceString(result['request_status']) : null) ??
-        (result ? coerceString(result['status']) : null)
-      const status = statusRaw ? statusRaw.toLowerCase() : null
-      const requestedName = coerceString(result?.['requested_name']) || coerceString(parameters?.name)
-      const message = result ? coerceString(result['message']) : null
-
-      let caption: string | null = null
-      if (status === 'pending') {
-        caption = requestedName
-          ? `Awaiting Create/Decline for ${requestedName}`
-          : 'Awaiting Create/Decline approval'
-      } else if (status === 'approved') {
-        caption = requestedName ? `Created ${requestedName}` : 'Spawn request approved'
-      } else if (status === 'rejected') {
-        caption = 'Spawn request declined'
-      } else if (message) {
-        caption = truncate(message, 56)
-      }
-
-      return {
-        label: requestedName ? `Create ${requestedName}` : 'Create agent',
-        caption: caption ?? entry.caption ?? 'Create agent',
-        summary: message ?? entry.summary ?? null,
-        separateFromPreview: true,
-      }
-    },
-  },
-  {
     name: 'request_human_input',
     label: 'Human input request',
     icon: MessageSquareQuote,

--- a/frontend/src/hooks/useTimelineCacheInjector.ts
+++ b/frontend/src/hooks/useTimelineCacheInjector.ts
@@ -2,6 +2,7 @@ import type { QueryClient, InfiniteData } from '@tanstack/react-query'
 
 import { fetchAgentTimeline, type TimelineResponse } from '../api/agentChat'
 import type { PendingActionRequest, PendingHumanInputAction, PendingHumanInputRequest, ProcessingSnapshot, TimelineEvent } from '../types/agentChat'
+import type { AgentRosterEntry } from '../types/agentRoster'
 import { compareTimelineCursors } from '../util/timelineCursor'
 import { mergeTimelineEvents } from '../stores/agentChatTimeline'
 import {
@@ -12,6 +13,10 @@ import {
 } from './useAgentTimeline'
 
 export const DEFAULT_CONTIGUOUS_BACKFILL_MAX_PAGES = 20
+
+type AgentRosterQueryData = {
+  agents: AgentRosterEntry[]
+}
 
 export type RefreshTimelineMode = 'fast' | 'contiguous'
 
@@ -57,6 +62,7 @@ export function replacePendingHumanInputRequestsInCache(
   pendingHumanInputRequests: PendingHumanInputRequest[],
 ) {
   const key = timelineQueryKey(agentId)
+  let nextPendingActionsForRoster: PendingActionRequest[] | null = null
   queryClient.setQueryData<InfiniteData<TimelinePage>>(key, (old) => {
     if (!old?.pages?.length) {
       return old
@@ -90,6 +96,7 @@ export function replacePendingHumanInputRequestsInCache(
           ...nonHumanActions,
         ]
       : nonHumanActions
+    nextPendingActionsForRoster = nextPendingActions
 
     pages[lastIndex] = {
       ...lastPage,
@@ -105,6 +112,11 @@ export function replacePendingHumanInputRequestsInCache(
       pages,
     }
   })
+  if (nextPendingActionsForRoster) {
+    updateRosterPendingActionCountInCache(queryClient, agentId, nextPendingActionsForRoster)
+  } else {
+    void queryClient.invalidateQueries({ queryKey: ['agent-roster'], exact: false })
+  }
 }
 
 export function replacePendingActionRequestsInCache(
@@ -112,6 +124,7 @@ export function replacePendingActionRequestsInCache(
   agentId: string,
   pendingActionRequests: PendingActionRequest[],
 ) {
+  updateRosterPendingActionCountInCache(queryClient, agentId, pendingActionRequests)
   const key = timelineQueryKey(agentId)
   queryClient.setQueryData<InfiniteData<TimelinePage>>(key, (old) => {
     if (!old?.pages?.length) {
@@ -137,6 +150,48 @@ export function replacePendingActionRequestsInCache(
       pages,
     }
   })
+}
+
+function getPendingActionRequestCount(action: PendingActionRequest): number {
+  switch (action.kind) {
+    case 'human_input':
+    case 'contact_requests':
+      return Math.max(1, action.count || action.requests.length)
+    case 'requested_secrets':
+      return Math.max(1, action.count || action.secrets.length)
+    case 'spawn_request':
+      return 1
+    default:
+      return 1
+  }
+}
+
+function updateRosterPendingActionCountInCache(
+  queryClient: QueryClient,
+  agentId: string,
+  pendingActionRequests: PendingActionRequest[],
+) {
+  const nextCount = pendingActionRequests.reduce((total, action) => total + getPendingActionRequestCount(action), 0)
+  queryClient.setQueriesData<AgentRosterQueryData>(
+    { queryKey: ['agent-roster'] },
+    (current) => {
+      if (!current?.agents?.length) {
+        return current
+      }
+      let changed = false
+      const nextAgents = current.agents.map((agent) => {
+        if (agent.id !== agentId) {
+          return agent
+        }
+        if ((agent.pendingActionRequestCount ?? 0) === nextCount) {
+          return agent
+        }
+        changed = true
+        return { ...agent, pendingActionRequestCount: nextCount }
+      })
+      return changed ? { ...current, agents: nextAgents } : current
+    },
+  )
 }
 
 function updateLatestTimelineRawInCache(

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -3070,6 +3070,7 @@ export function AgentChatPage({
       dailyCreditLow: false,
       last24hCreditBurn: null,
       isOrgOwned: false,
+      pendingActionRequestCount: 0,
     }
   }, [activeAgentId, resolvedAgentColorHex, resolvedAgentName, resolvedAvatarUrl])
   const rosterAgentsWithActiveMeta = useMemo(() => {
@@ -3532,6 +3533,7 @@ export function AgentChatPage({
           email: createdAgentEmail,
           signupPreviewState: personalSignupPreviewAvailable ? 'awaiting_first_reply_pause' : 'none',
           planningState: createdPlanningState,
+          pendingActionRequestCount: 0,
         }
         pendingAgentMetaRef.current = {
           agentId: result.agent_id,

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -2195,6 +2195,17 @@
   box-shadow: 0 -4px 22px -10px rgba(14, 165, 233, 0.22);
 }
 
+.composer-working-panel[data-has-pending-actions="true"]::before {
+  background:
+    radial-gradient(ellipse 76% 112% at 10% 0%, rgba(14, 165, 233, 0.18) 0%, rgba(14, 165, 233, 0.1) 45%, transparent 76%),
+    radial-gradient(ellipse 82% 116% at 92% 36%, rgba(251, 191, 36, 0.18) 0%, rgba(251, 191, 36, 0.1) 46%, transparent 78%),
+    linear-gradient(135deg, rgba(240, 249, 255, 0.88) 0%, rgba(255, 251, 235, 0.74) 100%);
+}
+
+.composer-working-panel[data-has-pending-actions="true"]::after {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.46) 0%, rgba(255, 255, 255, 0.26) 42%, rgba(255, 255, 255, 0.18) 100%);
+}
+
 .composer-working-panel[data-has-pending-actions="true"] .composer-working-header-row {
   background: rgba(255, 255, 255, 0.42);
 }
@@ -2442,6 +2453,7 @@
   height: auto;
   max-height: min(70vh, 32rem);
   overflow-y: auto;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.28) 0%, rgba(240, 249, 255, 0.18) 48%, rgba(255, 251, 235, 0.2) 100%);
 }
 
 .composer-working-pending-actions {

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -2386,6 +2386,10 @@
   .composer-working-tasks-badge {
     display: none;
   }
+
+  .composer-pending-action-nav__count {
+    display: none;
+  }
 }
 
 .composer-working-toggle {
@@ -2641,9 +2645,11 @@
 }
 
 .composer-insight-tab[data-priority="true"][data-active="true"] {
-  border-color: color-mix(in srgb, var(--tab-color, #0284c7) 88%, white);
-  background: var(--tab-color, #0284c7);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--tab-color, #0284c7) 58%, white) inset;
+  border-color: color-mix(in srgb, var(--tab-color, #0284c7) 58%, white);
+  background: color-mix(in srgb, var(--tab-color, #0284c7) 22%, white);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--tab-color, #0284c7) 22%, white) inset,
+    0 0 0 2px color-mix(in srgb, var(--tab-color, #0284c7) 8%, transparent);
 }
 
 .composer-working-panel[data-expanded="false"] .composer-insight-tab[data-priority="true"] {
@@ -2706,6 +2712,17 @@
 .composer-insight-tab[data-active="true"] .composer-insight-tab-count {
   color: white;
   font-weight: 600;
+}
+
+.composer-insight-tab[data-priority="true"][data-active="true"] .composer-insight-tab-label,
+.composer-insight-tab[data-priority="true"][data-active="true"] .composer-insight-tab-icon,
+.composer-insight-tab[data-priority="true"][data-active="true"] .composer-insight-tab-count {
+  color: var(--tab-color, #0284c7);
+  font-weight: 700;
+}
+
+.composer-insight-tab[data-priority="true"][data-active="true"] .composer-insight-tab-count {
+  background: color-mix(in srgb, var(--tab-color, #0284c7) 16%, white);
 }
 
 .composer-insight-tab[data-active="true"] .composer-insight-tab-count {

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -2307,11 +2307,16 @@
 }
 
 .composer-working-tasks-badge {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
   font-size: 0.6875rem;
   font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
   color: #64748b;
   background: rgba(100, 116, 139, 0.1);
-  padding: 0.125rem 0.5rem;
+  padding: 0.35rem 0.625rem;
   border-radius: 9999px;
 }
 
@@ -2406,6 +2411,7 @@
 }
 
 .composer-pending-action-nav + .composer-working-toggle,
+.composer-insight-tabs + .composer-pending-action-nav,
 .composer-insight-tabs + .composer-working-toggle {
   margin-left: 0;
 }
@@ -2637,6 +2643,28 @@
   background: var(--tab-color, #6b7280);
 }
 
+.composer-insight-tab[data-priority="true"] {
+  border: 1px solid color-mix(in srgb, var(--tab-color, #0284c7) 36%, transparent);
+  background: color-mix(in srgb, var(--tab-color, #0284c7) 13%, white);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.52) inset;
+}
+
+.composer-insight-tab[data-priority="true"]:hover {
+  background: color-mix(in srgb, var(--tab-color, #0284c7) 18%, white);
+}
+
+.composer-insight-tab[data-priority="true"][data-active="true"] {
+  border-color: color-mix(in srgb, var(--tab-color, #0284c7) 88%, white);
+  background: var(--tab-color, #0284c7);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--tab-color, #0284c7) 58%, white) inset;
+}
+
+.composer-working-panel[data-expanded="false"] .composer-insight-tab[data-priority="true"] {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--tab-color, #0284c7) 30%, white) inset,
+    0 0 0 3px color-mix(in srgb, var(--tab-color, #0284c7) 10%, transparent);
+}
+
 .composer-insight-tab-inner {
   display: none;
 }
@@ -2650,6 +2678,24 @@
   color: var(--tab-color, #7c4ca0);
   line-height: 1;
   transition: color 150ms ease;
+}
+
+.composer-insight-tab-count {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  min-width: 0.9rem;
+  height: 0.9rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--tab-color, #7c4ca0) 16%, white);
+  padding: 0 0.2rem;
+  color: var(--tab-color, #7c4ca0);
+  font-size: 0.56rem;
+  font-weight: 800;
+  line-height: 1;
+  transition: background 150ms ease, color 150ms ease;
 }
 
 .composer-insight-tab-icon {
@@ -2669,9 +2715,14 @@
 }
 
 .composer-insight-tab[data-active="true"] .composer-insight-tab-label,
-.composer-insight-tab[data-active="true"] .composer-insight-tab-icon {
+.composer-insight-tab[data-active="true"] .composer-insight-tab-icon,
+.composer-insight-tab[data-active="true"] .composer-insight-tab-count {
   color: white;
   font-weight: 600;
+}
+
+.composer-insight-tab[data-active="true"] .composer-insight-tab-count {
+  background: rgba(255, 255, 255, 0.22);
 }
 
 /* Countdown progress indicator */

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -6981,6 +6981,32 @@
   color: rgba(255, 255, 255, 0.74);
 }
 
+.agent-roster-pending-pill {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  align-items: center;
+  justify-content: center;
+  height: 0.875rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(14, 165, 233, 0.18);
+  background: rgba(224, 242, 254, 0.5);
+  padding: 0 0.36rem;
+  color: #0369a1;
+  font-size: 0.55rem;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-sidebar-agent .agent-roster-pending-pill {
+  border-color: rgba(125, 211, 252, 0.16);
+  background: rgba(125, 211, 252, 0.1);
+  color: rgba(186, 230, 253, 0.86);
+}
+
 .chat-sidebar-agent-state {
   font-size: 0.625rem;
   font-weight: 500;

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -2383,6 +2383,10 @@
 }
 
 @container (max-width: 767px) {
+  .composer-working-panel[data-has-pending-actions="true"] .composer-working-status {
+    display: none;
+  }
+
   .composer-working-tasks-badge {
     display: none;
   }

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -2190,30 +2190,6 @@
   display: none;
 }
 
-.composer-working-panel[data-has-pending-actions="true"] {
-  background: linear-gradient(135deg, rgba(240, 249, 255, 0.98) 0%, rgba(255, 251, 235, 0.96) 100%);
-  box-shadow: 0 -4px 22px -10px rgba(14, 165, 233, 0.22);
-}
-
-.composer-working-panel[data-has-pending-actions="true"]::before {
-  background:
-    radial-gradient(ellipse 76% 112% at 10% 0%, rgba(14, 165, 233, 0.18) 0%, rgba(14, 165, 233, 0.1) 45%, transparent 76%),
-    radial-gradient(ellipse 82% 116% at 92% 36%, rgba(251, 191, 36, 0.18) 0%, rgba(251, 191, 36, 0.1) 46%, transparent 78%),
-    linear-gradient(135deg, rgba(240, 249, 255, 0.88) 0%, rgba(255, 251, 235, 0.74) 100%);
-}
-
-.composer-working-panel[data-has-pending-actions="true"]::after {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.46) 0%, rgba(255, 255, 255, 0.26) 42%, rgba(255, 255, 255, 0.18) 100%);
-}
-
-.composer-working-panel[data-has-pending-actions="true"] .composer-working-header-row {
-  background: rgba(255, 255, 255, 0.42);
-}
-
-.composer-working-panel[data-has-pending-actions="true"] .composer-working-header-row:hover {
-  background: rgba(255, 255, 255, 0.62);
-}
-
 .composer-working-panel[data-has-pending-actions="true"] .composer-working-indicator {
   color: #0284c7;
   opacity: 1;
@@ -2453,7 +2429,6 @@
   height: auto;
   max-height: min(70vh, 32rem);
   overflow-y: auto;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.28) 0%, rgba(240, 249, 255, 0.18) 48%, rgba(255, 251, 235, 0.2) 100%);
 }
 
 .composer-working-pending-actions {

--- a/frontend/src/types/agentRoster.ts
+++ b/frontend/src/types/agentRoster.ts
@@ -40,6 +40,7 @@ export type AgentRosterEntry = {
   sms?: string | null
   signupPreviewState?: SignupPreviewState | null
   planningState?: PlanningState | null
+  pendingActionRequestCount?: number
   hasUnreadAgentMessage?: boolean
   latestAgentMessageId?: string | null
   latestAgentMessageAt?: string | null

--- a/static/js/native_integration_oauth_callback.js
+++ b/static/js/native_integration_oauth_callback.js
@@ -147,6 +147,25 @@ async function callbackErrorMessage(response) {
   return text;
 }
 
+async function recordConnectedAgentEvent(sessionData, csrfToken) {
+  if (!sessionData || !sessionData.agentId || !sessionData.agentEventUrl) {
+    return;
+  }
+  const response = await fetch(sessionData.agentEventUrl, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: buildCallbackHeaders(sessionData, csrfToken),
+    body: JSON.stringify({
+      agent_id: sessionData.agentId,
+      event_type: "connected",
+      files: [],
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(await callbackErrorMessage(response));
+  }
+}
+
 async function completeOAuth() {
   const params = new URLSearchParams(window.location.search);
   const error = params.get("error");
@@ -191,6 +210,12 @@ async function completeOAuth() {
     }
 
     localStorage.removeItem(`gobii:native_oauth_state:${state}`);
+    try {
+      setStatus("Notifying agent...");
+      await recordConnectedAgentEvent(sessionData, csrfToken);
+    } catch (eventError) {
+      console.warn("Native integration agent event failed", eventError);
+    }
     const isPopupFlow = Boolean(sessionData.popup);
     const notified = notifyOpener({ ok: true, providerKey: sessionData.providerKey });
     if (notified || isPopupFlow) {

--- a/tests/unit/test_agent_chat_access.py
+++ b/tests/unit/test_agent_chat_access.py
@@ -10,14 +10,19 @@ from unittest.mock import patch
 
 from api.models import (
     AgentCollaborator,
+    AgentSpawnRequest,
     BrowserUseAgent,
     BrowserUseAgentTask,
     CommsChannel,
+    CommsAllowlistRequest,
     Organization,
     OrganizationMembership,
     PersistentAgent,
     PersistentAgentCommsEndpoint,
+    PersistentAgentConversation,
+    PersistentAgentHumanInputRequest,
     PersistentAgentMessage,
+    PersistentAgentSecret,
     PersistentAgentSystemSkillState,
     UserFlags,
     UserPreference,
@@ -843,6 +848,59 @@ class AgentChatAccessTests(TestCase):
         self.assertIn("daily_credit_remaining", matching_entry)
         self.assertEqual(matching_entry.get("daily_credit_low"), False)
         self.assertEqual(matching_entry.get("last_24h_credit_burn"), 0.0)
+
+    def test_roster_includes_pending_action_request_count(self):
+        conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.org_agent,
+            channel=CommsChannel.WEB,
+            address=f"web://user/{self.user.id}/agent/{self.org_agent.id}",
+        )
+        PersistentAgentHumanInputRequest.objects.create(
+            agent=self.org_agent,
+            conversation=conversation,
+            question="Which plan should we use?",
+            requested_via_channel=CommsChannel.WEB,
+        )
+        AgentSpawnRequest.objects.create(
+            agent=self.org_agent,
+            requested_charter="Handle procurement approvals.",
+            handoff_message="Take over vendor approvals.",
+        )
+        requested_secret = PersistentAgentSecret(
+            agent=self.org_agent,
+            name="Procurement API Key",
+            description="Used for procurement sync",
+            secret_type=PersistentAgentSecret.SecretType.CREDENTIAL,
+            domain_pattern="https://procurement.example.com",
+            requested=True,
+        )
+        requested_secret.key = "procurement_api_key"
+        requested_secret.encrypted_value = b""
+        requested_secret.save()
+        CommsAllowlistRequest.objects.create(
+            agent=self.org_agent,
+            channel=CommsChannel.EMAIL,
+            address="approver@example.com",
+            reason="Need procurement approval",
+            purpose="Approve vendor contract",
+        )
+
+        response = self.client.get(
+            reverse("console_agent_roster"),
+            HTTP_X_GOBII_CONTEXT_TYPE="organization",
+            HTTP_X_GOBII_CONTEXT_ID=str(self.org.id),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        roster_by_id = {entry["id"]: entry for entry in response.json().get("agents", [])}
+        self.assertEqual(
+            roster_by_id[str(self.org_agent.id)]["pending_action_request_count"],
+            4,
+        )
+        self.assertEqual(
+            roster_by_id[str(self.org_agent_two.id)]["pending_action_request_count"],
+            0,
+        )
 
     def test_roster_marks_shared_agents_as_collaborator_gallery_entries(self):
         User = get_user_model()

--- a/tests/unit/test_native_integrations.py
+++ b/tests/unit/test_native_integrations.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
@@ -497,6 +498,27 @@ class NativeIntegrationTests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content, b"Invalid JSON payload: expected an object")
+
+    @patch(
+        "console.native_integrations_api.normalize_native_integration_event_files",
+        side_effect=ValidationError(["List-style validation error."]),
+    )
+    def test_agent_event_serializes_list_style_validation_error(self, mock_normalize):
+        response = self.client.post(
+            reverse("console-native-integration-agent-events", args=["google_drive"]),
+            data=json.dumps(
+                {
+                    "agent_id": str(self.agent.id),
+                    "event_type": "connected",
+                    "files": [],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["errors"], {"non_field_errors": ["List-style validation error."]})
+        mock_normalize.assert_called_once_with([])
 
     def test_list_reports_connected_state_for_apollo(self):
         cases = (

--- a/tests/unit/test_native_integrations.py
+++ b/tests/unit/test_native_integrations.py
@@ -27,7 +27,9 @@ from api.models import (
     OrganizationMembership,
     PersistentAgent,
     PersistentAgentEnabledTool,
+    PersistentAgentStep,
     PersistentAgentSystemSkillState,
+    PersistentAgentSystemStep,
 )
 from api.services.native_integrations import (
     APOLLO_PROVIDER,
@@ -272,6 +274,9 @@ class NativeIntegrationTests(TestCase):
                 "google_drive",
                 {
                     "google_drive_file_discovery",
+                    "google_sheets_chart",
+                    "google_sheets_create",
+                    "google_sheets_format",
                     "google_sheets_read",
                     "google_sheets_write",
                 },
@@ -371,12 +376,101 @@ class NativeIntegrationTests(TestCase):
             provider["picker_token_url"],
             reverse("console-native-integration-picker-token", args=["google_drive"]),
         )
+        self.assertEqual(
+            provider["agent_event_url"],
+            reverse("console-native-integration-agent-events", args=["google_drive"]),
+        )
         self.assertIn("granted_scopes", provider)
         self.assertIn("requested_scopes", provider)
         self.assertIn("available_capabilities", provider)
         self.assertIn("missing_capabilities", provider)
         self.assertIn("capability_summary", provider)
         self.assertIn("Read selected Google Sheets", provider["capability_summary"])
+
+    @patch("api.services.native_integration_events.process_agent_events_task.delay")
+    def test_agent_event_records_connected_step_and_queues_processing(self, mock_delay):
+        response = None
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("console-native-integration-agent-events", args=["google_drive"]),
+                data=json.dumps(
+                    {
+                        "agent_id": str(self.agent.id),
+                        "event_type": "connected",
+                        "files": [],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 201, response.content)
+        step = PersistentAgentStep.objects.get(id=response.json()["step_id"])
+        self.assertEqual(step.agent, self.agent)
+        self.assertIn("Google Drive was connected", step.description)
+        system_step = PersistentAgentSystemStep.objects.get(step=step)
+        self.assertEqual(system_step.code, PersistentAgentSystemStep.Code.SYSTEM_DIRECTIVE)
+        notes = json.loads(system_step.notes)
+        self.assertEqual(notes["provider_key"], "google_drive")
+        self.assertEqual(notes["event_type"], "connected")
+        self.assertEqual(notes["files"], [])
+        mock_delay.assert_called_once_with(str(self.agent.id))
+
+    @patch("api.services.native_integration_events.process_agent_events_task.delay")
+    def test_agent_event_records_selected_files(self, mock_delay):
+        selected_file = {
+            "external_id": "sheet-123",
+            "name": "Q2 Sales Tracker",
+            "mime_type": "application/vnd.google-apps.spreadsheet",
+            "web_url": "https://docs.google.com/spreadsheets/d/sheet-123/edit",
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                reverse("console-native-integration-agent-events", args=["google_drive"]),
+                data=json.dumps(
+                    {
+                        "agent_id": str(self.agent.id),
+                        "event_type": "files_selected",
+                        "files": [selected_file],
+                    }
+                ),
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 201, response.content)
+        system_step = PersistentAgentSystemStep.objects.get(step_id=response.json()["step_id"])
+        notes = json.loads(system_step.notes)
+        self.assertEqual(notes["event_type"], "files_selected")
+        self.assertEqual(notes["files"], [selected_file])
+        mock_delay.assert_called_once_with(str(self.agent.id))
+
+    def test_agent_event_rejects_agent_outside_owner_context(self):
+        other_user = User.objects.create_user(
+            username="other-native-user",
+            email="other-native@example.com",
+            password="password123",
+        )
+        other_browser_agent = BrowserUseAgent.objects.create(user=other_user, name="Other Browser")
+        other_agent = PersistentAgent.objects.create(
+            user=other_user,
+            name="Other Agent",
+            charter="other",
+            browser_use_agent=other_browser_agent,
+        )
+
+        response = self.client.post(
+            reverse("console-native-integration-agent-events", args=["google_drive"]),
+            data=json.dumps(
+                {
+                    "agent_id": str(other_agent.id),
+                    "event_type": "connected",
+                    "files": [],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
 
     def test_list_reports_connected_state_for_apollo(self):
         cases = (
@@ -753,6 +847,34 @@ class NativeIntegrationTests(TestCase):
 
     @patch("api.agent.tools.http_request.select_proxy_for_persistent_agent")
     @patch("api.agent.tools.http_request.requests.request")
+    def test_http_request_marks_native_non_2xx_responses_as_errors(self, mock_request, mock_proxy):
+        self._create_integration_secret(owner_user=self.user)
+        mock_proxy.return_value = None
+        mock_request.return_value = _mock_response(
+            b'{"error":{"message":"Unknown name bandingProperties at requests[2].add_banding"}}',
+            status_code=400,
+        )
+
+        result = execute_http_request(
+            self.agent,
+            {
+                "method": "POST",
+                "url": "https://sheets.googleapis.com/v4/spreadsheets/sheet-123:batchUpdate",
+                "body": '{"requests":[]}',
+                "will_continue_work": True,
+            },
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["status_code"], 400)
+        self.assertEqual(result["provider_key"], "google_drive")
+        self.assertEqual(result["method"], "POST")
+        self.assertIn("Google Drive API request failed", result["message"])
+        self.assertIn("addBanding.bandedRange", result["guidance"])
+        self.assertIn("content", result)
+
+    @patch("api.agent.tools.http_request.select_proxy_for_persistent_agent")
+    @patch("api.agent.tools.http_request.requests.request")
     def test_http_request_returns_native_integration_not_connected_before_provider_call(self, mock_request, mock_proxy):
         mock_proxy.return_value = None
 
@@ -1029,6 +1151,14 @@ class NativeIntegrationTests(TestCase):
         self.assertIn("List accessible spreadsheets", block)
         self.assertIn("Do not use web search or public `docs.google.com` results", block)
         self.assertIn("https://www.googleapis.com/drive/v3/files", block)
+        self.assertIn("POST https://sheets.googleapis.com/v4/spreadsheets with JSON body", block)
+        self.assertIn("Do not use Drive file creation for Google Sheets", block)
+        self.assertIn("freeze row 1", block)
+        self.assertIn("addBanding", block)
+        self.assertIn("bandedRange", block)
+        self.assertIn("hiddenDimensionStrategy", block)
+        self.assertIn("SHOW_ALL", block)
+        self.assertIn("do not include a `fields` parameter", block)
         self.assertIn("https://www.googleapis.com/drive/", block)
         self.assertIn("mimeType = 'application/vnd.google-apps.spreadsheet'", block)
         self.assertIn("name contains 'text'", block)
@@ -1043,6 +1173,8 @@ class NativeIntegrationTests(TestCase):
         self.assertIn("- Status: Google Drive is connected.", block)
         self.assertIn("Available capabilities", block)
         self.assertIn("Read selected Google Sheets", block)
+        self.assertIn("Create new Google Sheets spreadsheets", block)
+        self.assertIn("Create and update charts in selected Google Sheets", block)
         self.assertEqual(block.count("Read selected Google Sheets metadata and values"), 1)
         self.assertNotIn("connected with access for", block)
         self.assertIn("Granted scopes", block)

--- a/tests/unit/test_native_integrations.py
+++ b/tests/unit/test_native_integrations.py
@@ -472,6 +472,32 @@ class NativeIntegrationTests(TestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    def test_agent_event_rejects_malformed_agent_id(self):
+        response = self.client.post(
+            reverse("console-native-integration-agent-events", args=["google_drive"]),
+            data=json.dumps(
+                {
+                    "agent_id": "not-a-uuid",
+                    "event_type": "connected",
+                    "files": [],
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["errors"]["agent_id"], ["Invalid agent_id format."])
+
+    def test_agent_event_rejects_non_object_json_payload(self):
+        response = self.client.post(
+            reverse("console-native-integration-agent-events", args=["google_drive"]),
+            data=json.dumps([]),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, b"Invalid JSON payload: expected an object")
+
     def test_list_reports_connected_state_for_apollo(self):
         cases = (
             (APOLLO_PROVIDER, "Apollo", "apollo"),

--- a/tests/unit/test_spawn_agent_tool.py
+++ b/tests/unit/test_spawn_agent_tool.py
@@ -86,7 +86,7 @@ class SpawnAgentToolTests(TestCase):
         self.assertNotIn("specialist peer", prompt)
         self.assertNotIn("team of Gobiis", prompt)
 
-    def test_stale_spawn_agent_runtime_call_requires_meta_gobii_without_creating_request(self):
+    def test_stale_spawn_agent_runtime_call_is_unavailable_without_creating_request(self):
         params = {
             "charter": "Own contract review and summarize legal risk.",
             "handoff_message": "Review attached SOW and return redlines.",
@@ -102,7 +102,7 @@ class SpawnAgentToolTests(TestCase):
 
         self.assertIsNone(updated_tools)
         self.assertEqual(result.get("status"), "error")
-        self.assertIn("Meta Gobii", result.get("message", ""))
+        self.assertIn("not available", result.get("message", ""))
         self.assertFalse(AgentSpawnRequest.objects.filter(agent=self.personal_agent).exists())
 
     def test_meta_gobii_request_agent_creation_creates_pending_request_with_org_context_urls(self):


### PR DESCRIPTION
## Summary
- Add agent-visible native integration events so OAuth completion and Google Drive file selection wake the agent with explicit context.
- Improve Google Sheets guidance for creation, formatting, and chart binding, including safer defaults and valid Sheets batch update shapes.
- Expand native integration capability metadata and normalize provider-backed HTTP failures with clearer repair guidance.
- Update frontend OAuth / Picker flows and related tests to carry agent context and selected file metadata end to end.

## Testing
- `uv run python manage.py test --settings=config.test_settings api.evals.tests.test_google_sheets_native tests.unit.test_native_integrations`
- `npm run test -- src/components/agentChat/insights/GoogleDriveInsightPanel.test.tsx src/components/agentChat/insights/ApolloInsightPanel.test.tsx src/components/agentChat/insights/HubSpotInsightPanel.test.tsx src/components/mcp/NativeIntegrationShared.test.tsx src/components/homepage/HomepageIntegrationsModal.test.ts`
- `npx tsc -b --pretty false`