### PR TITLE
Discord tool improvements

### DIFF
--- a/api/agent/system_skills/defaults.py
+++ b/api/agent/system_skills/defaults.py
@@ -589,7 +589,7 @@ DISCORD_NATIVE_SYSTEM_SKILL = SystemSkillDefinition(
     skill_key=DISCORD_NATIVE_SYSTEM_SKILL_KEY,
     name="Discord",
     search_summary="Provision inbound Discord server/channel subscriptions through the native Gobii bot.",
-    tool_names=("discord_channel_subscriptions", "discord_send_message"),
+    tool_names=("discord_channel_subscriptions", "send_discord_message"),
     enables=(
         "receive Discord channel messages through the native Gobii Discord bot",
         "discover Discord guild channels claimed by the agent owner",
@@ -628,7 +628,7 @@ DISCORD_NATIVE_SYSTEM_SKILL = SystemSkillDefinition(
         "then call `ensure` with the selected `guild_id`, `channel_id`, and `channel_name` so future channel messages wake this agent.\n"
         "Only ask the user for raw server or channel IDs if discovery fails or returns no useful choices. "
         "Do not request Discord server IDs or channel IDs as secrets.\n"
-        "Use `discord_send_message` for outbound Discord replies to subscribed channels. Pass `channel_id`, `message`, and the correct `will_continue_work` value. "
+        "Use `send_discord_message` for outbound Discord replies to subscribed channels. Pass `channel_id`, `message`, and the correct `will_continue_work` value. "
         f"To upload files: {SEND_TOOL_ATTACHMENTS_DESCRIPTION} "
         "The backend sends through a channel webhook using the agent's name and avatar.\n"
         "Use `list` before creating duplicates when the current subscription state is unclear. Use `disable` only when the user asks to stop receiving messages from a subscribed channel.\n"

--- a/api/agent/tools/discord_send_message.py
+++ b/api/agent/tools/discord_send_message.py
@@ -32,7 +32,9 @@ def get_discord_send_message_tool() -> Dict[str, Any]:
                     },
                     "message": {
                         "type": "string",
-                        "description": "Message body to send. Optional when attachments are provided.",
+                        "description": "Message body to send. Optional when attachments are provided. For reports, use Markdown sections, bullets/tables, status labels, tasteful emoji labels; "
+                                       "preserve url/link/listing_url/detail_url item fields as clickable row labels or a Link column; source/feed URLs do not substitute for item links. "
+                                       "Do not pass placeholders or tool-call/XML syntax; it is sent literally.",
                     },
                     "attachments": {
                         "type": "array",

--- a/api/agent/tools/send_discord_message.py
+++ b/api/agent/tools/send_discord_message.py
@@ -14,11 +14,11 @@ from api.services.discord_bot import DiscordBotIntegrationError, send_channel_me
 logger = logging.getLogger(__name__)
 
 
-def get_discord_send_message_tool() -> Dict[str, Any]:
+def get_send_discord_message_tool() -> Dict[str, Any]:
     return {
         "type": "function",
         "function": {
-            "name": "discord_send_message",
+            "name": "send_discord_message",
             "description": (
                 "Send a message to a Discord channel subscribed through the native Gobii Discord bot. "
                 "The backend sends via a channel webhook using this agent's name and avatar."
@@ -52,7 +52,7 @@ def get_discord_send_message_tool() -> Dict[str, Any]:
     }
 
 
-def execute_discord_send_message(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[str, Any]:
+def execute_send_discord_message(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[str, Any]:
     channel_id = str(params.get("channel_id") or "").strip()
     body = str(params.get("message") or "").strip()
     attachment_paths = params.get("attachments")

--- a/api/agent/tools/tool_manager.py
+++ b/api/agent/tools/tool_manager.py
@@ -83,9 +83,9 @@ from .discord_channel_subscriptions import (
     get_discord_channel_subscriptions_tool,
     execute_discord_channel_subscriptions,
 )
-from .discord_send_message import (
-    get_discord_send_message_tool,
-    execute_discord_send_message,
+from .send_discord_message import (
+    get_send_discord_message_tool,
+    execute_send_discord_message,
 )
 from api.agent.system_skills.defaults import DISCORD_NATIVE_SYSTEM_SKILL_KEY
 from .meta_gobii import (
@@ -112,7 +112,7 @@ PYTHON_EXEC_TOOL_NAME = "python_exec"
 RUN_COMMAND_TOOL_NAME = "run_command"
 META_ADS_TOOL_NAME = "meta_ads"
 DISCORD_CHANNEL_SUBSCRIPTIONS_TOOL_NAME = "discord_channel_subscriptions"
-DISCORD_SEND_MESSAGE_TOOL_NAME = "discord_send_message"
+DISCORD_SEND_MESSAGE_TOOL_NAME = "send_discord_message"
 PIPEDREAM_TOOL_SERVER_NAME = "pipedream"
 DEFAULT_BUILTIN_TOOLS = {READ_FILE_TOOL_NAME, SQLITE_TOOL_NAME, CREATE_CHART_TOOL_NAME}
 
@@ -289,8 +289,8 @@ BUILTIN_TOOL_REGISTRY = {
         "system_skill_key": DISCORD_NATIVE_SYSTEM_SKILL_KEY,
     },
     DISCORD_SEND_MESSAGE_TOOL_NAME: {
-        "definition": get_discord_send_message_tool,
-        "executor": execute_discord_send_message,
+        "definition": get_send_discord_message_tool,
+        "executor": execute_send_discord_message,
         "search_hidden": True,
         "system_skill_key": DISCORD_NATIVE_SYSTEM_SKILL_KEY,
     },

--- a/api/migrations/0397_rename_discord_send_message_tool.py
+++ b/api/migrations/0397_rename_discord_send_message_tool.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+
+
+OLD_TOOL_NAME = "discord_send_message"
+NEW_TOOL_NAME = "send_discord_message"
+
+
+def rename_enabled_discord_send_tool(apps, schema_editor):
+    PersistentAgentEnabledTool = apps.get_model("api", "PersistentAgentEnabledTool")
+    _rename_enabled_tool_rows(PersistentAgentEnabledTool, OLD_TOOL_NAME, NEW_TOOL_NAME)
+
+
+def reverse_rename_enabled_discord_send_tool(apps, schema_editor):
+    PersistentAgentEnabledTool = apps.get_model("api", "PersistentAgentEnabledTool")
+    _rename_enabled_tool_rows(PersistentAgentEnabledTool, NEW_TOOL_NAME, OLD_TOOL_NAME)
+
+
+def _rename_enabled_tool_rows(PersistentAgentEnabledTool, old_tool_name, new_tool_name):
+    old_rows = list(
+        PersistentAgentEnabledTool.objects
+        .filter(tool_full_name=old_tool_name)
+        .only("id", "agent_id", "tool_full_name")
+    )
+    for old_row in old_rows:
+        if PersistentAgentEnabledTool.objects.filter(
+            agent_id=old_row.agent_id,
+            tool_full_name=new_tool_name,
+        ).exists():
+            old_row.delete()
+            continue
+
+        old_row.tool_full_name = new_tool_name
+        old_row.save(update_fields=["tool_full_name"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0396_persistentagenttoolcall_parent_tool_call"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_enabled_discord_send_tool,
+            reverse_rename_enabled_discord_send_tool,
+        ),
+    ]

--- a/api/migrations/0397_rename_discord_send_message_tool.py
+++ b/api/migrations/0397_rename_discord_send_message_tool.py
@@ -1,4 +1,5 @@
 from django.db import migrations
+from django.db.models import Subquery
 
 
 OLD_TOOL_NAME = "discord_send_message"
@@ -16,21 +17,18 @@ def reverse_rename_enabled_discord_send_tool(apps, schema_editor):
 
 
 def _rename_enabled_tool_rows(PersistentAgentEnabledTool, old_tool_name, new_tool_name):
-    old_rows = list(
+    already_enabled_agent_ids = (
         PersistentAgentEnabledTool.objects
-        .filter(tool_full_name=old_tool_name)
-        .only("id", "agent_id", "tool_full_name")
+        .filter(tool_full_name=new_tool_name)
+        .values("agent_id")
     )
-    for old_row in old_rows:
-        if PersistentAgentEnabledTool.objects.filter(
-            agent_id=old_row.agent_id,
-            tool_full_name=new_tool_name,
-        ).exists():
-            old_row.delete()
-            continue
-
-        old_row.tool_full_name = new_tool_name
-        old_row.save(update_fields=["tool_full_name"])
+    PersistentAgentEnabledTool.objects.filter(
+        tool_full_name=old_tool_name,
+        agent_id__in=Subquery(already_enabled_agent_ids),
+    ).delete()
+    PersistentAgentEnabledTool.objects.filter(tool_full_name=old_tool_name).update(
+        tool_full_name=new_tool_name
+    )
 
 
 class Migration(migrations.Migration):

--- a/tests/unit/test_discord_bot.py
+++ b/tests/unit/test_discord_bot.py
@@ -16,7 +16,7 @@ from django.utils import timezone
 from api.agent.system_skills.registry import get_system_skill_definition
 from api.agent.files.attachment_helpers import ResolvedAttachment
 from api.agent.tools.discord_channel_subscriptions import execute_discord_channel_subscriptions
-from api.agent.tools.discord_send_message import execute_discord_send_message
+from api.agent.tools.send_discord_message import execute_send_discord_message
 from api.agent.files.filespace_service import write_bytes_to_dir
 from api.models import (
     BrowserUseAgent,
@@ -857,7 +857,7 @@ class NativeDiscordBotTests(TestCase):
             ),
         ]
 
-        result = execute_discord_send_message(
+        result = execute_send_discord_message(
             self.agent,
             {
                 "channel_id": "10",
@@ -959,7 +959,7 @@ class NativeDiscordBotTests(TestCase):
         skill = get_system_skill_definition("discord_native")
 
         self.assertIn("discord_channel_subscriptions", skill.tool_names)
-        self.assertIn("discord_send_message", skill.tool_names)
+        self.assertIn("send_discord_message", skill.tool_names)
         self.assertNotIn("pipedream_trigger_subscriptions", skill.tool_names)
         self.assertIn("Use the native Gobii Discord bot tools", skill.prompt_instructions)
         self.assertIn("immediately call `discord_channel_subscriptions`", skill.prompt_instructions)

--- a/tests/unit/test_pipedream_trigger_subscriptions.py
+++ b/tests/unit/test_pipedream_trigger_subscriptions.py
@@ -970,7 +970,7 @@ class ConnectedAppChannelsSystemSkillTests(TestCase):
             "listen to discord channel messages",
             available_tool_names={
                 "discord_channel_subscriptions",
-                "discord_send_message",
+                "send_discord_message",
             },
         )
         self.assertEqual([match.skill_key for match in matches], ["discord_native"])
@@ -978,7 +978,7 @@ class ConnectedAppChannelsSystemSkillTests(TestCase):
             "discord integration, discord bot, discord webhook, pipedream discord",
             available_tool_names={
                 "discord_channel_subscriptions",
-                "discord_send_message",
+                "send_discord_message",
             },
         )
         self.assertEqual([match.skill_key for match in integration_matches], ["discord_native"])
@@ -995,7 +995,7 @@ class ConnectedAppChannelsSystemSkillTests(TestCase):
         self.assertTrue(
             PersistentAgentEnabledTool.objects.filter(
                 agent=agent,
-                tool_full_name="discord_send_message",
+                tool_full_name="send_discord_message",
             ).exists()
         )
         self.assertFalse(
@@ -1016,7 +1016,7 @@ class ConnectedAppChannelsSystemSkillTests(TestCase):
         self.assertIn("action=\"discover_channels\"", instructions)
         self.assertIn("ask the user to choose by channel name", instructions)
         self.assertIn("call `ensure` with the selected `guild_id`, `channel_id`, and `channel_name`", instructions)
-        self.assertIn("Use `discord_send_message` for outbound Discord replies", instructions)
+        self.assertIn("Use `send_discord_message` for outbound Discord replies", instructions)
         self.assertIn("Use the native Gobii Discord bot tools", instructions)
         self.assertNotIn("legacy fallback", instructions)
         self.assertNotIn("pipedream_trigger_subscriptions", instructions)


### PR DESCRIPTION
## Summary
- Renames the native Discord outbound tool from `discord_send_message` to `send_discord_message` for consistency with other `send_` tools.
- Updates the tool registration, system-skill guidance, and affected unit tests to use the new name.
- Adds a data migration to rename existing enabled-tool rows so already-configured agents keep their Discord send capability.

## Testing
- Ran the targeted Discord bot unit test covering attachment sending.
- Ran the targeted Discord system-skill test covering tool naming and prompt guidance.
- Ran the connected-app Discord skill tests covering enablement and persisted tool names.
- Ran `makemigrations --check --dry-run` to confirm no missing model migrations.