### PR TITLE
Skip console context headers on marketing form requests

### DIFF
--- a/frontend/src/api/agentChat.test.ts
+++ b/frontend/src/api/agentChat.test.ts
@@ -71,7 +71,7 @@ describe('resolveSpawnRequest', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await jsonRequest('/qualify/', {
+    await jsonRequest('/QUALIFY/', {
       method: 'POST',
       includeCsrf: true,
       json: {},

--- a/frontend/src/api/agentChat.test.ts
+++ b/frontend/src/api/agentChat.test.ts
@@ -2,10 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveSpawnRequest } from './agentChat'
 import { jsonRequest } from './http'
+import { storeConsoleContext } from '../util/consoleContextStorage'
 
 describe('resolveSpawnRequest', () => {
   beforeEach(() => {
     document.cookie = 'csrftoken=test-token'
+    window.sessionStorage.clear()
+    window.history.replaceState(null, '', '/')
   })
 
   it('includes the CSRF header for pending action mutations', async () => {
@@ -56,5 +59,70 @@ describe('resolveSpawnRequest', () => {
     const [, init] = fetchMock.mock.calls[0]
     const headers = new Headers(init?.headers)
     expect(headers.get('X-CSRFToken')).toBe('fresh-token')
+  })
+
+  it('does not include console context headers on marketing form requests', async () => {
+    storeConsoleContext({ type: 'organization', id: 'org-1', name: 'Test Org' })
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await jsonRequest('/qualify/', {
+      method: 'POST',
+      includeCsrf: true,
+      json: {},
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const headers = new Headers(init?.headers)
+    expect(headers.has('X-Gobii-Context-Type')).toBe(false)
+    expect(headers.has('X-Gobii-Context-Id')).toBe(false)
+  })
+
+  it('keeps console context headers on console API requests', async () => {
+    storeConsoleContext({ type: 'organization', id: 'org-1', name: 'Test Org' })
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await jsonRequest('/console/api/session/', {
+      method: 'GET',
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const headers = new Headers(init?.headers)
+    expect(headers.get('X-Gobii-Context-Type')).toBe('organization')
+    expect(headers.get('X-Gobii-Context-Id')).toBe('org-1')
+  })
+
+  it('does not include console context headers from marketing pages on relative requests', async () => {
+    window.history.replaceState(null, '', '/contact/')
+    storeConsoleContext({ type: 'organization', id: 'org-1', name: 'Test Org' })
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await jsonRequest('', {
+      method: 'POST',
+      includeCsrf: true,
+      json: {},
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const headers = new Headers(init?.headers)
+    expect(headers.has('X-Gobii-Context-Type')).toBe(false)
+    expect(headers.has('X-Gobii-Context-Id')).toBe(false)
   })
 })

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -51,7 +51,8 @@ function applyConsoleContextHeaders(headers: Headers): boolean {
 }
 
 function normalizePathname(pathname: string): string {
-  return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname
+  const cleaned = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname
+  return cleaned.toLowerCase()
 }
 
 function isMarketingContextHeaderPath(pathname: string): boolean {

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -15,6 +15,8 @@ export class HttpError extends Error {
 
 let loginRedirectScheduled = false
 
+const MARKETING_CONTEXT_HEADER_PATHS = new Set(['/contact', '/prequalify', '/qualify'])
+
 function getBrowserTimeZone(): string | null {
   try {
     if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
@@ -46,6 +48,34 @@ function applyConsoleContextHeaders(headers: Headers): boolean {
     applied = true
   }
   return applied
+}
+
+function normalizePathname(pathname: string): string {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname
+}
+
+function isMarketingContextHeaderPath(pathname: string): boolean {
+  return MARKETING_CONTEXT_HEADER_PATHS.has(normalizePathname(pathname))
+}
+
+function resolvePathname(input: RequestInfo | URL): string | null {
+  try {
+    if (input instanceof URL) {
+      return input.pathname
+    }
+    if (typeof Request !== 'undefined' && input instanceof Request) {
+      return new URL(input.url).pathname
+    }
+    const base = typeof window !== 'undefined' ? window.location.href : 'http://localhost/'
+    return new URL(String(input), base).pathname
+  } catch {
+    return null
+  }
+}
+
+function shouldApplyConsoleContextHeaders(input: RequestInfo | URL): boolean {
+  const requestPathname = resolvePathname(input)
+  return !requestPathname || !isMarketingContextHeaderPath(requestPathname)
 }
 
 export function buildLoginUrl(nextUrl?: string): string {
@@ -111,7 +141,7 @@ async function jsonFetchInternal<T>(
       headers.set('X-Gobii-Timezone', browserTimeZone)
     }
   }
-  const appliedContextHeaders = applyConsoleContextHeaders(headers)
+  const appliedContextHeaders = shouldApplyConsoleContextHeaders(input) ? applyConsoleContextHeaders(headers) : false
 
   const response = await fetch(input, {
     credentials: 'same-origin',


### PR DESCRIPTION
**Summary**
- Avoid sending console context headers from marketing-page requests such as `/contact`, `/prequalify`, and `/qualify`.
- Preserve console context headers for console API requests.
- Add tests covering marketing form requests, console API requests, and relative-path requests from marketing pages.

**Testing**
- Updated unit coverage in `frontend/src/api/agentChat.test.ts` for header behavior across request types.
- Not run (not requested).