### PR TITLE
Require options for request_human_input and route free-text to send tools

### DIFF
--- a/api/agent/comms/human_input_requests.py
+++ b/api/agent/comms/human_input_requests.py
@@ -38,6 +38,10 @@ BATCH_ANSWER_ENTRY_RE = re.compile(r"^\s*(?P<number>\d{1,2})[\)\.\:\-]\s*(?P<bod
 MAX_OPTION_COUNT = 6
 MAX_HUMAN_INPUT_QUESTION_LENGTH = 500
 DEFAULT_HUMAN_INPUT_REQUEST_EXPIRATION_DAYS = 3
+OPTIONS_REQUIRED_MESSAGE = (
+    "request_human_input requires at least one option. Use a send_* tool for free-text questions, "
+    "or include an Other / I'll explain option for open-ended answers."
+)
 HUMAN_INPUT_LLM_MAX_CANDIDATES = 20
 HUMAN_INPUT_LLM_MATCH_CONFIDENCE_THRESHOLD = 0.8
 
@@ -219,6 +223,15 @@ def build_option_payloads(raw_options: list[dict[str, Any]] | None) -> list[dict
             }
         )
     return options
+
+
+def _validate_human_input_options(raw_options: list[dict[str, Any]] | None) -> dict[str, Any] | None:
+    if not build_option_payloads(raw_options):
+        return {
+            "status": "error",
+            "message": OPTIONS_REQUIRED_MESSAGE,
+        }
+    return None
 
 
 def _latest_inbound_human_message(agent: PersistentAgent) -> PersistentAgentMessage | None:
@@ -550,6 +563,11 @@ def _create_human_input_request_for_target(
     if question_error:
         return None, question_error
     options = build_option_payloads(raw_options)
+    if not options:
+        return None, {
+            "status": "error",
+            "message": OPTIONS_REQUIRED_MESSAGE,
+        }
     input_mode = (
         PersistentAgentHumanInputRequest.InputMode.OPTIONS_PLUS_TEXT
         if options
@@ -605,6 +623,9 @@ def create_human_input_request(
     _, question_error = _validate_human_input_question(question)
     if question_error:
         return question_error
+    options_error = _validate_human_input_options(raw_options)
+    if options_error:
+        return options_error
 
     normalized_recipient, error = _normalize_human_input_recipient(recipient)
     if error:
@@ -650,6 +671,9 @@ def create_human_input_requests_batch(
         _, question_error = _validate_human_input_question(request.get("question"))
         if question_error:
             return question_error
+        options_error = _validate_human_input_options(request.get("options"))
+        if options_error:
+            return options_error
 
     normalized_recipient, error = _normalize_human_input_recipient(recipient)
     if error:

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -278,83 +278,8 @@ CONTINUATION_PHRASES = (
     "moving on to ",
 )
 
-BLOCKING_HUMAN_INPUT_PATTERNS = (
-    re.compile(r"\bbefore\s+(?:i|we)\b", re.IGNORECASE),
-    re.compile(r"\bi\s+need\s+to\s+know\b", re.IGNORECASE),
-    re.compile(r"\bi\s+need\b.*\b(?:first|before|from you)\b", re.IGNORECASE),
-    re.compile(r"\b(?:please|can you|could you)\s+(?:clarify|provide|share|confirm|choose|tell|send|point|direct|link)\b", re.IGNORECASE),
-    re.compile(r"\bwhich\b.*\bshould\s+(?:i|we)\b", re.IGNORECASE),
-    re.compile(r"\bwhat\b.*\bshould\s+(?:i|we)\b", re.IGNORECASE),
-    re.compile(r"\b(?:which|what)\b.*\bwould\s+you\s+like\s+(?:me|us)\b", re.IGNORECASE),
-)
-MARKDOWN_PUNCTUATION_RE = re.compile(r"[*_`>#\[\]]+")
-OPTIONAL_NON_BLOCKING_QUESTION_RE = re.compile(
-    r"\b(?:any tweaks|any changes|anything to adjust|otherwise\b|if not\b|unless you want)\b",
-    re.IGNORECASE,
-)
-
-
 class OrchestratorPromptStale(RuntimeError):
     """Raised when newer human input makes an in-flight orchestrator prompt stale."""
-
-
-def _looks_like_blocking_human_input_request(message_text: str) -> bool:
-    tableless_text = "\n".join(
-        line
-        for line in (message_text or "").splitlines()
-        if not line.lstrip().startswith("|")
-    )
-    if "?" not in tableless_text:
-        return False
-    if len(message_text or "") > 800 and (
-        "##" in message_text
-        or "###" in message_text
-        or "Sources" in message_text
-        or "|" in message_text
-    ):
-        return False
-
-    normalized = " ".join(tableless_text.split())
-    if OPTIONAL_NON_BLOCKING_QUESTION_RE.search(normalized):
-        return False
-    return bool("?" in normalized and any(pattern.search(normalized) for pattern in BLOCKING_HUMAN_INPUT_PATTERNS))
-
-
-def _extract_human_input_question(message_text: str) -> str:
-    for raw_line in (message_text or "").splitlines():
-        line = MARKDOWN_PUNCTUATION_RE.sub("", raw_line).strip(" -\t")
-        if "?" in line:
-            return _truncate_text_bytes(line, 500).strip()
-
-    fallback = MARKDOWN_PUNCTUATION_RE.sub("", message_text or "").strip()
-    return _truncate_text_bytes(fallback, 500).strip()
-
-
-def _request_human_input_params_from_blocking_chat_question(
-    agent: PersistentAgent,
-    message_text: str,
-    original_tool_params: Dict[str, Any],
-) -> Dict[str, Any]:
-    params = {
-        "question": _extract_human_input_question(message_text),
-        "will_continue_work": _coerce_optional_bool(original_tool_params.get("will_continue_work")) is True,
-    }
-    if agent.planning_state == PersistentAgent.PlanningState.PLANNING:
-        params["options"] = [
-            {
-                "label": "I'll provide details",
-                "description": "Share the missing planning detail before the agent continues.",
-            },
-            {
-                "label": "Use a default",
-                "description": "Let the agent choose a reasonable default and continue.",
-            },
-            {
-                "label": "Other",
-                "description": "Explain a different preference or constraint.",
-            },
-        ]
-    return params
 
 
 def _latest_inbound_message_text(agent: PersistentAgent) -> str:
@@ -2197,7 +2122,7 @@ def _message_tool_is_terminal(tool_name: str, tool_params: Dict[str, Any]) -> bo
     if tool_name not in MESSAGE_TOOL_NAMES:
         return False
     body = _message_tool_body_from_params(tool_name, tool_params)
-    if not body or _looks_like_blocking_human_input_request(body):
+    if not body:
         return False
     return not _message_tool_has_progress_intent(tool_name, tool_params)
 
@@ -2700,20 +2625,6 @@ def _prepare_tool_batch(
                     logger.debug("Failed to persist correction step", exc_info=True)
                 followup_required = True
                 break
-
-            if tool_name == "send_chat_message" and not batch_has_human_input_request:
-                message_body = str(tool_params.get("body") or "")
-                if _looks_like_blocking_human_input_request(message_body):
-                    tool_name = "request_human_input"
-                    tool_params = _request_human_input_params_from_blocking_chat_question(
-                        agent,
-                        message_body,
-                        tool_params,
-                    )
-                    logger.info(
-                        "Agent %s: routing blocking chat question to request_human_input.",
-                        agent.id,
-                    )
 
             if tool_name == "send_chat_message":
                 message_body = str(tool_params.get("body") or "")
@@ -3391,19 +3302,6 @@ def _build_implied_send_tool_call(
         return None, "Implied send failed: no deliverable web session."
     if channel != "web":
         return None, "Implied send failed: active web session required."
-
-    if _looks_like_blocking_human_input_request(message_text):
-        tool_params = {
-            "question": _extract_human_input_question(message_text),
-            "will_continue_work": will_continue_work,
-        }
-        return (
-            {
-                "id": "implied_human_input",
-                "function": {"name": "request_human_input", "arguments": json.dumps(tool_params)},
-            },
-            None,
-        )
 
     tool_params = {"to_address": to_address, "body": message_text}
     if will_continue_work:

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3398,10 +3398,10 @@ def _get_planning_mode_prompt_block() -> str:
         "- Treat named local time zones such as ET as sufficiently clear; handle DST and UTC conversion as "
         "implementation details instead of asking the user.\n"
         "- Do not ask planning questions about communication channels, delivery methods, integrations, accounts, or implementation approach unless the user explicitly asks to configure or choose them. Keep the conversation focused on the user's need, scope, and desired outcome. If goal/source/cadence/output are clear, call end_planning and use current conversation/contact setup.\n"
-        "- Use request_human_input for every planning question or blocker; never use send_chat_message/email/SMS as the question itself. Those messages are untracked and do not count.\n"
+        "- Human input rule: use request_human_input only for tracked option-based decisions; every request needs explicit options. Use send tools for free-text clarification and capability/status/policy answers.\n"
         "- Once request_human_input succeeds, questions are visible in web chat. Do not repeat them; an optional chat message may only frame why you asked or reference pending questions.\n"
         "- Each planning question must be its own request item. If asking multiple questions, prefer one request_human_input call with the `requests` parameter, where each item contains exactly one question; top-level `question` is fine for one.\n"
-        "- Prefer tangible, mutually exclusive options. DO NOT use request_human_input without any options; include an `Other / I'll explain` option for open-ended questions.\n"
+        "- Prefer tangible, mutually exclusive options; add `Other / I'll explain` when useful.\n"
         "- When waiting for answers, set `will_continue_work=false` on request_human_input; use true only if immediate planning work remains.\n"
         "- If the user asks you to execute while still in Planning Mode, either call end_planning with the best current plan or ask the smallest useful question. Do not start doing the task while planning mode is still active.\n"
         "- When the plan is ready, call end_planning(full_plan=...). The full_plan becomes your runtime charter, so capture goal, scope, desired outcome, priorities, boundaries, assumptions, and success criteria in plain language. Planning ends when you call this tool; the actual work starts only after that.\n"
@@ -3509,7 +3509,7 @@ def _get_system_instruction(
         delivery_context = (
             f"## Implied Send → {display_name}\n\n"
             "Your response text is a user message: use it only for questions, blockers, config changes, findings, or final deliverables. "
-            "Use request_human_input when the answer controls the next step. If the user explicitly asks you to ask for monitoring targets/scope before setup, use request_human_input before any setup/config mutation. "
+            "Use request_human_input only for tracked option-based decisions; use this chat for free-text questions and capability/status/policy answers. "
             "While working, respond with tool calls and no text; if an exact URL/result already succeeded, never search for it or refetch the same successful URL. "
             "Text-only messages auto-send and stop; add \"CONTINUE_WORK_SIGNAL\" alone to continue. "
             "To reach someone else, use explicit tools: "
@@ -3519,7 +3519,7 @@ def _get_system_instruction(
             "Write *to* them, not *about* them. Never say 'the user'—you're talking to them directly.\n\n"
         )
         response_structure = (
-            "Response structure: tools only while working; message for blockers/questions/findings/finals; request_human_input for blocking answers; empty response sleeps. "
+            "Response structure: tools only while working; message for blockers/questions/findings/finals; request_human_input only for option-based tracked decisions; empty response sleeps. "
             "Use CONTINUE_WORK_SIGNAL only after a message that must continue."
         )
         tool_calls_note = "Text + tools in one response is only for real user-facing content, never status narration. "
@@ -3528,7 +3528,7 @@ def _get_system_instruction(
         delivery_context = (
             "## Delivery & Response Behavior\n\n"
             "Text output is not delivered; communicate with send_email/send_sms/send_agent_message/send_chat_message. "
-            "Use request_human_input, not plain chat/email/SMS, when the next step depends on a human answer, including requested monitoring target/scope questions before setup. "
+            "Use request_human_input only for tracked option-based decisions; use send tools for free-text questions and capability/status/policy answers. "
             "If notifying by email/SMS too, include the same questions in that outbound body. "
             "send_chat_message broadcasts to active web chat users; if unavailable, use the most recent non-web channel from history/contacts. "
             "Focus on tool calls—text alone is not delivered.\n\n"

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -16,7 +16,6 @@ from api.agent.core.event_processing import (
     _contact_permission_params_from_misrouted_human_input,
     _process_agent_events_locked,
     _is_warning_status,
-    _looks_like_blocking_human_input_request,
     _normalize_tool_params,
     _parse_tool_call_params,
     _PreparedToolExecution,
@@ -403,14 +402,6 @@ class ToolParamParsingTests(SimpleTestCase):
         self.assertEqual(
             _sanitize_tool_name("mcp_brightdata_scrape_as_mcp_brightdata_scrape_as_markdown"),
             "mcp_brightdata_scrape_as_markdown",
-        )
-
-    def test_optional_tweak_question_is_not_blocking_human_input(self):
-        self.assertFalse(
-            _looks_like_blocking_human_input_request(
-                "I'll get the RSS feed parsed and the schedule wired up now. "
-                "Any tweaks before I lock this in? Otherwise I'm off and running!"
-            )
         )
 
     def test_misrouted_sms_approval_question_becomes_contact_permission(self):

--- a/api/agent/tools/request_human_input.py
+++ b/api/agent/tools/request_human_input.py
@@ -5,6 +5,7 @@ from typing import Any
 from api.agent.comms.human_input_requests import (
     MAX_HUMAN_INPUT_QUESTION_LENGTH,
     MAX_OPTION_COUNT,
+    OPTIONS_REQUIRED_MESSAGE,
     create_human_input_request,
     create_human_input_requests_batch,
 )
@@ -68,12 +69,11 @@ def get_request_human_input_tool() -> dict[str, Any]:
             "options": {
                 "type": "array",
                 "items": option_schema,
-                "description": (
-                    "Optional choices; omit or [] for free text. Required in Planning Mode; include an open-ended option."
-                ),
+                "minItems": 1,
+                "description": "Required choices; include an Other / I'll explain option for open-ended answers.",
             },
         },
-        "required": ["question"],
+        "required": ["question", "options"],
     }
 
     return {
@@ -81,9 +81,10 @@ def get_request_human_input_tool() -> dict[str, Any]:
         "function": {
             "name": "request_human_input",
             "description": (
-                "Create tracked human input for blockers/planning questions; it appears in web chat and does not send email/SMS. "
-                "Do not ask via chat/email/SMS instead; chat/email/SMS-only questions are not tracked. "
-                "In Planning Mode, planning questions must use this tool with options, at most three. "
+                "Create tracked, option-based human input; it appears in web chat and does not send email/SMS. "
+                "Every request needs at least one option; use send_chat_message/send_email/send_sms/send_agent_message for free-text questions or capability/status/policy answers. "
+                "Include an Other / I'll explain option when useful. "
+                "Planning questions should use at most three options. "
                 "Outside Planning Mode, do not use for preference surveys, timezone/channel choices, optional formatting, category example choices such as which vendor/company, non-blocking backfill/lookback, or reversible defaults you can choose and disclose. "
                 "Use it when the user explicitly asks you to ask for targets/scope before setup or missing targets/scope block a recurring monitor. "
                 f"Plain text only; max {MAX_HUMAN_INPUT_QUESTION_LENGTH} chars."
@@ -99,12 +100,13 @@ def get_request_human_input_tool() -> dict[str, Any]:
                     "options": {
                         "type": "array",
                         "items": option_schema,
-                        "description": "Optional choices; omit/[] for free text. Required in Planning Mode; include open-ended option.",
+                        "minItems": 1,
+                        "description": "Required choices; include an Other / I'll explain option for open-ended answers.",
                     },
                     "requests": {
                         "type": "array",
                         "items": request_schema,
-                        "description": "Multiple requests; omit top-level question/options. Planning Mode: at most three.",
+                        "description": "Multiple requests with options; omit top-level question/options. Planning Mode: at most three.",
                     },
                     "recipient": {
                         "description": "Optional explicit recipient; omit for the current implicit conversation target.",
@@ -158,6 +160,13 @@ def _normalize_request_options(raw_options: Any) -> tuple[list[dict[str, Any]] |
             }
         )
     return options, None
+
+
+def _missing_required_options_error() -> dict[str, Any]:
+    return {
+        "status": "error",
+        "message": OPTIONS_REQUIRED_MESSAGE,
+    }
 
 
 def _normalize_recipient(raw_recipient: Any) -> tuple[dict[str, str] | None, dict[str, Any] | None]:
@@ -222,20 +231,14 @@ def execute_request_human_input(agent: PersistentAgent, params: dict[str, Any]) 
             options, error = _normalize_request_options(raw_request.get("options"))
             if error:
                 return error
+            if not options:
+                return _missing_required_options_error()
             requests.append(
                 {
                     "question": question,
-                    "options": options or [],
+                    "options": options,
                 }
             )
-
-        if agent.planning_state == PersistentAgent.PlanningState.PLANNING and any(
-            not request["options"] for request in requests
-        ):
-            return {
-                "status": "error",
-                "message": "Planning Mode questions must include at least one option; include an Other / I'll explain option for open-ended questions.",
-            }
 
         omitted_request_count = 0
         if agent.planning_state == PersistentAgent.PlanningState.PLANNING and len(requests) > 3:
@@ -264,11 +267,8 @@ def execute_request_human_input(agent: PersistentAgent, params: dict[str, Any]) 
     if error:
         return error
 
-    if agent.planning_state == PersistentAgent.PlanningState.PLANNING and not options:
-        return {
-            "status": "error",
-            "message": "Planning Mode questions must include at least one option; include an Other / I'll explain option for open-ended questions.",
-        }
+    if not options:
+        return _missing_required_options_error()
     if agent.planning_state != PersistentAgent.PlanningState.PLANNING and options and len(options) > 3:
         return {
             "status": "error",

--- a/api/agent/tools/request_human_input.py
+++ b/api/agent/tools/request_human_input.py
@@ -120,6 +120,10 @@ def get_request_human_input_tool() -> dict[str, Any]:
                     },
                 },
                 "required": ["will_continue_work"],
+                "anyOf": [
+                    {"required": ["question", "options"]},
+                    {"required": ["requests"]},
+                ],
             },
         },
     }

--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -227,8 +227,7 @@ def get_send_chat_tool() -> Dict[str, Any]:
         "function": {
             "name": "send_chat_message",
             "description": (
-                "Send a user-facing web chat message for context, config changes, findings, or finals. "
-                "Use request_human_input instead when the agent has been blocked repeatedly or for a while and needs a tracked answer. "
+                "Send a user-facing web chat message for free-text questions, context, config changes, capability/status/policy answers, findings, or finals. "
                 "Do not narrate what you will do next or send progress-only notes about tool sequencing, plan mechanics, or internal reasoning."
             ),
             "parameters": {

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 import json
 
-from api.agent.comms.human_input_requests import dismiss_human_input_request
+from api.agent.comms.human_input_requests import MAX_OPTION_COUNT, dismiss_human_input_request
 from api.agent.core.processing_flags import get_human_inbound_generation
 from api.agent.tools.eval_synthetic_tools import (
     EVAL_SYNTHETIC_TOOL_DEFINITIONS,
@@ -532,8 +532,21 @@ def get_pending_human_input_requests(agent_id, run_id, *, after=None):
     return list(queryset.order_by("created_at", "id"))
 
 
+def _valid_human_input_options(raw_options):
+    if not isinstance(raw_options, list) or not 1 <= len(raw_options) <= MAX_OPTION_COUNT:
+        return False
+    for raw_option in raw_options:
+        if not isinstance(raw_option, dict):
+            return False
+        title = str(raw_option.get("title") or "").strip()
+        description = str(raw_option.get("description") or "").strip()
+        if not title or not description:
+            return False
+    return True
+
+
 def all_requests_have_options(requests):
-    return all(isinstance(request.options_json, list) and len(request.options_json) > 0 for request in requests)
+    return all(_valid_human_input_options(request.options_json) for request in requests)
 
 
 class BehaviorMicroScenario(EvalScenario, ScenarioExecutionTools):
@@ -2672,7 +2685,7 @@ class CommonUseCaseToolChoiceScenario(BehaviorMicroScenario):
     def _request_human_input_call_has_options(call):
         params = call.tool_params or {}
         options = params.get("options")
-        if isinstance(options, list) and options:
+        if _valid_human_input_options(options):
             return True
         for raw_requests_key in ("requests", "questions"):
             raw_requests = params.get(raw_requests_key)
@@ -2680,8 +2693,7 @@ class CommonUseCaseToolChoiceScenario(BehaviorMicroScenario):
                 continue
             return all(
                 isinstance(request, dict)
-                and isinstance(request.get("options"), list)
-                and len(request.get("options")) > 0
+                and _valid_human_input_options(request.get("options"))
                 for request in raw_requests
             )
         return False

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -326,6 +326,7 @@ COMMON_USE_CASE_RAW_EVAL_CASES = [
     {"slug": "common_use_case_135_search_scrape_two_sources", "category": "web_research", "prompt": "Search current warehouse robotics funding, scrape two strong sources, and cite both without extra query variants.", "expected_tools": ["mcp_brightdata_search_engine", "mcp_brightdata_scrape_as_markdown"], "forbidden_tools": ["spawn_web_task"], "plan_expected": False},
     {"slug": "common_use_case_136_apollo_connect_tool_search", "category": "integration_discovery", "prompt": "Connect my Apollo.io account so you can use it for lead sourcing.", "expected_tools": ["search_tools"], "forbidden_tools": ["request_human_input", "secure_credentials_request", "spawn_web_task"], "plan_expected": False},
     {"slug": "common_use_case_137_slack_connect_tool_search", "category": "integration_discovery", "prompt": "Connect Slack so you can read and summarize customer feedback from our support channel.", "expected_tools": ["search_tools"], "forbidden_tools": ["request_human_input", "secure_credentials_request", "spawn_web_task"], "plan_expected": False},
+    {"slug": "common_use_case_138_intercom_notes_capability_answer", "category": "tool_choice", "prompt": "Are you able to add internal notes to Intercom threads, different from replies?", "expected_tools": ["send_chat_message"], "forbidden_tools": ["request_human_input"], "plan_expected": False},
 ]
 
 COMMON_USE_CASE_EVAL_CASES = tuple(
@@ -2095,13 +2096,13 @@ class ToolChoiceMissingRecipientUsesHumanInputScenario(BehaviorMicroScenario):
 
         self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="verify_human_input")
         requests = get_pending_human_input_requests(agent_id, run_id, after=inbound.timestamp)
-        if requests:
+        if requests and all_requests_have_options(requests):
             self.record_task_result(
                 run_id,
                 None,
                 EvalRunTask.Status.PASSED,
                 task_name="verify_human_input",
-                observed_summary=f"Agent requested missing recipient/details via {len(requests)} human input request(s).",
+                observed_summary=f"Agent requested missing recipient/details via {len(requests)} option-based human input request(s).",
             )
         else:
             self.record_task_result(
@@ -2109,7 +2110,10 @@ class ToolChoiceMissingRecipientUsesHumanInputScenario(BehaviorMicroScenario):
                 None,
                 EvalRunTask.Status.FAILED,
                 task_name="verify_human_input",
-                observed_summary="Agent did not create a tracked human input request for missing email details.",
+                observed_summary=(
+                    f"Agent did not create an option-based tracked human input request for missing email details; "
+                    f"found {len(requests)} with options={all_requests_have_options(requests)}."
+                ),
             )
 
         self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="verify_no_send_email")
@@ -2651,6 +2655,8 @@ class CommonUseCaseToolChoiceScenario(BehaviorMicroScenario):
     def _call_satisfies_expected_tool(self, call, expected_tool_name):
         if call.tool_name not in self.case.accepted_tool_names_for_expected_tool(expected_tool_name):
             return False
+        if expected_tool_name == "request_human_input" and not self._request_human_input_call_has_options(call):
+            return False
         if (
             self.case.expected_params
             and len(self.case.expected_tools) == 1
@@ -2661,6 +2667,24 @@ class CommonUseCaseToolChoiceScenario(BehaviorMicroScenario):
         if config_field and call.tool_name == "sqlite_batch":
             return sqlite_batch_mutates_agent_config_field(call, config_field)
         return True
+
+    @staticmethod
+    def _request_human_input_call_has_options(call):
+        params = call.tool_params or {}
+        options = params.get("options")
+        if isinstance(options, list) and options:
+            return True
+        for raw_requests_key in ("requests", "questions"):
+            raw_requests = params.get(raw_requests_key)
+            if not isinstance(raw_requests, list) or not raw_requests:
+                continue
+            return all(
+                isinstance(request, dict)
+                and isinstance(request.get("options"), list)
+                and len(request.get("options")) > 0
+                for request in raw_requests
+            )
+        return False
 
 
 def _common_use_case_scenario_class(case):

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -7,7 +7,6 @@ from django.test import SimpleTestCase, TestCase, tag
 
 import api.evals.loader  # noqa: F401 - registers scenarios and suites
 from api.agent.core.event_processing import _get_completed_process_run_count
-from api.agent.core.event_processing import _looks_like_blocking_human_input_request
 from api.agent.core.prompt_context import _get_system_instruction, build_prompt_context_preview
 from api.agent.core.tool_results import _wrap_as_sqlite_result
 from api.agent.tools.create_chart import get_create_chart_tool
@@ -333,21 +332,6 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
                 "(https://www.ycombinator.com/companies?batch=Winter%202026)"
             ),
             0,
-        )
-
-    def test_blocking_question_detector_ignores_report_table_questions(self):
-        self.assertFalse(
-            _looks_like_blocking_human_input_request(
-                (
-                    "## Investment Memo\n\n"
-                    "| Criterion | Northstar | Competitor |\n"
-                    "| --- | --- | --- |\n"
-                    "| Vendor agnostic? | Yes | No |\n\n"
-                    "### Sources\n\n"
-                    "- https://northstar.example.test/blog/atlas-launch\n"
-                )
-                * 4
-            )
         )
 
     def test_chart_tool_description_requires_request_or_material_need(self):

--- a/tests/unit/test_agent_planning_mode.py
+++ b/tests/unit/test_agent_planning_mode.py
@@ -156,8 +156,8 @@ class PersistentAgentPlanningModeTests(TestCase):
         tool = get_request_human_input_tool()
         function = tool["function"]
 
-        self.assertIn("In Planning Mode, planning questions must use this tool", function["description"])
-        self.assertIn("chat/email/SMS-only questions are not tracked", function["description"])
+        self.assertIn("Every request needs at least one option", function["description"])
+        self.assertIn("send_chat_message/send_email/send_sms/send_agent_message for free-text questions", function["description"])
 
     def test_end_planning_replaces_charter_and_removes_planning_tool(self):
         self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
@@ -218,9 +218,8 @@ class PersistentAgentPlanningModeTests(TestCase):
         self.assertIn("`requests` parameter", prompt)
         self.assertIn("each item contains exactly one question", prompt)
         self.assertIn("`will_continue_work=false` on request_human_input", prompt)
-        self.assertIn("Use request_human_input for every planning question or blocker", prompt)
-        self.assertIn("never use send_chat_message/email/SMS as the question itself", prompt)
-        self.assertIn("untracked and do not count", prompt)
+        self.assertIn("Human input rule: use request_human_input only for tracked option-based decisions", prompt)
+        self.assertIn("Use send tools for free-text clarification and capability/status/policy answers", prompt)
         self.assertIn("questions are visible in web chat", prompt)
         self.assertIn("reference pending questions", prompt)
         self.assertIn(
@@ -286,7 +285,7 @@ class PersistentAgentPlanningModeTests(TestCase):
         self.assertIn("Keep planning non-technical and focused on what the user wants", prompt)
         self.assertIn("Use read-only research during planning only when the scope is unclear", prompt)
         self.assertIn("Named integration setup/use: if no enabled tool fits, call search_tools before asking how to connect", prompt)
-        self.assertIn("Use request_human_input for every planning question or blocker", prompt)
+        self.assertIn("Human input rule: use request_human_input only for tracked option-based decisions", prompt)
         self.assertIn("call end_planning first and only begin the work after planning has ended", prompt)
         self.assertEqual(prompt.count("Resume the pending planning turn."), 1)
         self.assertNotIn("REQUIRED: First-Run Welcome", prompt)

--- a/tests/unit/test_eval_behavior_micro_scenarios.py
+++ b/tests/unit/test_eval_behavior_micro_scenarios.py
@@ -109,9 +109,9 @@ class BehaviorMicroScenarioRegistrationTests(TestCase):
     def test_common_use_case_micro_evals_are_complete_and_registered(self):
         registered = ScenarioRegistry.list_all()
 
-        self.assertEqual(len(COMMON_USE_CASE_EVAL_CASES), 134)
-        self.assertEqual(len(COMMON_USE_CASE_MICRO_SCENARIO_SLUGS), 134)
-        self.assertEqual(len(set(COMMON_USE_CASE_MICRO_SCENARIO_SLUGS)), 134)
+        self.assertEqual(len(COMMON_USE_CASE_EVAL_CASES), 135)
+        self.assertEqual(len(COMMON_USE_CASE_MICRO_SCENARIO_SLUGS), 135)
+        self.assertEqual(len(set(COMMON_USE_CASE_MICRO_SCENARIO_SLUGS)), 135)
         self.assertTrue(set(COMMON_USE_CASE_MICRO_SCENARIO_SLUGS).issubset(TOOL_CHOICE_MICRO_SCENARIO_SLUGS))
         self.assertTrue(set(COMMON_USE_CASE_MICRO_SCENARIO_SLUGS).issubset(BEHAVIOR_MICRO_SCENARIO_SLUGS))
 
@@ -1528,8 +1528,47 @@ class BehaviorMicroHelperTests(TestCase):
         mock_delay.assert_not_called()
 
     def test_all_requests_have_options_requires_nonempty_options(self):
-        with_options = SimpleNamespace(options_json=[{"key": "yes", "title": "Yes"}])
+        with_options = SimpleNamespace(
+            options_json=[{"key": "yes", "title": "Yes", "description": "Proceed with yes."}]
+        )
         without_options = SimpleNamespace(options_json=[])
+        missing_description = SimpleNamespace(options_json=[{"key": "yes", "title": "Yes"}])
+        blank_title = SimpleNamespace(options_json=[{"key": "yes", "title": " ", "description": "Proceed."}])
 
         self.assertTrue(all_requests_have_options([with_options]))
         self.assertFalse(all_requests_have_options([with_options, without_options]))
+        self.assertFalse(all_requests_have_options([missing_description]))
+        self.assertFalse(all_requests_have_options([blank_title]))
+
+    def test_request_human_input_eval_tool_check_requires_valid_options(self):
+        valid_single = SimpleNamespace(
+            tool_params={"options": [{"title": "Yes", "description": "Proceed with yes."}]}
+        )
+        invalid_single = SimpleNamespace(
+            tool_params={"options": [{"title": "Yes"}]}
+        )
+        valid_batch = SimpleNamespace(
+            tool_params={
+                "requests": [
+                    {
+                        "question": "Proceed?",
+                        "options": [{"title": "Yes", "description": "Proceed with yes."}],
+                    }
+                ]
+            }
+        )
+        invalid_batch = SimpleNamespace(
+            tool_params={
+                "requests": [
+                    {
+                        "question": "Proceed?",
+                        "options": [{"title": "", "description": "Proceed with yes."}],
+                    }
+                ]
+            }
+        )
+
+        self.assertTrue(CommonUseCaseToolChoiceScenario._request_human_input_call_has_options(valid_single))
+        self.assertFalse(CommonUseCaseToolChoiceScenario._request_human_input_call_has_options(invalid_single))
+        self.assertTrue(CommonUseCaseToolChoiceScenario._request_human_input_call_has_options(valid_batch))
+        self.assertFalse(CommonUseCaseToolChoiceScenario._request_human_input_call_has_options(invalid_batch))

--- a/tests/unit/test_event_processing_human_input.py
+++ b/tests/unit/test_event_processing_human_input.py
@@ -90,11 +90,23 @@ class EventProcessingHumanInputTests(TestCase):
             "target_channel": "web",
             "target_address": "web://user/1/agent/1",
             "web_chat_visible": True,
-            "requests": [{"request_id": request_id, "question": "What should I do next?", "options": []}],
+            "requests": [
+                {
+                    "request_id": request_id,
+                    "question": "What should I do next?",
+                    "options": [{"title": "Proceed", "description": "Continue with this option."}],
+                }
+            ],
             "auto_sleep_ok": True,
         }
         mock_completion.return_value = (
-            self._tool_completion("request_human_input", '{"question": "What should I do next?"}'),
+            self._tool_completion(
+                "request_human_input",
+                (
+                    '{"question": "What should I do next?", '
+                    '"options": [{"title": "Proceed", "description": "Continue with this option."}]}'
+                ),
+            ),
             {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "model": "m", "provider": "p"},
         )
 
@@ -135,12 +147,22 @@ class EventProcessingHumanInputTests(TestCase):
             "target_channel": "web",
             "target_address": "web://user/1/agent/1",
             "web_chat_visible": True,
-            "requests": [{"request_id": request_id, "question": "What should I do next?", "options": []}],
+            "requests": [
+                {
+                    "request_id": request_id,
+                    "question": "What should I do next?",
+                    "options": [{"title": "Proceed", "description": "Continue with this option."}],
+                }
+            ],
             "auto_sleep_ok": True,
         }
         first_response = self._tool_completion(
             "request_human_input",
-            '{"question": "What should I do next?", "will_continue_work": true}',
+            (
+                '{"question": "What should I do next?", '
+                '"options": [{"title": "Proceed", "description": "Continue with this option."}], '
+                '"will_continue_work": true}'
+            ),
         )
         second_response = self._tool_completion(
             "send_chat_message",
@@ -189,7 +211,13 @@ class EventProcessingHumanInputTests(TestCase):
             "target_channel": "email",
             "target_address": "person@example.com",
             "web_chat_visible": True,
-            "requests": [{"request_id": request_id, "question": "What should I do next?", "options": []}],
+            "requests": [
+                {
+                    "request_id": request_id,
+                    "question": "What should I do next?",
+                    "options": [{"title": "Proceed", "description": "Continue with this option."}],
+                }
+            ],
             "next_message_suggestion": {
                 "channel": "email",
                 "address": "person@example.com",
@@ -202,7 +230,11 @@ class EventProcessingHumanInputTests(TestCase):
 
         first_response = self._tool_completion(
             "request_human_input",
-            '{"question": "What should I do next?", "will_continue_work": false}',
+            (
+                '{"question": "What should I do next?", '
+                '"options": [{"title": "Proceed", "description": "Continue with this option."}], '
+                '"will_continue_work": false}'
+            ),
         )
         mock_completion.return_value = (
             first_response,
@@ -215,7 +247,11 @@ class EventProcessingHumanInputTests(TestCase):
         self.assertEqual(mock_completion.call_count, 1)
         mock_request_human_input.assert_called_once_with(
             self.agent,
-            {"question": "What should I do next?", "will_continue_work": False},
+            {
+                "question": "What should I do next?",
+                "options": [{"title": "Proceed", "description": "Continue with this option."}],
+                "will_continue_work": False,
+            },
         )
         mock_send_email.assert_not_called()
         self.assertEqual(
@@ -250,7 +286,13 @@ class EventProcessingHumanInputTests(TestCase):
             "target_channel": "email",
             "target_address": "person@example.com",
             "web_chat_visible": True,
-            "requests": [{"request_id": request_id, "question": "What should I do next?", "options": []}],
+            "requests": [
+                {
+                    "request_id": request_id,
+                    "question": "What should I do next?",
+                    "options": [{"title": "Proceed", "description": "Continue with this option."}],
+                }
+            ],
             "next_message_suggestion": {
                 "channel": "email",
                 "address": "person@example.com",
@@ -262,7 +304,11 @@ class EventProcessingHumanInputTests(TestCase):
         }
         first_response = self._tool_completion(
             "request_human_input",
-            '{"question": "What should I do next?", "will_continue_work": true}',
+            (
+                '{"question": "What should I do next?", '
+                '"options": [{"title": "Proceed", "description": "Continue with this option."}], '
+                '"will_continue_work": true}'
+            ),
         )
         second_response = self._tool_completion(
             "send_email",
@@ -279,7 +325,11 @@ class EventProcessingHumanInputTests(TestCase):
         self.assertEqual(mock_completion.call_count, 2)
         mock_request_human_input.assert_called_once_with(
             self.agent,
-            {"question": "What should I do next?", "will_continue_work": True},
+            {
+                "question": "What should I do next?",
+                "options": [{"title": "Proceed", "description": "Continue with this option."}],
+                "will_continue_work": True,
+            },
         )
         mock_send_email.assert_called_once()
         self.assertEqual(

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -462,7 +462,7 @@ class ImpliedSendTests(TestCase):
             0,
         )
 
-    def test_planning_blocking_chat_question_routes_to_tracked_human_input(self):
+    def test_planning_chat_question_stays_chat_without_auto_conversion(self):
         self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
         self.agent.save(update_fields=["planning_state", "updated_at"])
 
@@ -499,11 +499,11 @@ class ImpliedSendTests(TestCase):
 
         self.assertEqual(len(prepared.prepared_calls), 1)
         routed = prepared.prepared_calls[0]
-        self.assertEqual(routed.tool_name, "request_human_input")
-        self.assertIn("target company", routed.tool_params["question"])
-        self.assertEqual(len(routed.tool_params["options"]), 3)
+        self.assertEqual(routed.tool_name, "send_chat_message")
+        self.assertIn("target company", routed.tool_params["body"])
+        self.assertFalse(routed.tool_params["will_continue_work"])
 
-    def test_clarify_chat_question_routes_to_tracked_human_input(self):
+    def test_clarify_chat_question_stays_chat_outside_planning(self):
         prepared = ep._prepare_tool_batch(
             self.agent,
             tool_calls=[
@@ -539,8 +539,8 @@ class ImpliedSendTests(TestCase):
 
         self.assertEqual(len(prepared.prepared_calls), 1)
         routed = prepared.prepared_calls[0]
-        self.assertEqual(routed.tool_name, "request_human_input")
-        self.assertIn("project", routed.tool_params["question"])
+        self.assertEqual(routed.tool_name, "send_chat_message")
+        self.assertIn("project", routed.tool_params["body"])
         self.assertFalse(routed.tool_params["will_continue_work"])
 
     def test_defaultable_schedule_setup_question_gets_runtime_correction(self):
@@ -1621,7 +1621,7 @@ class ImpliedSendTests(TestCase):
     @patch("api.agent.core.event_processing.execute_send_chat_message", return_value={"status": "ok", "auto_sleep_ok": True})
     @patch("api.agent.core.event_processing.build_prompt_context")
     @patch("api.agent.core.event_processing._completion_with_failover")
-    def test_implied_send_routes_blocking_question_to_human_input(
+    def test_implied_send_keeps_free_text_question_as_chat_outside_planning(
         self,
         mock_completion,
         mock_build_prompt,
@@ -1652,23 +1652,18 @@ class ImpliedSendTests(TestCase):
         with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
             ep._run_agent_loop(self.agent, is_first_run=False)
 
-        self.assertFalse(mock_send_chat.called)
-        mock_request_human_input.assert_called_once()
-        params = mock_request_human_input.call_args[0][1]
-        self.assertEqual(
-            params,
-            {
-                "question": "Before I start researching, which target account segment should I research?",
-                "will_continue_work": False,
-            },
-        )
+        mock_send_chat.assert_called_once()
+        mock_request_human_input.assert_not_called()
+        params = mock_send_chat.call_args[0][1]
+        self.assertIn("which target account segment", params["body"])
+        self.assertIsNone(params.get("will_continue_work"))
 
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_request_human_input", return_value={"status": "ok", "auto_sleep_ok": True})
     @patch("api.agent.core.event_processing.execute_send_chat_message", return_value={"status": "ok", "auto_sleep_ok": True})
     @patch("api.agent.core.event_processing.build_prompt_context")
     @patch("api.agent.core.event_processing._completion_with_failover")
-    def test_implied_send_routes_would_you_like_question_to_human_input(
+    def test_implied_send_keeps_would_you_like_question_as_chat_outside_planning(
         self,
         mock_completion,
         mock_build_prompt,
@@ -1700,23 +1695,18 @@ class ImpliedSendTests(TestCase):
         with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
             ep._run_agent_loop(self.agent, is_first_run=False)
 
-        self.assertFalse(mock_send_chat.called)
-        mock_request_human_input.assert_called_once()
-        params = mock_request_human_input.call_args[0][1]
-        self.assertEqual(
-            params,
-            {
-                "question": "Which target account segment would you like me to research?",
-                "will_continue_work": False,
-            },
-        )
+        mock_send_chat.assert_called_once()
+        mock_request_human_input.assert_not_called()
+        params = mock_send_chat.call_args[0][1]
+        self.assertIn("Which target account segment", params["body"])
+        self.assertIsNone(params.get("will_continue_work"))
 
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_request_human_input", return_value={"status": "ok", "auto_sleep_ok": True})
     @patch("api.agent.core.event_processing.execute_send_chat_message", return_value={"status": "ok", "auto_sleep_ok": True})
     @patch("api.agent.core.event_processing.build_prompt_context")
     @patch("api.agent.core.event_processing._completion_with_failover")
-    def test_explicit_chat_blocking_question_routes_to_human_input(
+    def test_explicit_chat_keeps_free_text_question_as_chat_outside_planning(
         self,
         mock_completion,
         mock_build_prompt,
@@ -1761,23 +1751,18 @@ class ImpliedSendTests(TestCase):
         with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
             ep._run_agent_loop(self.agent, is_first_run=False)
 
-        self.assertFalse(mock_send_chat.called)
-        mock_request_human_input.assert_called_once()
-        params = mock_request_human_input.call_args[0][1]
-        self.assertEqual(
-            params,
-            {
-                "question": "Before I start monitoring, which competitors should I track?",
-                "will_continue_work": False,
-            },
-        )
+        mock_send_chat.assert_called_once()
+        mock_request_human_input.assert_not_called()
+        params = mock_send_chat.call_args[0][1]
+        self.assertEqual(params["body"], "Before I start monitoring, which competitors should I track?")
+        self.assertIsNone(params.get("will_continue_work"))
 
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_request_human_input", return_value={"status": "ok", "auto_sleep_ok": True})
     @patch("api.agent.core.event_processing.execute_send_chat_message", return_value={"status": "ok", "auto_sleep_ok": True})
     @patch("api.agent.core.event_processing.build_prompt_context")
     @patch("api.agent.core.event_processing._completion_with_failover")
-    def test_explicit_chat_source_request_routes_to_human_input(
+    def test_explicit_chat_source_request_stays_chat_outside_planning(
         self,
         mock_completion,
         mock_build_prompt,
@@ -1826,19 +1811,11 @@ class ImpliedSendTests(TestCase):
         with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
             ep._run_agent_loop(self.agent, is_first_run=False)
 
-        self.assertFalse(mock_send_chat.called)
-        mock_request_human_input.assert_called_once()
-        params = mock_request_human_input.call_args[0][1]
-        self.assertEqual(
-            params,
-            {
-                "question": (
-                    "I don't have any project status data available yet. Could you point me to where I "
-                    "can find the latest project status? For example:"
-                ),
-                "will_continue_work": False,
-            },
-        )
+        mock_send_chat.assert_called_once()
+        mock_request_human_input.assert_not_called()
+        params = mock_send_chat.call_args[0][1]
+        self.assertIn("project status data", params["body"])
+        self.assertIsNone(params.get("will_continue_work"))
 
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_send_chat_message", return_value={"status": "ok", "auto_sleep_ok": True})
@@ -2540,10 +2517,10 @@ class DailyLimitMessageOnlyModeTests(TestCase):
         ):
             ep._run_agent_loop(self.agent, is_first_run=False)
 
-        self.assertFalse(mock_send_chat.called)
-        mock_request_human_input.assert_called_once()
-        params = mock_request_human_input.call_args[0][1]
-        self.assertIs(params.get("will_continue_work"), False)
+        mock_send_chat.assert_called_once()
+        mock_request_human_input.assert_not_called()
+        params = mock_send_chat.call_args[0][1]
+        self.assertIsNone(params.get("will_continue_work"))
 
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_send_email", return_value={"status": "ok", "auto_sleep_ok": True})

--- a/tests/unit/test_human_input_requests.py
+++ b/tests/unit/test_human_input_requests.py
@@ -322,6 +322,13 @@ class HumanInputRequestTests(TestCase):
         )
         self.assertEqual(function["parameters"]["required"], ["will_continue_work"])
         self.assertEqual(
+            function["parameters"]["anyOf"],
+            [
+                {"required": ["question", "options"]},
+                {"required": ["requests"]},
+            ],
+        )
+        self.assertEqual(
             function["parameters"]["properties"]["requests"]["items"]["required"],
             ["question", "options"],
         )

--- a/tests/unit/test_human_input_requests.py
+++ b/tests/unit/test_human_input_requests.py
@@ -294,14 +294,15 @@ class HumanInputRequestTests(TestCase):
             raw_payload=raw_payload or {"source": "test"},
         )
 
-    def test_tool_definition_allows_optional_options(self):
+    def test_tool_definition_requires_options(self):
         tool = get_request_human_input_tool()
         function = tool["function"]
         description = function["description"]
         self.assertEqual(function["name"], "request_human_input")
         self.assertIn("appears in web chat", description)
         self.assertIn("does not send email/SMS", description)
-        self.assertIn("Do not ask via chat/email/SMS instead", description)
+        self.assertIn("Every request needs at least one option", description)
+        self.assertIn("for free-text questions or capability/status/policy answers", description)
         self.assertIn("Plain text only", description)
         self.assertIn("at most three", description)
         self.assertIn("non-blocking backfill", description)
@@ -314,6 +315,7 @@ class HumanInputRequestTests(TestCase):
         self.assertIn("will_continue_work", function["parameters"]["properties"])
         self.assertEqual(function["parameters"]["properties"]["question"]["maxLength"], 500)
         self.assertIn("Plain text only", function["parameters"]["properties"]["question"]["description"])
+        self.assertEqual(function["parameters"]["properties"]["options"]["minItems"], 1)
         self.assertIn(
             "use true when you will send an email/SMS containing these questions",
             function["parameters"]["properties"]["will_continue_work"]["description"],
@@ -321,7 +323,11 @@ class HumanInputRequestTests(TestCase):
         self.assertEqual(function["parameters"]["required"], ["will_continue_work"])
         self.assertEqual(
             function["parameters"]["properties"]["requests"]["items"]["required"],
-            ["question"],
+            ["question", "options"],
+        )
+        self.assertEqual(
+            function["parameters"]["properties"]["requests"]["items"]["properties"]["options"]["minItems"],
+            1,
         )
         self.assertEqual(
             function["parameters"]["properties"]["requests"]["items"]["properties"]["question"]["maxLength"],
@@ -332,8 +338,20 @@ class HumanInputRequestTests(TestCase):
             function["parameters"]["properties"]["requests"]["description"],
         )
 
-    def test_execute_request_human_input_creates_free_text_request(self):
-        before = timezone.now()
+    def test_execute_request_human_input_rejects_missing_options(self):
+        result = execute_request_human_input(
+            self.agent,
+            {
+                "question": "What should I tell the team?",
+            },
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("requires at least one option", result["message"])
+        self.assertIn("send_* tool", result["message"])
+        self.assertFalse(PersistentAgentHumanInputRequest.objects.filter(agent=self.agent).exists())
+
+    def test_execute_request_human_input_rejects_empty_options(self):
         result = execute_request_human_input(
             self.agent,
             {
@@ -341,38 +359,17 @@ class HumanInputRequestTests(TestCase):
                 "options": [],
             },
         )
-        after = timezone.now()
 
-        self.assertEqual(result["status"], "ok")
-        self.assertNotIn("reference_code", result)
-        self.assertEqual(result["request_ids"], [result["request_id"]])
-        self.assertEqual(result["requests_count"], 1)
-        self.assertEqual(result["target_channel"], CommsChannel.WEB)
-        self.assertEqual(result["target_address"], self.user_address)
-        self.assertTrue(result["web_chat_visible"])
-        self.assertTrue(result["auto_sleep_ok"])
-        self.assertNotIn("relay_mode", result)
-        self.assertNotIn("relay_payload", result)
-        self.assertNotIn("next_message_suggestion", result)
-        self.assertEqual(result["requests"][0]["question"], "What should I tell the team?")
-        request_obj = PersistentAgentHumanInputRequest.objects.get(id=result["request_id"])
-        self.assertEqual(
-            request_obj.input_mode,
-            PersistentAgentHumanInputRequest.InputMode.FREE_TEXT_ONLY,
-        )
-        self.assertEqual(request_obj.conversation_id, self.conversation.id)
-        self.assertEqual(request_obj.recipient_channel, "")
-        self.assertEqual(request_obj.recipient_address, "")
-        self.assertIsNone(request_obj.requested_message_id)
-        self.assertGreaterEqual(request_obj.expires_at, before + timedelta(days=3))
-        self.assertLessEqual(request_obj.expires_at, after + timedelta(days=3))
+        self.assertEqual(result["status"], "error")
+        self.assertIn("requires at least one option", result["message"])
+        self.assertFalse(PersistentAgentHumanInputRequest.objects.filter(agent=self.agent).exists())
 
     def test_execute_request_human_input_will_continue_true_keeps_panel_request_active(self):
         result = execute_request_human_input(
             self.agent,
             {
                 "question": "What should I tell the team?",
-                "options": [],
+                "options": [{"title": "Proceed", "description": "Continue with this direction."}],
                 "will_continue_work": True,
             },
         )
@@ -396,13 +393,10 @@ class HumanInputRequestTests(TestCase):
         )
 
         self.assertEqual(result["status"], "error")
-        self.assertIn("Planning Mode questions must include at least one option", result["message"])
+        self.assertIn("requires at least one option", result["message"])
         self.assertFalse(PersistentAgentHumanInputRequest.objects.filter(agent=self.agent).exists())
 
-    def test_execute_request_human_input_requires_batch_options_in_planning_mode(self):
-        self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
-        self.agent.save(update_fields=["planning_state", "updated_at"])
-
+    def test_execute_request_human_input_rejects_batch_missing_options(self):
         result = execute_request_human_input(
             self.agent,
             {
@@ -420,7 +414,7 @@ class HumanInputRequestTests(TestCase):
         )
 
         self.assertEqual(result["status"], "error")
-        self.assertIn("Planning Mode questions must include at least one option", result["message"])
+        self.assertIn("requires at least one option", result["message"])
         self.assertFalse(PersistentAgentHumanInputRequest.objects.filter(agent=self.agent).exists())
 
     def test_execute_request_human_input_limits_planning_batch_to_three_questions(self):
@@ -492,7 +486,7 @@ class HumanInputRequestTests(TestCase):
             self.agent,
             {
                 "question": "x" * 500,
-                "options": [],
+                "options": [{"title": "Proceed", "description": "Continue with this answer."}],
             },
         )
 
@@ -504,7 +498,7 @@ class HumanInputRequestTests(TestCase):
             self.agent,
             {
                 "question": "x" * 501,
-                "options": [],
+                "options": [{"title": "Proceed", "description": "Continue with this answer."}],
             },
         )
 
@@ -524,7 +518,7 @@ class HumanInputRequestTests(TestCase):
                     },
                     {
                         "question": "What should happen second?",
-                        "options": [],
+                        "options": [{"title": "Wait", "description": "Pause until this is ready."}],
                     },
                 ],
             },
@@ -563,8 +557,14 @@ class HumanInputRequestTests(TestCase):
             self.agent,
             {
                 "requests": [
-                    {"question": "What should happen first?"},
-                    {"question": "x" * 501},
+                    {
+                        "question": "What should happen first?",
+                        "options": [{"title": "Ship", "description": "Move now."}],
+                    },
+                    {
+                        "question": "x" * 501,
+                        "options": [{"title": "Wait", "description": "Pause until this is ready."}],
+                    },
                 ],
             },
         )
@@ -625,8 +625,14 @@ class HumanInputRequestTests(TestCase):
                 self.agent,
                 {
                     "requests": [
-                        {"question": "What should happen first?"},
-                        {"question": "What should happen second?"},
+                        {
+                            "question": "What should happen first?",
+                            "options": [{"title": "First option", "description": "Do this first."}],
+                        },
+                        {
+                            "question": "What should happen second?",
+                            "options": [{"title": "Second option", "description": "Do this second."}],
+                        },
                     ],
                 },
             )
@@ -714,6 +720,7 @@ class HumanInputRequestTests(TestCase):
             self.agent,
             {
                 "question": "Who should review this?",
+                "options": [{"title": "Use this recipient", "description": "Send the review question here."}],
                 "recipient": {
                     "channel": CommsChannel.EMAIL,
                     "address": collaborator.email.upper(),
@@ -801,8 +808,14 @@ class HumanInputRequestTests(TestCase):
                         "address": self.user.email,
                     },
                     "requests": [
-                        {"question": "What should happen first?"},
-                        {"question": "What should happen second?"},
+                        {
+                            "question": "What should happen first?",
+                            "options": [{"title": "Ship first", "description": "Prioritize this item."}],
+                        },
+                        {
+                            "question": "What should happen second?",
+                            "options": [{"title": "Ship second", "description": "Prioritize this item second."}],
+                        },
                     ],
                 },
             )
@@ -1128,7 +1141,7 @@ class HumanInputRequestTests(TestCase):
         result = create_human_input_request(
             self.agent,
             question="Who should join the kickoff?",
-            raw_options=[],
+            raw_options=[{"title": "Other / I'll explain", "description": "Reply with the person or team to include."}],
         )
         request_obj = PersistentAgentHumanInputRequest.objects.get(id=result["request_id"])
 
@@ -1160,7 +1173,7 @@ class HumanInputRequestTests(TestCase):
         result = create_human_input_request(
             org_agent,
             question="Who should review the budget?",
-            raw_options=[],
+            raw_options=[{"title": "Other / I'll explain", "description": "Reply with the person or team to include."}],
         )
         request_obj = PersistentAgentHumanInputRequest.objects.get(id=result["request_id"])
 
@@ -1187,7 +1200,7 @@ class HumanInputRequestTests(TestCase):
         result = create_human_input_request(
             self.agent,
             question="What should we tell the customer?",
-            raw_options=[],
+            raw_options=[{"title": "Other / I'll explain", "description": "Reply with the customer update to use."}],
         )
         request_obj = PersistentAgentHumanInputRequest.objects.get(id=result["request_id"])
 
@@ -1548,7 +1561,7 @@ class HumanInputRequestTests(TestCase):
         result = create_human_input_request(
             self.agent,
             question="Which reviewer should approve this?",
-            raw_options=[],
+            raw_options=[{"title": "Other / I'll explain", "description": "Reply with the reviewer to use."}],
             recipient={
                 "channel": CommsChannel.WEB,
                 "address": build_web_user_address(collaborator.id, self.agent.id),
@@ -1583,7 +1596,7 @@ class HumanInputRequestTests(TestCase):
         result = create_human_input_request(
             self.agent,
             question="What should we tell the customer?",
-            raw_options=[],
+            raw_options=[{"title": "Other / I'll explain", "description": "Reply with the customer update to use."}],
         )
         request_obj = PersistentAgentHumanInputRequest.objects.get(id=result["request_id"])
         reply = self._create_cross_channel_message(
@@ -1774,8 +1787,14 @@ class HumanInputRequestTests(TestCase):
             self.agent,
             {
                 "requests": [
-                    {"question": "What ships first?"},
-                    {"question": "When should we launch?"},
+                    {
+                        "question": "What ships first?",
+                        "options": [{"title": "Option A", "description": "Use the first provided answer."}],
+                    },
+                    {
+                        "question": "When should we launch?",
+                        "options": [{"title": "Option B", "description": "Use the second provided answer."}],
+                    },
                 ],
             },
         )

--- a/tests/unit/test_prompt_capabilities.py
+++ b/tests/unit/test_prompt_capabilities.py
@@ -272,7 +272,7 @@ class AgentCapabilitiesPromptTests(TestCase):
         contents = "\n".join(message["content"] for message in context)
 
         self.assertIn("Your response text is a user message", contents)
-        self.assertIn("monitoring targets/scope before setup", contents)
+        self.assertIn("Use request_human_input only for tracked option-based decisions", contents)
         self.assertIn("never search for it or refetch the same successful URL", contents)
         self.assertIn("update your ongoing charter/schedule", contents)
         self.assertIn("While working, respond with tool calls and no text", contents)
@@ -283,9 +283,7 @@ class AgentCapabilitiesPromptTests(TestCase):
         description = tool["function"]["description"]
         will_continue_description = tool["function"]["parameters"]["properties"]["will_continue_work"]["description"]
 
-        self.assertIn("context, config changes, findings, or finals.", description)
-        self.assertIn("Use request_human_input instead when the agent has been blocked repeatedly", description)
-        self.assertIn("needs a tracked answer", description)
+        self.assertIn("free-text questions, context, config changes, capability/status/policy answers, findings, or finals.", description)
         self.assertIn("Do not narrate what you will do next", description)
         self.assertIn("Never send a message solely to justify continuing work", will_continue_description)
 


### PR DESCRIPTION
## Summary
- Require `request_human_input` options at execution time and in the tool schema, while preserving historical `FREE_TEXT_ONLY` records for rendering and resolution.
- Remove heuristic conversions from chat text to human input; free-text questions stay on send tools, and `request_human_input` is reserved for tracked option-based decisions.
- Tighten planning and delivery prompts so send tools handle free-text, capability, status, and policy questions, with updated eval coverage for the Jody/Intercom case.

## Testing
- Updated focused unit tests for human input creation, event processing, implied send behavior, planning prompts, and tool descriptions.
- Added/updated behavior micro eval coverage to enforce option-based `request_human_input` usage and forbid the regression case.
- Focused test suite passed locally.