### PR TITLE
Clear stale sandbox proxies when selection falls back or routing is disabled

### DIFF
--- a/api/proxy_selection.py
+++ b/api/proxy_selection.py
@@ -27,6 +27,9 @@ def proxy_has_recent_health_pass(proxy_server, health_check_days: int = 45) -> b
     Returns:
         True if proxy has successful health check within the specified days
     """
+    if not proxy_server or not proxy_server.is_active:
+        return False
+
     recent_cutoff = timezone.now() - timedelta(days=health_check_days)
     return proxy_server.health_check_results.filter(
         status="PASSED", checked_at__gte=recent_cutoff
@@ -67,7 +70,13 @@ def select_proxy(
     
     # Priority 2: Preferred proxy (if healthy)
     if preferred_proxy:
-        if proxy_has_recent_health_pass(preferred_proxy, health_check_days):
+        if not preferred_proxy.is_active:
+            logger.info(
+                "Preferred proxy inactive%s, selecting alternative: %s",
+                context_desc,
+                preferred_proxy,
+            )
+        elif proxy_has_recent_health_pass(preferred_proxy, health_check_days):
             logger.info(
                 "Using preferred proxy (recently healthy)%s: %s",
                 context_desc,

--- a/api/services/sandbox_compute.py
+++ b/api/services/sandbox_compute.py
@@ -53,6 +53,7 @@ _NO_PROXY_ENV_KEYS = (
     "NO_PROXY",
     "no_proxy",
 )
+_SANDBOX_PROXY_CLEARED_ATTR = "_sandbox_proxy_cleared"
 _CUSTOM_TOOL_SQLITE_MIME_TYPE = "application/vnd.sqlite3"
 _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
 _ACTIVE_CONVERSATION_CHANNEL_CACHE_ATTR = "_sandbox_active_conversation_channel"
@@ -953,34 +954,84 @@ def _restore_sqlite_file_content(db_path: str, content: bytes) -> None:
         _remove_sqlite_sidecars(db_path)
 
 
+def _proxy_id(proxy: Any) -> Optional[str]:
+    proxy_id = getattr(proxy, "id", proxy)
+    return str(proxy_id) if proxy_id else None
+
+
+def _clear_proxy_for_session(agent, session: AgentComputeSession, *, reason: str) -> None:
+    old_proxy = getattr(session, "proxy_server", None)
+    old_proxy_id = _proxy_id(old_proxy) or _proxy_id(getattr(session, "proxy_server_id", None))
+    if old_proxy is None and not old_proxy_id:
+        return
+
+    session.proxy_server = None
+    setattr(session, _SANDBOX_PROXY_CLEARED_ATTR, True)
+    session.save(update_fields=["proxy_server", "updated_at"])
+    logger.info(
+        "Cleared sandbox proxy for agent=%s old_proxy=%s new_proxy=None reason=%s",
+        agent.id,
+        old_proxy_id,
+        reason,
+    )
+
+
 def _select_proxy_for_session(agent, session: AgentComputeSession) -> Optional[Any]:
+    setattr(session, _SANDBOX_PROXY_CLEARED_ATTR, False)
+
     if not getattr(settings, "ENABLE_PROXY_ROUTING", True):
+        _clear_proxy_for_session(agent, session, reason="routing_disabled")
         return None
-    preferred_proxy = session.proxy_server if session.proxy_server and session.proxy_server.is_active else None
+
+    proxy_required = _proxy_required()
+    current_proxy = session.proxy_server
+    current_proxy_id = _proxy_id(current_proxy)
+    current_proxy_inactive = bool(current_proxy and not current_proxy.is_active)
+    preferred_proxy = current_proxy if current_proxy and current_proxy.is_active else None
+
     try:
         if preferred_proxy:
             proxy = select_proxy(
                 preferred_proxy=preferred_proxy,
-                allow_no_proxy_in_debug=not _proxy_required(),
+                allow_no_proxy_in_debug=not proxy_required,
                 context_id=f"sandbox_agent_{agent.id}",
             )
         else:
             proxy = select_proxy_for_persistent_agent(
                 agent,
-                allow_no_proxy_in_debug=not _proxy_required(),
+                allow_no_proxy_in_debug=not proxy_required,
             )
     except RuntimeError as exc:
-        if _proxy_required():
-            raise SandboxComputeUnavailable(str(exc)) from exc
+        if current_proxy_inactive:
+            _clear_proxy_for_session(agent, session, reason="inactive_proxy")
+        if proxy_required:
+            raise SandboxComputeUnavailable("No proxy server available for sandbox compute.") from exc
         logger.warning("Sandbox proxy selection failed for agent=%s: %s", agent.id, exc)
         proxy = None
 
-    if _proxy_required() and not proxy:
+    if proxy_required and not proxy:
+        if current_proxy_inactive:
+            _clear_proxy_for_session(agent, session, reason="inactive_proxy")
         raise SandboxComputeUnavailable("No proxy server available for sandbox compute.")
 
-    if proxy and proxy != session.proxy_server:
+    if not proxy:
+        _clear_proxy_for_session(
+            agent,
+            session,
+            reason="inactive_proxy" if current_proxy_inactive else "no_proxy_available",
+        )
+        return None
+
+    if proxy != session.proxy_server:
         session.proxy_server = proxy
         session.save(update_fields=["proxy_server", "updated_at"])
+        logger.info(
+            "Updated sandbox proxy for agent=%s old_proxy=%s new_proxy=%s reason=%s",
+            agent.id,
+            current_proxy_id,
+            _proxy_id(proxy),
+            "inactive_proxy" if current_proxy_inactive else "proxy_selected",
+        )
     return proxy
 
 

--- a/api/services/sandbox_compute.py
+++ b/api/services/sandbox_compute.py
@@ -315,6 +315,9 @@ class SandboxComputeBackend:
     def deploy_or_resume(self, agent, session: AgentComputeSession) -> SandboxSessionUpdate:
         raise NotImplementedError
 
+    def cleanup_cleared_proxy(self, agent) -> None:
+        return None
+
     def run_command(
         self,
         agent,
@@ -959,10 +962,21 @@ def _proxy_id(proxy: Any) -> Optional[str]:
     return str(proxy_id) if proxy_id else None
 
 
+def _safe_getattr(obj: Any, name: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    return getattr(obj, name, default)
+
+
 def _clear_proxy_for_session(agent, session: AgentComputeSession, *, reason: str) -> None:
-    old_proxy = getattr(session, "proxy_server", None)
-    old_proxy_id = _proxy_id(old_proxy) or _proxy_id(getattr(session, "proxy_server_id", None))
-    if old_proxy is None and not old_proxy_id:
+    old_proxy_id = _safe_getattr(session, "proxy_server_id", None)
+    if old_proxy_id is None:
+        old_proxy = _safe_getattr(session, "proxy_server", None)
+        old_proxy_id = _proxy_id(old_proxy)
+    else:
+        old_proxy_id = str(old_proxy_id)
+
+    if not old_proxy_id:
         return
 
     session.proxy_server = None
@@ -1360,7 +1374,12 @@ class SandboxComputeService:
             agent=agent,
             defaults={"state": AgentComputeSession.State.STOPPED},
         )
-        _select_proxy_for_session(agent, session)
+        try:
+            _select_proxy_for_session(agent, session)
+        except SandboxComputeUnavailable:
+            if getattr(session, _SANDBOX_PROXY_CLEARED_ATTR, False):
+                self._backend.cleanup_cleared_proxy(agent)
+            raise
         previous_state = session.state
         started = session.state != AgentComputeSession.State.RUNNING
         mode = "bootstrap" if started else "refresh"

--- a/api/services/sandbox_kubernetes.py
+++ b/api/services/sandbox_kubernetes.py
@@ -17,6 +17,7 @@ from api.services.sandbox_compute import (
     SandboxComputeBackend,
     SandboxComputeUnavailable,
     SandboxSessionUpdate,
+    _SANDBOX_PROXY_CLEARED_ATTR,
     _requires_agent_pod_discovery,
 )
 from api.services.system_settings import (
@@ -274,6 +275,8 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
         egress_service_name = None
         no_proxy = None
         workspace_reset = False
+        if not session.proxy_server and getattr(session, _SANDBOX_PROXY_CLEARED_ATTR, False):
+            self._delete_egress_proxy(agent)
         if session.proxy_server:
             if not self._egress_proxy_image:
                 raise SandboxComputeUnavailable(

--- a/api/services/sandbox_kubernetes.py
+++ b/api/services/sandbox_kubernetes.py
@@ -381,6 +381,9 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
             workspace_reset=workspace_reset,
         )
 
+    def cleanup_cleared_proxy(self, agent) -> None:
+        self._delete_egress_proxy(agent)
+
     def run_command(
         self,
         agent,

--- a/tests/unit/test_proxy_selection.py
+++ b/tests/unit/test_proxy_selection.py
@@ -94,6 +94,15 @@ class ProxySelectionTests(TestCase):
             checked_at=timezone.now() - timedelta(hours=1)
         )
 
+        # Deactivated proxies can still have old successful checks; selection should
+        # rely on the active flag first.
+        ProxyHealthCheckResult.objects.create(
+            proxy_server=self.inactive_proxy,
+            health_check_spec=self.health_check_spec,
+            status=ProxyHealthCheckResult.Status.PASSED,
+            checked_at=timezone.now() - timedelta(days=1)
+        )
+
     @tag("batch_proxy_selection")
     def test_proxy_has_recent_health_pass_default_days(self):
         """Test proxy health check with default 45-day window."""
@@ -103,7 +112,7 @@ class ProxySelectionTests(TestCase):
         # Unhealthy proxy should fail (old success, recent failure)
         self.assertFalse(proxy_has_recent_health_pass(self.unhealthy_proxy))
         
-        # Inactive proxy should fail (no health checks)
+        # Inactive proxy should fail even with a recent successful health check
         self.assertFalse(proxy_has_recent_health_pass(self.inactive_proxy))
     
     def test_proxy_has_recent_health_pass_custom_days(self):
@@ -136,6 +145,26 @@ class ProxySelectionTests(TestCase):
         
         result = select_proxy(preferred_proxy=self.unhealthy_proxy)
         self.assertEqual(result, self.healthy_proxy)
+        mock_select_random.assert_called_once()
+
+    @patch('api.models.BrowserUseAgent.select_random_proxy')
+    def test_select_proxy_with_inactive_preferred_has_alternative(self, mock_select_random):
+        mock_select_random.return_value = self.healthy_proxy
+
+        result = select_proxy(preferred_proxy=self.inactive_proxy)
+
+        self.assertEqual(result, self.healthy_proxy)
+        mock_select_random.assert_called_once()
+
+    @patch('api.models.BrowserUseAgent.select_random_proxy')
+    @override_settings(GOBII_PROPRIETARY_MODE=True, DEBUG=False)
+    def test_select_proxy_with_inactive_preferred_no_alternative_raises(self, mock_select_random):
+        mock_select_random.return_value = None
+
+        with self.assertRaises(RuntimeError) as context:
+            select_proxy(preferred_proxy=self.inactive_proxy, allow_no_proxy_in_debug=False)
+
+        self.assertIn("No proxy available", str(context.exception))
         mock_select_random.assert_called_once()
     
     @patch('api.models.BrowserUseAgent.select_random_proxy')

--- a/tests/unit/test_sandbox_compute.py
+++ b/tests/unit/test_sandbox_compute.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase, override_settings, tag
@@ -13,10 +13,12 @@ from api.models import (
     ProxyServer,
 )
 from api.services.sandbox_compute import (
+    SandboxComputeService,
     SandboxComputeUnavailable,
     _SANDBOX_PROXY_CLEARED_ATTR,
     _active_conversation_channel,
     _allowed_env_keys,
+    _clear_proxy_for_session,
     _proxy_env_for_session,
     _select_proxy_for_session,
 )
@@ -192,6 +194,52 @@ class SandboxComputeProxySelectionTests(TestCase):
         session.refresh_from_db()
         self.assertIsNone(session.proxy_server)
         self.assertTrue(getattr(session, _SANDBOX_PROXY_CLEARED_ATTR))
+
+    def test_clear_proxy_for_session_uses_proxy_id_without_loading_relation(self):
+        session = AgentComputeSession.objects.create(
+            agent=self.agent,
+            state=AgentComputeSession.State.RUNNING,
+            proxy_server=self.inactive_proxy,
+        )
+        session = AgentComputeSession.objects.get(agent=self.agent)
+        self.assertNotIn("proxy_server", session._state.fields_cache)
+
+        with self.assertNumQueries(1):
+            _clear_proxy_for_session(self.agent, session, reason="inactive_proxy")
+
+        session.refresh_from_db()
+        self.assertIsNone(session.proxy_server)
+        self.assertTrue(getattr(session, _SANDBOX_PROXY_CLEARED_ATTR))
+
+    def test_required_proxy_failure_cleans_stale_egress_proxy(self):
+        session = AgentComputeSession.objects.create(
+            agent=self.agent,
+            state=AgentComputeSession.State.RUNNING,
+            proxy_server=self.inactive_proxy,
+        )
+        backend = Mock()
+
+        with patch("api.services.sandbox_compute._resolve_backend", return_value=backend), patch(
+            "api.services.sandbox_compute.sandbox_compute_enabled",
+            return_value=True,
+        ), patch(
+            "api.services.sandbox_compute._proxy_required",
+            return_value=True,
+        ), patch(
+            "api.services.sandbox_compute.select_proxy_for_persistent_agent",
+            return_value=None,
+        ):
+            service = SandboxComputeService()
+            with self.assertRaisesMessage(
+                SandboxComputeUnavailable,
+                "No proxy server available for sandbox compute.",
+            ):
+                service._ensure_session(self.agent, source="test")
+
+        backend.cleanup_cleared_proxy.assert_called_once_with(self.agent)
+        backend.deploy_or_resume.assert_not_called()
+        session.refresh_from_db()
+        self.assertIsNone(session.proxy_server)
 
     def test_inactive_session_proxy_is_cleared_when_optional_proxy_unavailable(self):
         session = AgentComputeSession.objects.create(

--- a/tests/unit/test_sandbox_compute.py
+++ b/tests/unit/test_sandbox_compute.py
@@ -152,6 +152,26 @@ class SandboxComputeProxySelectionTests(TestCase):
         self.assertEqual(session.proxy_server, self.active_proxy)
         self.assertFalse(getattr(session, _SANDBOX_PROXY_CLEARED_ATTR))
 
+    def test_inactive_agent_preferred_proxy_is_not_reused_for_session(self):
+        self.agent.browser_use_agent.preferred_proxy = self.inactive_proxy
+        self.agent.browser_use_agent.save(update_fields=["preferred_proxy"])
+        session = AgentComputeSession.objects.create(
+            agent=self.agent,
+            state=AgentComputeSession.State.RUNNING,
+            proxy_server=self.inactive_proxy,
+        )
+
+        with patch("api.services.sandbox_compute._proxy_required", return_value=False), patch(
+            "api.models.BrowserUseAgent.select_random_proxy",
+            return_value=self.active_proxy,
+        ):
+            result = _select_proxy_for_session(self.agent, session)
+
+        self.assertEqual(result, self.active_proxy)
+        session.refresh_from_db()
+        self.assertEqual(session.proxy_server, self.active_proxy)
+        self.assertFalse(getattr(session, _SANDBOX_PROXY_CLEARED_ATTR))
+
     def test_inactive_session_proxy_is_cleared_when_required_proxy_unavailable(self):
         session = AgentComputeSession.objects.create(
             agent=self.agent,

--- a/tests/unit/test_sandbox_compute.py
+++ b/tests/unit/test_sandbox_compute.py
@@ -1,10 +1,25 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase, override_settings, tag
 
-from api.models import BrowserUseAgent, CommsChannel, PersistentAgent, PersistentAgentConversation
-from api.services.sandbox_compute import _active_conversation_channel, _allowed_env_keys, _proxy_env_for_session
+from api.models import (
+    AgentComputeSession,
+    BrowserUseAgent,
+    CommsChannel,
+    PersistentAgent,
+    PersistentAgentConversation,
+    ProxyServer,
+)
+from api.services.sandbox_compute import (
+    SandboxComputeUnavailable,
+    _SANDBOX_PROXY_CLEARED_ATTR,
+    _active_conversation_channel,
+    _allowed_env_keys,
+    _proxy_env_for_session,
+    _select_proxy_for_session,
+)
 
 
 @tag("batch_agent_lifecycle")
@@ -86,3 +101,109 @@ class SandboxComputeAnalyticsTests(TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(_active_conversation_channel(self.agent), CommsChannel.WEB)
             self.assertEqual(_active_conversation_channel(self.agent), CommsChannel.WEB)
+
+
+@tag("batch_agent_lifecycle")
+class SandboxComputeProxySelectionTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username="sandbox-proxy-user",
+            email="sandbox-proxy-user@example.com",
+            password="pw",
+        )
+        browser_agent = BrowserUseAgent.objects.create(user=self.user, name="Sandbox Proxy Browser")
+        self.agent = PersistentAgent.objects.create(
+            user=self.user,
+            name="Sandbox Proxy Agent",
+            charter="sandbox proxy charter",
+            browser_use_agent=browser_agent,
+        )
+        self.inactive_proxy = ProxyServer.objects.create(
+            name="Inactive Sandbox Proxy",
+            proxy_type=ProxyServer.ProxyType.HTTP,
+            host="inactive-proxy.example.com",
+            port=8010,
+            is_active=False,
+        )
+        self.active_proxy = ProxyServer.objects.create(
+            name="Active Sandbox Proxy",
+            proxy_type=ProxyServer.ProxyType.HTTP,
+            host="active-proxy.example.com",
+            port=8011,
+            is_active=True,
+        )
+
+    def test_inactive_session_proxy_is_replaced_with_selected_proxy(self):
+        session = AgentComputeSession.objects.create(
+            agent=self.agent,
+            state=AgentComputeSession.State.RUNNING,
+            proxy_server=self.inactive_proxy,
+        )
+
+        with patch("api.services.sandbox_compute._proxy_required", return_value=False), patch(
+            "api.services.sandbox_compute.select_proxy_for_persistent_agent",
+            return_value=self.active_proxy,
+        ):
+            result = _select_proxy_for_session(self.agent, session)
+
+        self.assertEqual(result, self.active_proxy)
+        session.refresh_from_db()
+        self.assertEqual(session.proxy_server, self.active_proxy)
+        self.assertFalse(getattr(session, _SANDBOX_PROXY_CLEARED_ATTR))
+
+    def test_inactive_session_proxy_is_cleared_when_required_proxy_unavailable(self):
+        session = AgentComputeSession.objects.create(
+            agent=self.agent,
+            state=AgentComputeSession.State.RUNNING,
+            proxy_server=self.inactive_proxy,
+        )
+
+        with patch("api.services.sandbox_compute._proxy_required", return_value=True), patch(
+            "api.services.sandbox_compute.select_proxy_for_persistent_agent",
+            return_value=None,
+        ):
+            with self.assertRaisesMessage(
+                SandboxComputeUnavailable,
+                "No proxy server available for sandbox compute.",
+            ):
+                _select_proxy_for_session(self.agent, session)
+
+        session.refresh_from_db()
+        self.assertIsNone(session.proxy_server)
+        self.assertTrue(getattr(session, _SANDBOX_PROXY_CLEARED_ATTR))
+
+    def test_inactive_session_proxy_is_cleared_when_optional_proxy_unavailable(self):
+        session = AgentComputeSession.objects.create(
+            agent=self.agent,
+            state=AgentComputeSession.State.RUNNING,
+            proxy_server=self.inactive_proxy,
+        )
+
+        with patch("api.services.sandbox_compute._proxy_required", return_value=False), patch(
+            "api.services.sandbox_compute.select_proxy_for_persistent_agent",
+            return_value=None,
+        ):
+            result = _select_proxy_for_session(self.agent, session)
+
+        self.assertIsNone(result)
+        session.refresh_from_db()
+        self.assertIsNone(session.proxy_server)
+        self.assertTrue(getattr(session, _SANDBOX_PROXY_CLEARED_ATTR))
+
+    @override_settings(ENABLE_PROXY_ROUTING=False)
+    def test_proxy_routing_disabled_clears_existing_session_proxy(self):
+        session = AgentComputeSession.objects.create(
+            agent=self.agent,
+            state=AgentComputeSession.State.RUNNING,
+            proxy_server=self.active_proxy,
+        )
+
+        with patch("api.services.sandbox_compute.select_proxy_for_persistent_agent") as select_proxy:
+            result = _select_proxy_for_session(self.agent, session)
+
+        self.assertIsNone(result)
+        select_proxy.assert_not_called()
+        session.refresh_from_db()
+        self.assertIsNone(session.proxy_server)
+        self.assertTrue(getattr(session, _SANDBOX_PROXY_CLEARED_ATTR))

--- a/tests/unit/test_sandbox_kubernetes.py
+++ b/tests/unit/test_sandbox_kubernetes.py
@@ -16,6 +16,7 @@ from api.services.sandbox_kubernetes import (
     _pod_readiness_summary,
     _pod_name,
 )
+from api.services.sandbox_compute import _SANDBOX_PROXY_CLEARED_ATTR
 
 SANDBOX_POD_RESOURCES = {
     "requests": {"cpu": "500m", "memory": "1Gi"},
@@ -606,6 +607,38 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
             egress_service_name="sandbox-egress-agent-proxy-drift",
             no_proxy="localhost,127.0.0.1,.svc,.cluster.local",
         )
+
+    def test_deploy_or_resume_deletes_egress_proxy_when_session_proxy_was_cleared(self):
+        backend = self._backend()
+        agent = SimpleNamespace(id="agent-proxy-cleared")
+        session = SimpleNamespace(proxy_server=None, workspace_snapshot=None)
+        setattr(session, _SANDBOX_PROXY_CLEARED_ATTR, True)
+        existing_pod = _build_pod_manifest(
+            pod_name="sandbox-agent-agent-proxy-cleared",
+            pvc_name="sandbox-workspace-agent-proxy-cleared",
+            namespace="default",
+            image="ghcr.io/example/sandbox:latest",
+            runtime_class="gvisor",
+            service_account="sandbox-sa",
+            configmap_name="sandbox-config",
+            secret_name="sandbox-secret",
+            agent_id="agent-proxy-cleared",
+            resources=SANDBOX_POD_RESOURCES,
+            workspace_volume_mode="pvc",
+        )
+        backend._delete_egress_proxy = Mock()
+        backend._create_pvc = Mock()
+        backend._create_service = Mock()
+        backend._get_pod = Mock(return_value=existing_pod)
+        backend._delete_pod = Mock()
+        backend._create_pod = Mock()
+        backend._wait_for_pod_ready = Mock(return_value=True)
+
+        with patch("api.services.sandbox_kubernetes._resource_exists", side_effect=[True, True]):
+            result = backend.deploy_or_resume(agent, session)
+
+        self.assertEqual(result.state, "running")
+        backend._delete_egress_proxy.assert_called_once_with(agent)
 
     def test_deploy_or_resume_recreates_sandbox_pod_when_resource_drifted(self):
         backend = self._backend()


### PR DESCRIPTION
## Summary
- Clear `AgentComputeSession.proxy_server` when proxy routing is disabled or no proxy can be selected.
- Track when a stale proxy was explicitly cleared so Kubernetes teardown can remove any egress proxy resources.
- Add unit coverage for inactive proxies, unavailable proxies, and routing-disabled sessions.

## Testing
- Added focused unit tests for sandbox proxy selection and Kubernetes egress proxy cleanup.
- Not run (not requested)