### PR TITLE
Include recent custom tool source in agent judge context

### DIFF
--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -1028,10 +1028,14 @@ def _custom_tool_sources_context(
     if not tool_names:
         return []
 
-    custom_tools = {
-        tool.tool_name: tool
-        for tool in PersistentAgentCustomTool.objects.filter(agent=agent, tool_name__in=tool_names)
-    }
+    try:
+        custom_tools = {
+            tool.tool_name: tool
+            for tool in PersistentAgentCustomTool.objects.filter(agent=agent, tool_name__in=tool_names)
+        }
+    except DatabaseError:
+        logger.debug("Unable to query custom tools for judge context.", exc_info=True)
+        custom_tools = {}
 
     sources: list[dict[str, Any]] = []
     for tool_name in tool_names:

--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -30,6 +30,7 @@ from api.models import (
     LLMRoutingProfile,
     PersistentAgent,
     PersistentAgentCompletion,
+    PersistentAgentCustomTool,
     PersistentAgentJudgeSuggestion,
     PersistentAgentMessage,
     PersistentAgentSkill,
@@ -821,7 +822,11 @@ def _build_trajectory_packet(
         .values("id", "body", "created_at", "delivered_at", "is_active")[:JUDGE_RECENT_DIRECTIVE_LIMIT]
     )
     plan_snapshot = _plan_snapshot(agent)
-    current_context = _build_current_context_snapshot(agent, prompt_limits)
+    current_context = _build_current_context_snapshot(
+        agent,
+        prompt_limits,
+        recent_tool_calls=recent_tool_calls,
+    )
 
     return {
         "agent": {
@@ -844,8 +849,8 @@ def _build_trajectory_packet(
                 "evidence from timing, parameters, results, messages, or steps."
             ),
             (
-                "When trigger_context.custom_tool_sources is present, inspect that source as direct evidence "
-                "for the custom tool behavior involved in the trigger."
+                "When trigger_context.custom_tool_sources or current_context.custom_tool_sources is present, "
+                "inspect that source as direct evidence for the custom tool behavior involved in the trajectory."
             ),
         ],
         "trigger_reasons": trigger_reasons,
@@ -881,6 +886,11 @@ def _build_trajectory_packet(
                 "credentials, destructive action, or legal/policy judgment."
             ),
             "If the current approach is failing, suggest a concrete strategy shift grounded in available tools.",
+            (
+                "When custom tool source, parameters, results, or recent calls show a tool should be created "
+                "or updated, use a strategy_shift directive that tells the agent exactly what custom tool "
+                "change to make."
+            ),
         ],
         "capability_manifest": _capability_manifest(tools, prompt_limits),
         "current_context": current_context,
@@ -908,9 +918,15 @@ def _plan_snapshot(agent: PersistentAgent) -> dict[str, Any]:
     }
 
 
-def _build_current_context_snapshot(agent: PersistentAgent, prompt_limits: JudgePromptLimits) -> dict[str, Any]:
+def _build_current_context_snapshot(
+    agent: PersistentAgent,
+    prompt_limits: JudgePromptLimits,
+    *,
+    recent_tool_calls: list[PersistentAgentToolCall] | None = None,
+) -> dict[str, Any]:
     return {
         "skills": _skill_context(agent, prompt_limits),
+        "custom_tool_sources": _custom_tool_sources_context(agent, recent_tool_calls or []),
         "sqlite": _sqlite_context_snapshot(),
     }
 
@@ -989,6 +1005,75 @@ def _sqlite_context_snapshot() -> dict[str, Any]:
             "digest": "",
             "error": "unavailable",
         }
+
+
+def _custom_tool_sources_context(
+    agent: PersistentAgent,
+    recent_tool_calls: list[PersistentAgentToolCall],
+) -> list[dict[str, Any]]:
+    try:
+        from api.agent.tools.custom_tools import CUSTOM_TOOL_PREFIX, read_custom_tool_source_text
+    except ImportError:
+        logger.debug("Unable to import custom tool source helpers for judge context.", exc_info=True)
+        return []
+
+    tool_names: list[str] = []
+    seen: set[str] = set()
+    for call in reversed(recent_tool_calls):
+        tool_name = str(call.tool_name or "").strip()
+        if not tool_name.startswith(CUSTOM_TOOL_PREFIX) or tool_name in seen:
+            continue
+        seen.add(tool_name)
+        tool_names.append(tool_name)
+    if not tool_names:
+        return []
+
+    custom_tools = {
+        tool.tool_name: tool
+        for tool in PersistentAgentCustomTool.objects.filter(agent=agent, tool_name__in=tool_names)
+    }
+
+    sources: list[dict[str, Any]] = []
+    for tool_name in tool_names:
+        tool = custom_tools.get(tool_name)
+        if tool is None:
+            sources.append(
+                {
+                    "source_type": "custom_tool_source",
+                    "trajectory_scope": "recent_tool_call_history",
+                    "tool_name": tool_name,
+                    "source_error": "Custom tool metadata not found for recent tool call.",
+                }
+            )
+            continue
+
+        source_context: dict[str, Any] = {
+            "source_type": "custom_tool_source",
+            "trajectory_scope": "recent_tool_call_history",
+            "tool_name": tool.tool_name,
+            "name": tool.name or "",
+            "description": _truncate(tool.description or "", 1000),
+            "source_path": tool.source_path,
+            "parameters_schema": tool.parameters_schema if isinstance(tool.parameters_schema, dict) else {},
+            "timeout_seconds": tool.timeout_seconds,
+        }
+        try:
+            source_text, source_error = read_custom_tool_source_text(agent, tool.source_path)
+        except (OSError, RuntimeError, ValueError, DatabaseError):
+            logger.debug(
+                "Unable to read custom tool source for judge context: agent=%s tool=%s",
+                getattr(agent, "id", None),
+                tool.tool_name,
+                exc_info=True,
+            )
+            source_context["source_error"] = "Failed to read custom tool source."
+        else:
+            if source_error:
+                source_context["source_error"] = source_error
+            else:
+                source_context["source_code"] = source_text or ""
+        sources.append(source_context)
+    return sources
 
 
 def _capability_manifest(tools: list[dict[str, Any]], prompt_limits: JudgePromptLimits) -> list[dict[str, str]]:
@@ -1102,7 +1187,8 @@ def _judge_system_prompt() -> str:
         "Keep message short. For intelligence_upgrade, recommend the minimum higher tier that would likely "
         "help. Base suggestions only on evidence in the packet. Separate directly observed facts from "
         "inferred causes; when a cause is uncertain, say so instead of presenting it as fact. Prefer concrete "
-        "operational guidance over diagnosis."
+        "operational guidance over diagnosis. When custom tool source, params, results, or recent calls show "
+        "that a custom tool should be created or changed, you may recommend that as a strategy_shift directive."
     )
 
 
@@ -1165,6 +1251,12 @@ def _build_judge_user_prompt(
             "trigger_context",
             _json_section(trajectory.get("trigger_context") or {}),
             weight=9,
+        )
+    if current_context.get("custom_tool_sources"):
+        high_priority.section_text(
+            "custom_tool_sources",
+            _json_section(current_context.get("custom_tool_sources") or []),
+            weight=8,
         )
     high_priority.section_text(
         "messages",

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.db import DatabaseError
 from django.test import TestCase, tag
 from django.utils import timezone
 from waffle.models import Flag
@@ -429,6 +430,38 @@ class AgentJudgeTests(TestCase):
         read_source.assert_not_called()
         custom_tool_sources = trigger.trajectory["current_context"]["custom_tool_sources"]
         self.assertEqual(custom_tool_sources[0]["tool_name"], "custom_missing")
+        self.assertEqual(
+            custom_tool_sources[0]["source_error"],
+            "Custom tool metadata not found for recent tool call.",
+        )
+
+    def test_recent_custom_tool_query_error_adds_source_error(self):
+        step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Tool call: custom_unavailable",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="custom_unavailable",
+            tool_params={},
+            result='{"status":"error","message":"database unavailable"}',
+            status="error",
+        )
+
+        with patch(
+            "api.agent.core.agent_judge.PersistentAgentCustomTool.objects.filter",
+            side_effect=DatabaseError("database unavailable"),
+        ), patch("api.agent.tools.custom_tools.read_custom_tool_source_text") as read_source:
+            trigger = build_judge_trigger(
+                self.agent,
+                tools=[],
+                extra_trigger_reasons=["manual_custom_tool_review"],
+            )
+
+        self.assertIsNotNone(trigger)
+        read_source.assert_not_called()
+        custom_tool_sources = trigger.trajectory["current_context"]["custom_tool_sources"]
+        self.assertEqual(custom_tool_sources[0]["tool_name"], "custom_unavailable")
         self.assertEqual(
             custom_tool_sources[0]["source_error"],
             "Custom tool metadata not found for recent tool call.",

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -33,6 +33,7 @@ from api.models import (
     PersistentAgent,
     PersistentAgentCompletion,
     PersistentAgentCommsEndpoint,
+    PersistentAgentCustomTool,
     PersistentAgentJudgeSuggestion,
     PersistentAgentMessage,
     PersistentAgentSkill,
@@ -335,6 +336,103 @@ class AgentJudgeTests(TestCase):
         self.assertIn("custom_tool_sources", user_content)
         self.assertIn("/tools/outreach_sender.py", user_content)
         self.assertIn("ctx.call_tool('send_email', params)", user_content)
+
+    def test_recent_custom_tool_call_includes_source_in_judge_prompt(self):
+        source_code = (
+            "from _gobii_ctx import main\n\n"
+            "def run(params, ctx):\n"
+            "    return {'count': params.get('limit', 0)}\n\n"
+            "if __name__ == '__main__': main(run)\n"
+        )
+        PersistentAgentCustomTool.objects.create(
+            agent=self.agent,
+            name="Counter",
+            tool_name="custom_counter",
+            description="Count records for a report.",
+            source_path="/tools/counter.py",
+            parameters_schema={
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer"},
+                },
+            },
+            timeout_seconds=120,
+        )
+        step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Tool call: custom_counter",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="custom_counter",
+            tool_params={"limit": 5},
+            result='{"status":"ok","result":{"count":5}}',
+            status="complete",
+        )
+
+        with patch(
+            "api.agent.tools.custom_tools.read_custom_tool_source_text",
+            return_value=(source_code, None),
+        ) as read_source:
+            trigger = build_judge_trigger(
+                self.agent,
+                tools=[],
+                extra_trigger_reasons=["manual_custom_tool_review"],
+            )
+
+        self.assertIsNotNone(trigger)
+        read_source.assert_called_once_with(self.agent, "/tools/counter.py")
+        custom_tool_sources = trigger.trajectory["current_context"]["custom_tool_sources"]
+        self.assertEqual(custom_tool_sources[0]["tool_name"], "custom_counter")
+        self.assertEqual(custom_tool_sources[0]["source_path"], "/tools/counter.py")
+        self.assertEqual(custom_tool_sources[0]["parameters_schema"]["properties"]["limit"]["type"], "integer")
+        self.assertEqual(custom_tool_sources[0]["timeout_seconds"], 120)
+        self.assertEqual(custom_tool_sources[0]["source_code"], source_code)
+
+        limits = JudgePromptLimits(
+            prompt_token_budget=2500,
+            message_history_limit=2,
+            tool_call_history_limit=2,
+            skill_prompt_limit=1,
+            enabled_tool_limit=1,
+        )
+        with patch("api.agent.core.agent_judge._create_token_estimator", return_value=lambda text: len(text.split())):
+            messages = _build_judge_messages(trigger.trajectory, model="test-model", prompt_limits=limits)
+
+        self.assertIn("custom tool should be created or changed", messages[0]["content"])
+        user_content = messages[1]["content"]
+        self.assertIn("<custom_tool_sources>", user_content)
+        self.assertIn("/tools/counter.py", user_content)
+        self.assertIn("return {'count': params.get('limit', 0)}", user_content)
+
+    def test_recent_custom_tool_call_missing_metadata_adds_source_error(self):
+        step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Tool call: custom_missing",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="custom_missing",
+            tool_params={},
+            result='{"status":"error","message":"not available"}',
+            status="error",
+        )
+
+        with patch("api.agent.tools.custom_tools.read_custom_tool_source_text") as read_source:
+            trigger = build_judge_trigger(
+                self.agent,
+                tools=[],
+                extra_trigger_reasons=["manual_custom_tool_review"],
+            )
+
+        self.assertIsNotNone(trigger)
+        read_source.assert_not_called()
+        custom_tool_sources = trigger.trajectory["current_context"]["custom_tool_sources"]
+        self.assertEqual(custom_tool_sources[0]["tool_name"], "custom_missing")
+        self.assertEqual(
+            custom_tool_sources[0]["source_error"],
+            "Custom tool metadata not found for recent tool call.",
+        )
 
     def test_judge_tool_does_not_offer_request_human_input_suggestion(self):
         tool = _judge_tool_definition()


### PR DESCRIPTION
## Summary
- Add recent `custom_*` tool source material to the agent judge trajectory packet when those tools appear in the retained tool-call history.
- Include custom tool metadata, source code when readable, and explicit source errors when metadata or source cannot be loaded.
- Update judge guidance so it can recommend creating or updating a custom tool via `strategy_shift` when the evidence supports it.

## Testing
- Added unit coverage for recent custom tool source inclusion in the judge prompt.
- Added coverage for the missing-metadata fallback path.
- Ran `uv run python manage.py test tests.unit.test_agent_llm_judge --settings=config.test_settings` with Segment env vars blanked; 34 tests passed.
- Ran `uv run python -m compileall -q api/agent/core/agent_judge.py tests/unit/test_agent_llm_judge.py`.