### PR TITLE
Skip unfinished-plan correction in daily-limit message-only mode

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -2989,6 +2989,7 @@ def _finalize_tool_batch(
     agent: PersistentAgent,
     execution_outcomes: list[_ToolExecutionOutcome],
     *,
+    daily_credit_state: dict | None = None,
     attach_completion: Any,
     attach_prompt_archive: Any,
 ) -> _FinalizedToolBatch:
@@ -3127,6 +3128,7 @@ def _finalize_tool_batch(
         agent.planning_state != PersistentAgent.PlanningState.PLANNING
         and terminal_message_delivery_ok
         and not followup_required
+        and not is_daily_hard_limit_message_only_mode(daily_credit_state)
         and _plan_has_unfinished_items(agent)
     ):
         _record_terminal_send_unfinished_plan_correction(
@@ -6274,6 +6276,11 @@ def _run_agent_loop(
                 finalized_batch = _finalize_tool_batch(
                     agent,
                     executed_batch.execution_outcomes,
+                    daily_credit_state=(
+                        credit_snapshot.get("daily_state")
+                        if isinstance(credit_snapshot, dict)
+                        else None
+                    ),
                     attach_completion=_attach_completion,
                     attach_prompt_archive=_attach_prompt_archive,
                 )

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -6279,7 +6279,7 @@ def _run_agent_loop(
                     daily_credit_state=(
                         credit_snapshot.get("daily_state")
                         if isinstance(credit_snapshot, dict)
-                        else None
+                        else daily_state
                     ),
                     attach_completion=_attach_completion,
                     attach_prompt_archive=_attach_prompt_archive,

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -256,6 +256,63 @@ class MessageToolExplicitContinuationTests(TestCase):
             ).exists()
         )
 
+    def test_daily_limit_terminal_message_with_unfinished_plan_can_stop(self):
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Synthesize final report",
+            status=PersistentAgentKanbanCard.Status.TODO,
+            priority=1,
+        )
+        prepared = _PreparedToolExecution(
+            idx=1,
+            tool_name="send_chat_message",
+            tool_params={"body": "I hit today's limit. Please raise it to continue.", "will_continue_work": False},
+            exec_params={"body": "I hit today's limit. Please raise it to continue.", "will_continue_work": False},
+            pending_step=None,
+            credits_consumed=None,
+            consumed_credit=None,
+            call_id="call_1",
+            explicit_continue=False,
+            inferred_continue=False,
+            parallel_safe=False,
+            parallel_ineligible_reason=None,
+        )
+
+        finalized = _finalize_tool_batch(
+            self.agent,
+            [
+                _ToolExecutionOutcome(
+                    prepared=prepared,
+                    result={
+                        "status": "ok",
+                        "message": "Web chat message sent.",
+                        "message_id": str(uuid4()),
+                        "auto_sleep_ok": True,
+                    },
+                    duration_ms=1,
+                    updated_tools=None,
+                    variable_map={},
+                )
+            ],
+            daily_credit_state={
+                "hard_limit": Decimal("5"),
+                "hard_limit_remaining": Decimal("0"),
+                "used": Decimal("5"),
+            },
+            attach_completion=lambda kwargs: None,
+            attach_prompt_archive=lambda step: None,
+        )
+
+        self.assertTrue(finalized.terminal_message_delivery_ok)
+        self.assertFalse(finalized.followup_required)
+        self.assertIs(finalized.last_explicit_continue, False)
+        self.assertFalse(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description__contains="current plan still has unfinished items",
+            ).exists()
+        )
+
     def test_planning_mode_terminal_message_with_unfinished_plan_allows_stale_skip(self):
         self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
         self.agent.save(update_fields=["planning_state"])


### PR DESCRIPTION
## Summary
- Prevent terminal message sends from being blocked by unfinished-plan cleanup when the agent is already in daily hard-limit message-only mode.
- Thread the current daily credit state into batch finalization so the sleep decision can distinguish normal mode from message-only mode.
- Add a regression test covering terminal message delivery at hard limit with unfinished plan items.

## Testing
- `uv run python manage.py test api.agent.core.tests.test_event_processing.MessageToolExplicitContinuationTests --settings=config.test_settings`
- `uv run python manage.py test api.agent.core.tests.test_event_processing --settings=config.test_settings`