### PR TITLE
Add parent result IDs for nested custom-tool calls

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -1279,6 +1279,7 @@ def _persist_tool_call_step(
     consumed_credit: Any,
     attach_completion: Any,
     attach_prompt_archive: Any,
+    parent_tool_call: Any = None,
 ) -> Optional["PersistentAgentStep"]:
     """Persist a tool call step with robust error handling.
 
@@ -1312,6 +1313,7 @@ def _persist_tool_call_step(
         tool_call_status = status or "complete"
         PersistentAgentToolCall.objects.create(
             step=step,
+            parent_tool_call=parent_tool_call,
             tool_name=safe_tool_name,
             tool_params=tool_params,
             result=normalized_result,
@@ -1409,6 +1411,7 @@ def _create_pending_tool_call_step(
     consumed_credit: Any,
     attach_completion: Any,
     attach_prompt_archive: Any,
+    parent_tool_call: Any = None,
 ) -> Optional["PersistentAgentStep"]:
     from api.models import PersistentAgentStep, PersistentAgentToolCall
 
@@ -1426,6 +1429,7 @@ def _create_pending_tool_call_step(
         attach_prompt_archive(step)
         PersistentAgentToolCall.objects.create(
             step=step,
+            parent_tool_call=parent_tool_call,
             tool_name=safe_tool_name,
             tool_params=tool_params,
             result="",
@@ -1459,6 +1463,7 @@ def _finalize_pending_tool_call_step(
     result_content: str,
     execution_duration_ms: Optional[int],
     status: str,
+    parent_tool_call: Any = None,
 ) -> None:
     from api.models import PersistentAgentToolCall
 
@@ -1500,6 +1505,7 @@ def _finalize_pending_tool_call_step(
         if tool_call is None:
             tool_call = PersistentAgentToolCall.objects.create(
                 step=step,
+                parent_tool_call=parent_tool_call,
                 tool_name=safe_tool_name,
                 tool_params=tool_params,
                 result=normalized_result,
@@ -1513,7 +1519,11 @@ def _finalize_pending_tool_call_step(
             tool_call.result = normalized_result
             tool_call.execution_duration_ms = execution_duration_ms
             tool_call.status = status
-            tool_call.save(update_fields=["tool_name", "tool_params", "result", "execution_duration_ms", "status"])
+            update_fields = ["tool_name", "tool_params", "result", "execution_duration_ms", "status"]
+            if parent_tool_call is not None and tool_call.parent_tool_call_id is None:
+                tool_call.parent_tool_call = parent_tool_call
+                update_fields.append("parent_tool_call")
+            tool_call.save(update_fields=update_fields)
     except Exception as exc:
         agent = _agent_from_step(step)
         if agent is not None:

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -4329,9 +4329,11 @@ def _get_unified_history_prompt(
                 "tool_name",
                 "step__completion_id",
                 "parent_tool_call_id",
+                "parent_tool_call__tool_name",
             )
         )
         tool_call_parent_ids: Dict[str, str] = {}
+        tool_call_parent_names: Dict[str, str] = {}
         for row in tool_call_results:
             step_id = str(row["step_id"])
             step = step_lookup.get(step_id)
@@ -4349,7 +4351,11 @@ def _get_unified_history_prompt(
             tool_call_completion_ids[step_id] = str(completion_id) if completion_id else None
             parent_tool_call_id = row.get("parent_tool_call_id")
             if parent_tool_call_id:
-                tool_call_parent_ids[step_id] = str(parent_tool_call_id)
+                parent_id = str(parent_tool_call_id)
+                tool_call_parent_ids[step_id] = parent_id
+                parent_tool_name = row.get("parent_tool_call__tool_name") or ""
+                if parent_tool_name:
+                    tool_call_parent_names[step_id] = str(parent_tool_name)
             tool_call_records.append(
                 ToolCallResultRecord(
                     step_id=step_id,
@@ -4425,6 +4431,9 @@ def _get_unified_history_prompt(
             parent_tool_call_id = tool_call_parent_ids.get(str(s.id))
             parent_result_info = tool_result_prompt_info.get(parent_tool_call_id) if parent_tool_call_id else None
             if parent_result_info:
+                parent_tool_name = tool_call_parent_names.get(str(s.id))
+                if parent_tool_name:
+                    components["parent_tool_name"] = parent_tool_name
                 components["parent_result_id"] = parent_result_info.result_id
             if getattr(s, "credits_cost", None) is not None:
                 components["cost"] = f"{s.credits_cost} credits"
@@ -4679,6 +4688,7 @@ def _get_unified_history_prompt(
         # Component weights within each event
         COMPONENT_WEIGHTS = {
             "meta": 3,        # High priority - always want to see what happened
+            "parent_tool_name": 3,  # High priority - identifies the parent tool without a lookup
             "parent_result_id": 3,  # High priority - preserves nested tool attribution
             "cost": 2,        # Helpful for budgeting; small and should remain visible
             "params": 1,      # Low priority - can be shrunk aggressively

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -4323,8 +4323,15 @@ def _get_unified_history_prompt(
         tool_call_results = (
             PersistentAgentToolCall.objects
             .filter(step_id__in=list(step_lookup.keys()))
-            .values("step_id", "result", "tool_name", "step__completion_id")
+            .values(
+                "step_id",
+                "result",
+                "tool_name",
+                "step__completion_id",
+                "parent_tool_call_id",
+            )
         )
+        tool_call_parent_ids: Dict[str, str] = {}
         for row in tool_call_results:
             step_id = str(row["step_id"])
             step = step_lookup.get(step_id)
@@ -4340,6 +4347,9 @@ def _get_unified_history_prompt(
                 continue
             completion_id = row.get("step__completion_id")
             tool_call_completion_ids[step_id] = str(completion_id) if completion_id else None
+            parent_tool_call_id = row.get("parent_tool_call_id")
+            if parent_tool_call_id:
+                tool_call_parent_ids[step_id] = str(parent_tool_call_id)
             tool_call_records.append(
                 ToolCallResultRecord(
                     step_id=step_id,
@@ -4348,6 +4358,25 @@ def _get_unified_history_prompt(
                     result_text=result_text,
                 )
             )
+        missing_parent_ids = set(tool_call_parent_ids.values()) - {record.step_id for record in tool_call_records}
+        if missing_parent_ids:
+            parent_tool_call_results = (
+                PersistentAgentToolCall.objects
+                .filter(step_id__in=missing_parent_ids)
+                .values("step_id", "result", "tool_name", "step__created_at")
+            )
+            for row in parent_tool_call_results:
+                result_text = row.get("result") or ""
+                if not result_text:
+                    continue
+                tool_call_records.append(
+                    ToolCallResultRecord(
+                        step_id=str(row["step_id"]),
+                        tool_name=row.get("tool_name") or "",
+                        created_at=row["step__created_at"],
+                        result_text=result_text,
+                    )
+                )
         if tool_call_records:
             newest_record = max(tool_call_records, key=lambda record: record.created_at)
             newest_completion_id = tool_call_completion_ids.get(newest_record.step_id)
@@ -4390,6 +4419,10 @@ def _get_unified_history_prompt(
                 "meta": f"[{s.created_at.isoformat()}] Tool {tc.tool_name} called.",
                 "params": json.dumps(tc.tool_params)
             }
+            parent_tool_call_id = tool_call_parent_ids.get(str(s.id))
+            parent_result_info = tool_result_prompt_info.get(parent_tool_call_id) if parent_tool_call_id else None
+            if parent_result_info:
+                components["parent_result_id"] = parent_result_info.result_id
             if getattr(s, "credits_cost", None) is not None:
                 components["cost"] = f"{s.credits_cost} credits"
             result_info = tool_result_prompt_info.get(str(s.id))
@@ -4643,6 +4676,7 @@ def _get_unified_history_prompt(
         # Component weights within each event
         COMPONENT_WEIGHTS = {
             "meta": 3,        # High priority - always want to see what happened
+            "parent_result_id": 3,  # High priority - preserves nested tool attribution
             "cost": 2,        # Helpful for budgeting; small and should remain visible
             "params": 1,      # Low priority - can be shrunk aggressively
             "prompt": 1,      # Browser task/user prompt context; useful but repeatable

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -4363,15 +4363,18 @@ def _get_unified_history_prompt(
             parent_tool_call_results = (
                 PersistentAgentToolCall.objects
                 .filter(step_id__in=missing_parent_ids)
-                .values("step_id", "result", "tool_name", "step__created_at")
+                .values("step_id", "result", "tool_name", "step__created_at", "step__completion_id")
             )
             for row in parent_tool_call_results:
                 result_text = row.get("result") or ""
                 if not result_text:
                     continue
+                step_id = str(row["step_id"])
+                completion_id = row.get("step__completion_id")
+                tool_call_completion_ids[step_id] = str(completion_id) if completion_id else None
                 tool_call_records.append(
                     ToolCallResultRecord(
-                        step_id=str(row["step_id"]),
+                        step_id=step_id,
                         tool_name=row.get("tool_name") or "",
                         created_at=row["step__created_at"],
                         result_text=result_text,

--- a/api/agent/tools/tracked_runtime.py
+++ b/api/agent/tools/tracked_runtime.py
@@ -4,11 +4,13 @@ import time
 from decimal import Decimal
 from typing import Any, Dict, Optional
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from api.agent.comms.human_input_requests import (
     attach_originating_step_from_result,
     track_human_input_request_created,
 )
-from api.models import PersistentAgent, PersistentAgentStep
+from api.models import PersistentAgent, PersistentAgentStep, PersistentAgentToolCall
 
 from .runtime_execution_context import tool_execution_context
 from .tool_runtime import execute_runtime_tool_call
@@ -38,6 +40,15 @@ def _no_prompt_archive(_step: PersistentAgentStep) -> None:
     return None
 
 
+def _parent_tool_call_from_step(parent_step: Optional[PersistentAgentStep]) -> Optional[PersistentAgentToolCall]:
+    if parent_step is None:
+        return None
+    try:
+        return parent_step.tool_call
+    except ObjectDoesNotExist:
+        return None
+
+
 def execute_tracked_runtime_tool_call(
     agent: PersistentAgent,
     *,
@@ -58,6 +69,7 @@ def execute_tracked_runtime_tool_call(
     )
 
     attach_completion = _build_attach_completion(parent_step)
+    parent_tool_call = _parent_tool_call_from_step(parent_step)
 
     if not _enforce_tool_rate_limit(
         agent,
@@ -87,6 +99,7 @@ def execute_tracked_runtime_tool_call(
         consumed_credit=consumed_credit,
         attach_completion=attach_completion,
         attach_prompt_archive=_no_prompt_archive,
+        parent_tool_call=parent_tool_call,
     )
 
     result = None
@@ -132,6 +145,7 @@ def execute_tracked_runtime_tool_call(
             result_content=result_content,
             execution_duration_ms=duration_ms,
             status=tool_status,
+            parent_tool_call=parent_tool_call,
         )
         step = pending_step
     else:
@@ -146,6 +160,7 @@ def execute_tracked_runtime_tool_call(
             consumed_credit=consumed_credit,
             attach_completion=attach_completion,
             attach_prompt_archive=_no_prompt_archive,
+            parent_tool_call=parent_tool_call,
         )
 
     if step is not None and tool_name == "request_human_input" and isinstance(result, dict):

--- a/api/agent/tools/tracked_runtime.py
+++ b/api/agent/tools/tracked_runtime.py
@@ -4,8 +4,6 @@ import time
 from decimal import Decimal
 from typing import Any, Dict, Optional
 
-from django.core.exceptions import ObjectDoesNotExist
-
 from api.agent.comms.human_input_requests import (
     attach_originating_step_from_result,
     track_human_input_request_created,
@@ -43,10 +41,7 @@ def _no_prompt_archive(_step: PersistentAgentStep) -> None:
 def _parent_tool_call_from_step(parent_step: Optional[PersistentAgentStep]) -> Optional[PersistentAgentToolCall]:
     if parent_step is None:
         return None
-    try:
-        return parent_step.tool_call
-    except ObjectDoesNotExist:
-        return None
+    return parent_step.tool_call if hasattr(parent_step, "tool_call") else None
 
 
 def execute_tracked_runtime_tool_call(

--- a/api/migrations/0396_persistentagenttoolcall_parent_tool_call.py
+++ b/api/migrations/0396_persistentagenttoolcall_parent_tool_call.py
@@ -1,0 +1,24 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0395_litellm_pricing_model_overrides"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="persistentagenttoolcall",
+            name="parent_tool_call",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Parent tool call that spawned this nested tool call, when applicable.",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="child_tool_calls",
+                to="api.persistentagenttoolcall",
+            ),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -12527,6 +12527,14 @@ class PersistentAgentToolCall(models.Model):
         related_name="tool_call",
     )
 
+    parent_tool_call = models.ForeignKey(
+        "self",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="child_tool_calls",
+        help_text="Parent tool call that spawned this nested tool call, when applicable.",
+    )
     tool_name = models.CharField(max_length=256)
     tool_params = models.JSONField(null=True, blank=True)
     result = models.TextField(blank=True, help_text="Raw result or output from the tool call (may be large)")

--- a/tests/unit/test_custom_tools.py
+++ b/tests/unit/test_custom_tools.py
@@ -67,6 +67,7 @@ from api.models import (
     PersistentAgentStep,
     PersistentAgentSystemStep,
     PersistentAgentSystemSkillState,
+    PersistentAgentToolCall,
     SystemSkillProfile,
     TaskCredit,
     UserQuota,
@@ -1992,6 +1993,13 @@ def run(params, ctx):
             credits_cost=Decimal("0.000"),
             task_credit=credit,
         )
+        parent_tool_call = PersistentAgentToolCall.objects.create(
+            step=parent_step,
+            tool_name="custom_wrapper",
+            tool_params={},
+            result=json.dumps({"status": "running"}),
+            status="complete",
+        )
         custom_tool = PersistentAgentCustomTool.objects.create(
             agent=self.agent,
             name="Wrapper",
@@ -2032,7 +2040,7 @@ def run(params, ctx):
         nested_steps = (
             PersistentAgentStep.objects.filter(agent=self.agent)
             .exclude(id=parent_step.id)
-            .select_related("tool_call", "completion", "task_credit")
+            .select_related("tool_call", "tool_call__parent_tool_call", "completion", "task_credit")
         )
         self.assertEqual(nested_steps.count(), 1)
         nested_step = nested_steps.get()
@@ -2040,6 +2048,8 @@ def run(params, ctx):
         self.assertEqual(nested_step.credits_cost, Decimal("0.040"))
         self.assertEqual(nested_step.task_credit_id, credit.id)
         self.assertEqual(nested_step.tool_call.tool_name, "update_charter")
+        self.assertEqual(nested_step.tool_call.parent_tool_call_id, parent_tool_call.pk)
+        self.assertEqual(nested_step.tool_call.parent_tool_call.tool_name, "custom_wrapper")
         self.assertEqual(nested_step.tool_call.status, "complete")
         self.assertIn("Charter updated successfully.", nested_step.tool_call.result)
 

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -1799,6 +1799,10 @@ class PromptContextBuilderTests(TestCase):
         self.assertIsNotNone(user_message)
         content = user_message['content']
         self.assertIn(
+            "<parent_tool_name>custom_wrapper</parent_tool_name>",
+            content,
+        )
+        self.assertIn(
             "<parent_result_id>111111</parent_result_id>",
             content,
         )

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -3,6 +3,7 @@ import re
 import sqlite3
 import shutil
 import tempfile
+import uuid
 from datetime import timedelta
 from decimal import Decimal
 from types import SimpleNamespace
@@ -1764,6 +1765,44 @@ class PromptContextBuilderTests(TestCase):
         content = user_message['content']
         self.assertIn("_tool_call>", content)
         self.assertIn("<cost>1.234 credits</cost>", content)
+
+    def test_tool_call_history_includes_parent_result_id_component(self):
+        parent_step = PersistentAgentStep.objects.create(
+            id=uuid.UUID("11111111-1111-4111-8111-111111111111"),
+            agent=self.agent,
+            description="Tool call: custom_wrapper",
+        )
+        parent_tool_call = PersistentAgentToolCall.objects.create(
+            step=parent_step,
+            tool_name="custom_wrapper",
+            tool_params={},
+            result=json.dumps({"status": "ok"}),
+        )
+        child_step = PersistentAgentStep.objects.create(
+            id=uuid.UUID("22222222-2222-4222-8222-222222222222"),
+            agent=self.agent,
+            description="Tool call: send_email",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=child_step,
+            parent_tool_call=parent_tool_call,
+            tool_name="send_email",
+            tool_params={"to": "person@example.com"},
+            result=json.dumps({"status": "sent"}),
+        )
+
+        with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
+             patch('api.agent.core.prompt_context.ensure_comms_compacted'):
+            context, _, _ = build_prompt_context(self.agent)
+
+        user_message = next((m for m in context if m['role'] == 'user'), None)
+        self.assertIsNotNone(user_message)
+        content = user_message['content']
+        self.assertIn(
+            "<parent_result_id>111111</parent_result_id>",
+            content,
+        )
+        self.assertNotIn(f"<parent_result_id>{parent_tool_call.pk}</parent_result_id>", content)
 
     def test_completed_browser_tasks_use_unified_history_window_not_tool_history_limit(self):
         self._configure_unified_history_limits(


### PR DESCRIPTION
## Summary
- Added a durable `parent_tool_call` FK on `PersistentAgentToolCall` so nested runtime calls can retain attribution.
- Prompt history now surfaces the parent tool’s queryable `parent_result_id` instead of the raw tool-call id.
- Nested custom-tool execution now threads parent attribution through pending and finalized tool calls.

## Testing
- Added unit coverage for custom-tool bridge persistence of parent attribution.
- Added prompt-context coverage for rendering `parent_result_id` in unified history.
- Verified the targeted Django test modules passed locally.
- Verified migration state was clean and `git diff --check` passed.