### PR TITLE
Fix MCP server delete cache invalidation and surface cleaner delete errors

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -14021,8 +14021,7 @@ def touch_profile_on_embeddings_tier_endpoint_change(sender, instance, **kwargs)
 
 
 @receiver(post_save, sender=MCPServerConfig)
-@receiver(post_delete, sender=MCPServerConfig)
-def invalidate_mcp_tool_cache_for_server(sender, instance, **kwargs):
+def refresh_mcp_tool_cache_for_server(sender, instance, **kwargs):
     server_id = getattr(instance, "id", None)
     if server_id:
         invalidate_mcp_tool_cache(str(server_id))
@@ -14034,9 +14033,22 @@ def invalidate_mcp_tool_cache_for_server(sender, instance, **kwargs):
             schedule_mcp_tool_discovery(str(server_id), reason="config_changed")
 
 
-@receiver(post_save, sender=MCPServerOAuthCredential)
 @receiver(post_delete, sender=MCPServerOAuthCredential)
-def invalidate_mcp_tool_cache_for_credentials(sender, instance, **kwargs):
+def invalidate_mcp_tool_cache_for_deleted_credentials(sender, instance, **kwargs):
+    server_id = getattr(instance, "server_config_id", None)
+    if server_id:
+        invalidate_mcp_tool_cache(str(server_id))
+
+
+@receiver(post_delete, sender=MCPServerConfig)
+def invalidate_mcp_tool_cache_for_deleted_server(sender, instance, **kwargs):
+    server_id = getattr(instance, "id", None)
+    if server_id:
+        invalidate_mcp_tool_cache(str(server_id))
+
+
+@receiver(post_save, sender=MCPServerOAuthCredential)
+def refresh_mcp_tool_cache_for_credentials(sender, instance, **kwargs):
     server_id = getattr(instance, "server_config_id", None)
     if server_id:
         invalidate_mcp_tool_cache(str(server_id))

--- a/frontend/src/components/mcp/DeleteServerDialog.tsx
+++ b/frontend/src/components/mcp/DeleteServerDialog.tsx
@@ -56,8 +56,9 @@ export function DeleteServerDialog({ serverName, deleteUrl, onClose, onDeleted, 
 
 function resolveErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof HttpError) {
-    if (typeof error.body === 'string' && error.body) {
-      return error.body
+    const bodyMessage = resolveBodyMessage(error.body, fallback)
+    if (bodyMessage) {
+      return bodyMessage
     }
     if (typeof error.statusText === 'string' && error.statusText) {
       return error.statusText
@@ -67,4 +68,28 @@ function resolveErrorMessage(error: unknown, fallback: string): string {
     return (error as { message: string }).message
   }
   return fallback
+}
+
+function resolveBodyMessage(body: unknown, fallback: string): string | null {
+  if (typeof body === 'string') {
+    const trimmed = body.trim()
+    if (!trimmed) {
+      return null
+    }
+    return isHtmlResponse(trimmed) ? fallback : trimmed
+  }
+  if (body && typeof body === 'object') {
+    for (const key of ['message', 'detail', 'error']) {
+      const value = (body as Record<string, unknown>)[key]
+      if (typeof value === 'string' && value.trim()) {
+        return value
+      }
+    }
+  }
+  return null
+}
+
+function isHtmlResponse(body: string): boolean {
+  const normalized = body.slice(0, 200).toLowerCase()
+  return normalized.includes('<!doctype') || normalized.includes('<html') || normalized.includes('<body')
 }

--- a/frontend/src/components/mcp/DeleteServerDialog.tsx
+++ b/frontend/src/components/mcp/DeleteServerDialog.tsx
@@ -56,7 +56,7 @@ export function DeleteServerDialog({ serverName, deleteUrl, onClose, onDeleted, 
 
 function resolveErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof HttpError) {
-    const bodyMessage = resolveBodyMessage(error.body, fallback)
+    const bodyMessage = resolveBodyMessage(error.body)
     if (bodyMessage) {
       return bodyMessage
     }
@@ -70,13 +70,13 @@ function resolveErrorMessage(error: unknown, fallback: string): string {
   return fallback
 }
 
-function resolveBodyMessage(body: unknown, fallback: string): string | null {
+function resolveBodyMessage(body: unknown): string | null {
   if (typeof body === 'string') {
     const trimmed = body.trim()
     if (!trimmed) {
       return null
     }
-    return isHtmlResponse(trimmed) ? fallback : trimmed
+    return isHtmlResponse(trimmed) ? null : trimmed
   }
   if (body && typeof body === 'object') {
     for (const key of ['message', 'detail', 'error']) {

--- a/tests/unit/test_console_mcp_servers.py
+++ b/tests/unit/test_console_mcp_servers.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 
 from api.models import (
     MCPServerConfig,
+    MCPServerOAuthCredential,
     MCPServerOAuthSession,
     PipedreamAppSelection,
     Organization,
@@ -289,6 +290,59 @@ class MCPServerCrudAPITests(TestCase):
         self.assertFalse(props["has_command"])
         self.assertTrue(props["is_active"])
         self.assertIsNone(track_kwargs.get("organization"))
+
+    @patch("api.services.mcp_tool_discovery.schedule_mcp_tool_discovery")
+    @patch("console.api_views._track_org_event_for_console")
+    @patch("console.api_views.get_mcp_manager")
+    def test_delete_org_oauth_server_does_not_schedule_discovery(
+        self,
+        mock_get_mcp_manager,
+        mock_track_event,
+        mock_schedule_discovery,
+    ):
+        org = Organization.objects.create(name="Delete Org", slug="delete-org", created_by=self.user)
+        OrganizationMembership.objects.create(
+            org=org,
+            user=self.user,
+            role=OrganizationMembership.OrgRole.OWNER,
+        )
+        session = self.client.session
+        session["context_type"] = "organization"
+        session["context_id"] = str(org.id)
+        session["context_name"] = org.name
+        session.save()
+        server = MCPServerConfig.objects.create(
+            scope=MCPServerConfig.Scope.ORGANIZATION,
+            organization=org,
+            name="notion",
+            display_name="Notion",
+            url="https://mcp.notion.com/mcp",
+            auth_method=MCPServerConfig.AuthMethod.OAUTH2,
+        )
+        credential = MCPServerOAuthCredential.objects.create(
+            server_config=server,
+            organization=org,
+            client_id="notion-client",
+            expires_at=timezone.now() - timedelta(minutes=5),
+        )
+        agent = _create_console_test_agent(user=self.user, organization=org, name="Notion Agent")
+        assignment = PersistentAgentMCPServer.objects.create(agent=agent, server_config=server)
+        mock_schedule_discovery.reset_mock()
+
+        response = self.client.delete(reverse("console-mcp-server-detail", args=[server.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(MCPServerConfig.objects.filter(id=server.id).exists())
+        self.assertFalse(MCPServerOAuthCredential.objects.filter(id=credential.id).exists())
+        self.assertFalse(PersistentAgentMCPServer.objects.filter(id=assignment.id).exists())
+        mock_schedule_discovery.assert_not_called()
+        mock_get_mcp_manager.return_value.remove_server.assert_called_once_with(str(server.id))
+        mock_track_event.assert_called_once()
+        track_args, track_kwargs = mock_track_event.call_args
+        self.assertEqual(track_args[1], AnalyticsEvent.MCP_SERVER_DELETED)
+        self.assertEqual(track_args[2]["server_id"], str(server.id))
+        self.assertEqual(track_args[2]["server_scope"], MCPServerConfig.Scope.ORGANIZATION)
+        self.assertEqual(track_kwargs.get("organization"), org)
 
     def test_create_server_validation_errors(self):
         response = self.client.post(


### PR DESCRIPTION
## Summary
- Separate MCP cache invalidation so server and credential deletes invalidate correctly without scheduling rediscovery.
- Improve delete dialog error parsing to handle structured API error payloads and avoid showing raw HTML responses.
- Add coverage for deleting an org-scoped MCP server and verify rediscovery is not scheduled.

## Testing
- Added a focused unit test for MCP server deletion behavior.
- Not run (not requested).