### PR TITLE
Allow sleep_until_next_trigger in daily hard-limit mode

### DIFF
--- a/api/agent/core/daily_limit_mode.py
+++ b/api/agent/core/daily_limit_mode.py
@@ -10,10 +10,21 @@ DAILY_LIMIT_MESSAGE_TOOL_NAMES = frozenset(
         "send_agent_message",
     }
 )
+DAILY_LIMIT_SLEEP_TOOL_NAME = "sleep_until_next_trigger"
+DAILY_LIMIT_ALLOWED_TOOL_NAMES = DAILY_LIMIT_MESSAGE_TOOL_NAMES | frozenset(
+    {DAILY_LIMIT_SLEEP_TOOL_NAME}
+)
+DAILY_LIMIT_ALLOWED_TOOL_NAMES_TEXT = (
+    "send_email, send_sms, send_chat_message, send_agent_message, and sleep_until_next_trigger"
+)
 
 
 def is_daily_limit_message_tool(tool_name: str | None) -> bool:
     return bool(tool_name and tool_name in DAILY_LIMIT_MESSAGE_TOOL_NAMES)
+
+
+def is_daily_limit_allowed_tool(tool_name: str | None) -> bool:
+    return bool(tool_name and tool_name in DAILY_LIMIT_ALLOWED_TOOL_NAMES)
 
 
 def is_daily_hard_limit_message_only_mode(daily_credit_state: dict | None) -> bool:
@@ -52,6 +63,6 @@ def filter_tools_for_daily_limit_message_only_mode(tools: Sequence[dict]) -> lis
         function_block = tool.get("function")
         if not isinstance(function_block, dict):
             continue
-        if is_daily_limit_message_tool(function_block.get("name")):
+        if is_daily_limit_allowed_tool(function_block.get("name")):
             filtered.append(tool)
     return filtered

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -105,10 +105,11 @@ from api.evals.credit_policy import is_eval_credit_exempt_context
 from api.evals.execution import get_current_eval_routing_profile
 from . import internal_reasoning
 from .daily_limit_mode import (
+    DAILY_LIMIT_ALLOWED_TOOL_NAMES_TEXT,
     DAILY_LIMIT_MESSAGE_TOOL_NAMES,
     filter_tools_for_daily_limit_message_only_mode,
+    is_daily_limit_allowed_tool,
     is_daily_hard_limit_message_only_mode,
-    is_daily_limit_message_tool,
 )
 from .agent_judge import maybe_run_agent_judge
 from .prompt_context import (
@@ -2535,14 +2536,14 @@ def _prepare_tool_batch(
 
             if (
                 is_daily_hard_limit_message_only_mode(daily_state)
-                and not is_daily_limit_message_tool(tool_name)
+                and not is_daily_limit_allowed_tool(tool_name)
             ):
                 try:
                     step_kwargs = {
                         "agent": agent,
                         "description": (
-                            "Daily hard limit mode is active. Only message tools are allowed right now: "
-                            "send_email, send_sms, send_chat_message, send_agent_message. "
+                            "Daily hard limit mode is active. Only message and sleep tools are allowed right now: "
+                            f"{DAILY_LIMIT_ALLOWED_TOOL_NAMES_TEXT}. "
                             f"Do not call {tool_name}; message the user and ask them to raise the limit."
                         ),
                     }
@@ -4440,7 +4441,7 @@ def _ensure_credit_for_tool(
         if credit_snapshot is not None:
             credit_snapshot["daily_state"] = daily_state
 
-    if is_daily_hard_limit_message_only_mode(daily_state) and is_daily_limit_message_tool(tool_name):
+    if is_daily_hard_limit_message_only_mode(daily_state) and is_daily_limit_allowed_tool(tool_name):
         if available is not None and available != TASKS_UNLIMITED and Decimal(available) <= Decimal("0"):
             msg_desc = (
                 f"Skipped tool '{tool_name}' due to insufficient credits mid-loop."
@@ -4466,7 +4467,7 @@ def _ensure_credit_for_tool(
             return False
         if span is not None:
             try:
-                span.add_event("Message tool allowed in daily-limit message-only mode")
+                span.add_event("Tool allowed in daily-limit message-only mode")
                 span.set_attribute("credit_check.daily_limit_message_only_mode", True)
             except Exception:
                 pass

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -114,7 +114,10 @@ from .tool_results import (
     ToolResultPromptInfo,
     prepare_tool_results_for_prompt,
 )
-from .daily_limit_mode import is_daily_hard_limit_message_only_mode
+from .daily_limit_mode import (
+    DAILY_LIMIT_ALLOWED_TOOL_NAMES_TEXT,
+    is_daily_hard_limit_message_only_mode,
+)
 from .contact_results import store_contacts_for_prompt
 from .contact_snapshot import build_contacts_snapshot_records
 from .file_results import FileSQLiteRecord, store_files_for_prompt
@@ -139,9 +142,7 @@ SQLITE_MESSAGES_SNAPSHOT_MAX_BYTES = 5_000_000
 SQLITE_MESSAGES_SNAPSHOT_MAX_RECORDS = 10_000
 CONTACT_PROMPT_INLINE_LIMIT = 25
 CONTACT_PROMPT_SAMPLE_LIMIT = 10
-MESSAGE_ONLY_TOOL_NAMES_TEXT = (
-    "send_email, send_sms, send_chat_message, and send_agent_message"
-)
+MESSAGE_ONLY_TOOL_NAMES_TEXT = DAILY_LIMIT_ALLOWED_TOOL_NAMES_TEXT
 SQLITE_EFFICIENCY_WARNING = (
     "SQLite efficiency warning: you've been reading full __tool_results.result_text blobs one at a time. "
     "Stop fetching by single result_id; run one shaped query across all needed rows using IN/CTEs/"
@@ -2786,7 +2787,8 @@ def add_budget_awareness_sections(
                     "daily_limit_message_only_mode",
                     (
                         "DAILY HARD LIMIT MODE: You reached today's hard task limit. "
-                        f"Only message tools are available until the user raises the limit: {MESSAGE_ONLY_TOOL_NAMES_TEXT}. "
+                        "Only message and sleep tools are available until the user raises the limit: "
+                        f"{MESSAGE_ONLY_TOOL_NAMES_TEXT}. "
                         "Do not attempt any other tools or non-message work right now. "
                         f"Ask the user to raise the limit with one of these links: settings {links['settings_url']} ; "
                         f"double {links['double_limit_url']} ; unlimited {links['unlimited_limit_url']}. "

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -692,7 +692,8 @@ class DailyLimitPromptContextTests(TestCase):
         self.assertIn(settings_url, content)
         self.assertIn(f"double {double_limit_url_prefix}?token=", content)
         self.assertIn(f"unlimited {unlimited_limit_url_prefix}?token=", content)
-        self.assertIn("Only message tools are available until the user raises the limit", content)
+        self.assertIn("Only message and sleep tools are available until the user raises the limit", content)
+        self.assertIn("sleep_until_next_trigger", content)
         self.assertIn("Once the user raises the limit, you can continue the task.", content)
 
 

--- a/api/evals/scenarios/daily_credit_prompt.py
+++ b/api/evals/scenarios/daily_credit_prompt.py
@@ -9,7 +9,7 @@ from django.core.files.storage import default_storage
 from django.urls import reverse
 from django.utils import timezone
 
-from api.agent.core.daily_limit_mode import DAILY_LIMIT_MESSAGE_TOOL_NAMES
+from api.agent.core.daily_limit_mode import DAILY_LIMIT_ALLOWED_TOOL_NAMES
 from api.evals.base import EvalScenario, ScenarioTask
 from api.evals.execution import ScenarioExecutionTools
 from api.evals.registry import register_scenario
@@ -389,7 +389,7 @@ class DailyCreditPromptHardLimitHitScenario(DailyCreditPromptScenario):
         )
         return (
             "DAILY HARD LIMIT MODE",
-            "Only message tools are available until the user raises the limit",
+            "Only message and sleep tools are available until the user raises the limit",
             settings_url,
             f"double {double_limit_url_prefix}?token=",
             f"unlimited {unlimited_limit_url_prefix}?token=",
@@ -408,7 +408,7 @@ class DailyCreditPromptHardLimitHitScenario(DailyCreditPromptScenario):
         )
         disallowed = [
             call for call in calls
-            if call.tool_name not in DAILY_LIMIT_MESSAGE_TOOL_NAMES
+            if call.tool_name not in DAILY_LIMIT_ALLOWED_TOOL_NAMES
         ]
         if disallowed:
             self.record_task_result(
@@ -417,7 +417,7 @@ class DailyCreditPromptHardLimitHitScenario(DailyCreditPromptScenario):
                 EvalRunTask.Status.FAILED,
                 task_name="verify_message_only_tools",
                 observed_summary=(
-                    f"Hard-limit run used non-message tool(s): {[call.tool_name for call in disallowed]}."
+                    f"Hard-limit run used disallowed tool(s): {[call.tool_name for call in disallowed]}."
                 ),
                 artifacts={"step": disallowed[0].step},
             )
@@ -427,6 +427,6 @@ class DailyCreditPromptHardLimitHitScenario(DailyCreditPromptScenario):
             None,
             EvalRunTask.Status.PASSED,
             task_name="verify_message_only_tools",
-            observed_summary="Hard-limit run used only message tools.",
+            observed_summary="Hard-limit run used only daily-limit allowed tools.",
         )
         return True

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -1979,6 +1979,7 @@ class DailyLimitMessageOnlyModeTests(TestCase):
             self._tool_definition("send_sms"),
             self._tool_definition("send_chat_message"),
             self._tool_definition("send_agent_message"),
+            self._tool_definition("sleep_until_next_trigger"),
             self._tool_definition("sqlite_query"),
         ]
         mock_get_daily_state.return_value = self._daily_limit_state()
@@ -2009,7 +2010,13 @@ class DailyLimitMessageOnlyModeTests(TestCase):
 
         self.assertEqual(
             observed_tool_names,
-            ["send_email", "send_sms", "send_chat_message", "send_agent_message"],
+            [
+                "send_email",
+                "send_sms",
+                "send_chat_message",
+                "send_agent_message",
+                "sleep_until_next_trigger",
+            ],
         )
 
     @patch("api.agent.core.event_processing.execute_enabled_tool")
@@ -2050,7 +2057,7 @@ class DailyLimitMessageOnlyModeTests(TestCase):
         mock_execute_enabled_tool.assert_not_called()
         correction_step = PersistentAgentStep.objects.filter(
             agent=self.agent,
-            description__contains="Only message tools are allowed right now",
+            description__contains="Only message and sleep tools are allowed right now",
         ).first()
         self.assertIsNotNone(correction_step)
 
@@ -2059,7 +2066,10 @@ class DailyLimitMessageOnlyModeTests(TestCase):
         "api.agent.core.event_processing.TaskCreditService.check_and_consume_credit_for_owner",
         return_value={"success": True, "credit": None},
     )
-    @patch("api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner", return_value=Decimal("5"))
+    @patch(
+        "api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner",
+        return_value=Decimal("5"),
+    )
     @patch("api.agent.core.event_processing.build_prompt_context")
     @patch("api.agent.core.event_processing.get_agent_daily_credit_state")
     @patch("api.agent.core.event_processing.get_agent_tools")
@@ -2113,6 +2123,57 @@ class DailyLimitMessageOnlyModeTests(TestCase):
         self.assertIsNotNone(tool_call)
         self.assertIsNone(tool_call.step.credits_cost)
         self.assertIsNone(tool_call.step.completion_id)
+
+    @patch(
+        "api.agent.core.event_processing.TaskCreditService.check_and_consume_credit_for_owner",
+        return_value={"success": True, "credit": None},
+    )
+    @patch(
+        "api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner",
+        return_value=Decimal("5"),
+    )
+    @patch("api.agent.core.event_processing.build_prompt_context")
+    @patch("api.agent.core.event_processing.get_agent_daily_credit_state")
+    @patch("api.agent.core.event_processing.get_agent_tools")
+    @patch("api.agent.core.event_processing.settings.GOBII_PROPRIETARY_MODE", True)
+    def test_daily_limit_mode_allows_sleep_without_consuming_credit(
+        self,
+        mock_get_tools,
+        mock_get_daily_state,
+        mock_build_prompt,
+        _mock_available,
+        mock_consume,
+    ):
+        mock_get_tools.return_value = [self._tool_definition("sleep_until_next_trigger")]
+        mock_get_daily_state.return_value = self._daily_limit_state()
+        mock_build_prompt.return_value = ([{"role": "system", "content": "sys"}], 1000, None)
+        completion = self._completion(
+            tool_calls=[self._tool_call("sleep_until_next_trigger", {})]
+        )
+
+        with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1), patch(
+            "api.agent.core.event_processing._completion_with_failover",
+            return_value=(
+                completion,
+                {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                    "model": "m",
+                    "provider": "p",
+                },
+            ),
+        ):
+            ep._run_agent_loop(self.agent, is_first_run=False)
+
+        mock_consume.assert_not_called()
+        sleep_step = PersistentAgentStep.objects.filter(
+            agent=self.agent,
+            description="Decided to sleep until next trigger.",
+        ).order_by("-id").first()
+        self.assertIsNotNone(sleep_step)
+        self.assertIsNone(sleep_step.credits_cost)
+        self.assertIsNone(sleep_step.task_credit)
 
     @patch("api.agent.core.event_processing._should_imply_continue", return_value=False)
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})


### PR DESCRIPTION
## Summary
- Add `sleep_until_next_trigger` to the daily hard-limit allowlist alongside the four message tools.
- Keep the runtime credit checks and prompt guidance aligned with the new allowed-tool set.
- Update the daily-credit eval verifier and add regression coverage for explicit sleep in message-only mode.

## Testing
- Ran targeted Django tests for daily-limit prompt context and event-processing coverage.
- `git diff --check` passed.