### PR TITLE
Pin google-cloud-storage to 3.11.0 and harden filespace sync fallback

### DIFF
--- a/api/services/sandbox_filespace_sync.py
+++ b/api/services/sandbox_filespace_sync.py
@@ -48,7 +48,15 @@ def _encode_node_content_b64(node: AgentFsNode) -> Optional[str]:
     try:
         with node.content.open("rb") as handle:
             content = handle.read()
-    except (OSError, TypeError, ValueError):
+    except (OSError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Filespace pull inline content read failed for node=%s path=%s content=%s: %s",
+            node.id,
+            node.path,
+            node.content.name,
+            exc,
+            exc_info=True,
+        )
         return None
     if not isinstance(content, (bytes, bytearray)):
         return None

--- a/api/services/sandbox_filespace_sync.py
+++ b/api/services/sandbox_filespace_sync.py
@@ -48,7 +48,7 @@ def _encode_node_content_b64(node: AgentFsNode) -> Optional[str]:
     try:
         with node.content.open("rb") as handle:
             content = handle.read()
-    except (OSError, ValueError):
+    except (OSError, TypeError, ValueError):
         return None
     if not isinstance(content, (bytes, bytearray)):
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "django-turnstile~=0.1.3",
   "django-waffle~=5.0.0",
   "django-pglock~=1.8.0",
-  "google-cloud-storage~=3.1.0",
+  "google-cloud-storage==3.11.0",
   "gunicorn==23.0.0",
   "zstandard~=0.23.0",
   "json-schema-to-pydantic~=0.4.1",

--- a/tests/unit/test_sandbox_compute_sync.py
+++ b/tests/unit/test_sandbox_compute_sync.py
@@ -235,6 +235,32 @@ class SandboxComputeSyncTests(TestCase):
         )
         self.assertEqual(manifest.get("sync_cursor"), expected_cursor.isoformat() if expected_cursor else None)
 
+    def test_pull_manifest_falls_back_to_download_url_when_storage_read_type_error(self):
+        write_result = write_bytes_to_dir(
+            agent=self.agent,
+            content_bytes=b"tool source",
+            extension="",
+            mime_type="text/x-python",
+            path="/tools/custom.py",
+            overwrite=True,
+        )
+        self.assertEqual(write_result.get("status"), "ok")
+
+        with patch(
+            "django.db.models.fields.files.FieldFile.open",
+            side_effect=TypeError("_GzipDecoder.decompress() got an unexpected keyword argument 'max_length'"),
+        ), patch(
+            "api.services.sandbox_filespace_sync.build_signed_filespace_download_url",
+            return_value="https://files.example/download",
+        ):
+            manifest = build_filespace_pull_manifest(self.agent)
+
+        self.assertEqual(manifest.get("status"), "ok")
+        entries = manifest.get("files") or []
+        tool_entry = next(entry for entry in entries if entry.get("path") == "/tools/custom.py")
+        self.assertNotIn("content_b64", tool_entry)
+        self.assertEqual(tool_entry["download_url"], "https://files.example/download")
+
     def test_running_session_refreshes_pull_using_cursor(self):
         backend = _DummyBackend()
         now = timezone.now()

--- a/uv.lock
+++ b/uv.lock
@@ -1691,7 +1691,7 @@ requires-dist = [
     { name = "exa-py", specifier = "==1.14.16" },
     { name = "fastmcp", specifier = ">=2.11.3" },
     { name = "genson", specifier = "~=1.2.2" },
-    { name = "google-cloud-storage", specifier = "~=3.1.0" },
+    { name = "google-cloud-storage", specifier = "==3.11.0" },
     { name = "gunicorn", specifier = "==23.0.0" },
     { name = "imapclient", specifier = "~=2.3" },
     { name = "inscriptis", specifier = "==2.6.0" },
@@ -1884,7 +1884,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "3.1.1"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -1894,9 +1894,9 @@ dependencies = [
     { name = "google-resumable-media" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/84/6afc2ffdf31f6247a6bab6ba070e073fb05e0fda56adf59ce52ac591a033/google_cloud_storage-3.1.1.tar.gz", hash = "sha256:f9c8f965cafd1d38509f8e2b070339e0e9e5bf050774653bf36213d4ea6104c0", size = 7668109, upload-time = "2025-06-18T11:06:52.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/8953e2993e604c8882fd441b5b2de624a2dfe7e6144c6166d7b477509596/google_cloud_storage-3.11.0.tar.gz", hash = "sha256:498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b", size = 17335639, upload-time = "2026-06-03T16:14:04.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/4f/b922e919f6e1ea5905f1427fadf1a3f56a85e79e2b0037fec182f6b437dd/google_cloud_storage-3.1.1-py3-none-any.whl", hash = "sha256:ba7e6ae2be5a7a08742f001e23ec6a0c17d78c620f63bf8e0e7c2cbdddb407de", size = 175464, upload-time = "2025-06-18T11:06:51.043Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7e/ee0dd1a67ac75d29d0c438969d85d4fadbc4bcab47b0a8ccfa7eb22f643c/google_cloud_storage-3.11.0-py3-none-any.whl", hash = "sha256:cfcc33aa6b899ec9dd1771286f8e79fbed5c35c1c174718071b079aa827f37c2", size = 339654, upload-time = "2026-06-03T16:12:46.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `google-cloud-storage` to `3.11.0` to match the newer `urllib3` decoder contract used in prod.
- Update the lockfile to keep the platform image resolution consistent.
- Catch storage read `TypeError` during filespace manifest generation and fall back to signed download URLs instead of crashing sandbox sync.
- Add a regression test covering the fallback path.

## Testing
- `uv lock`
- `uv run python manage.py test tests.unit.test_sandbox_compute_sync.SandboxComputeSyncTests.test_pull_manifest_includes_checksum_and_cursor tests.unit.test_sandbox_compute_sync.SandboxComputeSyncTests.test_targeted_workspace_pull_bypasses_session_cursor tests.unit.test_sandbox_compute_sync.SandboxComputeSyncTests.test_pull_manifest_falls_back_to_download_url_when_storage_read_type_error --settings=config.test_settings`