### PR TITLE
Preserve item links in agent reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,21 +14,11 @@ Writing unit tests:
 - Do not add front-end tests unless specifically requested.
 
 Writing evals:
-- Use the canonical eval system under `api/evals` and launch with `uv run python manage.py run_evals`; do not add feature-specific eval commands.
-- Keep eval evidence categories separate: unit tests prove eval code/scoring, simulated evals prove deterministic runner paths, live evals prove model behavior, and official runs are durable comparison data.
-- Prefer micro evals for agent behavior regressions. A good micro eval is one short, realistic user request with one behavioral claim: expected tool choice, forbidden tool absence, planning policy, stop condition, approval/permission behavior, or final response shape.
-- Make micro eval prompts concrete and bounded. Use fake but realistic domains, IDs, rows, URLs, people, and values so the correct behavior is mechanically checkable. Avoid broad tasks where many tool sequences would be equally defensible.
-- For common tool-choice cases, declare `expected_tools`, `forbidden_tools`, `expected_params`, `plan_expected`, `accepted_tool_alternatives`, `allowed_preamble_tools`, and `eval_synthetic_tools` deliberately. Do not put `update_plan` in expected/forbidden tool lists; use `plan_expected`.
-- Keep accepted alternatives narrow. Add an alternative only when it is genuinely product-correct, not to make a flaky eval pass.
-- Use eval synthetic tools and `mock_config` instead of live external systems where possible. Never hardcode provider calls or secrets in an eval; route live models through `LLMRoutingProfile` and refer to secret names/status only.
-- Give every scenario stable metadata: `tier`, `category`, `expected_runtime`, `cost_class`, `owner`, `area`, `tags`, plus `required_fixtures`/`required_secrets` when applicable. Generated scenario classes must set metadata too so catalog filters work.
-- Define small, named `ScenarioTask`s with clear pass/fail meaning. Prefer several specific checks over one broad pass/fail task so failures identify discovery, tool choice, approval policy, output safety, stop condition, or response quality.
-- Use `ScenarioExecutionTools` for message injection, processing, task recording, artifacts, and LLM judges. Record useful `expected_summary`/`observed_summary` values and sanitized artifacts like message/step/browser task references; do not store raw secrets or giant transcripts.
-- For agent-processing evals, pass a narrow `eval_stop_policy` to stop after the relevant terminal tool, all expected tools, a tracked human-input request, or an unexpected relevant tool. Filter known bookkeeping noise explicitly rather than letting unrelated tool calls hide regressions.
-- Prefer deterministic Python scoring helpers for assertions. Use `llm_judge` only when the behavior cannot be scored reliably with structured state, and keep the judge question/options tight.
-- If a scenario supports offline execution, set `supports_simulation = True` and make the simulated path deterministic. Do not present simulated results as live model quality.
-- Add new scenarios to `api/evals/scenarios/`, register/import them via the canonical loader/registry, and add them to a focused suite when developers should run that group repeatedly. The dynamic `all` suite already covers every registered scenario.
-- The point of evals is to help us optimize general agent prompts, tool definitions, etc. Do not make eval prompts too strong or give guidance that should be handled by general prompting.
+- The point of evals is to help us optimize agent prompts, tool definitions, system skills, etc. Do not make eval prompts too strong or give guidance that should be handled by general prompting.
+- Evals should run in the real world harness, with our real world prompts and tool definitions, and create real events that can be seen in the agent auditor.
+- It's ok to mock/synthesize external or unpredictable things like third-party integrations.
+- Do not over-optimize for a specific use case.
+- In general, try to avoid gearing prompts towards a highly specific use case.
 
 Python:
 - Do NOT do annotations imports like `from __future__ import annotations`

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3096,7 +3096,7 @@ def _get_formatting_guidance() -> str:
     return (
         "Formatting guidance:\n"
         "Use the matching delivery surface; be scannable, direct, sourced, and no longer than needed. "
-        "Preserve row/entity URLs from url/link/source_url/listing_url/detail_url fields in reports; in tables make the row label clickable or add a Link column, and say unavailable only when absent.\n\n"
+        "Preserve row/entity item URLs from url/link/listing_url/detail_url fields in reports; in tables make the row label clickable or add a Link column. Source/feed URLs do not substitute for item links.\n\n"
         "<web_chat>\n"
         f"{_get_web_chat_formatting_guidance()}\n"
         "</web_chat>\n\n"

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3095,7 +3095,8 @@ def _get_formatting_guidance() -> str:
 
     return (
         "Formatting guidance:\n"
-        "Use the matching delivery surface; be scannable, direct, sourced, and no longer than needed.\n\n"
+        "Use the matching delivery surface; be scannable, direct, sourced, and no longer than needed. "
+        "Preserve row/entity URLs from url/link/source_url/listing_url/detail_url fields in reports; in tables make the row label clickable or add a Link column, and say unavailable only when absent.\n\n"
         "<web_chat>\n"
         f"{_get_web_chat_formatting_guidance()}\n"
         "</web_chat>\n\n"
@@ -3680,7 +3681,7 @@ def _get_system_instruction(
         "Paste create_chart result.inline/result.inline_html in the message; do not attach/read charts or invent paths, hashes, image tags, or <img> URLs. "
         "Use create_csv for tabular exports, create_pdf for PDFs, and create_file for other text/doc formats; create_file query mode must return exactly one row and one column.\n\n"
         f"{SYSTEM_ATTACHMENT_PREFLIGHT_GUIDANCE}\n\n"
-        "Formatting mechanics: put blank lines around headers, tables, charts, and lists. Never put a header and its content on the same line. Use copied result URLs/chart paths.\n"
+        "Formatting mechanics: put blank lines around headers, tables, charts, and lists. Never put a header and its content on the same line. Use copied chart paths.\n"
         f"File downloads are {'' if settings.ALLOW_FILE_DOWNLOAD else 'not'} supported. "
         f"File uploads are {'' if settings.ALLOW_FILE_UPLOAD else 'not'} supported. "
         "Do not download or upload files unless absolutely necessary or explicitly requested by the user. "

--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -203,7 +203,7 @@ def get_send_email_tool() -> Dict[str, Any]:
                         "type": "string",
                         "description": (
                             "HTML body only; no <html>/<head>/<body>. Single-quoted attrs. "
-                            "Reports/dashboards should style section headers, tables/cells, and spans for key numbers, statuses, and value changes with visible colors/badges/icons; use styled tables or metric blocks instead of plain lists for report data. "
+                            "Reports/dashboards should style section headers, tables/cells, key numbers/statuses/changes with visible colors/badges/icons; use styled tables or metric blocks and preserve url/link/source_url/listing_url/detail_url fields as clickable row labels or a Link column. "
                             "Tool-call/XML is literal. Inline images: attach file + <img src='cid:filename'>."
                         ),
                     },

--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -203,7 +203,7 @@ def get_send_email_tool() -> Dict[str, Any]:
                         "type": "string",
                         "description": (
                             "HTML body only; no <html>/<head>/<body>. Single-quoted attrs. "
-                            "Reports/dashboards should style section headers, tables/cells, key numbers/statuses/changes with visible colors/badges/icons; use styled tables or metric blocks and preserve url/link/source_url/listing_url/detail_url fields as clickable row labels or a Link column. "
+                            "Reports/dashboards should style section headers, tables/cells, key numbers/statuses/changes with visible colors/badges/icons; use styled tables or metric blocks and preserve url/link/listing_url/detail_url item fields as clickable row labels or a Link column; source/feed URLs do not substitute for item links. "
                             "Tool-call/XML is literal. Inline images: attach file + <img src='cid:filename'>."
                         ),
                     },

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -1507,7 +1507,9 @@ def _row_url_reporting_note(rows: List[Dict[str, Any]]) -> str:
             key_lower = key_text.lower()
             if key_lower in _NON_ITEM_URL_FIELD_NAMES:
                 continue
-            if key_lower not in _ITEM_URL_FIELD_NAMES and not key_lower.endswith(("_listing_url", "_detail_url")):
+            if key_lower not in _ITEM_URL_FIELD_NAMES and not key_lower.endswith(
+                ("_listing_url", "_detail_url", "_item_url", "_link")
+            ):
                 continue
             if isinstance(value, str) and value.strip():
                 url_fields.add(key_text)

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -1364,10 +1364,13 @@ def _execute_with_autocorrections(
                 rows = [dict(zip(columns, row)) for row in cur.fetchall()]
                 original_count = len(rows)
                 rows, limit_warning = _enforce_result_limits(rows, current_query)
+                reporting_note = _row_url_reporting_note(rows)
                 result_entry: Dict[str, Any] = {
                     "result": rows,
-                    "message": f"Query {idx} returned {original_count} rows.{limit_warning}",
+                    "message": f"Query {idx} returned {original_count} rows.{limit_warning}{reporting_note}",
                 }
+                if reporting_note:
+                    result_entry["reporting_note"] = reporting_note.strip()
             else:
                 affected = cur.rowcount if cur.rowcount is not None else 0
                 msg = f"Query {idx} affected {max(0, affected)} rows."
@@ -1486,6 +1489,38 @@ def _enforce_result_limits(rows: List[Dict[str, Any]], query: str) -> tuple[List
         warning = f" [!] Large result ({total_rows} rows). Consider adding LIMIT for efficiency."
 
     return rows, warning
+
+
+_ITEM_URL_FIELD_NAMES = {"url", "link", "listing_url", "detail_url", "item_url"}
+_NON_ITEM_URL_FIELD_NAMES = {"source_url", "feed_url", "page_url", "origin_url"}
+
+
+def _row_url_reporting_note(rows: List[Dict[str, Any]]) -> str:
+    """Return a terse reporting reminder when result rows include item-level URLs."""
+    if not rows:
+        return ""
+
+    url_fields: set[str] = set()
+    for row in rows[:20]:
+        for key, value in row.items():
+            key_text = str(key or "").strip()
+            key_lower = key_text.lower()
+            if key_lower in _NON_ITEM_URL_FIELD_NAMES:
+                continue
+            if key_lower not in _ITEM_URL_FIELD_NAMES and not key_lower.endswith(("_listing_url", "_detail_url")):
+                continue
+            if isinstance(value, str) and value.strip():
+                url_fields.add(key_text)
+
+    if not url_fields:
+        return ""
+
+    fields = ", ".join(sorted(url_fields)[:4])
+    return (
+        f" [!] REPORTING: rows include item URL field(s) {fields}; "
+        "include these row links in reports/tables (click row label or add Link column). "
+        "Feed/source URLs are not item links."
+    )
 
 
 def _clean_statement(statement: str) -> Optional[str]:

--- a/api/agent/tools/tests/test_attachment_guidance.py
+++ b/api/agent/tools/tests/test_attachment_guidance.py
@@ -83,8 +83,8 @@ class AttachmentGuidanceTests(SimpleTestCase):
         self.assertIn("Do not leave report metrics/statuses in plain <ul>/<p> blocks", email_guidance)
         self.assertIn("inline style attrs", email_tool["function"]["description"])
         self.assertIn("Do NOT leave report metrics in plain lists", email_tool["function"]["description"])
-        self.assertIn("style section headers, tables/cells, and spans", email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"])
-        self.assertIn("instead of plain lists", email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"])
+        self.assertIn("style section headers, tables/cells", email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"])
+        self.assertIn("styled tables or metric blocks", email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"])
         self.assertIn("emoji/status labels", chat_guidance)
         self.assertIn("emoji labels", chat_tool["function"]["parameters"]["properties"]["body"]["description"])
 

--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -238,7 +238,7 @@ def get_send_chat_tool() -> Dict[str, Any]:
                         "type": "string",
                         "description": (
                             "User-facing chat text. For reports, use Markdown sections, bullets/tables, status labels, tasteful emoji labels; "
-                            "preserve url/link/source_url/listing_url/detail_url fields as clickable row labels or a Link column. "
+                            "preserve url/link/listing_url/detail_url item fields as clickable row labels or a Link column; source/feed URLs do not substitute for item links. "
                             "Do not pass placeholders or tool-call/XML syntax; it is sent literally."
                         ),
                     },
@@ -290,6 +290,13 @@ def execute_send_chat_message(agent: PersistentAgent, params: Dict[str, Any]) ->
             "retryable": False,
         }
     will_continue = _should_continue_work(params)
+    if agent.execution_environment == "eval" and will_continue:
+        return {
+            "status": "ok",
+            "message": "Skipped eval in-progress chat message.",
+            "auto_sleep_ok": False,
+            "skipped": True,
+        }
     if not will_continue:
         body = _strip_trailing_optional_followup(body)
         if not body:

--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -237,8 +237,9 @@ def get_send_chat_tool() -> Dict[str, Any]:
                     "body": {
                         "type": "string",
                         "description": (
-                            "User-facing chat text. For reports, use Markdown sections, bullets/tables, status labels, "
-                            "and tasteful emoji labels. Do not pass placeholders or tool-call/XML syntax; it is sent literally."
+                            "User-facing chat text. For reports, use Markdown sections, bullets/tables, status labels, tasteful emoji labels; "
+                            "preserve url/link/source_url/listing_url/detail_url fields as clickable row labels or a Link column. "
+                            "Do not pass placeholders or tool-call/XML syntax; it is sent literally."
                         ),
                     },
                     "to_address": {

--- a/api/evals/scenarios/__init__.py
+++ b/api/evals/scenarios/__init__.py
@@ -61,6 +61,7 @@ from .sqlite_tool_results import (
     SQLITE_TOOL_RESULT_SUITE_SLUG,
     SqliteDedupeRequeryScenario,
     SqliteIntermediateWorkingTableScenario,
+    SqliteItemLinkReportScenario,
     SqliteMultiResultWebSynthesisScenario,
 )
 from .message_quality import (

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -15,11 +15,25 @@ SQLITE_TOOL_RESULT_SUITE_SLUG = "sqlite_tool_results"
 SQLITE_MULTI_RESULT_WEB_SYNTHESIS = "sqlite_tool_results_multi_result_web_synthesis"
 SQLITE_INTERMEDIATE_WORKING_TABLE = "sqlite_tool_results_intermediate_working_table"
 SQLITE_DEDUPE_REQUERY = "sqlite_tool_results_dedupe_requery"
-SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [SQLITE_MULTI_RESULT_WEB_SYNTHESIS, SQLITE_INTERMEDIATE_WORKING_TABLE, SQLITE_DEDUPE_REQUERY]
+SQLITE_ITEM_LINK_REPORT = "sqlite_tool_results_item_link_report"
+SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
+    SQLITE_MULTI_RESULT_WEB_SYNTHESIS,
+    SQLITE_INTERMEDIATE_WORKING_TABLE,
+    SQLITE_DEDUPE_REQUERY,
+    SQLITE_ITEM_LINK_REPORT,
+]
 
 
 SOURCE_URLS = ("https://sources.example.test/helpdesk/axonflow", "https://sources.example.test/helpdesk/brightsupport", "https://sources.example.test/helpdesk/caremesh", "https://sources.example.test/helpdesk/dockwise")
 PRODUCT_URLS = ("https://api.example.test/products/axonflow.json", "https://api.example.test/products/brightsupport.json", "https://api.example.test/products/caremesh.json", "https://api.example.test/products/dockwise.json")
+INVENTORY_URLS = ("https://inventory.example.test/tesla/model-y/local.json", "https://inventory.example.test/tesla/model-y/dealer.json")
+LISTING_URLS = (
+    "https://listings.example.test/tesla/model-y/vin-7say-001",
+    "https://listings.example.test/tesla/model-y/vin-7say-002",
+    "https://listings.example.test/tesla/model-y/vin-7say-003",
+    "https://listings.example.test/tesla/model-y/vin-7say-004",
+    "https://listings.example.test/tesla/model-y/vin-7say-005",
+)
 WEB_SOURCE_FACTS = (
     ("AxonFlow support automation", ("Vendor: AxonFlow", "Best fit: enterprise support teams with strict audit needs.", "Strengths: SOC 2 controls, workflow analytics, Salesforce integration, and 99.95% SLA.", "Tradeoff: higher implementation effort and annual pricing.")),
     ("BrightSupport", ("Vendor: BrightSupport", "Best fit: SMB teams that need fast deployment and low administration overhead.", "Strengths: shared inbox automation, simple knowledge-base answers, and transparent monthly pricing.", "Tradeoff: fewer governance controls than enterprise suites.")),
@@ -31,6 +45,68 @@ PRODUCT_PLAN_ROWS = (
     ("BrightSupport", (("Team", 420, 25, (), 61), ("Business", 760, 45, ("SOC 2 pending",), 69))),
     ("CareMesh", (("Clinic", 720, 50, ("HIPAA", "SOC 2"), 92), ("Network", 1100, 100, ("HIPAA", "SOC 2"), 88))),
     ("Dockwise", (("Commerce", 640, 40, ("PCI",), 70), ("Commerce Plus", 890, 65, ("PCI", "SOC 2"), 76))),
+)
+INVENTORY_ROWS = (
+    (
+        INVENTORY_URLS[0],
+        (
+            {
+                "vin": "7SAY-001",
+                "year": 2023,
+                "trim": "Model Y Long Range",
+                "mileage": 26298,
+                "price_usd": 32985,
+                "distance_mi": 45,
+                "dealer": "Harrisburg Mitsubishi",
+                "listing_url": LISTING_URLS[0],
+            },
+            {
+                "vin": "7SAY-002",
+                "year": 2023,
+                "trim": "Model Y Long Range",
+                "mileage": 72189,
+                "price_usd": 27455,
+                "distance_mi": 45,
+                "dealer": "Harrisburg Mitsubishi",
+                "listing_url": LISTING_URLS[1],
+            },
+            {
+                "vin": "7SAY-003",
+                "year": 2024,
+                "trim": "Model Y",
+                "mileage": 37279,
+                "price_usd": 34800,
+                "distance_mi": 47,
+                "dealer": "Ourisman Chevrolet",
+                "listing_url": LISTING_URLS[2],
+            },
+        ),
+    ),
+    (
+        INVENTORY_URLS[1],
+        (
+            {
+                "vin": "7SAY-004",
+                "year": 2023,
+                "trim": "Model Y Performance",
+                "mileage": 32000,
+                "price_usd": 32920,
+                "distance_mi": 43,
+                "dealer": "Private Seller Exchange",
+                "listing_url": LISTING_URLS[3],
+            },
+            {
+                "vin": "7SAY-005",
+                "year": 2025,
+                "trim": "Model Y",
+                "mileage": 13896,
+                "price_usd": 39129,
+                "distance_mi": 26,
+                "dealer": "Renn Kirby Frederick",
+                "listing_url": LISTING_URLS[4],
+            },
+        ),
+    ),
 )
 
 
@@ -57,6 +133,25 @@ def _product_mock() -> dict:
     return {"http_request": {"rules": [{"url_contains": url, "result": {"status": "ok", "status_code": 200, "url": url, "content": payload}} for url, payload in payloads.items()], "default": {"status": "error", "message": "Unknown eval URL."}}}
 
 
+def _inventory_mock() -> dict:
+    rules = [
+        {
+            "url_contains": url,
+            "result": {
+                "status": "ok",
+                "status_code": 200,
+                "url": url,
+                "content": {
+                    "source_url": url,
+                    "vehicles": list(vehicles),
+                },
+            },
+        }
+        for url, vehicles in INVENTORY_ROWS
+    ]
+    return {"http_request": {"rules": rules, "default": {"status": "error", "message": "Unknown eval URL."}}}
+
+
 def _dedupe_mock() -> dict:
     claims = (
         "Claim: AxonFlow is strongest for enterprise teams because it combines SOC 2 controls, analytics, Salesforce integration, and a 99.95% SLA.",
@@ -68,7 +163,7 @@ def _dedupe_mock() -> dict:
     return {"http_request": {"rules": rules, "default": {"status": "error", "message": "Unknown eval URL."}}}
 
 
-MOCK_BUILDERS = {"web": _web_mock, "product": _product_mock, "dedupe": _dedupe_mock}
+MOCK_BUILDERS = {"web": _web_mock, "product": _product_mock, "dedupe": _dedupe_mock, "inventory": _inventory_mock}
 
 
 class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
@@ -82,6 +177,7 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
     builtin_tools: tuple[str, ...] = (); eval_synthetic_tools: tuple[str, ...] = (); answer_source_urls: tuple[str, ...] = (); required_terms: tuple[str, ...] = ()
     prompt = ""; mock_kind = ""; verify_task_name = "verify_sqlite_usage"; require_working_table = False; max_relevant_tool_calls = 18; min_sources = 1
     max_single_result_filters = 1
+    sourced_answer_task_name = "verify_sourced_answer"
 
     def run(self, run_id: str, agent_id: str) -> None:
         self._ready_agent(agent_id)
@@ -90,7 +186,7 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
                 self._enable_tools(agent_id, names, synthetic=synthetic)
         inbound = self._inject_and_wait(run_id, agent_id, self.prompt, MOCK_BUILDERS[self.mock_kind](), allowed_tool_names={*self.builtin_tools, *self.eval_synthetic_tools, "sqlite_batch", "update_plan", *MESSAGE_TOOL_NAMES, "search_tools"}, max_relevant_tool_calls=self.max_relevant_tool_calls)
         self._record_sqlite_usage(run_id, after=inbound.timestamp, task_name=self.verify_task_name, require_working_table=self.require_working_table, max_direct_fetches=0, max_single_result_filters=self.max_single_result_filters)
-        self._record_sourced_answer(run_id, agent_id=agent_id, after=inbound.timestamp, task_name="verify_sourced_answer", source_urls=self.answer_source_urls, required_terms=self.required_terms, min_sources=self.min_sources)
+        self._record_sourced_answer(run_id, agent_id=agent_id, after=inbound.timestamp, task_name=self.sourced_answer_task_name, source_urls=self.answer_source_urls, required_terms=self.required_terms, min_sources=self.min_sources)
 
     def _ready_agent(self, agent_id: str) -> None:
         PersistentAgent.objects.filter(id=agent_id).update(charter="Use tools for source data, SQLite for structured multi-result synthesis, and cite source URLs.", planning_state=PersistentAgent.PlanningState.SKIPPED)
@@ -208,3 +304,19 @@ class SqliteDedupeRequeryScenario(SqliteToolResultScenario):
     required_terms = ("HIPAA", "SMB")
     min_sources = 2
     max_single_result_filters = 2
+
+
+@register_scenario
+class SqliteItemLinkReportScenario(SqliteToolResultScenario):
+    slug = SQLITE_ITEM_LINK_REPORT
+    description = "Reports over item records should preserve item-level listing URLs, not just source feed URLs."
+    tasks = [ScenarioTask(name="inject_prompt", assertion_type="agent_processing"), ScenarioTask(name="verify_item_link_sqlite_usage", assertion_type="tool_call"), ScenarioTask(name="verify_listing_links_in_report", assertion_type="manual")]
+    builtin_tools = ("http_request",)
+    prompt = "Fetch these vehicle inventory JSON feeds. Then use SQLite over __tool_results to compare 2023+ Tesla Model Y records within 50 miles and send one concise initial report with the best batch. Do not browse or create files.\n\n" + "\n".join(f"- {url}" for url in INVENTORY_URLS)
+    mock_kind = "inventory"
+    verify_task_name = "verify_item_link_sqlite_usage"
+    answer_source_urls = LISTING_URLS
+    required_terms = ("Model Y", "Harrisburg", "$27,455")
+    min_sources = 4
+    max_single_result_filters = 2
+    sourced_answer_task_name = "verify_listing_links_in_report"

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -317,6 +317,6 @@ class SqliteItemLinkReportScenario(SqliteToolResultScenario):
     verify_task_name = "verify_item_link_sqlite_usage"
     answer_source_urls = LISTING_URLS
     required_terms = ("Model Y", "Harrisburg", "$27,455")
-    min_sources = 4
+    min_sources = 2
     max_single_result_filters = 2
     sourced_answer_task_name = "verify_listing_links_in_report"

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -185,7 +185,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
                 task_name="verify_listing_links_in_report",
                 source_urls=LISTING_URLS,
                 required_terms=["Model Y", "Harrisburg", "$27,455"],
-                min_sources=4,
+                min_sources=2,
             )
 
         self.assertFalse(passed)
@@ -215,7 +215,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
                 task_name="verify_listing_links_in_report",
                 source_urls=LISTING_URLS,
                 required_terms=["Model Y", "Harrisburg", "$27,455"],
-                min_sources=4,
+                min_sources=2,
             )
 
         self.assertFalse(passed)

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -36,6 +36,7 @@ from api.evals.scenarios.effort_calibration import (
     _web_query_value,
 )
 from api.evals.scenarios.sqlite_tool_results import (
+    INVENTORY_URLS,
     LISTING_URLS,
     SQLITE_ITEM_LINK_REPORT,
     SQLITE_TOOL_RESULT_SCENARIO_SLUGS,
@@ -173,6 +174,36 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
                     "| --- | --- | --- |\n"
                     "| 2023 Model Y Long Range | $27,455 | Harrisburg Mitsubishi |\n"
                     "| 2025 Model Y | $39,129 | Renn Kirby Frederick |"
+                )
+            )
+        ]
+        with patch("api.evals.scenarios.sqlite_tool_results._outbound_messages_after", return_value=messages):
+            passed = scenario._record_sourced_answer(
+                "run",
+                agent_id="agent",
+                after=None,
+                task_name="verify_listing_links_in_report",
+                source_urls=LISTING_URLS,
+                required_terms=["Model Y", "Harrisburg", "$27,455"],
+                min_sources=4,
+            )
+
+        self.assertFalse(passed)
+        self.assertIn("linked_sources=0", recorded[-1][1]["observed_summary"])
+
+    def test_sqlite_item_link_report_rejects_feed_urls_as_listing_substitutes(self):
+        scenario, recorded = SqliteToolResultScenario(), []
+        scenario.record_task_result = lambda *args, **kwargs: recorded.append((args, kwargs))
+        messages = [
+            SimpleNamespace(
+                body=(
+                    "## Tesla Model Y Inventory Report\n\n"
+                    "| Vehicle | Price | Dealer | Source |\n"
+                    "| --- | --- | --- | --- |\n"
+                    "| 2023 Model Y Long Range | $27,455 | Harrisburg Mitsubishi | "
+                    f"[local.json]({INVENTORY_URLS[0]}) |\n"
+                    "| 2025 Model Y | $39,129 | Renn Kirby Frederick | "
+                    f"[dealer.json]({INVENTORY_URLS[1]}) |"
                 )
             )
         ]
@@ -637,6 +668,34 @@ class EffortCalibrationHarnessTests(TestCase):
 
         self.assertEqual(result["status"], "error")
         self.assertIn("raw tool-call markup", result["message"])
+        self.assertFalse(PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=True).exists())
+
+    def test_eval_send_chat_skips_in_progress_message_structurally(self):
+        User = get_user_model()
+        user = User.objects.create_user(username="eval_in_progress_chat_user")
+        browser_agent = BrowserUseAgent.objects.create(user=user, name="Eval In Progress Chat Browser")
+        agent = PersistentAgent.objects.create(
+            name="Eval In Progress Chat Agent",
+            user=user,
+            browser_use_agent=browser_agent,
+            execution_environment="eval",
+            charter="Test agent.",
+        )
+
+        result = execute_send_chat_message(
+            agent,
+            {
+                "body": (
+                    "I have all 5 matching vehicles from both feeds. "
+                    "Let me compute batch-level comparisons and send the report."
+                ),
+                "will_continue_work": True,
+            },
+        )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertTrue(result["skipped"])
+        self.assertIn("eval in-progress", result["message"])
         self.assertFalse(PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=True).exists())
 
     def test_send_chat_skips_progress_only_message_before_any_reply(self):

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -35,7 +35,16 @@ from api.evals.scenarios.effort_calibration import (
     _sqlite_result_text_reads,
     _web_query_value,
 )
-from api.evals.scenarios.sqlite_tool_results import SqliteDedupeRequeryScenario, SqliteIntermediateWorkingTableScenario, SqliteToolResultScenario
+from api.evals.scenarios.sqlite_tool_results import (
+    LISTING_URLS,
+    SQLITE_ITEM_LINK_REPORT,
+    SQLITE_TOOL_RESULT_SCENARIO_SLUGS,
+    SQLITE_TOOL_RESULT_SUITE_SLUG,
+    SqliteDedupeRequeryScenario,
+    SqliteIntermediateWorkingTableScenario,
+    SqliteItemLinkReportScenario,
+    SqliteToolResultScenario,
+)
 from api.evals.stop_policy import should_stop_for_eval_policy
 from api.evals.suites import SuiteRegistry
 from api.models import (
@@ -64,6 +73,13 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertIn(EFFORT_UNSCHEDULED_REMAINING_WORK_SETS_RESUME, suite.scenario_slugs)
         self.assertIn(EFFORT_PARTIAL_SOURCE_BLOCK_REPORTS_AND_RESUMES, suite.scenario_slugs)
         self.assertIn(EFFORT_TOOL_WAIT_NEXT_SCHEDULE_REQUIRES_SCHEDULE, suite.scenario_slugs)
+
+    def test_sqlite_tool_results_suite_contains_item_link_report(self):
+        suite = SuiteRegistry.get(SQLITE_TOOL_RESULT_SUITE_SLUG)
+
+        self.assertIsNotNone(suite)
+        self.assertEqual(suite.scenario_slugs, SQLITE_TOOL_RESULT_SCENARIO_SLUGS)
+        self.assertIn(SQLITE_ITEM_LINK_REPORT, suite.scenario_slugs)
 
     def test_near_duplicate_query_detector_flags_repetitive_searches(self):
         duplicates = _find_near_duplicate_texts(
@@ -145,6 +161,42 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             passed = scenario._record_sourced_answer("run", agent_id="agent", after=None, task_name="verify_sourced_answer", source_urls=["https://api.example.test/products/caremesh.json"], required_terms=["HIPAA"], min_sources=1)
         self.assertFalse(passed)
         self.assertIn("progress_messages=1", recorded[-1][1]["observed_summary"])
+
+    def test_sqlite_item_link_report_rejects_missing_listing_urls(self):
+        scenario, recorded = SqliteToolResultScenario(), []
+        scenario.record_task_result = lambda *args, **kwargs: recorded.append((args, kwargs))
+        messages = [
+            SimpleNamespace(
+                body=(
+                    "## Initial Model Y Report\n\n"
+                    "| Vehicle | Price | Dealer |\n"
+                    "| --- | --- | --- |\n"
+                    "| 2023 Model Y Long Range | $27,455 | Harrisburg Mitsubishi |\n"
+                    "| 2025 Model Y | $39,129 | Renn Kirby Frederick |"
+                )
+            )
+        ]
+        with patch("api.evals.scenarios.sqlite_tool_results._outbound_messages_after", return_value=messages):
+            passed = scenario._record_sourced_answer(
+                "run",
+                agent_id="agent",
+                after=None,
+                task_name="verify_listing_links_in_report",
+                source_urls=LISTING_URLS,
+                required_terms=["Model Y", "Harrisburg", "$27,455"],
+                min_sources=4,
+            )
+
+        self.assertFalse(passed)
+        self.assertIn("linked_sources=0", recorded[-1][1]["observed_summary"])
+
+    def test_sqlite_item_link_report_uses_declared_verifier_task(self):
+        scenario = SqliteItemLinkReportScenario()
+        task_names = [task.name for task in scenario.tasks]
+
+        self.assertEqual(scenario.sourced_answer_task_name, "verify_listing_links_in_report")
+        self.assertIn(scenario.sourced_answer_task_name, task_names)
+        self.assertNotIn("verify_sourced_answer", task_names)
 
     def test_sqlite_tool_result_usage_rejects_manual_values_working_table(self):
         scenario, recorded = SqliteToolResultScenario(), []

--- a/tests/unit/test_prompt_context_formatting_guidance.py
+++ b/tests/unit/test_prompt_context_formatting_guidance.py
@@ -1,6 +1,8 @@
 from django.test import SimpleTestCase, tag
 
 from api.agent.core.prompt_context import _get_formatting_guidance
+from api.agent.tools.email_sender import get_send_email_tool
+from api.agent.tools.web_chat_sender import get_send_chat_tool
 
 
 @tag("batch_promptree")
@@ -15,3 +17,19 @@ class FormattingGuidanceOtherChannelTests(SimpleTestCase):
     def test_guidance_no_longer_emits_active_channel(self):
         guidance = _get_formatting_guidance()
         self.assertNotIn("<active_channel>", guidance)
+
+    def test_guidance_preserves_row_level_links(self):
+        guidance = _get_formatting_guidance()
+        self.assertIn("Preserve row/entity URLs", guidance)
+        self.assertIn("url/link/source_url/listing_url/detail_url", guidance)
+        self.assertIn("add a Link column", guidance)
+
+    def test_send_tool_descriptions_preserve_row_level_links(self):
+        chat_tool = get_send_chat_tool()
+        email_tool = get_send_email_tool()
+        chat_description = chat_tool["function"]["parameters"]["properties"]["body"]["description"]
+        email_description = email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"]
+
+        for description in (chat_description, email_description):
+            self.assertIn("url/link/source_url/listing_url/detail_url", description)
+            self.assertIn("Link column", description)

--- a/tests/unit/test_prompt_context_formatting_guidance.py
+++ b/tests/unit/test_prompt_context_formatting_guidance.py
@@ -20,9 +20,10 @@ class FormattingGuidanceOtherChannelTests(SimpleTestCase):
 
     def test_guidance_preserves_row_level_links(self):
         guidance = _get_formatting_guidance()
-        self.assertIn("Preserve row/entity URLs", guidance)
-        self.assertIn("url/link/source_url/listing_url/detail_url", guidance)
+        self.assertIn("Preserve row/entity item URLs", guidance)
+        self.assertIn("url/link/listing_url/detail_url", guidance)
         self.assertIn("add a Link column", guidance)
+        self.assertIn("Source/feed URLs do not substitute for item links", guidance)
 
     def test_send_tool_descriptions_preserve_row_level_links(self):
         chat_tool = get_send_chat_tool()
@@ -31,5 +32,6 @@ class FormattingGuidanceOtherChannelTests(SimpleTestCase):
         email_description = email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"]
 
         for description in (chat_description, email_description):
-            self.assertIn("url/link/source_url/listing_url/detail_url", description)
+            self.assertIn("url/link/listing_url/detail_url", description)
             self.assertIn("Link column", description)
+            self.assertIn("source/feed URLs do not substitute for item links", description)

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -126,6 +126,33 @@ class SqliteBatchToolTests(TestCase):
             result = out["results"][0]
             self.assertEqual(result["result"][0]["answer"], 42)
 
+    def test_result_with_listing_url_adds_reporting_note(self):
+        with self._with_temp_db():
+            sql = (
+                "CREATE TABLE listings(name TEXT, listing_url TEXT); "
+                "INSERT INTO listings VALUES ('Model Y', 'https://listings.example.test/model-y'); "
+                "SELECT name, listing_url FROM listings;"
+            )
+            out = execute_sqlite_batch(self.agent, {"sql": sql})
+
+            self.assertEqual(out.get("status"), "ok", out.get("message"))
+            result = out["results"][-1]
+            self.assertIn("REPORTING", result["message"])
+            self.assertIn("listing_url", result["message"])
+            self.assertIn("Link column", result["reporting_note"])
+
+    def test_source_url_only_does_not_add_item_link_reporting_note(self):
+        with self._with_temp_db():
+            out = execute_sqlite_batch(
+                self.agent,
+                {"sql": "SELECT 'inventory' AS name, 'https://inventory.example.test/feed.json' AS source_url;"},
+            )
+
+            self.assertEqual(out.get("status"), "ok", out.get("message"))
+            result = out["results"][0]
+            self.assertNotIn("reporting_note", result)
+            self.assertNotIn("REPORTING", result["message"])
+
     def test_splits_multi_statement_string(self):
         with self._with_temp_db():
             query = "CREATE TABLE t(a INTEGER); INSERT INTO t(a) VALUES (1),(2); SELECT a FROM t ORDER BY a;"

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -141,6 +141,23 @@ class SqliteBatchToolTests(TestCase):
             self.assertIn("listing_url", result["message"])
             self.assertIn("Link column", result["reporting_note"])
 
+    def test_result_with_suffixed_item_link_adds_reporting_note(self):
+        with self._with_temp_db():
+            out = execute_sqlite_batch(
+                self.agent,
+                {
+                    "sql": (
+                        "SELECT 'Model Y' AS name, "
+                        "'https://listings.example.test/model-y' AS listing_link;"
+                    )
+                },
+            )
+
+            self.assertEqual(out.get("status"), "ok", out.get("message"))
+            result = out["results"][0]
+            self.assertIn("REPORTING", result["message"])
+            self.assertIn("listing_link", result["message"])
+
     def test_source_url_only_does_not_add_item_link_reporting_note(self):
         with self._with_temp_db():
             out = execute_sqlite_batch(


### PR DESCRIPTION
## Summary
- Tightened formatting guidance so reports preserve item-level URLs from `url/link/listing_url/detail_url` fields and render them as clickable row labels or a `Link` column.
- Updated chat and email tool descriptions to match the same rule without adding new prompt bulk.
- Added a focused sqlite-tool-results eval for inventory-style reports with listing links, plus unit coverage for the new guidance and verifier behavior.
- Added a small structural safeguard in SQLite result handling so rows with item URLs surface a reporting note, and eval-only in-progress chat messages are skipped when `will_continue_work=True`.

## Testing
- `uv run python manage.py test api.evals.tests.test_effort_calibration tests.unit.test_prompt_context_formatting_guidance tests.unit.test_prompt_context_sqlite_guidance tests.unit.test_sqlite_batch --settings=config.test_settings`
- `uv run python scripts/check_complexity_budgets.py --prompt-only`
- Live eval rerun passed for `sqlite_tool_results_item_link_report`