### PR TITLE
Fix escaped HTML handling in PDF generation

### DIFF
--- a/api/agent/tools/create_pdf.py
+++ b/api/agent/tools/create_pdf.py
@@ -421,15 +421,21 @@ def _contains_blocked_asset_references(html: str) -> bool:
     return parser.blocked
 
 
-ESCAPED_HTML_TAG_RE = re.compile(r"&lt;\s*/?\s*[a-z][\w:-]*(?:\s|/|&gt;)", re.IGNORECASE)
-RAW_HTML_TAG_RE = re.compile(r"<\s*/?\s*[a-z][\w:-]*(?:\s|/|>)", re.IGNORECASE)
+ESCAPED_HTML_TAG_RE = re.compile(r"&lt;/?\s*[a-z][\w:-]*(?:\s|/|&gt;)", re.IGNORECASE)
+ESCAPED_HTML_CLOSE_TAG_RE = re.compile(r"&lt;/\s*[a-z][\w:-]*\s*&gt;", re.IGNORECASE)
+RAW_HTML_TAG_RE = re.compile(r"</?\s*[a-z][\w:-]*(?:\s|/|>)", re.IGNORECASE)
+LEADING_ESCAPED_HTML_TAG_RE = re.compile(r"\s*&lt;/?\s*[a-z][\w:-]*(?:\s|/|&gt;)", re.IGNORECASE)
 
 
 def _looks_like_escaped_html_document(html: str) -> bool:
     if RAW_HTML_TAG_RE.search(html):
         return False
-    escaped_tag_count = len(ESCAPED_HTML_TAG_RE.findall(html))
-    return escaped_tag_count >= 4 or bool(escaped_tag_count and ESCAPED_HTML_TAG_RE.match(html.lstrip()))
+    escaped_tag_count = sum(1 for _ in zip(range(4), ESCAPED_HTML_TAG_RE.finditer(html)))
+    return bool(escaped_tag_count) and (
+        escaped_tag_count >= 4
+        or LEADING_ESCAPED_HTML_TAG_RE.match(html)
+        or ESCAPED_HTML_CLOSE_TAG_RE.search(html)
+    )
 
 
 def _normalize_escaped_html_input(html: str) -> str:

--- a/api/agent/tools/create_pdf.py
+++ b/api/agent/tools/create_pdf.py
@@ -512,6 +512,79 @@ def _contains_blocked_asset_references(html: str) -> bool:
     return parser.blocked
 
 
+HTML_TAG_NAMES = (
+    "html",
+    "head",
+    "body",
+    "main",
+    "section",
+    "article",
+    "header",
+    "footer",
+    "style",
+    "div",
+    "span",
+    "p",
+    "br",
+    "h[1-6]",
+    "table",
+    "thead",
+    "tbody",
+    "tfoot",
+    "tr",
+    "td",
+    "th",
+    "ul",
+    "ol",
+    "li",
+    "strong",
+    "em",
+    "img",
+    "a",
+)
+HTML_TAG_PATTERN = "|".join(HTML_TAG_NAMES)
+ESCAPED_HTML_TAG_RE = re.compile(
+    rf"&lt;\s*/?\s*(?:{HTML_TAG_PATTERN})(?:\s|/|&gt;)",
+    re.IGNORECASE,
+)
+RAW_HTML_TAG_RE = re.compile(
+    rf"<\s*/?\s*(?:{HTML_TAG_PATTERN})(?:\s|/|>)",
+    re.IGNORECASE,
+)
+
+
+def _escaped_html_tag_count(html: str) -> int:
+    return len(ESCAPED_HTML_TAG_RE.findall(html))
+
+
+def _raw_html_tag_count(html: str) -> int:
+    return len(RAW_HTML_TAG_RE.findall(html))
+
+
+def _looks_like_escaped_html_document(html: str) -> bool:
+    escaped_tag_count = _escaped_html_tag_count(html)
+    if escaped_tag_count == 0 or _raw_html_tag_count(html) > 0:
+        return False
+
+    starts_with_escaped_tag = bool(ESCAPED_HTML_TAG_RE.match(html.lstrip()))
+    return escaped_tag_count >= 4 or starts_with_escaped_tag
+
+
+def _normalize_escaped_html_input(html: str) -> str:
+    if _looks_like_escaped_html_document(html):
+        return html_lib.unescape(html)
+
+    once_unescaped = html_lib.unescape(html)
+    if once_unescaped != html and _looks_like_escaped_html_document(once_unescaped):
+        return once_unescaped
+
+    return html
+
+
+def _contains_unrenderable_escaped_html(html: str) -> bool:
+    return _looks_like_escaped_html_document(html)
+
+
 def _coerce_markdown_images_to_html(html: str) -> str:
     def replace(match: re.Match) -> str:
         alt = html_lib.escape(match.group("alt") or "", quote=True)
@@ -566,7 +639,7 @@ def get_create_pdf_tool() -> Dict[str, Any]:
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "html": {"type": "string", "description": "HTML string to convert into a PDF."},
+                    "html": {"type": "string", "description": "Raw HTML string to convert into a PDF; do not HTML-escape tags."},
                     "file_path": {
                         "type": "string",
                         "description": (
@@ -591,6 +664,13 @@ def execute_create_pdf(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
         return {"status": "error", "message": "Missing required parameter: html"}
 
     html = decode_unicode_escapes(html)
+    html = _normalize_escaped_html_input(html)
+    if _contains_unrenderable_escaped_html(html):
+        return {
+            "status": "error",
+            "message": "HTML appears entity-escaped. Pass raw tags like <div>, not &lt;div&gt;.",
+        }
+
     html = _coerce_markdown_images_to_html(html)
 
     # Substitute $[path] variables with data URIs (PDF needs embedded content, not URLs)

--- a/api/agent/tools/create_pdf.py
+++ b/api/agent/tools/create_pdf.py
@@ -19,22 +19,16 @@ logger = logging.getLogger(__name__)
 EXTENSION = ".pdf"
 MIME_TYPE = "application/pdf"
 
-# Comprehensive PDF styling for publication-quality output
 DEFAULT_PRINT_CSS = """
-/* ==========================================================================
-   PAGE SETUP & RUNNING HEADERS/FOOTERS
-   ========================================================================== */
 @page {
     size: Letter;
     margin: 25mm 20mm 30mm 20mm;
-
     @top-center {
         content: string(doc-title);
         font-size: 9pt;
         color: #666;
         font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     }
-
     @bottom-center {
         content: counter(page);
         font-size: 9pt;
@@ -42,28 +36,16 @@ DEFAULT_PRINT_CSS = """
         font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     }
 }
-
-/* Named page for cover - no headers/footers */
 @page cover {
     @top-center { content: none; }
     @bottom-center { content: none; }
 }
-
-/* First page - no page number */
 @page :first {
     @bottom-center { content: none; }
 }
-
-/* ==========================================================================
-   STRING SET FOR RUNNING HEADERS
-   ========================================================================== */
 .doc-title, h1:first-of-type {
     string-set: doc-title content();
 }
-
-/* ==========================================================================
-   BASE TYPOGRAPHY - Modern Minimal
-   ========================================================================== */
 html, body {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
                  "Helvetica Neue", Arial, sans-serif;
@@ -71,7 +53,6 @@ html, body {
     line-height: 1.6;
     color: #1a1a1a;
 }
-
 h1, h2, h3, h4, h5, h6 {
     font-weight: 600;
     line-height: 1.3;
@@ -81,38 +62,22 @@ h1, h2, h3, h4, h5, h6 {
     break-after: avoid;
     break-inside: avoid;
 }
-
 h1 { font-size: 24pt; margin-top: 0; }
 h2 { font-size: 18pt; }
 h3 { font-size: 14pt; }
 h4 { font-size: 12pt; }
 h5, h6 { font-size: 11pt; }
-
 p { margin: 0 0 1em 0; }
-
-/* ==========================================================================
-   CRITICAL PAGE BREAK HANDLING
-   ========================================================================== */
-
-/* Keep headings with following content */
 h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + * {
     break-before: avoid;
 }
-
-/* Orphan/widow control */
 p, li, dd, dt {
     orphans: 3;
     widows: 3;
 }
-
-/* Figures, images stay together */
 figure, img {
     break-inside: avoid;
 }
-
-/* ==========================================================================
-   TABLES - Repeating headers across pages
-   ========================================================================== */
 table {
     break-inside: auto;
     border-collapse: collapse;
@@ -120,29 +85,23 @@ table {
     margin: 1em 0;
     font-size: 10pt;
 }
-
 thead {
     display: table-header-group;
 }
-
 tfoot {
     display: table-footer-group;
 }
-
 tbody {
     display: table-row-group;
 }
-
 tr {
     break-inside: avoid;
 }
-
 th, td {
     padding: 10px 12px;
     text-align: left;
     border-bottom: 1px solid #e9ecef;
 }
-
 th {
     font-weight: 600;
     background: #f8f9fa;
@@ -151,24 +110,17 @@ th {
     font-size: 9pt;
     letter-spacing: 0.5px;
 }
-
 tbody tr:last-child td {
     border-bottom: none;
 }
-
 tbody tr:nth-child(even) {
     background: #fafbfc;
 }
-
-/* ==========================================================================
-   CODE BLOCKS
-   ========================================================================== */
 pre, code {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
                  "Liberation Mono", monospace;
     font-size: 9.5pt;
 }
-
 pre {
     break-inside: avoid;
     overflow-wrap: break-word;
@@ -179,15 +131,9 @@ pre {
     padding: 1em;
     margin: 1em 0;
 }
-
-/* For very long code blocks, allow breaking */
 pre.allow-break {
     break-inside: auto;
 }
-
-/* ==========================================================================
-   BLOCKQUOTES
-   ========================================================================== */
 blockquote {
     margin: 1.5em 0;
     padding: 1em 1.5em;
@@ -197,63 +143,39 @@ blockquote {
     font-style: italic;
     break-inside: avoid;
 }
-
 blockquote p:last-child {
     margin-bottom: 0;
 }
-
-/* ==========================================================================
-   LISTS
-   ========================================================================== */
 ul, ol {
     margin: 1em 0;
     padding-left: 1.5em;
 }
-
 li {
     margin-bottom: 0.5em;
 }
-
 li > ul, li > ol {
     margin-top: 0.5em;
     margin-bottom: 0;
 }
-
-/* ==========================================================================
-   UTILITY CLASSES
-   ========================================================================== */
-
-/* Force page break after element */
 .page-break {
     break-after: always;
 }
-
-/* Force page break before element */
 .page-break-before {
     break-before: always;
 }
-
-/* Keep element together (no internal breaks) */
 .no-break {
     break-inside: avoid;
 }
-
-/* Logical section - prefer breaking before, not inside */
 .section {
     break-inside: avoid-page;
     break-before: auto;
 }
-
 .section > h1:first-child,
 .section > h2:first-child,
 .section > h3:first-child,
 .section > h4:first-child {
     break-after: avoid;
 }
-
-/* ==========================================================================
-   COVER PAGE
-   ========================================================================== */
 .cover-page {
     page: cover;
     break-after: always;
@@ -264,47 +186,34 @@ li > ul, li > ol {
     min-height: 100vh;
     text-align: center;
 }
-
 .cover-page h1 {
     font-size: 36pt;
     font-weight: 700;
     margin-bottom: 0.5em;
     color: #111;
 }
-
 .cover-page .subtitle {
     font-size: 16pt;
     color: #666;
     margin-bottom: 2em;
 }
-
 .cover-page .meta {
     font-size: 11pt;
     color: #888;
 }
-
-/* ==========================================================================
-   LINKS (show URL in print)
-   ========================================================================== */
 a {
     color: #4C78A8;
     text-decoration: none;
 }
-
 a[href^="http"]:after {
     content: " (" attr(href) ")";
     font-size: 0.8em;
     color: #888;
 }
-
 a[href^="#"]:after,
 a.no-url:after {
     content: none;
 }
-
-/* ==========================================================================
-   HORIZONTAL RULES
-   ========================================================================== */
 hr {
     border: none;
     border-top: 1px solid #e9ecef;
@@ -512,77 +421,24 @@ def _contains_blocked_asset_references(html: str) -> bool:
     return parser.blocked
 
 
-HTML_TAG_NAMES = (
-    "html",
-    "head",
-    "body",
-    "main",
-    "section",
-    "article",
-    "header",
-    "footer",
-    "style",
-    "div",
-    "span",
-    "p",
-    "br",
-    "h[1-6]",
-    "table",
-    "thead",
-    "tbody",
-    "tfoot",
-    "tr",
-    "td",
-    "th",
-    "ul",
-    "ol",
-    "li",
-    "strong",
-    "em",
-    "img",
-    "a",
-)
-HTML_TAG_PATTERN = "|".join(HTML_TAG_NAMES)
-ESCAPED_HTML_TAG_RE = re.compile(
-    rf"&lt;\s*/?\s*(?:{HTML_TAG_PATTERN})(?:\s|/|&gt;)",
-    re.IGNORECASE,
-)
-RAW_HTML_TAG_RE = re.compile(
-    rf"<\s*/?\s*(?:{HTML_TAG_PATTERN})(?:\s|/|>)",
-    re.IGNORECASE,
-)
-
-
-def _escaped_html_tag_count(html: str) -> int:
-    return len(ESCAPED_HTML_TAG_RE.findall(html))
-
-
-def _raw_html_tag_count(html: str) -> int:
-    return len(RAW_HTML_TAG_RE.findall(html))
+ESCAPED_HTML_TAG_RE = re.compile(r"&lt;\s*/?\s*[a-z][\w:-]*(?:\s|/|&gt;)", re.IGNORECASE)
+RAW_HTML_TAG_RE = re.compile(r"<\s*/?\s*[a-z][\w:-]*(?:\s|/|>)", re.IGNORECASE)
 
 
 def _looks_like_escaped_html_document(html: str) -> bool:
-    escaped_tag_count = _escaped_html_tag_count(html)
-    if escaped_tag_count == 0 or _raw_html_tag_count(html) > 0:
+    if RAW_HTML_TAG_RE.search(html):
         return False
-
-    starts_with_escaped_tag = bool(ESCAPED_HTML_TAG_RE.match(html.lstrip()))
-    return escaped_tag_count >= 4 or starts_with_escaped_tag
+    escaped_tag_count = len(ESCAPED_HTML_TAG_RE.findall(html))
+    return escaped_tag_count >= 4 or bool(escaped_tag_count and ESCAPED_HTML_TAG_RE.match(html.lstrip()))
 
 
 def _normalize_escaped_html_input(html: str) -> str:
-    if _looks_like_escaped_html_document(html):
-        return html_lib.unescape(html)
-
     once_unescaped = html_lib.unescape(html)
-    if once_unescaped != html and _looks_like_escaped_html_document(once_unescaped):
+    if _looks_like_escaped_html_document(html) or (
+        once_unescaped != html and _looks_like_escaped_html_document(once_unescaped)
+    ):
         return once_unescaped
-
     return html
-
-
-def _contains_unrenderable_escaped_html(html: str) -> bool:
-    return _looks_like_escaped_html_document(html)
 
 
 def _coerce_markdown_images_to_html(html: str) -> str:
@@ -665,7 +521,7 @@ def execute_create_pdf(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
 
     html = decode_unicode_escapes(html)
     html = _normalize_escaped_html_input(html)
-    if _contains_unrenderable_escaped_html(html):
+    if _looks_like_escaped_html_document(html):
         return {
             "status": "error",
             "message": "HTML appears entity-escaped. Pass raw tags like <div>, not &lt;div&gt;.",

--- a/api/agent/tools/tests/test_image_embedding.py
+++ b/api/agent/tools/tests/test_image_embedding.py
@@ -9,12 +9,7 @@ from api.agent.tools.agent_variables import (
     substitute_variables_as_data_uris,
     substitute_variables_with_filespace,
 )
-from api.agent.tools.create_pdf import (
-    _coerce_markdown_images_to_html,
-    _looks_like_escaped_html_document,
-    _normalize_escaped_html_input,
-    execute_create_pdf,
-)
+from api.agent.tools import create_pdf
 
 
 @tag("context_hints_batch")
@@ -56,28 +51,30 @@ class ImageEmbeddingHelperTests(SimpleTestCase):
 
     def test_markdown_images_convert_to_html_for_pdf(self):
         html = "See ![Sales]($[/charts/foo.svg])"
-        result = _coerce_markdown_images_to_html(html)
+        result = create_pdf._coerce_markdown_images_to_html(html)
 
         self.assertIn("<img", result)
         self.assertIn("src=\"$[/charts/foo.svg]\"", result)
         self.assertIn("alt=\"Sales\"", result)
 
     def test_escaped_pdf_markup_is_normalized_to_raw_html(self):
-        html = "&lt;h1&gt;Title&lt;/h1&gt;&lt;p&gt;Body&lt;/p&gt;"
-        result = _normalize_escaped_html_input(html)
-
-        self.assertEqual(result, "<h1>Title</h1><p>Body</p>")
+        cases = [
+            ("&lt;h1&gt;Title&lt;/h1&gt;&lt;p&gt;Body&lt;/p&gt;", "<h1>Title</h1><p>Body</p>"),
+            ("Summary: &lt;strong&gt;Q4&lt;/strong&gt;", "Summary: <strong>Q4</strong>"),
+        ]
+        for html, expected in cases:
+            self.assertEqual(create_pdf._normalize_escaped_html_input(html), expected)
 
     def test_literal_angle_bracket_text_is_not_normalized(self):
         html = "Use &lt; and &gt; symbols, or mention &lt;div&gt; and &lt;p&gt; in prose."
-        result = _normalize_escaped_html_input(html)
+        result = create_pdf._normalize_escaped_html_input(html)
 
         self.assertEqual(result, html)
-        self.assertFalse(_looks_like_escaped_html_document(result))
+        self.assertFalse(create_pdf._looks_like_escaped_html_document(result))
 
     @patch("api.agent.tools.create_pdf.get_max_file_size", return_value=None)
     def test_double_escaped_pdf_markup_is_rejected(self, get_max_file_size_mock):
-        result = execute_create_pdf(
+        result = create_pdf.execute_create_pdf(
             self.agent,
             {
                 "html": "&amp;lt;h1&amp;gt;Title&amp;lt;/h1&amp;gt;",
@@ -96,7 +93,7 @@ class ImageEmbeddingHelperTests(SimpleTestCase):
 
     @patch("api.agent.tools.create_pdf.get_max_file_size", return_value=None)
     def test_escaped_external_asset_is_blocked_after_normalization(self, get_max_file_size_mock):
-        result = execute_create_pdf(
+        result = create_pdf.execute_create_pdf(
             self.agent,
             {
                 "html": "&lt;img src='https://example.com/chart.png'&gt;",

--- a/api/agent/tools/tests/test_image_embedding.py
+++ b/api/agent/tools/tests/test_image_embedding.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.test import SimpleTestCase, tag
 
@@ -8,7 +9,12 @@ from api.agent.tools.agent_variables import (
     substitute_variables_as_data_uris,
     substitute_variables_with_filespace,
 )
-from api.agent.tools.create_pdf import _coerce_markdown_images_to_html
+from api.agent.tools.create_pdf import (
+    _coerce_markdown_images_to_html,
+    _contains_unrenderable_escaped_html,
+    _normalize_escaped_html_input,
+    execute_create_pdf,
+)
 
 
 @tag("context_hints_batch")
@@ -55,3 +61,58 @@ class ImageEmbeddingHelperTests(SimpleTestCase):
         self.assertIn("<img", result)
         self.assertIn("src=\"$[/charts/foo.svg]\"", result)
         self.assertIn("alt=\"Sales\"", result)
+
+    def test_escaped_pdf_markup_is_normalized_to_raw_html(self):
+        html = "&lt;h1&gt;Title&lt;/h1&gt;&lt;p&gt;Body&lt;/p&gt;"
+        result = _normalize_escaped_html_input(html)
+
+        self.assertEqual(result, "<h1>Title</h1><p>Body</p>")
+
+    def test_literal_angle_bracket_text_is_not_normalized(self):
+        html = "Use &lt; and &gt; symbols, or mention &lt;div&gt; and &lt;p&gt; in prose."
+        result = _normalize_escaped_html_input(html)
+
+        self.assertEqual(result, html)
+        self.assertFalse(_contains_unrenderable_escaped_html(result))
+
+    @patch("api.agent.tools.create_pdf.get_max_file_size", return_value=None)
+    def test_double_escaped_pdf_markup_is_rejected(self, get_max_file_size_mock):
+        result = execute_create_pdf(
+            self.agent,
+            {
+                "html": "&amp;lt;h1&amp;gt;Title&amp;lt;/h1&amp;gt;",
+                "file_path": "/exports/report.pdf",
+            },
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "status": "error",
+                "message": "HTML appears entity-escaped. Pass raw tags like <div>, not &lt;div&gt;.",
+            },
+        )
+        get_max_file_size_mock.assert_not_called()
+
+    @patch("api.agent.tools.create_pdf.get_max_file_size", return_value=None)
+    def test_escaped_external_asset_is_blocked_after_normalization(self, get_max_file_size_mock):
+        result = execute_create_pdf(
+            self.agent,
+            {
+                "html": "&lt;img src='https://example.com/chart.png'&gt;",
+                "file_path": "/exports/report.pdf",
+            },
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "status": "error",
+                "message": (
+                    "HTML contains external or local asset references (URLs are not allowed). "
+                    "To embed charts: use <img src='$[/charts/...]'> with the $[path] from create_chart's inline_html field. "
+                    "The $[path] syntax is required—it gets replaced with embedded data."
+                ),
+            },
+        )
+        get_max_file_size_mock.assert_called_once_with()

--- a/api/agent/tools/tests/test_image_embedding.py
+++ b/api/agent/tools/tests/test_image_embedding.py
@@ -11,7 +11,7 @@ from api.agent.tools.agent_variables import (
 )
 from api.agent.tools.create_pdf import (
     _coerce_markdown_images_to_html,
-    _contains_unrenderable_escaped_html,
+    _looks_like_escaped_html_document,
     _normalize_escaped_html_input,
     execute_create_pdf,
 )
@@ -73,7 +73,7 @@ class ImageEmbeddingHelperTests(SimpleTestCase):
         result = _normalize_escaped_html_input(html)
 
         self.assertEqual(result, html)
-        self.assertFalse(_contains_unrenderable_escaped_html(result))
+        self.assertFalse(_looks_like_escaped_html_document(result))
 
     @patch("api.agent.tools.create_pdf.get_max_file_size", return_value=None)
     def test_double_escaped_pdf_markup_is_rejected(self, get_max_file_size_mock):


### PR DESCRIPTION
## Summary
- Normalize clearly escaped HTML before PDF rendering so raw tags are passed to WeasyPrint.
- Reject double-escaped PDF markup with a clear error instead of silently generating a broken document.
- Keep external asset blocking in place after normalization so escaped URLs are still caught.
- Trim non-semantic CSS comments and spacing from the default PDF stylesheet.
- Add focused tests for normalization, rejection, and asset blocking behavior.

## Testing
- `uv run python manage.py test api.agent.tools.tests.test_image_embedding --settings=config.test_settings`