### PR TITLE
Fix chart tool inference and reserved-keyword handling

### DIFF
--- a/api/agent/tools/create_chart.py
+++ b/api/agent/tools/create_chart.py
@@ -65,7 +65,7 @@ def _is_numeric_value(value: Any) -> bool:
 
 
 def _is_numeric_column(data: List[Dict], column: str) -> bool:
-    observed_values = [row.get(column) for row in data if row.get(column) is not None]
+    observed_values = [value for row in data if (value := row.get(column)) is not None]
     if not observed_values:
         return False
     return all(_is_numeric_value(value) for value in observed_values)
@@ -143,7 +143,15 @@ def _infer_missing_chart_params(
 
 def _format_query_error(error: str) -> str:
     normalized = error.lower()
-    if "values" in normalized and "syntax error" in normalized:
+    is_values_keyword_error = any(
+        marker in normalized
+        for marker in (
+            'near "values"',
+            "near 'values'",
+            "near `values`",
+        )
+    )
+    if is_values_keyword_error and "syntax error" in normalized:
         return (
             f"{error}. SQLite treats `values` as reserved syntax. "
             "Use a safe alias such as `lead_count`, then pass `values: \"lead_count\"` to create_chart."

--- a/api/agent/tools/create_chart.py
+++ b/api/agent/tools/create_chart.py
@@ -39,6 +39,14 @@ CHART_TYPES = {
     "scatter",
 }
 
+TWO_COLUMN_SINGLE_SERIES_CHART_TYPES = {
+    "bar",
+    "horizontal_bar",
+    "line",
+    "area",
+    "scatter",
+}
+
 
 def _execute_query_for_data(query: str) -> tuple[List[Dict], Optional[List[str]], Optional[str]]:
     """Execute a SQL query and return results as a list of dicts."""
@@ -50,6 +58,97 @@ def _execute_query_for_data(query: str) -> tuple[List[Dict], Optional[List[str]]
 def _extract_values(data: List[Dict], key: str) -> List[Any]:
     """Extract values for a given key from list of dicts."""
     return [row.get(key) for row in data]
+
+
+def _is_numeric_value(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_numeric_column(data: List[Dict], column: str) -> bool:
+    observed_values = [row.get(column) for row in data if row.get(column) is not None]
+    if not observed_values:
+        return False
+    return all(_is_numeric_value(value) for value in observed_values)
+
+
+def _result_columns(data: List[Dict], result_columns: Optional[List[str]]) -> List[str]:
+    if result_columns:
+        return result_columns
+    if data and isinstance(data[0], dict):
+        return list(data[0].keys())
+    return []
+
+
+def _other_two_column(columns: List[str], selected_column: Any) -> Optional[str]:
+    if not isinstance(selected_column, str) or selected_column not in columns:
+        return None
+    return next((column for column in columns if column != selected_column), None)
+
+
+def _classify_two_columns(data: List[Dict], columns: List[str]) -> tuple[Optional[str], Optional[str]]:
+    if len(columns) != 2:
+        return None, None
+
+    first, second = columns
+    first_is_numeric = _is_numeric_column(data, first)
+    second_is_numeric = _is_numeric_column(data, second)
+    if first_is_numeric and not second_is_numeric:
+        return second, first
+    if second_is_numeric and not first_is_numeric:
+        return first, second
+    return None, None
+
+
+def _infer_two_column_params(
+    params: Dict[str, Any],
+    data: List[Dict],
+    columns: List[str],
+    label_key: str,
+    numeric_key: str,
+) -> Dict[str, Any]:
+    if len(columns) != 2:
+        return params
+
+    inferred = dict(params)
+    if not inferred.get(label_key) and not inferred.get(numeric_key):
+        label_column, numeric_column = _classify_two_columns(data, columns)
+        if label_column and numeric_column:
+            inferred[label_key] = label_column
+            inferred[numeric_key] = numeric_column
+    elif inferred.get(label_key) and not inferred.get(numeric_key):
+        numeric_column = _other_two_column(columns, inferred.get(label_key))
+        if numeric_column and _is_numeric_column(data, numeric_column):
+            inferred[numeric_key] = numeric_column
+    elif inferred.get(numeric_key) and not inferred.get(label_key):
+        label_column = _other_two_column(columns, inferred.get(numeric_key))
+        if label_column:
+            inferred[label_key] = label_column
+
+    return inferred
+
+
+def _infer_missing_chart_params(
+    chart_type: str,
+    params: Dict[str, Any],
+    data: List[Dict],
+    result_columns: Optional[List[str]],
+) -> Dict[str, Any]:
+    columns = _result_columns(data, result_columns)
+    if chart_type in ("pie", "donut"):
+        return _infer_two_column_params(params, data, columns, "labels", "values")
+    if chart_type in TWO_COLUMN_SINGLE_SERIES_CHART_TYPES:
+        return _infer_two_column_params(params, data, columns, "x", "y")
+    return params
+
+
+def _format_query_error(error: str) -> str:
+    normalized = error.lower()
+    if "values" in normalized and "syntax error" in normalized:
+        return (
+            f"{error}. SQLite treats `values` as reserved syntax. "
+            "Use a safe alias such as `lead_count`, then pass `values: \"lead_count\"` to create_chart."
+        )
+    return error
 
 
 def _setup_style():
@@ -314,9 +413,10 @@ def get_create_chart_tool() -> Dict[str, Any]:
             "name": "create_chart",
             "description": (
                 "Create a chart artifact from a SQL query when the user requests a chart or a visual is materially necessary. "
-                "Do not use this for routine summaries just because numbers are present. The query runs against SQLite; SELECT column names become x/y/values/labels keys. "
+                "Do not use this for routine summaries just because numbers are present. The query runs against SQLite; chart parameters reference SELECT result column names. "
                 "Types: bar, horizontal_bar, stacked_bar, line, area, stacked_area, pie, donut, scatter. "
-                "Pie/donut use values+labels; others use x+y (y may be list). Returns file/inline/inline_html/attach; paste inline/HTML, do not read chart files."
+                "Pie/donut: pass labels and values as tool parameters naming existing SELECT columns; use safe SQL aliases like category and lead_count, not AS values. "
+                "Other charts use x+y (y may be list). Returns file/inline/inline_html/attach; paste inline/HTML, do not read chart files."
             ),
             "parameters": {
                 "type": "object",
@@ -328,7 +428,7 @@ def get_create_chart_tool() -> Dict[str, Any]:
                     },
                     "query": {
                         "type": "string",
-                        "description": "SQL SELECT query. Column names become data keys for x/y/values/labels."
+                        "description": "SQL SELECT query. Use safe output column names, then reference those names from x/y/values/labels."
                     },
                     "x": {
                         "type": "string",
@@ -343,7 +443,7 @@ def get_create_chart_tool() -> Dict[str, Any]:
                     },
                     "values": {
                         "type": "string",
-                        "description": "Column name for numeric values (pie/donut)."
+                        "description": "Existing SELECT column name for numeric values (pie/donut). Avoid SQL aliases named values; use a safe alias like lead_count."
                     },
                     "labels": {
                         "type": "string",
@@ -415,13 +515,13 @@ def _validate_requested_chart_columns(
         "Requested chart columns are missing from query results. "
         f"Missing: {', '.join(missing_columns)}. "
         f"Available: {', '.join(str(col) for col in available_columns)}. "
-        "Ensure your SELECT aliases exactly match x/y/values/labels."
+        "Use safe SELECT aliases and pass those column names through the chart parameters."
     )
 
 
 def execute_create_chart(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[str, Any]:
     """Execute the create_chart tool."""
-    chart_type = params.get("type")
+    chart_type = str(params.get("type") or "").strip().lower()
     query = params.get("query")
 
     # Validate required params
@@ -435,9 +535,11 @@ def execute_create_chart(agent: PersistentAgent, params: Dict[str, Any]) -> Dict
     # Execute query to get data
     data, result_columns, error = _execute_query_for_data(query)
     if error:
-        return {"status": "error", "message": error}
+        return {"status": "error", "message": _format_query_error(error)}
     if not data:
         return {"status": "error", "message": "Query returned no rows - nothing to chart"}
+
+    params = _infer_missing_chart_params(chart_type, params, data, result_columns)
 
     # Validate chart-specific params
     if chart_type in ("pie", "donut"):

--- a/api/agent/tools/static_tools.py
+++ b/api/agent/tools/static_tools.py
@@ -14,6 +14,7 @@ PLANNING_MODE_DISABLED_TOOL_NAMES = frozenset({
     "request_contact_permission",
     "spawn_web_task",
     "update_plan",
+    "create_chart"
 })
 
 

--- a/tests/unit/test_create_chart.py
+++ b/tests/unit/test_create_chart.py
@@ -48,7 +48,7 @@ class CreateChartToolTests(TestCase):
         self.assertEqual(result["status"], "error")
         message = result["message"].lower()
         self.assertIn(f"available: {', '.join(expected_available)}", message)
-        self.assertIn("aliases exactly match", message)
+        self.assertIn("safe select aliases", message)
 
         missing_part = message.split("missing: ", 1)[1].split(".", 1)[0]
         found_missing_set = {column.strip() for column in missing_part.split(",")}
@@ -65,6 +65,7 @@ class CreateChartToolTests(TestCase):
         self.assertIn("type", tool["function"]["parameters"]["properties"])
         self.assertIn("query", tool["function"]["parameters"]["properties"])
         self.assertIn("query", tool["function"]["parameters"]["required"])
+        self.assertIn("not AS values", tool["function"]["description"])
 
     def test_missing_type_returns_error(self):
         result = execute_create_chart(
@@ -106,6 +107,20 @@ class CreateChartToolTests(TestCase):
             self.assertEqual(result["status"], "error")
             self.assertIn("query failed", result["message"].lower())
 
+    def test_values_keyword_query_error_returns_specific_guidance(self):
+        with patch(
+            "api.agent.tools.create_chart._execute_query_for_data",
+            return_value=([], None, 'Query failed: near "values": syntax error'),
+        ):
+            result = execute_create_chart(
+                self.agent,
+                {"type": "donut", "query": "SELECT industry AS labels, COUNT(*) AS values FROM t"},
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("reserved syntax", result["message"].lower())
+        self.assertIn('values: "lead_count"', result["message"])
+
     def test_invalid_chart_type_returns_error(self):
         result = execute_create_chart(
             self.agent,
@@ -115,22 +130,62 @@ class CreateChartToolTests(TestCase):
         self.assertIn("invalid", result["message"].lower())
 
     def test_bar_chart_requires_x_and_y(self):
-        with mock_query_data([{"month": "Jan", "value": 100}]):
+        with mock_query_data([{"month": "Jan", "segment": "Online", "value": 100}]):
             result = execute_create_chart(
                 self.agent,
-                {"type": "bar", "query": "SELECT month, value FROM t"},
+                {"type": "bar", "query": "SELECT month, segment, value FROM t"},
             )
             self.assertEqual(result["status"], "error")
             self.assertIn("x", result["message"].lower())
 
     def test_pie_chart_requires_values_and_labels(self):
-        with mock_query_data([{"category": "A", "amount": 100}]):
+        with mock_query_data([{"category": "A", "segment": "Online", "amount": 100}]):
             result = execute_create_chart(
                 self.agent,
-                {"type": "pie", "query": "SELECT category, amount FROM t"},
+                {"type": "pie", "query": "SELECT category, segment, amount FROM t"},
             )
             self.assertEqual(result["status"], "error")
             self.assertIn("values", result["message"].lower())
+
+    @patch("api.agent.files.filespace_service.write_bytes_to_dir")
+    @patch("api.agent.files.attachment_helpers.build_signed_filespace_download_url")
+    def test_bar_chart_infers_x_and_y_from_two_column_result(self, mock_signed_url, mock_write):
+        mock_write.return_value = {"status": "ok", "path": "/charts/inferred_bar.svg", "node_id": "id1"}
+        mock_signed_url.return_value = "https://example.com/inferred_bar.svg"
+
+        with mock_query_data([
+            {"month": "Jan", "revenue": 100},
+            {"month": "Feb", "revenue": 150},
+        ]):
+            result = execute_create_chart(
+                self.agent,
+                {"type": "bar", "query": "SELECT month, revenue FROM t"},
+            )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["file"], "$[/charts/inferred_bar.svg]")
+        mock_write.assert_called_once()
+        mock_signed_url.assert_called_once()
+
+    @patch("api.agent.files.filespace_service.write_bytes_to_dir")
+    @patch("api.agent.files.attachment_helpers.build_signed_filespace_download_url")
+    def test_donut_chart_infers_values_and_labels_from_two_column_result(self, mock_signed_url, mock_write):
+        mock_write.return_value = {"status": "ok", "path": "/charts/inferred_donut.svg", "node_id": "id1"}
+        mock_signed_url.return_value = "https://example.com/inferred_donut.svg"
+
+        with mock_query_data([
+            {"industry": "Construction", "lead_count": 9},
+            {"industry": "Travel Nurse Housing", "lead_count": 1},
+        ]):
+            result = execute_create_chart(
+                self.agent,
+                {"type": "donut\n", "query": "SELECT industry, COUNT(*) AS lead_count FROM lodging_leads"},
+            )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["file"], "$[/charts/inferred_donut.svg]")
+        mock_write.assert_called_once()
+        mock_signed_url.assert_called_once()
 
     def test_non_pie_chart_missing_columns_returns_error(self):
         self._assert_missing_columns_error(


### PR DESCRIPTION
## Summary
- Normalize `create_chart` type values and add conservative inference for missing chart params when the SQL result has a clear two-column shape.
- Improve chart tool wording so it no longer nudges agents toward `AS values`, and return a specific hint when SQLite rejects `values` as a reserved keyword.
- Trim duplication in the inference helpers and disable `create_chart` in planning-mode tool lists.
- Add focused unit coverage for inferred bar/donut charts, newline-normalized chart types, and the reserved-keyword error path.

## Testing
- Ran `uv run python manage.py test tests.unit.test_create_chart --settings=config.test_settings` successfully.