### PR TITLE
Refactor agent chat timeline rendering and scroll handling

### DIFF
--- a/frontend/src/components/agentChat/AgentChatLayout.test.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.test.tsx
@@ -18,8 +18,8 @@ vi.mock('./AgentComposer', () => ({
   AgentComposer: () => <div data-testid="agent-composer" />,
 }))
 
-vi.mock('./TimelineVirtualItem', () => ({
-  TimelineVirtualItem: ({ event, onMessageLinkClick }: { event?: { messageLinkHref?: string | null }, onMessageLinkClick?: (href: string) => boolean | void }) => {
+vi.mock('./TimelineEventItem', () => ({
+  TimelineEventItem: ({ event, onMessageLinkClick }: { event?: { messageLinkHref?: string | null }, onMessageLinkClick?: (href: string) => boolean | void }) => {
     const href = event?.messageLinkHref
     if (!href) {
       return null

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -2,24 +2,17 @@ import type { KeyboardEvent, MouseEvent, ReactNode, Ref } from 'react'
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { Flag, Loader2, Zap } from 'lucide-react'
 import '../../styles/agentChatLegacy.css'
-import { TypingIndicator, deriveTypingStatusText } from './TypingIndicator'
+import { deriveTypingStatusText } from './TypingIndicator'
 import { track } from '../../util/analytics'
 import { AnalyticsEvent } from '../../constants/analyticsEvents'
 import { AgentComposer } from './AgentComposer'
-import { TimelineVirtualItem } from './TimelineVirtualItem'
-import { StreamingReplyCard } from './StreamingReplyCard'
-import { StreamingThinkingCard } from './StreamingThinkingCard'
+import { AgentTimelinePane } from './AgentTimelinePane'
 import { ChatSidebar } from './ChatSidebar'
 import { AgentChatBanner, type ConnectionStatusTone } from './AgentChatBanner'
 import { AgentChatSettingsPanel } from './AgentChatSettingsPanel'
 import { AgentChatAddonsPanel } from './AgentChatAddonsPanel'
 import { PlanPanel } from './PlanPanel'
 import { HighPriorityBanner, type HighPriorityBannerConfig } from './HighPriorityBanner'
-import { HardLimitCalloutCard } from './HardLimitCalloutCard'
-import { ContactCapCalloutCard } from './ContactCapCalloutCard'
-import { TaskCreditsCalloutCard } from './TaskCreditsCalloutCard'
-import { ScheduledResumeCard } from './ScheduledResumeCard'
-import { StarterPromptSuggestions } from './StarterPromptSuggestions'
 import { reportAgentMessageIssue, trackAgentMessageCopy } from '../../api/agentChat'
 import { AgentSignupPreviewPanel } from './AgentSignupPreviewPanel'
 import { getInitialAgentChatSidebarMode } from './sidebarMode'
@@ -168,16 +161,6 @@ function getAppMessageLinkShellPage(href: string): AppMessageLinkShellPage | nul
   }
 }
 
-function timelineEventKey(event: SimplifiedTimelineItem): string {
-  if (event.kind === 'collapsed-group') {
-    return `collapsed:${event.cursor}`
-  }
-  if (event.kind === 'steps' && event.entries.length > 0) {
-    return `cluster:${event.entries[0].id}`
-  }
-  return event.cursor
-}
-
 type AgentChatLayoutProps = AgentTimelineProps & {
   displayEvents?: SimplifiedTimelineItem[]
   statusExpansionTargets?: StatusExpansionTargets
@@ -295,10 +278,13 @@ type AgentChatLayoutProps = AgentTimelineProps & {
     attachments?: File[],
   ) => void | Promise<void>
   onComposerFocus?: () => void
+  onComposerRequestScrollToBottom?: () => void
   autoScrollPinned?: boolean
   isNearBottom?: boolean
   hasUnseenActivity?: boolean
   timelineRef?: Ref<HTMLDivElement>
+  timelineContentRef?: Ref<HTMLDivElement>
+  composerShellRef?: Ref<HTMLDivElement>
   loadingOlder?: boolean
   loadingNewer?: boolean
   initialLoading?: boolean
@@ -491,10 +477,13 @@ export function AgentChatLayout({
   onBlockedCollaborate,
   onSendMessage,
   onComposerFocus,
+  onComposerRequestScrollToBottom,
   autoScrollPinned = true,
   isNearBottom = true,
   hasUnseenActivity = false,
   timelineRef,
+  timelineContentRef,
+  composerShellRef,
   loadingOlder = false,
   loadingNewer = false,
   initialLoading = false,
@@ -921,7 +910,6 @@ export function AgentChatLayout({
     && !hasMoreNewer
     && nextScheduledAt,
   )
-  const showBottomSentinel = !initialLoading && !hasMoreNewer
   const starterPromptCount = typeof window !== 'undefined' && window.innerWidth < 768 ? 2 : 3
   const {
     starterPrompts,
@@ -1623,173 +1611,70 @@ export function AgentChatLayout({
           style={composerPalette.cssVars}
         >
           <div className="agent-chat-workspace-main">
-          <div className="agent-chat-timeline-region">
-            {/* Scrollable timeline container */}
-            <div ref={timelineRef} id="timeline-shell" data-scroll-pinned={autoScrollPinned ? 'true' : 'false'}>
-              {/* Spacer pushes content to bottom when there's extra space */}
-              <div id="timeline-spacer" aria-hidden="true" />
-              <div id="timeline-inner">
-                <div id="timeline-events" className="flex flex-col" data-has-jump-button={showJumpButton ? 'true' : 'false'} data-has-working-panel={showProcessingIndicator ? 'true' : 'false'}>
-                {loadingOlder ? (
-                  <div className="timeline-load-control" data-side="older" data-state="loading">
-                    <div className="timeline-load-button" role="status">
-                      <span className="timeline-load-indicator" data-loading="true" aria-hidden="true" />
-                      <span className="timeline-load-label">Loading…</span>
-                    </div>
-                  </div>
-                ) : showOlderLoadButton && onLoadOlder ? (
-                  <div className="timeline-load-control" data-side="older" data-state="ready">
-                    <button type="button" className="timeline-load-button" onClick={onLoadOlder}>
-                      <span className="timeline-load-indicator" aria-hidden="true" />
-                      <span className="timeline-load-label">Load older activity</span>
-                    </button>
-                  </div>
-                ) : null}
-
-                {initialLoading ? (
-                  <div className="flex items-center justify-center py-10" aria-live="polite" aria-busy="true">
-                    <div className="flex flex-col items-center gap-3 text-center">
-                      <Loader2 size={28} className="animate-spin text-blue-600" aria-hidden="true" />
-                      <div>
-                        <p className="text-sm font-semibold text-slate-700">Loading conversation…</p>
-                      </div>
-                    </div>
-                  </div>
-                ) : timelineRenderEvents.map((event, index) => (
-                  <TimelineVirtualItem
-                    key={timelineEventKey(event)}
-                    event={event}
-                    isLatestEvent={index === timelineRenderEvents.length - 1}
-                    agentFirstName={agentFirstName}
-                    agentColorHex={agentColorHex || undefined}
-                    agentAvatarUrl={agentAvatarUrl}
-                    viewerUserId={viewerUserId ?? null}
-                    viewerEmail={viewerEmail ?? null}
-                    suppressedThinkingCursor={suppressedThinkingCursor}
-                    statusExpansionTargets={statusExpansionTargets}
-                    animateIncoming={realtimeEventCursors?.has(event.cursor) ?? false}
-                    onIncomingAnimationConsumed={onRealtimeEventAnimationConsumed}
-                    onMessageLinkClick={handleMessageLinkClick}
-                    onMessageCopied={handleMessageCopied}
-                    onReportMessage={handleReportMessage}
-                  />
-                ))}
-                {showScheduledResumeEvent ? (
-                  <ScheduledResumeCard nextScheduledAt={nextScheduledAt} />
-                ) : null}
-                {showHardLimitCallout ? (
-                  <HardLimitCalloutCard
-                    onOpenSettings={handleSettingsOpen}
-                    onQuickIncrease={quickIncreaseTarget !== null ? handleQuickIncreaseLimit : undefined}
-                    quickIncreaseLabel={quickIncreaseLabel ?? undefined}
-                    quickIncreaseBusy={quickIncreaseBusy}
-                    upgradeUrl={hardLimitUpgradeUrl}
-                    showUpsell={hardLimitShowUpsell}
-                  />
-                ) : null}
-                {showNoSeatsCallout ? (
-                  <TaskCreditsCalloutCard
-                    billingIssue="no_org_seats"
-                    onPurchaseSeats={handlePurchaseSeats}
-                    variant="out"
-                  />
-                ) : showTaskCreditsCallout ? (
-                  <TaskCreditsCalloutCard
-                    onOpenPacks={taskPackCanManageBilling && (taskPackOptions?.length ?? 0) > 0
-                      ? () => handleAddonsOpen('tasks')
-                      : undefined}
-                    showUpgrade={showTaskCreditsUpgrade}
-                    onDismiss={handleTaskCreditsDismiss}
-                    variant={taskCreditsWarningVariant === 'out' ? 'out' : 'low'}
-                  />
-                ) : null}
-                {showContactCapCallout ? (
-                  <ContactCapCalloutCard
-                    onOpenPacks={contactPackCanManageBilling && contactPackOptions.length > 0
-                      ? () => handleAddonsOpen('contacts')
-                      : undefined}
-                    showUpgrade={contactPackShowUpgrade}
-                    onDismiss={handleContactCapDismiss}
-                  />
-                ) : null}
-                {pendingActionRequests.length === 0
-                && signupPreviewState === 'none'
-                && (starterPromptsLoading || starterPrompts.length > 0) ? (
-                  <StarterPromptSuggestions
-                    prompts={starterPrompts}
-                    loading={starterPromptsLoading}
-                    loadingCount={starterPromptCount}
-                    disabled={starterPromptSubmitting || starterPromptsDisabled || composerDisabled}
-                    onSelect={handleStarterPromptSelect}
-                  />
-                ) : null}
-
-                {showStreamingThinking ? (
-                  <StreamingThinkingCard
-                    reasoning={streaming?.reasoning || ''}
-                    isStreaming={isStreaming}
-                  />
-                ) : null}
-
-                {showStreamingSlot && !hasMoreNewer ? (
-                  <div id="streaming-response-slot" className="streaming-response-slot flex flex-col">
-                    {hasStreamingContent ? (
-                      <StreamingReplyCard
-                        content={streaming?.content || ''}
-                        agentFirstName={agentFirstName}
-                        agentAvatarUrl={agentAvatarUrl}
-                        agentColorHex={agentColorHex}
-                        isStreaming={isStreaming}
-                        onLinkClick={handleMessageLinkClick}
-                      />
-                    ) : null}
-                  </div>
-                ) : null}
-
-                {showTypingIndicator ? (
-                  <TypingIndicator
-                    statusText={typingStatusText}
-                    agentColorHex={agentColorHex || undefined}
-                    agentAvatarUrl={agentAvatarUrl}
-                    agentFirstName={agentFirstName}
-                    hidden={hideTypingIndicator}
-                  />
-                ) : null}
-
-                {showBottomSentinel ? (
-                  <div id="timeline-bottom-sentinel" className="timeline-bottom-sentinel" aria-hidden="true" />
-                ) : null}
-
-                {loadingNewer ? (
-                  <div className="timeline-load-control" data-side="newer" data-state="loading">
-                    <div className="timeline-load-button" role="status">
-                      <span className="timeline-load-indicator" data-loading="true" aria-hidden="true" />
-                      <span className="timeline-load-label">Loading…</span>
-                    </div>
-                  </div>
-                ) : null}
-                </div>
-              </div>
-
-            </div>
-          </div>
-
-          {/* Jump button outside scroll container so position:fixed works on iOS Safari */}
-          <button
-            id="jump-to-latest"
-            className="jump-to-latest"
-            type="button"
-            aria-label="Jump to latest"
-            aria-hidden={showJumpButton ? 'false' : 'true'}
-            onClick={onJumpToLatest}
-            data-has-activity={hasUnseenActivity ? 'true' : 'false'}
-            data-visible={showJumpButton ? 'true' : 'false'}
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14m0 0-5-5m5 5 5-5" />
-            </svg>
-            <span className="sr-only">Jump to latest</span>
-          </button>
+          <AgentTimelinePane
+            agentAvatarUrl={agentAvatarUrl}
+            agentColorHex={agentColorHex}
+            agentFirstName={agentFirstName}
+            animateCursors={realtimeEventCursors}
+            autoScrollPinned={autoScrollPinned}
+            composerDisabled={composerDisabled}
+            contactCapOpenPacks={contactPackCanManageBilling && contactPackOptions.length > 0 ? () => handleAddonsOpen('contacts') : undefined}
+            contactCapShowUpgrade={contactPackShowUpgrade}
+            events={timelineRenderEvents}
+            hardLimitShowUpsell={hardLimitShowUpsell}
+            hardLimitUpgradeUrl={hardLimitUpgradeUrl}
+            hasMoreNewer={hasMoreNewer}
+            hasStreamingContent={hasStreamingContent}
+            hasUnseenActivity={hasUnseenActivity}
+            hideTypingIndicator={hideTypingIndicator}
+            initialLoading={initialLoading}
+            isStreaming={isStreaming}
+            loadingNewer={loadingNewer}
+            loadingOlder={loadingOlder}
+            nextScheduledAt={nextScheduledAt}
+            onContactCapDismiss={handleContactCapDismiss}
+            onHardLimitOpenSettings={handleSettingsOpen}
+            onHardLimitQuickIncrease={quickIncreaseTarget !== null ? handleQuickIncreaseLimit : undefined}
+            onIncomingAnimationConsumed={onRealtimeEventAnimationConsumed}
+            onJumpToLatest={onJumpToLatest}
+            onLoadOlder={onLoadOlder}
+            onMessageCopied={handleMessageCopied}
+            onMessageLinkClick={handleMessageLinkClick}
+            onPurchaseSeats={handlePurchaseSeats}
+            onReportMessage={handleReportMessage}
+            onStarterPromptSelect={handleStarterPromptSelect}
+            onTaskCreditsDismiss={handleTaskCreditsDismiss}
+            onTaskCreditsOpenPacks={taskPackCanManageBilling && (taskPackOptions?.length ?? 0) > 0 ? () => handleAddonsOpen('tasks') : undefined}
+            quickIncreaseBusy={quickIncreaseBusy}
+            quickIncreaseLabel={quickIncreaseLabel ?? undefined}
+            showContactCapCallout={showContactCapCallout}
+            showHardLimitCallout={showHardLimitCallout}
+            showJumpButton={showJumpButton}
+            showNoSeatsCallout={showNoSeatsCallout}
+            showOlderLoadButton={showOlderLoadButton}
+            showProcessingIndicator={showProcessingIndicator}
+            showScheduledResumeEvent={showScheduledResumeEvent}
+            showStarterPrompts={pendingActionRequests.length === 0 && signupPreviewState === 'none' && (starterPromptsLoading || starterPrompts.length > 0)}
+            showStreamingSlot={showStreamingSlot}
+            showStreamingThinking={showStreamingThinking}
+            showTaskCreditsCallout={showTaskCreditsCallout}
+            showTaskCreditsUpgrade={showTaskCreditsUpgrade}
+            showTypingIndicator={showTypingIndicator}
+            starterPromptCount={starterPromptCount}
+            starterPromptSubmitting={starterPromptSubmitting}
+            starterPrompts={starterPrompts}
+            starterPromptsDisabled={starterPromptsDisabled}
+            starterPromptsLoading={starterPromptsLoading}
+            statusExpansionTargets={statusExpansionTargets}
+            streaming={streaming}
+            suppressedThinkingCursor={suppressedThinkingCursor}
+            taskCreditsWarningVariant={taskCreditsWarningVariant}
+            timelineContentRef={timelineContentRef}
+            timelineRef={timelineRef}
+            typingStatusText={typingStatusText}
+            viewerEmail={viewerEmail}
+            viewerUserId={viewerUserId}
+          />
 
           {/* Composer at bottom of flex layout */}
           {spawnIntentLoading ? (
@@ -1852,6 +1737,8 @@ export function AgentChatLayout({
               onResolveContactRequests={onResolveContactRequests}
               onViewAllContactRequests={onViewAllContactRequests}
               onFocus={onComposerFocus}
+              onRequestScrollToBottom={onComposerRequestScrollToBottom}
+              externalShellRef={composerShellRef}
               agentFirstName={agentFirstName}
               isProcessing={showProcessingIndicator}
               processingTasks={processingWebTasks}

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, ClipboardEvent, FormEvent, KeyboardEvent } from 'react'
+import type { ChangeEvent, ClipboardEvent, FormEvent, KeyboardEvent, Ref } from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components'
 import { ArrowUp, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Gauge, KeyRound, Loader2, Mail, MessageSquare, MessageSquareQuote, OctagonAlert, Paperclip, Plus, Rocket, Sparkles, TriangleAlert, Zap, X } from 'lucide-react'
@@ -443,6 +443,7 @@ type AgentComposerProps = {
   // Key that triggers re-focus when changed (e.g., agentId for switching agents)
   focusKey?: string | null
   onFocus?: () => void
+  onRequestScrollToBottom?: () => void
   // Working panel props
   insightsPanelExpandedPreference?: boolean | null
   onInsightsPanelExpandedPreferenceChange?: (expanded: boolean) => void
@@ -482,6 +483,7 @@ type AgentComposerProps = {
   hubspotNativeTabEnabled?: boolean
   discordNativeTabEnabled?: boolean
   compact?: boolean
+  externalShellRef?: Ref<HTMLDivElement>
 }
 
 export const AgentComposer = memo(function AgentComposer({
@@ -504,6 +506,7 @@ export const AgentComposer = memo(function AgentComposer({
   autoFocus = false,
   focusKey,
   onFocus,
+  onRequestScrollToBottom,
   insightsPanelExpandedPreference = null,
   onInsightsPanelExpandedPreferenceChange,
   agentFirstName = 'Agent',
@@ -542,6 +545,7 @@ export const AgentComposer = memo(function AgentComposer({
   hubspotNativeTabEnabled = false,
   discordNativeTabEnabled = false,
   compact = false,
+  externalShellRef,
 }: AgentComposerProps) {
   const [body, setBody] = useState('')
   const [attachments, setAttachments] = useState<File[]>([])
@@ -559,6 +563,16 @@ export const AgentComposer = memo(function AgentComposer({
   const [appsModal, showAppsModal] = useModal()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const shellRef = useRef<HTMLDivElement | null>(null)
+  const composedShellRef = useCallback((node: HTMLDivElement | null) => {
+    shellRef.current = node
+    if (typeof externalShellRef === 'function') {
+      externalShellRef(node)
+      return
+    }
+    if (externalShellRef) {
+      externalShellRef.current = node
+    }
+  }, [externalShellRef])
   const focusScrollTimeoutRef = useRef<number | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const dragCounter = useRef(0)
@@ -734,12 +748,8 @@ export const AgentComposer = memo(function AgentComposer({
 
   const scrollToBottom = useCallback(() => {
     if (!isTouchDevice) return
-    // Container scrolling: scroll the timeline-shell, not the window
-    const container = document.getElementById('timeline-shell')
-    if (container) {
-      container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' })
-    }
-  }, [isTouchDevice])
+    onRequestScrollToBottom?.()
+  }, [isTouchDevice, onRequestScrollToBottom])
 
   const selectWorkingTab = useCallback((tabId: string) => {
     if (!resolvedWorkingExpanded) {
@@ -1831,7 +1841,7 @@ export const AgentComposer = memo(function AgentComposer({
     <div
       className="composer-shell"
       id="agent-composer-shell"
-      ref={shellRef}
+      ref={composedShellRef}
       data-processing={isProcessing ? 'true' : 'false'}
       data-expanded={resolvedWorkingExpanded ? 'true' : 'false'}
       data-panel-visible={showWorkingPanel ? 'true' : 'false'}

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -1,4 +1,4 @@
-import type { Ref } from 'react'
+import { useMemo, type Ref } from 'react'
 import { Loader2 } from 'lucide-react'
 import { TimelineEventItem } from './TimelineEventItem'
 import { StreamingReplyCard } from './StreamingReplyCard'
@@ -152,6 +152,15 @@ export function AgentTimelinePane({
   viewerEmail,
   viewerUserId,
 }: AgentTimelinePaneProps) {
+  const lastRenderedIndex = useMemo(() => {
+    for (let index = events.length - 1; index >= 0; index -= 1) {
+      if (events[index].kind !== 'plan' && events[index].kind !== 'kanban') {
+        return index
+      }
+    }
+    return -1
+  }, [events])
+
   return (
     <>
       <div className="agent-chat-timeline-region">
@@ -192,7 +201,7 @@ export function AgentTimelinePane({
                   <div key={timelineEventKey(event)} data-timeline-item="true">
                     <TimelineEventItem
                       event={event}
-                      isLatestEvent={index === events.length - 1}
+                      isLatestEvent={index === lastRenderedIndex}
                       agentFirstName={agentFirstName}
                       agentColorHex={agentColorHex || undefined}
                       agentAvatarUrl={agentAvatarUrl}

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -1,0 +1,318 @@
+import type { Ref } from 'react'
+import { Loader2 } from 'lucide-react'
+import { TimelineEventItem } from './TimelineEventItem'
+import { StreamingReplyCard } from './StreamingReplyCard'
+import { StreamingThinkingCard } from './StreamingThinkingCard'
+import { TypingIndicator } from './TypingIndicator'
+import { ScheduledResumeCard } from './ScheduledResumeCard'
+import { HardLimitCalloutCard } from './HardLimitCalloutCard'
+import { ContactCapCalloutCard } from './ContactCapCalloutCard'
+import { TaskCreditsCalloutCard } from './TaskCreditsCalloutCard'
+import { StarterPromptSuggestions, type StarterPrompt } from './StarterPromptSuggestions'
+import type { SimplifiedTimelineItem } from '../../hooks/useSimplifiedTimeline'
+import type { AgentMessage, StreamState } from '../../types/agentChat'
+import type { StatusExpansionTargets } from './statusExpansion'
+
+function timelineEventKey(event: SimplifiedTimelineItem): string {
+  if (event.kind === 'collapsed-group') {
+    return `collapsed:${event.cursor}`
+  }
+  if (event.kind === 'steps' && event.entries.length > 0) {
+    return `cluster:${event.entries[0].id}`
+  }
+  return event.cursor
+}
+
+type AgentTimelinePaneProps = {
+  agentAvatarUrl?: string | null
+  agentColorHex?: string | null
+  agentFirstName: string
+  animateCursors?: Set<string>
+  autoScrollPinned: boolean
+  composerDisabled?: boolean
+  contactCapOpenPacks?: () => void
+  contactCapShowUpgrade?: boolean
+  events: SimplifiedTimelineItem[]
+  hardLimitShowUpsell?: boolean
+  hardLimitUpgradeUrl?: string | null
+  hasMoreNewer?: boolean
+  hasStreamingContent?: boolean
+  hasUnseenActivity?: boolean
+  hideTypingIndicator?: boolean
+  initialLoading?: boolean
+  isStreaming?: boolean
+  loadingNewer?: boolean
+  loadingOlder?: boolean
+  nextScheduledAt?: string | null
+  onContactCapDismiss?: () => void
+  onHardLimitOpenSettings: () => void
+  onHardLimitQuickIncrease?: () => void
+  onIncomingAnimationConsumed?: (cursor: string) => void
+  onJumpToLatest?: () => void
+  onLoadOlder?: () => void
+  onMessageCopied?: (message: AgentMessage) => void | Promise<void>
+  onMessageLinkClick?: (href: string) => boolean | void
+  onPurchaseSeats?: () => void
+  onReportMessage?: (message: AgentMessage) => void
+  onStarterPromptSelect?: (prompt: StarterPrompt, position: number) => Promise<void>
+  onTaskCreditsDismiss?: () => void
+  onTaskCreditsOpenPacks?: () => void
+  quickIncreaseBusy?: boolean
+  quickIncreaseLabel?: string
+  showContactCapCallout?: boolean
+  showHardLimitCallout?: boolean
+  showJumpButton?: boolean
+  showNoSeatsCallout?: boolean
+  showOlderLoadButton?: boolean
+  showProcessingIndicator?: boolean
+  showScheduledResumeEvent?: boolean
+  showStarterPrompts?: boolean
+  showStreamingSlot?: boolean
+  showStreamingThinking?: boolean
+  showTaskCreditsCallout?: boolean
+  showTaskCreditsUpgrade?: boolean
+  showTypingIndicator?: boolean
+  starterPromptCount: number
+  starterPromptSubmitting?: boolean
+  starterPrompts: StarterPrompt[]
+  starterPromptsDisabled?: boolean
+  starterPromptsLoading?: boolean
+  statusExpansionTargets?: StatusExpansionTargets
+  streaming?: StreamState | null
+  suppressedThinkingCursor?: string | null
+  taskCreditsWarningVariant?: 'low' | 'out' | null
+  timelineContentRef?: Ref<HTMLDivElement>
+  timelineRef?: Ref<HTMLDivElement>
+  typingStatusText: string
+  viewerEmail?: string | null
+  viewerUserId?: number | null
+}
+
+export function AgentTimelinePane({
+  agentAvatarUrl,
+  agentColorHex,
+  agentFirstName,
+  animateCursors,
+  autoScrollPinned,
+  composerDisabled = false,
+  contactCapOpenPacks,
+  contactCapShowUpgrade = false,
+  events,
+  hardLimitShowUpsell = false,
+  hardLimitUpgradeUrl = null,
+  hasMoreNewer = false,
+  hasStreamingContent = false,
+  hasUnseenActivity = false,
+  hideTypingIndicator = false,
+  initialLoading = false,
+  isStreaming = false,
+  loadingNewer = false,
+  loadingOlder = false,
+  nextScheduledAt = null,
+  onContactCapDismiss,
+  onHardLimitOpenSettings,
+  onHardLimitQuickIncrease,
+  onIncomingAnimationConsumed,
+  onJumpToLatest,
+  onLoadOlder,
+  onMessageCopied,
+  onMessageLinkClick,
+  onPurchaseSeats,
+  onReportMessage,
+  onStarterPromptSelect,
+  onTaskCreditsDismiss,
+  onTaskCreditsOpenPacks,
+  quickIncreaseBusy = false,
+  quickIncreaseLabel,
+  showContactCapCallout = false,
+  showHardLimitCallout = false,
+  showJumpButton = false,
+  showNoSeatsCallout = false,
+  showOlderLoadButton = false,
+  showProcessingIndicator = false,
+  showScheduledResumeEvent = false,
+  showStarterPrompts = false,
+  showStreamingSlot = false,
+  showStreamingThinking = false,
+  showTaskCreditsCallout = false,
+  showTaskCreditsUpgrade = false,
+  showTypingIndicator = false,
+  starterPromptCount,
+  starterPromptSubmitting = false,
+  starterPrompts,
+  starterPromptsDisabled = false,
+  starterPromptsLoading = false,
+  statusExpansionTargets,
+  streaming,
+  suppressedThinkingCursor = null,
+  taskCreditsWarningVariant = null,
+  timelineContentRef,
+  timelineRef,
+  typingStatusText,
+  viewerEmail,
+  viewerUserId,
+}: AgentTimelinePaneProps) {
+  return (
+    <>
+      <div className="agent-chat-timeline-region">
+        <div ref={timelineRef} id="timeline-shell" data-scroll-pinned={autoScrollPinned ? 'true' : 'false'}>
+          <div id="timeline-spacer" aria-hidden="true" />
+          <div id="timeline-inner">
+            <div ref={timelineContentRef} id="timeline-events" className="flex flex-col" data-has-jump-button={showJumpButton ? 'true' : 'false'} data-has-working-panel={showProcessingIndicator ? 'true' : 'false'}>
+              {loadingOlder ? (
+                <div className="timeline-load-control" data-side="older" data-state="loading">
+                  <div className="timeline-load-button" role="status">
+                    <span className="timeline-load-indicator" data-loading="true" aria-hidden="true" />
+                    <span className="timeline-load-label">Loading…</span>
+                  </div>
+                </div>
+              ) : showOlderLoadButton && onLoadOlder ? (
+                <div className="timeline-load-control" data-side="older" data-state="ready">
+                  <button type="button" className="timeline-load-button" onClick={onLoadOlder}>
+                    <span className="timeline-load-indicator" aria-hidden="true" />
+                    <span className="timeline-load-label">Load older activity</span>
+                  </button>
+                </div>
+              ) : null}
+
+              {initialLoading ? (
+                <div className="flex items-center justify-center py-10" aria-live="polite" aria-busy="true">
+                  <div className="flex flex-col items-center gap-3 text-center">
+                    <Loader2 size={28} className="animate-spin text-blue-600" aria-hidden="true" />
+                    <div>
+                      <p className="text-sm font-semibold text-slate-700">Loading conversation…</p>
+                    </div>
+                  </div>
+                </div>
+              ) : events.map((event, index) => {
+                if (event.kind === 'plan' || event.kind === 'kanban') {
+                  return null
+                }
+                return (
+                  <div key={timelineEventKey(event)} data-timeline-item="true">
+                    <TimelineEventItem
+                      event={event}
+                      isLatestEvent={index === events.length - 1}
+                      agentFirstName={agentFirstName}
+                      agentColorHex={agentColorHex || undefined}
+                      agentAvatarUrl={agentAvatarUrl}
+                      viewerUserId={viewerUserId ?? null}
+                      viewerEmail={viewerEmail ?? null}
+                      suppressedThinkingCursor={suppressedThinkingCursor}
+                      statusExpansionTargets={statusExpansionTargets}
+                      animateIncoming={animateCursors?.has(event.cursor) ?? false}
+                      onIncomingAnimationConsumed={onIncomingAnimationConsumed}
+                      onMessageLinkClick={onMessageLinkClick}
+                      onMessageCopied={onMessageCopied}
+                      onReportMessage={onReportMessage}
+                    />
+                  </div>
+                )
+              })}
+              {showScheduledResumeEvent ? (
+                <ScheduledResumeCard nextScheduledAt={nextScheduledAt} />
+              ) : null}
+              {showHardLimitCallout ? (
+                <HardLimitCalloutCard
+                  onOpenSettings={onHardLimitOpenSettings}
+                  onQuickIncrease={onHardLimitQuickIncrease}
+                  quickIncreaseLabel={quickIncreaseLabel}
+                  quickIncreaseBusy={quickIncreaseBusy}
+                  upgradeUrl={hardLimitUpgradeUrl}
+                  showUpsell={hardLimitShowUpsell}
+                />
+              ) : null}
+              {showNoSeatsCallout ? (
+                <TaskCreditsCalloutCard
+                  billingIssue="no_org_seats"
+                  onPurchaseSeats={onPurchaseSeats}
+                  variant="out"
+                />
+              ) : showTaskCreditsCallout ? (
+                <TaskCreditsCalloutCard
+                  onOpenPacks={onTaskCreditsOpenPacks}
+                  showUpgrade={showTaskCreditsUpgrade}
+                  onDismiss={onTaskCreditsDismiss}
+                  variant={taskCreditsWarningVariant === 'out' ? 'out' : 'low'}
+                />
+              ) : null}
+              {showContactCapCallout ? (
+                <ContactCapCalloutCard
+                  onOpenPacks={contactCapOpenPacks}
+                  showUpgrade={contactCapShowUpgrade}
+                  onDismiss={onContactCapDismiss}
+                />
+              ) : null}
+              {showStarterPrompts ? (
+                <StarterPromptSuggestions
+                  prompts={starterPrompts}
+                  loading={starterPromptsLoading}
+                  loadingCount={starterPromptCount}
+                  disabled={starterPromptSubmitting || starterPromptsDisabled || composerDisabled}
+                  onSelect={onStarterPromptSelect}
+                />
+              ) : null}
+
+              {showStreamingThinking ? (
+                <StreamingThinkingCard
+                  reasoning={streaming?.reasoning || ''}
+                  isStreaming={isStreaming}
+                />
+              ) : null}
+
+              {showStreamingSlot && !hasMoreNewer ? (
+                <div id="streaming-response-slot" className="streaming-response-slot flex flex-col">
+                  {hasStreamingContent ? (
+                    <StreamingReplyCard
+                      content={streaming?.content || ''}
+                      agentFirstName={agentFirstName}
+                      agentAvatarUrl={agentAvatarUrl}
+                      agentColorHex={agentColorHex}
+                      isStreaming={isStreaming}
+                      onLinkClick={onMessageLinkClick}
+                    />
+                  ) : null}
+                </div>
+              ) : null}
+
+              {showTypingIndicator ? (
+                <TypingIndicator
+                  statusText={typingStatusText}
+                  agentColorHex={agentColorHex || undefined}
+                  agentAvatarUrl={agentAvatarUrl}
+                  agentFirstName={agentFirstName}
+                  hidden={hideTypingIndicator}
+                />
+              ) : null}
+
+              {loadingNewer ? (
+                <div className="timeline-load-control" data-side="newer" data-state="loading">
+                  <div className="timeline-load-button" role="status">
+                    <span className="timeline-load-indicator" data-loading="true" aria-hidden="true" />
+                    <span className="timeline-load-label">Loading…</span>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <button
+        id="jump-to-latest"
+        className="jump-to-latest"
+        type="button"
+        aria-label="Jump to latest"
+        aria-hidden={showJumpButton ? 'false' : 'true'}
+        onClick={onJumpToLatest}
+        data-has-activity={hasUnseenActivity ? 'true' : 'false'}
+        data-visible={showJumpButton ? 'true' : 'false'}
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14m0 0-5-5m5 5 5-5" />
+        </svg>
+        <span className="sr-only">Jump to latest</span>
+      </button>
+    </>
+  )
+}

--- a/frontend/src/components/agentChat/TimelineEventItem.tsx
+++ b/frontend/src/components/agentChat/TimelineEventItem.tsx
@@ -8,7 +8,7 @@ import type { AgentMessage } from '../../types/agentChat'
 import { buildThinkingCluster, flattenTimelineEventsToEntries } from './activityEntryUtils'
 import type { StatusExpansionTargets } from './statusExpansion'
 
-type TimelineVirtualItemProps = {
+type TimelineEventItemProps = {
   event: SimplifiedTimelineItem
   isLatestEvent: boolean
   agentFirstName: string
@@ -25,7 +25,7 @@ type TimelineVirtualItemProps = {
   onReportMessage?: (message: AgentMessage) => void
 }
 
-export const TimelineVirtualItem = memo(function TimelineVirtualItem({
+export const TimelineEventItem = memo(function TimelineEventItem({
   event,
   isLatestEvent,
   agentFirstName,
@@ -40,7 +40,7 @@ export const TimelineVirtualItem = memo(function TimelineVirtualItem({
   onMessageLinkClick,
   onMessageCopied,
   onReportMessage,
-}: TimelineVirtualItemProps) {
+}: TimelineEventItemProps) {
   const collapsedEntries = useMemo(() => {
     if (event.kind !== 'collapsed-group') {
       return []

--- a/frontend/src/components/agentChat/useTimelineScrollController.ts
+++ b/frontend/src/components/agentChat/useTimelineScrollController.ts
@@ -44,6 +44,7 @@ type PrependAnchor = {
   element: HTMLElement | null
   offsetTop: number
   pageCount: number
+  scrollHeight: number
 }
 
 export function useTimelineScrollController({
@@ -68,6 +69,7 @@ export function useTimelineScrollController({
   const didInitialJumpRef = useRef(false)
   const fetchOlderInFlightRef = useRef(false)
   const scrollFrameRef = useRef<number | null>(null)
+  const acrossFramesRafRef = useRef<number | null>(null)
   const followupScrollFramesRef = useRef(0)
   const programmaticScrollUntilRef = useRef(0)
   const prependAnchorRef = useRef<PrependAnchor | null>(null)
@@ -128,26 +130,35 @@ export function useTimelineScrollController({
       window.cancelAnimationFrame(scrollFrameRef.current)
       scrollFrameRef.current = null
     }
+    if (acrossFramesRafRef.current !== null) {
+      window.cancelAnimationFrame(acrossFramesRafRef.current)
+      acrossFramesRafRef.current = null
+    }
   }, [])
 
   const scrollToBottomAcrossFrames = useCallback((frames: number) => {
-    followupScrollFramesRef.current = Math.max(followupScrollFramesRef.current, frames)
+    if (acrossFramesRafRef.current !== null) {
+      window.cancelAnimationFrame(acrossFramesRafRef.current)
+      acrossFramesRafRef.current = null
+    }
+    followupScrollFramesRef.current = frames
     const run = () => {
       if (followupScrollFramesRef.current <= 0) {
+        acrossFramesRafRef.current = null
         return
       }
       followupScrollFramesRef.current -= 1
       scrollToBottomNow()
-      window.requestAnimationFrame(run)
+      acrossFramesRafRef.current = window.requestAnimationFrame(run)
     }
-    window.requestAnimationFrame(run)
+    acrossFramesRafRef.current = window.requestAnimationFrame(run)
   }, [scrollToBottomNow])
 
   const capturePrependAnchor = useCallback((): PrependAnchor => {
     const container = containerRef.current
     const content = contentNode
     if (!container || !content) {
-      return { element: null, offsetTop: 0, pageCount }
+      return { element: null, offsetTop: 0, pageCount, scrollHeight: 0 }
     }
 
     const containerTop = container.getBoundingClientRect().top
@@ -157,6 +168,7 @@ export function useTimelineScrollController({
       element,
       offsetTop: element ? element.getBoundingClientRect().top - containerTop : 0,
       pageCount,
+      scrollHeight: container.scrollHeight,
     }
   }, [contentNode, pageCount])
 
@@ -171,7 +183,10 @@ export function useTimelineScrollController({
       const containerTop = container.getBoundingClientRect().top
       const nextOffsetTop = anchor.element.getBoundingClientRect().top - containerTop
       container.scrollTop += nextOffsetTop - anchor.offsetTop
+    } else if (anchor.scrollHeight > 0) {
+      container.scrollTop += container.scrollHeight - anchor.scrollHeight
     }
+    lastScrollTopRef.current = container.scrollTop
 
     ignorePinUntilRef.current = Date.now() + PREPEND_RESTORE_GUARD_MS
     prependAnchorRef.current = null
@@ -349,6 +364,9 @@ export function useTimelineScrollController({
   useEffect(() => () => {
     if (scrollFrameRef.current !== null) {
       window.cancelAnimationFrame(scrollFrameRef.current)
+    }
+    if (acrossFramesRafRef.current !== null) {
+      window.cancelAnimationFrame(acrossFramesRafRef.current)
     }
     followupScrollFramesRef.current = 0
   }, [])

--- a/frontend/src/components/agentChat/useTimelineScrollController.ts
+++ b/frontend/src/components/agentChat/useTimelineScrollController.ts
@@ -72,6 +72,7 @@ export function useTimelineScrollController({
   const programmaticScrollUntilRef = useRef(0)
   const prependAnchorRef = useRef<PrependAnchor | null>(null)
   const ignorePinUntilRef = useRef(0)
+  const lastScrollTopRef = useRef(0)
 
   const [timelineNode, setTimelineNode] = useState<HTMLDivElement | null>(null)
   const [contentNode, setContentNode] = useState<HTMLDivElement | null>(null)
@@ -80,12 +81,7 @@ export function useTimelineScrollController({
   const [timelineCanScroll, setTimelineCanScroll] = useState(false)
 
   useEffect(() => {
-    if (!autoScrollPinned) {
-      pinnedRef.current = false
-      return
-    }
-    const container = containerRef.current
-    pinnedRef.current = !container || !canScroll(container) || bottomDistance(container) <= NEAR_BOTTOM_PX
+    pinnedRef.current = autoScrollPinned
   }, [autoScrollPinned])
 
   const setPinned = useCallback((nextPinned: boolean) => {
@@ -219,6 +215,7 @@ export function useTimelineScrollController({
 
   const timelineRef: RefCallback<HTMLDivElement> = useCallback((node) => {
     containerRef.current = node
+    lastScrollTopRef.current = node?.scrollTop ?? 0
     setTimelineNode(node)
     syncMeasurements(node)
   }, [syncMeasurements])
@@ -244,6 +241,9 @@ export function useTimelineScrollController({
     }
 
     const handleScroll = () => {
+      const previousScrollTop = lastScrollTopRef.current
+      const nextScrollTop = container.scrollTop
+      lastScrollTopRef.current = nextScrollTop
       syncMeasurements(container)
 
       if (
@@ -257,7 +257,7 @@ export function useTimelineScrollController({
       const distance = bottomDistance(container)
       if (distance <= NEAR_BOTTOM_PX) {
         setPinned(true)
-      } else if (distance > UNPIN_PX) {
+      } else if (distance > UNPIN_PX && nextScrollTop < previousScrollTop - 2) {
         setPinned(false)
       }
 
@@ -320,9 +320,9 @@ export function useTimelineScrollController({
   useEffect(() => {
     syncMeasurements()
     if (pinnedRef.current && !prependAnchorRef.current) {
-      scrollToBottom()
+      scrollToBottomAcrossFrames(2)
     }
-  }, [contentVersion, scrollToBottom, syncMeasurements])
+  }, [contentVersion, scrollToBottomAcrossFrames, syncMeasurements])
 
   useEffect(() => {
     const container = timelineNode
@@ -333,7 +333,7 @@ export function useTimelineScrollController({
     const observer = new ResizeObserver(() => {
       syncMeasurements(container)
       if (pinnedRef.current && !prependAnchorRef.current) {
-        scrollToBottom()
+        scrollToBottomAcrossFrames(2)
       }
     })
     observer.observe(container)
@@ -344,7 +344,7 @@ export function useTimelineScrollController({
       observer.observe(composerNode)
     }
     return () => observer.disconnect()
-  }, [composerNode, contentNode, scrollToBottom, syncMeasurements, timelineNode])
+  }, [composerNode, contentNode, scrollToBottomAcrossFrames, syncMeasurements, timelineNode])
 
   useEffect(() => () => {
     if (scrollFrameRef.current !== null) {

--- a/frontend/src/components/agentChat/useTimelineScrollController.ts
+++ b/frontend/src/components/agentChat/useTimelineScrollController.ts
@@ -1,0 +1,388 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefCallback,
+} from 'react'
+
+const NEAR_BOTTOM_PX = 96
+const UNPIN_PX = 160
+const TOP_LOAD_PX = 160
+const PROGRAMMATIC_SCROLL_MS = 180
+const SCROLLABLE_EPSILON_PX = 1
+const PREPEND_RESTORE_GUARD_MS = 250
+
+type TimelineScrollControllerOptions = {
+  activeAgentId: string | null
+  autoScrollPinned: boolean
+  contentVersion: string
+  eventCount: number
+  fetchPreviousPage: () => Promise<unknown>
+  hasMoreOlder: boolean
+  hasPreviousPage: boolean
+  initialLoading: boolean
+  isFetchPreviousPageError: boolean
+  isFetchingPreviousPage: boolean
+  isNewAgent: boolean
+  loadingOlder: boolean
+  pageCount: number
+  setAutoScrollPinned: (pinned: boolean) => void
+  switchingAgentId: string | null
+}
+
+function bottomDistance(container: HTMLElement): number {
+  return container.scrollHeight - container.scrollTop - container.clientHeight
+}
+
+function canScroll(container: HTMLElement | null): boolean {
+  return Boolean(container && container.scrollHeight > container.clientHeight + SCROLLABLE_EPSILON_PX)
+}
+
+type PrependAnchor = {
+  element: HTMLElement | null
+  offsetTop: number
+  pageCount: number
+}
+
+export function useTimelineScrollController({
+  activeAgentId,
+  autoScrollPinned,
+  contentVersion,
+  eventCount,
+  fetchPreviousPage,
+  hasMoreOlder,
+  hasPreviousPage,
+  initialLoading,
+  isFetchPreviousPageError,
+  isFetchingPreviousPage,
+  isNewAgent,
+  loadingOlder,
+  pageCount,
+  setAutoScrollPinned,
+  switchingAgentId,
+}: TimelineScrollControllerOptions) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const pinnedRef = useRef(autoScrollPinned)
+  const didInitialJumpRef = useRef(false)
+  const fetchOlderInFlightRef = useRef(false)
+  const scrollFrameRef = useRef<number | null>(null)
+  const followupScrollFramesRef = useRef(0)
+  const programmaticScrollUntilRef = useRef(0)
+  const prependAnchorRef = useRef<PrependAnchor | null>(null)
+  const ignorePinUntilRef = useRef(0)
+
+  const [timelineNode, setTimelineNode] = useState<HTMLDivElement | null>(null)
+  const [contentNode, setContentNode] = useState<HTMLDivElement | null>(null)
+  const [composerNode, setComposerNode] = useState<HTMLDivElement | null>(null)
+  const [isNearBottom, setIsNearBottom] = useState(true)
+  const [timelineCanScroll, setTimelineCanScroll] = useState(false)
+
+  useEffect(() => {
+    if (!autoScrollPinned) {
+      pinnedRef.current = false
+      return
+    }
+    const container = containerRef.current
+    pinnedRef.current = !container || !canScroll(container) || bottomDistance(container) <= NEAR_BOTTOM_PX
+  }, [autoScrollPinned])
+
+  const setPinned = useCallback((nextPinned: boolean) => {
+    if (pinnedRef.current === nextPinned) {
+      return
+    }
+    pinnedRef.current = nextPinned
+    setAutoScrollPinned(nextPinned)
+  }, [setAutoScrollPinned])
+
+  const syncMeasurements = useCallback((container = containerRef.current) => {
+    if (!container) {
+      return
+    }
+    const nearBottom = bottomDistance(container) <= NEAR_BOTTOM_PX
+    setIsNearBottom((current) => (current === nearBottom ? current : nearBottom))
+    const scrollable = canScroll(container)
+    setTimelineCanScroll((current) => (current === scrollable ? current : scrollable))
+  }, [])
+
+  const scrollToBottomNow = useCallback(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+    programmaticScrollUntilRef.current = Date.now() + PROGRAMMATIC_SCROLL_MS
+    container.scrollTop = container.scrollHeight
+    setIsNearBottom(true)
+  }, [])
+
+  const scrollToBottom = useCallback(() => {
+    if (scrollFrameRef.current !== null) {
+      return
+    }
+    scrollFrameRef.current = window.requestAnimationFrame(() => {
+      scrollFrameRef.current = null
+      scrollToBottomNow()
+    })
+  }, [scrollToBottomNow])
+
+  const cancelPendingBottomScroll = useCallback(() => {
+    followupScrollFramesRef.current = 0
+    if (scrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(scrollFrameRef.current)
+      scrollFrameRef.current = null
+    }
+  }, [])
+
+  const scrollToBottomAcrossFrames = useCallback((frames: number) => {
+    followupScrollFramesRef.current = Math.max(followupScrollFramesRef.current, frames)
+    const run = () => {
+      if (followupScrollFramesRef.current <= 0) {
+        return
+      }
+      followupScrollFramesRef.current -= 1
+      scrollToBottomNow()
+      window.requestAnimationFrame(run)
+    }
+    window.requestAnimationFrame(run)
+  }, [scrollToBottomNow])
+
+  const capturePrependAnchor = useCallback((): PrependAnchor => {
+    const container = containerRef.current
+    const content = contentNode
+    if (!container || !content) {
+      return { element: null, offsetTop: 0, pageCount }
+    }
+
+    const containerTop = container.getBoundingClientRect().top
+    const items = Array.from(content.querySelectorAll<HTMLElement>('[data-timeline-item="true"]'))
+    const element = items.find((item) => item.getBoundingClientRect().bottom >= containerTop) ?? items[0] ?? null
+    return {
+      element,
+      offsetTop: element ? element.getBoundingClientRect().top - containerTop : 0,
+      pageCount,
+    }
+  }, [contentNode, pageCount])
+
+  const restorePrependAnchor = useCallback(() => {
+    const container = containerRef.current
+    const anchor = prependAnchorRef.current
+    if (!container || !anchor) {
+      return
+    }
+
+    if (anchor.element && anchor.element.isConnected) {
+      const containerTop = container.getBoundingClientRect().top
+      const nextOffsetTop = anchor.element.getBoundingClientRect().top - containerTop
+      container.scrollTop += nextOffsetTop - anchor.offsetTop
+    }
+
+    ignorePinUntilRef.current = Date.now() + PREPEND_RESTORE_GUARD_MS
+    prependAnchorRef.current = null
+    syncMeasurements(container)
+  }, [syncMeasurements])
+
+  const pinAndJumpToBottom = useCallback(() => {
+    pinnedRef.current = true
+    setAutoScrollPinned(true)
+    scrollToBottomNow()
+    scrollToBottomAcrossFrames(3)
+  }, [scrollToBottomAcrossFrames, scrollToBottomNow, setAutoScrollPinned])
+
+  const requestPreviousPage = useCallback(() => {
+    if (
+      fetchOlderInFlightRef.current
+      || !hasPreviousPage
+      || isFetchingPreviousPage
+      || isFetchPreviousPageError
+    ) {
+      return
+    }
+
+    cancelPendingBottomScroll()
+    prependAnchorRef.current = capturePrependAnchor()
+    setPinned(false)
+    fetchOlderInFlightRef.current = true
+    void fetchPreviousPage().finally(() => {
+      fetchOlderInFlightRef.current = false
+    })
+  }, [
+    fetchPreviousPage,
+    hasPreviousPage,
+    isFetchPreviousPageError,
+    isFetchingPreviousPage,
+    pageCount,
+    cancelPendingBottomScroll,
+    capturePrependAnchor,
+    setPinned,
+  ])
+
+  const timelineRef: RefCallback<HTMLDivElement> = useCallback((node) => {
+    containerRef.current = node
+    setTimelineNode(node)
+    syncMeasurements(node)
+  }, [syncMeasurements])
+
+  const timelineContentRef: RefCallback<HTMLDivElement> = useCallback((node) => {
+    setContentNode(node)
+  }, [])
+
+  const composerShellRef: RefCallback<HTMLDivElement> = useCallback((node) => {
+    setComposerNode(node)
+  }, [])
+
+  useEffect(() => {
+    didInitialJumpRef.current = false
+    fetchOlderInFlightRef.current = false
+    prependAnchorRef.current = null
+  }, [activeAgentId])
+
+  useEffect(() => {
+    const container = timelineNode
+    if (!container) {
+      return
+    }
+
+    const handleScroll = () => {
+      syncMeasurements(container)
+
+      if (
+        Date.now() < programmaticScrollUntilRef.current
+        || Date.now() < ignorePinUntilRef.current
+        || prependAnchorRef.current
+      ) {
+        return
+      }
+
+      const distance = bottomDistance(container)
+      if (distance <= NEAR_BOTTOM_PX) {
+        setPinned(true)
+      } else if (distance > UNPIN_PX) {
+        setPinned(false)
+      }
+
+      if (
+        container.scrollTop <= TOP_LOAD_PX
+        && canScroll(container)
+        && didInitialJumpRef.current
+        && !initialLoading
+        && !isNewAgent
+        && !switchingAgentId
+        && eventCount > 0
+      ) {
+        requestPreviousPage()
+      }
+    }
+
+    syncMeasurements(container)
+    container.addEventListener('scroll', handleScroll, { passive: true })
+    return () => container.removeEventListener('scroll', handleScroll)
+  }, [
+    eventCount,
+    initialLoading,
+    isNewAgent,
+    requestPreviousPage,
+    setPinned,
+    switchingAgentId,
+    syncMeasurements,
+    timelineNode,
+  ])
+
+  useLayoutEffect(() => {
+    const anchor = prependAnchorRef.current
+    if (!anchor) {
+      return
+    }
+
+    if (pageCount > anchor.pageCount) {
+      restorePrependAnchor()
+      return
+    }
+
+    if (!isFetchingPreviousPage) {
+      prependAnchorRef.current = null
+    }
+  }, [contentVersion, isFetchingPreviousPage, pageCount, restorePrependAnchor])
+
+  useEffect(() => {
+    if (isNewAgent) {
+      didInitialJumpRef.current = true
+      pinAndJumpToBottom()
+      return
+    }
+
+    if (!initialLoading && eventCount > 0 && !didInitialJumpRef.current) {
+      didInitialJumpRef.current = true
+      pinAndJumpToBottom()
+    }
+  }, [eventCount, initialLoading, isNewAgent, pinAndJumpToBottom])
+
+  useEffect(() => {
+    syncMeasurements()
+    if (pinnedRef.current && !prependAnchorRef.current) {
+      scrollToBottom()
+    }
+  }, [contentVersion, scrollToBottom, syncMeasurements])
+
+  useEffect(() => {
+    const container = timelineNode
+    if (!container || typeof ResizeObserver === 'undefined') {
+      return
+    }
+
+    const observer = new ResizeObserver(() => {
+      syncMeasurements(container)
+      if (pinnedRef.current && !prependAnchorRef.current) {
+        scrollToBottom()
+      }
+    })
+    observer.observe(container)
+    if (contentNode) {
+      observer.observe(contentNode)
+    }
+    if (composerNode) {
+      observer.observe(composerNode)
+    }
+    return () => observer.disconnect()
+  }, [composerNode, contentNode, scrollToBottom, syncMeasurements, timelineNode])
+
+  useEffect(() => () => {
+    if (scrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(scrollFrameRef.current)
+    }
+    followupScrollFramesRef.current = 0
+  }, [])
+
+  const scrollOnComposerFocus = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0
+    if (isTouch) {
+      pinAndJumpToBottom()
+    }
+  }, [pinAndJumpToBottom])
+
+  const showOlderLoadButton = (
+    !initialLoading
+    && !isNewAgent
+    && !switchingAgentId
+    && eventCount > 0
+    && hasMoreOlder
+    && !loadingOlder
+    && !timelineCanScroll
+  )
+
+  return {
+    autoScrollPinnedRef: pinnedRef,
+    isNearBottom,
+    pinAndJumpToBottom,
+    requestPreviousPage,
+    scrollOnComposerFocus,
+    scrollToBottom,
+    showOlderLoadButton,
+    timelineContentRef,
+    timelineRef,
+    composerShellRef,
+  }
+}

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -64,6 +63,7 @@ import { getInitialAgentChatSidebarMode } from '../components/agentChat/sidebarM
 import { findLatestStatusExpansionTargets } from '../components/agentChat/statusExpansion'
 import { parseToolSearchResult } from '../components/agentChat/tooling/searchUtils'
 import type { ConnectionStatusTone } from '../components/agentChat/AgentChatBanner'
+import { useTimelineScrollController } from '../components/agentChat/useTimelineScrollController'
 import { useAgentChatSocket } from '../hooks/useAgentChatSocket'
 import { useAgentWebSession } from '../hooks/useAgentWebSession'
 import { useAgentRoster } from '../hooks/useAgentRoster'
@@ -116,7 +116,6 @@ const ROSTER_REFRESH_INTERVAL_MS = 20_000
 const ROSTER_PENDING_AVATAR_REFRESH_INTERVAL_MS = 4_000
 const ROSTER_PENDING_AVATAR_TRACK_WINDOW_MS = 90_000
 const AUDIT_URL_TEMPLATE_PLACEHOLDER = '00000000-0000-0000-0000-000000000000'
-const TIMELINE_SCROLLABILITY_EPSILON_PX = 1
 const SIGNUP_PREVIEW_PANEL_SOURCE = 'signup_preview_panel'
 const INSIGHTS_IDLE_FETCH_DELAY_MS = 1200
 const RESOLVED_NOISE_DARK_TEXTURE_URL = new URL(noiseDarkTextureUrl, import.meta.url).toString()
@@ -996,20 +995,7 @@ export type AgentChatPageProps = {
 
 const STREAMING_STALE_MS = 6000
 const STREAMING_REFRESH_INTERVAL_MS = 6000
-const AUTO_SCROLL_REPIN_SUPPRESSION_MS = 1500
-const BOTTOM_REPIN_THRESHOLD_PX = 50
-const NEAR_BOTTOM_THRESHOLD_PX = 100
-const TOP_LOAD_THRESHOLD_PX = 200
-const BOTTOM_EXIT_THRESHOLD_PX = 1
-const PROGRAMMATIC_SCROLL_GUARD_MS = 150
 const RESUME_TIMELINE_BACKFILL_MAX_NEWER_PAGES = DEFAULT_CONTIGUOUS_BACKFILL_MAX_PAGES
-
-function isEditableEventTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) {
-    return false
-  }
-  return target.closest('input, textarea, select, [contenteditable="true"]') !== null
-}
 
 export function AgentChatPage({
   agentId,
@@ -1070,7 +1056,6 @@ export function AgentChatPage({
   } = useSubscriptionStore()
   const isNewAgent = agentId === null
   const isSelectionView = agentId === undefined
-  const timelineRef = useRef<HTMLDivElement | null>(null)
   const pendingCreateRef = useRef<{
     body: string
     attachments: File[]
@@ -1295,8 +1280,6 @@ export function AgentChatPage({
   const insightsPaused = useAgentChatStore((state) => state.insightsPaused)
   const autoScrollPinned = useAgentChatStore((state) => state.autoScrollPinned)
   const setAutoScrollPinned = useAgentChatStore((state) => state.setAutoScrollPinned)
-  const suppressAutoScrollPin = useAgentChatStore((state) => state.suppressAutoScrollPin)
-  const autoScrollPinSuppressedUntil = useAgentChatStore((state) => state.autoScrollPinSuppressedUntil)
   const previousViewedAgentIdRef = useRef<string | null>(activeAgentId)
 
   useEffect(() => {
@@ -1338,184 +1321,59 @@ export function AgentChatPage({
     () => collapseDetailedStatusRuns(timelineEvents, statusExpansionTargets, { keepTrailingActivityExpanded }),
     [keepTrailingActivityExpanded, timelineEvents, statusExpansionTargets],
   )
-  const [timelineCanScrollForOlder, setTimelineCanScrollForOlder] = useState(false)
-  const [isNearBottom, setIsNearBottom] = useState(true)
-
-  const canLoadOlderViaScroll = useCallback((container: HTMLElement | null) => {
-    if (!container) {
-      return false
-    }
-    return container.scrollHeight > container.clientHeight + TIMELINE_SCROLLABILITY_EPSILON_PX
-  }, [])
-
-  const syncTimelineScrollability = useCallback((container: HTMLElement | null) => {
-    const next = canLoadOlderViaScroll(container)
-    setTimelineCanScrollForOlder((current) => (current === next ? current : next))
-    return next
-  }, [canLoadOlderViaScroll])
-
-  const showOlderLoadButton = (
-    !initialLoading
-    && !isNewAgent
-    && !switchingAgentId
-    && timelineEvents.length > 0
-    && timelineHasMoreOlder
-    && !timelineLoadingOlder
-    && !timelineCanScrollForOlder
-  )
-
-  const prevPageCountRef = useRef(timelineQuery.data?.pages?.length ?? 0)
-  const prevScrollHeightRef = useRef(0)
-  const prependTrackingAgentIdRef = useRef<string | null>(activeAgentId)
-  const preservePrependViewportRef = useRef(false)
-  const olderPageRequestInFlightRef = useRef(false)
-  const autoScrollPinnedRef = useRef(autoScrollPinned)
-  const autoScrollPinSuppressedUntilRef = useRef(autoScrollPinSuppressedUntil)
-  const lastProgrammaticScrollAtRef = useRef(0)
-  const forceScrollOnNextUpdateRef = useRef(false)
-  const didInitialScrollRef = useRef(false)
-  const isNearBottomRef = useRef(isNearBottom)
-  const autoRepinTimeoutRef = useRef<number | null>(null)
-  const composerFocusNudgeTimeoutRef = useRef<number | null>(null)
-  const userTouchActiveRef = useRef(false)
-  const touchEndTimerRef = useRef<number | null>(null)
+  const latestTimelineCursor = timelineEvents.length ? timelineEvents[timelineEvents.length - 1].cursor : ''
+  const timelineStreamingVersion = timelineStreaming
+    ? [
+        timelineStreaming.streamId,
+        timelineStreaming.cursor ?? '',
+        timelineStreaming.done ? 'done' : 'active',
+        timelineStreaming.content.length,
+        timelineStreaming.reasoning.length,
+      ].join(':')
+    : 'none'
+  const timelineScrollContentVersion = [
+    timelineEvents.length,
+    latestTimelineCursor,
+    timelineStreamingVersion,
+    timelineLoadingOlder ? 'older' : 'older-idle',
+    timelineLoadingNewer ? 'newer' : 'newer-idle',
+    timelineHasMoreNewer ? 'has-newer' : 'latest',
+    timelineHasUnseenActivity ? 'unseen' : 'seen',
+    timelineProcessingActive ? 'processing' : 'idle',
+    timelineAwaitingResponse ? 'awaiting' : 'settled',
+  ].join('|')
+  const {
+    autoScrollPinnedRef,
+    isNearBottom,
+    pinAndJumpToBottom,
+    requestPreviousPage,
+    scrollOnComposerFocus,
+    scrollToBottom,
+    showOlderLoadButton,
+    timelineContentRef,
+    timelineRef: captureTimelineRef,
+    composerShellRef,
+  } = useTimelineScrollController({
+    activeAgentId,
+    autoScrollPinned,
+    contentVersion: timelineScrollContentVersion,
+    eventCount: timelineEvents.length,
+    fetchPreviousPage: timelineQuery.fetchPreviousPage,
+    hasMoreOlder: timelineHasMoreOlder,
+    hasPreviousPage: Boolean(timelineQuery.hasPreviousPage),
+    initialLoading,
+    isFetchPreviousPageError: timelineQuery.isFetchPreviousPageError,
+    isFetchingPreviousPage: timelineQuery.isFetchingPreviousPage,
+    isNewAgent,
+    loadingOlder: timelineLoadingOlder,
+    pageCount: timelineQuery.data?.pages?.length ?? 0,
+    setAutoScrollPinned,
+    switchingAgentId,
+  })
   const pinnedAtSuspendRef = useRef(autoScrollPinned)
   const resumeBackfillInFlightRef = useRef<Promise<void> | null>(null)
   const resumeBackfillRunIdRef = useRef(0)
   const allowAgentRefreshRef = useRef(false)
-
-  // Track if we should scroll on next content update (captured before DOM changes)
-  const shouldScrollOnNextUpdateRef = useRef(autoScrollPinned)
-
-  useLayoutEffect(() => {
-    autoScrollPinnedRef.current = autoScrollPinned
-    autoScrollPinSuppressedUntilRef.current = autoScrollPinSuppressedUntil
-    isNearBottomRef.current = isNearBottom
-  }, [autoScrollPinned, autoScrollPinSuppressedUntil, isNearBottom])
-
-  const syncNearBottomState = useCallback((container: HTMLElement | null): number | null => {
-    if (!container) {
-      return null
-    }
-    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
-    const nearBottom = distanceFromBottom <= NEAR_BOTTOM_THRESHOLD_PX
-    isNearBottomRef.current = nearBottom
-    setIsNearBottom((previous) => (previous === nearBottom ? previous : nearBottom))
-    return distanceFromBottom
-  }, [])
-
-  const freezeTimelineViewport = useCallback(() => {
-    const wasPinned = autoScrollPinnedRef.current
-    shouldScrollOnNextUpdateRef.current = false
-    forceScrollOnNextUpdateRef.current = false
-    autoScrollPinnedRef.current = false
-    autoScrollPinSuppressedUntilRef.current = Date.now() + AUTO_SCROLL_REPIN_SUPPRESSION_MS
-    if (wasPinned) {
-      setAutoScrollPinned(false)
-    }
-    suppressAutoScrollPin(AUTO_SCROLL_REPIN_SUPPRESSION_MS)
-    if (autoRepinTimeoutRef.current !== null) {
-      window.clearTimeout(autoRepinTimeoutRef.current)
-      autoRepinTimeoutRef.current = null
-    }
-  }, [setAutoScrollPinned, suppressAutoScrollPin])
-
-  const requestPreviousPage = useCallback(() => {
-    if (
-      olderPageRequestInFlightRef.current
-      || !timelineQuery.hasPreviousPage
-      || timelineQuery.isFetchingPreviousPage
-      || timelineQuery.isFetchPreviousPageError
-    ) {
-      return
-    }
-
-    freezeTimelineViewport()
-    prevPageCountRef.current = timelineQuery.data?.pages?.length ?? 0
-    prevScrollHeightRef.current = timelineRef.current?.scrollHeight ?? 0
-    preservePrependViewportRef.current = true
-    olderPageRequestInFlightRef.current = true
-    void timelineQuery.fetchPreviousPage().finally(() => {
-      olderPageRequestInFlightRef.current = false
-    })
-  }, [
-    timelineQuery.data?.pages?.length,
-    timelineQuery.fetchPreviousPage,
-    timelineQuery.hasPreviousPage,
-    timelineQuery.isFetchingPreviousPage,
-    timelineQuery.isFetchPreviousPageError,
-    freezeTimelineViewport,
-  ])
-
-  useEffect(() => {
-    olderPageRequestInFlightRef.current = false
-  }, [activeAgentId])
-
-  // Auto-trigger older loading when scrolled near top
-  useEffect(() => {
-    const container = timelineRef.current
-    const canReachOlderViaScroll = canLoadOlderViaScroll(container)
-    const nearTopByScroll = container ? container.scrollTop <= TOP_LOAD_THRESHOLD_PX : false
-    if (
-      !didInitialScrollRef.current
-      || initialLoading
-      || isNewAgent
-      || switchingAgentId
-      || !timelineEvents.length
-      || !canReachOlderViaScroll
-    ) {
-      return
-    }
-    if (nearTopByScroll) {
-      requestPreviousPage()
-    }
-  }, [
-    initialLoading,
-    isNewAgent,
-    canLoadOlderViaScroll,
-    requestPreviousPage,
-    switchingAgentId,
-    timelineEvents.length,
-  ])
-
-  // Preserve the viewport when older pages prepend above the current scroll position.
-  useLayoutEffect(() => {
-    const pageCount = timelineQuery.data?.pages?.length ?? 0
-    if (prependTrackingAgentIdRef.current !== activeAgentId) {
-      prependTrackingAgentIdRef.current = activeAgentId
-      preservePrependViewportRef.current = false
-      prevPageCountRef.current = pageCount
-      prevScrollHeightRef.current = timelineRef.current?.scrollHeight ?? 0
-      return
-    }
-
-    if (preservePrependViewportRef.current && pageCount > prevPageCountRef.current && prevPageCountRef.current > 0) {
-      const container = timelineRef.current
-      if (container) {
-        const newScrollHeight = container.scrollHeight
-        const delta = newScrollHeight - prevScrollHeightRef.current
-        if (delta > 0) {
-          container.scrollTop += delta
-        }
-        syncTimelineScrollability(container)
-        syncNearBottomState(container)
-      }
-    }
-
-    if (preservePrependViewportRef.current && timelineQuery.isFetchingPreviousPage) {
-      return
-    }
-
-    preservePrependViewportRef.current = false
-    prevPageCountRef.current = pageCount
-    prevScrollHeightRef.current = timelineRef.current?.scrollHeight ?? 0
-  }, [
-    activeAgentId,
-    syncNearBottomState,
-    syncTimelineScrollability,
-    timelineQuery.data?.pages?.length,
-    timelineQuery.isFetchingPreviousPage,
-  ])
 
   const [collaboratorInviteOpen, setCollaboratorInviteOpen] = useState(false)
   const [publicShareOpen, setPublicShareOpen] = useState(false)
@@ -1875,46 +1733,6 @@ export function AgentChatPage({
     setPendingAvatarTracking((current) => prunePendingAvatarTracking(current, rosterQuery.data.agents))
   }, [rosterQuery.data?.agents])
 
-  const shouldAutoFollowTimeline = useCallback(() => {
-    return autoScrollPinnedRef.current && isNearBottomRef.current && !userTouchActiveRef.current
-  }, [])
-
-  const repinAutoScrollIfAtBottom = useCallback((container: HTMLElement | null) => {
-    if (!container || autoScrollPinnedRef.current) {
-      return
-    }
-    // Respect the suppression window after intentional user scroll-up
-    if (autoScrollPinSuppressedUntilRef.current && Date.now() < autoScrollPinSuppressedUntilRef.current) {
-      return
-    }
-    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
-    if (distanceFromBottom > BOTTOM_REPIN_THRESHOLD_PX) {
-      return
-    }
-    // If unseen events are waiting in pending cache, force a post-flush jump so
-    // we don't strand the viewport just above newly injected latest content.
-    if (timelineHasUnseenActivity) {
-      forceScrollOnNextUpdateRef.current = true
-    }
-    autoScrollPinnedRef.current = true
-    setAutoScrollPinned(true)
-  }, [setAutoScrollPinned, timelineHasUnseenActivity])
-
-  const unpinAutoScrollFromUserGesture = useCallback(() => {
-    if (!autoScrollPinnedRef.current) {
-      return
-    }
-    freezeTimelineViewport()
-    autoRepinTimeoutRef.current = window.setTimeout(() => {
-      autoRepinTimeoutRef.current = null
-      repinAutoScrollIfAtBottom(document.getElementById('timeline-shell'))
-    }, AUTO_SCROLL_REPIN_SUPPRESSION_MS + 16)
-  }, [freezeTimelineViewport, repinAutoScrollIfAtBottom])
-
-  useEffect(() => {
-    didInitialScrollRef.current = false
-  }, [activeAgentId])
-
   useEffect(() => {
     resumeBackfillRunIdRef.current += 1
     resumeBackfillInFlightRef.current = null
@@ -1925,259 +1743,12 @@ export function AgentChatPage({
     setCollaboratorInviteOpen(false)
   }, [activeAgentId])
 
-  // IntersectionObserver-based bottom detection - simpler and more reliable than scroll math
-  const bottomSentinelRef = useRef<HTMLElement | null>(null)
-  // Track whether sentinel exists to re-run effect when it appears
-  const hasSentinel = !initialLoading && !timelineHasMoreNewer
-  useEffect(() => {
-    // Find the bottom sentinel element and scroll container
-    const sentinel = document.getElementById('timeline-bottom-sentinel')
-    const container = document.getElementById('timeline-shell')
-    bottomSentinelRef.current = sentinel
-
-    // If no sentinel yet, mark as at-bottom by default (will be corrected when it appears)
-    if (!sentinel || !container) {
-      isNearBottomRef.current = true
-      setIsNearBottom(true)
-      return
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        const distanceFromBottom = syncNearBottomState(container)
-        const atBottom = entry.isIntersecting
-          && typeof distanceFromBottom === 'number'
-          && distanceFromBottom <= BOTTOM_REPIN_THRESHOLD_PX
-
-        // Auto-restick only when the user is truly at the bottom.
-        if (atBottom) {
-          repinAutoScrollIfAtBottom(container)
-        }
-      },
-      {
-        // Use container as root for container scrolling
-        root: container,
-        // Extend bottom edge so sentinel is "visible" before fully in view.
-        rootMargin: '0px 0px 50px 0px',
-        threshold: 0,
-      },
-    )
-
-    syncNearBottomState(container)
-    observer.observe(sentinel)
-    return () => observer.disconnect()
-  }, [hasSentinel, repinAutoScrollIfAtBottom, syncNearBottomState])
-
-  // Detect user scrolling UP to immediately unpin (wheel, touch, keyboard, scrollbar drag)
-  useEffect(() => {
-    const container = document.getElementById('timeline-shell')
-    if (!container) return
-
-    let lastScrollTop = container.scrollTop
-
-    // Catch scrollbar drags / momentum scrolling where wheel events may not fire consistently.
-    const handleScroll = () => {
-      const nextScrollTop = container.scrollTop
-      const distanceFromBottom = syncNearBottomState(container)
-      const canReachOlderViaScroll = syncTimelineScrollability(container)
-      if (
-        didInitialScrollRef.current
-        && !initialLoading
-        && !isNewAgent
-        && !switchingAgentId
-        && timelineEvents.length
-        && canReachOlderViaScroll
-        && nextScrollTop <= TOP_LOAD_THRESHOLD_PX
-      ) {
-        requestPreviousPage()
-      }
-      // Don't try to re-pin while user is actively touching — let their scroll intent take priority
-      if (!userTouchActiveRef.current) {
-        repinAutoScrollIfAtBottom(container)
-      }
-      const movedAwayFromBottom = typeof distanceFromBottom === 'number'
-        && distanceFromBottom > BOTTOM_EXIT_THRESHOLD_PX
-      // Guard against false unpins from programmatic scrolls (scrollIntoView can cause transient scrollTop decreases).
-      // Bypass the guard when the user is actively touching — touch scroll is always user-initiated.
-      if (
-        movedAwayFromBottom
-        && nextScrollTop < lastScrollTop - 2
-        && (userTouchActiveRef.current || Date.now() - lastProgrammaticScrollAtRef.current > PROGRAMMATIC_SCROLL_GUARD_MS)
-      ) {
-        unpinAutoScrollFromUserGesture()
-      }
-      lastScrollTop = nextScrollTop
-    }
-
-    // Detect scroll-up via wheel
-    const handleWheel = (e: WheelEvent) => {
-      const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
-      if (e.deltaY < 0 && distanceFromBottom > BOTTOM_EXIT_THRESHOLD_PX) {
-        unpinAutoScrollFromUserGesture()
-      }
-    }
-
-    // Track touch lifecycle to suppress programmatic scrolls while user is touching
-    let touchStartY: number | null = null
-    const handleTouchStart = (e: TouchEvent) => {
-      if (touchEndTimerRef.current !== null) {
-        window.clearTimeout(touchEndTimerRef.current)
-        touchEndTimerRef.current = null
-      }
-      userTouchActiveRef.current = true
-      touchStartY = e.touches[0]?.clientY ?? null
-    }
-    // Detect upward swipe directly via touch movement — more reliable than waiting
-    // for scroll events on mobile, which can be blocked by the programmatic scroll guard.
-    const handleTouchMove = (e: TouchEvent) => {
-      if (!autoScrollPinnedRef.current || touchStartY === null) return
-      const currentY = e.touches[0]?.clientY
-      if (currentY === undefined) return
-      // Finger moving down on screen = scrolling up (revealing older content)
-      if (currentY - touchStartY > 10) {
-        const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
-        if (distanceFromBottom > BOTTOM_EXIT_THRESHOLD_PX) {
-          unpinAutoScrollFromUserGesture()
-        }
-      }
-    }
-    const handleTouchEnd = () => {
-      touchStartY = null
-      if (touchEndTimerRef.current !== null) {
-        window.clearTimeout(touchEndTimerRef.current)
-      }
-      touchEndTimerRef.current = window.setTimeout(() => {
-        userTouchActiveRef.current = false
-        touchEndTimerRef.current = null
-      }, 200)
-    }
-
-    // Detect scroll-up via keyboard
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!autoScrollPinnedRef.current) return
-      if (isEditableEventTarget(e.target)) return
-      const scrollUpKeys = ['ArrowUp', 'PageUp', 'Home']
-      const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
-      if (scrollUpKeys.includes(e.key) && distanceFromBottom > BOTTOM_EXIT_THRESHOLD_PX) {
-        unpinAutoScrollFromUserGesture()
-      }
-    }
-
-    // Listen on the container, not window
-    syncNearBottomState(container)
-    syncTimelineScrollability(container)
-    container.addEventListener('scroll', handleScroll, { passive: true })
-    container.addEventListener('wheel', handleWheel, { passive: true })
-    container.addEventListener('touchstart', handleTouchStart, { passive: true })
-    container.addEventListener('touchmove', handleTouchMove, { passive: true })
-    container.addEventListener('touchend', handleTouchEnd, { passive: true })
-    container.addEventListener('touchcancel', handleTouchEnd, { passive: true })
-    window.addEventListener('keydown', handleKeyDown) // Keyboard stays on window
-
-    return () => {
-      container.removeEventListener('scroll', handleScroll)
-      container.removeEventListener('wheel', handleWheel)
-      container.removeEventListener('touchstart', handleTouchStart)
-      container.removeEventListener('touchmove', handleTouchMove)
-      container.removeEventListener('touchend', handleTouchEnd)
-      container.removeEventListener('touchcancel', handleTouchEnd)
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [
-    initialLoading,
-    isNewAgent,
-    repinAutoScrollIfAtBottom,
-    requestPreviousPage,
-    syncTimelineScrollability,
-    switchingAgentId,
-    syncNearBottomState,
-    timelineEvents.length,
-    unpinAutoScrollFromUserGesture,
-  ])
-
-  // Unpin auto-scroll when processing ends so user's reading position is preserved
-  const prevProcessingRef = useRef(timelineProcessingActive)
-  useEffect(() => {
-    const wasProcessing = prevProcessingRef.current
-    prevProcessingRef.current = timelineProcessingActive
-    if (wasProcessing && !timelineProcessingActive && !isNearBottomRef.current && !autoScrollPinnedRef.current) {
-      setAutoScrollPinned(false)
-    }
-  }, [timelineProcessingActive, setAutoScrollPinned])
-
-  // Capture scroll decision BEFORE content changes to avoid race with scroll handler
-  const prevEventsRef = useRef(timelineEvents)
-  const prevStreamingRef = useRef(timelineStreaming)
-
-  if (timelineEvents !== prevEventsRef.current || timelineStreaming !== prevStreamingRef.current) {
-    shouldScrollOnNextUpdateRef.current = autoScrollPinned && isNearBottom
-    prevEventsRef.current = timelineEvents
-    prevStreamingRef.current = timelineStreaming
-  }
-
-  const pendingScrollFrameRef = useRef<number | null>(null)
-
-  // Lightweight auto-follow: just set scrollTop, no overflow toggle.
-  // Used by ResizeObserver callbacks to avoid layout thrashing during rapid layout updates.
-  // Does NOT update lastProgrammaticScrollAtRef — that guard is for user-initiated
-  // programmatic scrolls (jump-to-latest, send). Auto-follow must not block detection
-  // of user scroll-up gestures (especially momentum scrolling after touch end on mobile).
-  const snapToBottom = useCallback(() => {
-    const container = document.getElementById('timeline-shell')
-    if (!container) return
-    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
-    // Already at bottom — skip to avoid triggering scroll events
-    if (distanceFromBottom < 2) return
-    container.scrollTop = container.scrollHeight
-    isNearBottomRef.current = true
-    setIsNearBottom(true)
-  }, [])
-
-  // Full jump with iOS momentum kill — used for user-initiated actions
-  // (send message, click jump button, composer focus, initial scroll).
-  const jumpToBottom = useCallback(() => {
-    const container = document.getElementById('timeline-shell')
-    if (!container) return
-    lastProgrammaticScrollAtRef.current = Date.now()
-    // Kill iOS momentum scrolling — toggling overflow forces the scroll to stop immediately
-    container.style.overflowY = 'hidden'
-    container.scrollTop = container.scrollHeight + 10000
-    requestAnimationFrame(() => { container.style.overflowY = '' })
-    isNearBottomRef.current = true
-    setIsNearBottom(true)
-  }, [])
-
-  // rAF-coalesced auto-follow (for ResizeObserver / content change paths)
-  const scrollToBottom = useCallback(() => {
-    if (pendingScrollFrameRef.current !== null) {
-      return
-    }
-    pendingScrollFrameRef.current = requestAnimationFrame(() => {
-      pendingScrollFrameRef.current = null
-      snapToBottom()
-    })
-  }, [snapToBottom])
-
-  const executeAutoFollow = useCallback(() => {
-    scrollToBottom()
-    isNearBottomRef.current = true
-    setIsNearBottom(true)
-  }, [scrollToBottom])
-
   const runContiguousTimelineBackfill = useCallback(async (agentIdToRefresh: string) => {
     return refreshTimelineLatestInCache(queryClient, agentIdToRefresh, {
       mode: 'contiguous',
       maxNewerPages: RESUME_TIMELINE_BACKFILL_MAX_NEWER_PAGES,
     })
   }, [queryClient])
-
-  const repinAndJumpToBottom = useCallback(() => {
-    autoScrollPinnedRef.current = true
-    forceScrollOnNextUpdateRef.current = true
-    setAutoScrollPinned(true)
-    jumpToBottom()
-    scrollToBottom()
-  }, [jumpToBottom, scrollToBottom, setAutoScrollPinned])
 
   const syncLatestTimeline = useCallback(async (
     agentIdToRefresh: string,
@@ -2190,8 +1761,8 @@ export function AgentChatPage({
     if (!repinToLatest) {
       return
     }
-    repinAndJumpToBottom()
-  }, [repinAndJumpToBottom, runContiguousTimelineBackfill])
+    pinAndJumpToBottom()
+  }, [pinAndJumpToBottom, runContiguousTimelineBackfill])
 
   const triggerResumeTimelineBackfill = useCallback(() => {
     const currentAgentId = activeAgentIdRef.current
@@ -2238,138 +1809,6 @@ export function AgentChatPage({
     },
     { resumeThrottleMs: 4000 },
   )
-
-  // Keep track of composer height to adjust scroll when it changes
-  const prevComposerHeight = useRef<number | null>(null)
-
-  useEffect(() => {
-    const composer = document.getElementById('agent-composer-shell')
-    const container = document.getElementById('timeline-shell')
-    if (!composer || !container) return
-
-    const observer = new ResizeObserver((entries) => {
-      const height = entries[0].borderBoxSize?.[0]?.blockSize ?? entries[0].contentRect.height
-      const shouldFollow = shouldAutoFollowTimeline()
-
-      if (prevComposerHeight.current !== null) {
-        const delta = height - prevComposerHeight.current
-        // If composer grew and we're at the bottom, scroll down to keep content visible
-        if (delta > 0 && shouldFollow) {
-          container.scrollTop += delta
-        }
-      }
-
-      prevComposerHeight.current = height
-
-      // If pinned, ensure we stay at the bottom
-      if (shouldFollow) {
-        executeAutoFollow()
-        return
-      }
-      syncNearBottomState(container)
-    })
-
-    observer.observe(composer)
-    return () => observer.disconnect()
-  }, [executeAutoFollow, shouldAutoFollowTimeline, syncNearBottomState])
-
-  const [timelineNode, setTimelineNode] = useState<HTMLDivElement | null>(null)
-  const captureTimelineRef = useCallback((node: HTMLDivElement | null) => {
-    timelineRef.current = node
-    syncTimelineScrollability(node)
-    setTimelineNode(node)
-  }, [syncTimelineScrollability])
-
-  // Observe timeline changes (e.g. images loading, new DOM elements) to keep pinned to bottom
-  useEffect(() => {
-    if (!timelineNode) {
-      setTimelineCanScrollForOlder(false)
-      return
-    }
-    const inner = document.getElementById('timeline-events')
-
-    const observer = new ResizeObserver(() => {
-      syncTimelineScrollability(timelineNode)
-      const shouldFollow = shouldAutoFollowTimeline()
-      // If pinned, ensure we stay at the bottom when content changes
-      // Skip while user is actively touching to prevent scroll fighting on mobile
-      // Uses rAF-coalesced scrollToBottom to avoid ResizeObserver feedback loops
-      if (shouldFollow) {
-        executeAutoFollow()
-        return
-      }
-      syncNearBottomState(timelineNode)
-    })
-
-    observer.observe(timelineNode)
-    if (inner) {
-      observer.observe(inner)
-    }
-    return () => observer.disconnect()
-  }, [executeAutoFollow, syncTimelineScrollability, timelineNode, shouldAutoFollowTimeline, syncNearBottomState])
-
-  useEffect(() => () => {
-    if (pendingScrollFrameRef.current !== null) {
-      cancelAnimationFrame(pendingScrollFrameRef.current)
-    }
-  }, [])
-
-  useEffect(() => () => {
-    if (autoRepinTimeoutRef.current !== null) {
-      window.clearTimeout(autoRepinTimeoutRef.current)
-    }
-    if (composerFocusNudgeTimeoutRef.current !== null) {
-      window.clearTimeout(composerFocusNudgeTimeoutRef.current)
-    }
-    if (touchEndTimerRef.current !== null) {
-      window.clearTimeout(touchEndTimerRef.current)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (isNewAgent) {
-      // New agent: no events yet, but ensure auto-scroll is pinned for when content arrives
-      didInitialScrollRef.current = true
-      setAutoScrollPinned(true)
-      return
-    }
-    if (!initialLoading && timelineEvents.length && !didInitialScrollRef.current) {
-      didInitialScrollRef.current = true
-      setAutoScrollPinned(true)
-      // Immediate scroll attempt
-      jumpToBottom()
-      // Plus delayed scroll to catch any async layout (images, fonts, etc)
-      const timeout = setTimeout(() => jumpToBottom(), 50)
-      return () => clearTimeout(timeout)
-    }
-  }, [timelineEvents.length, initialLoading, isNewAgent, jumpToBottom, setAutoScrollPinned])
-
-  useLayoutEffect(() => {
-    if (forceScrollOnNextUpdateRef.current) {
-      // Force scroll (user-initiated actions like send, jump-to-latest) — always honor
-      forceScrollOnNextUpdateRef.current = false
-      shouldScrollOnNextUpdateRef.current = false
-      jumpToBottom()
-    } else if (shouldScrollOnNextUpdateRef.current) {
-      // Auto scroll (new content while pinned) — use lightweight snap to avoid layout thrashing
-      shouldScrollOnNextUpdateRef.current = false
-      if (!userTouchActiveRef.current) {
-        snapToBottom()
-      }
-    }
-  }, [
-    jumpToBottom,
-    snapToBottom,
-    timelineEvents,
-    timelineStreaming,
-    timelineLoadingOlder,
-    timelineLoadingNewer,
-    timelineHasMoreNewer,
-    timelineHasUnseenActivity,
-    initialLoading,
-    timelineProcessingActive,
-    timelineAwaitingResponse,
-  ])
 
   const rosterContextMismatch = Boolean(
     effectiveContext
@@ -3427,28 +2866,13 @@ export function AgentChatPage({
         await syncLatestTimeline(currentAgentId, { repinToLatest: true })
         return
       }
-      repinAndJumpToBottom()
+      pinAndJumpToBottom()
     })()
-  }, [repinAndJumpToBottom, syncLatestTimeline, timelineHasMoreNewer])
+  }, [pinAndJumpToBottom, syncLatestTimeline, timelineHasMoreNewer])
 
   const handleComposerFocus = useCallback(() => {
-    if (typeof window === 'undefined') return
-    const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0
-    if (!isTouch) return
-
-    setAutoScrollPinned(true)
-    forceScrollOnNextUpdateRef.current = true
-    jumpToBottom()
-
-    if (composerFocusNudgeTimeoutRef.current !== null) {
-      window.clearTimeout(composerFocusNudgeTimeoutRef.current)
-    }
-    composerFocusNudgeTimeoutRef.current = window.setTimeout(() => {
-      jumpToBottom()
-      scrollToBottom()
-      composerFocusNudgeTimeoutRef.current = null
-    }, 180)
-  }, [jumpToBottom, scrollToBottom, setAutoScrollPinned])
+    scrollOnComposerFocus()
+  }, [scrollOnComposerFocus])
 
   const handleUpgrade = useCallback(async (plan: PlanTier, source?: string) => {
     const resolvedSource = source ?? upgradeModalSource ?? 'upgrade_modal'
@@ -4829,6 +4253,7 @@ export function AgentChatPage({
         planSnapshot={latestPlanSnapshot}
         {...chatLayoutSidebarProps}
         onComposerFocus={handleComposerFocus}
+        onComposerRequestScrollToBottom={scrollToBottom}
         onClose={onClose}
         dailyCredits={dailyCreditsInfo}
         dailyCreditsStatus={dailyCreditsStatus}
@@ -4919,6 +4344,8 @@ export function AgentChatPage({
         isNearBottom={isNearBottom}
         hasUnseenActivity={timelineHasUnseenActivity}
         timelineRef={captureTimelineRef}
+        timelineContentRef={timelineContentRef}
+        composerShellRef={composerShellRef}
         loadingOlder={timelineLoadingOlder}
         loadingNewer={timelineLoadingNewer}
         initialLoading={initialLoading}

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3050,11 +3050,6 @@
   display: none;
 }
 
-.timeline-bottom-sentinel {
-  width: 100%;
-  height: 1px;
-}
-
 .timeline-load-button {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Extracted the timeline rendering into `AgentTimelinePane` and renamed the item renderer to `TimelineEventItem` for clearer ownership.
- Reworked chat scrolling around a smaller controller with explicit pinned, prepend-restore, and jump-to-latest paths.
- Wired layout refs through the chat shell and removed the old bottom sentinel / scattered scroll helpers.

## Testing
- Focused frontend tests for `AgentChatPage` and `AgentChatLayout` passed.
- Frontend app build passed, including TypeScript compilation and production bundling.