### PR TITLE
Preserve tool result sections during prompt shrinking

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -156,11 +156,10 @@ BROWSER_TASK_RESULT_BLOCK_RE = re.compile(
     r"<result>\s*(?P<payload>.*?)\s*</result>",
     re.DOTALL | re.IGNORECASE,
 )
-TOOL_RESULT_PROMPT_COMPONENTS = frozenset({
-    "result",
+TOOL_RESULT_LOOKUP_COMPONENTS = frozenset({
+    "parent_result_id",
     "result_id",
     "result_meta",
-    "result_preview",
     "result_schema",
 })
 
@@ -4708,10 +4707,10 @@ def _get_unified_history_prompt(
             "cost": 2,        # Helpful for budgeting; small and should remain visible
             "params": 1,      # Low priority - can be shrunk aggressively
             "prompt": 1,      # Browser task/user prompt context; useful but repeatable
-            "result": 1,      # Sized upstream by tool_results.py; keep intact here.
+            "result": 1,      # Payload body; can be shrunk to protect model limits.
             "result_meta": 2, # Medium priority - supports tool result lookup
-            "result_schema": 1, # Sized upstream by tool_results.py; keep intact here.
-            "result_preview": 1, # Sized upstream by tool_results.py; keep intact here.
+            "result_schema": 1, # Query/shape hint from tool_results.py; keep intact.
+            "result_preview": 1, # Payload preview; can be shrunk to protect model limits.
             "result_summary": 1, # Low priority - browser task prose summary
             "files": 3,       # High priority - direct filespace paths for follow-up actions
             "content": 2,     # Medium priority for message content (SMS, etc.)
@@ -4739,16 +4738,15 @@ def _get_unified_history_prompt(
             for component_name, component_content in components.items():
                 component_weight = COMPONENT_WEIGHTS.get(component_name, 1)
 
-                # Tool result bodies and lookup metadata are already aggressively
-                # shaped by tool_results.py; a second promptree HMT pass can
-                # remove the exact result_id, query hints, or JSON shape the
-                # preview was intended to preserve.
-                non_shrinkable = component_name in TOOL_RESULT_PROMPT_COMPONENTS
+                # Preserve lookup metadata shaped by tool_results.py. Payload
+                # bodies remain shrinkable so promptree can still enforce the
+                # model budget when many small or fresh inline results pile up.
+                non_shrinkable = component_name in TOOL_RESULT_LOOKUP_COMPONENTS
 
                 # Apply HMT shrinking to bulky content
                 shrinker = None
                 if not non_shrinkable and (
-                    component_name in ("params", "prompt", "result_summary", "body") or
+                    component_name in ("params", "prompt", "result", "result_preview", "result_summary", "body") or
                     (component_name == "content" and len(component_content) > 250)
                 ):
                     shrinker = "hmt"

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -156,6 +156,13 @@ BROWSER_TASK_RESULT_BLOCK_RE = re.compile(
     r"<result>\s*(?P<payload>.*?)\s*</result>",
     re.DOTALL | re.IGNORECASE,
 )
+TOOL_RESULT_PROMPT_COMPONENTS = frozenset({
+    "result",
+    "result_id",
+    "result_meta",
+    "result_preview",
+    "result_schema",
+})
 
 
 def _config_allows_implied_send(params_with_hints: Mapping[str, Any] | None) -> bool:
@@ -4701,10 +4708,10 @@ def _get_unified_history_prompt(
             "cost": 2,        # Helpful for budgeting; small and should remain visible
             "params": 1,      # Low priority - can be shrunk aggressively
             "prompt": 1,      # Browser task/user prompt context; useful but repeatable
-            "result": 1,      # Low priority - can be shrunk aggressively
+            "result": 1,      # Sized upstream by tool_results.py; keep intact here.
             "result_meta": 2, # Medium priority - supports tool result lookup
-            "result_schema": 1, # Low priority - schema can be shrunk aggressively
-            "result_preview": 1, # Low priority - preview only
+            "result_schema": 1, # Sized upstream by tool_results.py; keep intact here.
+            "result_preview": 1, # Sized upstream by tool_results.py; keep intact here.
             "result_summary": 1, # Low priority - browser task prose summary
             "files": 3,       # High priority - direct filespace paths for follow-up actions
             "content": 2,     # Medium priority for message content (SMS, etc.)
@@ -4732,10 +4739,16 @@ def _get_unified_history_prompt(
             for component_name, component_content in components.items():
                 component_weight = COMPONENT_WEIGHTS.get(component_name, 1)
 
+                # Tool result bodies and lookup metadata are already aggressively
+                # shaped by tool_results.py; a second promptree HMT pass can
+                # remove the exact result_id, query hints, or JSON shape the
+                # preview was intended to preserve.
+                non_shrinkable = component_name in TOOL_RESULT_PROMPT_COMPONENTS
+
                 # Apply HMT shrinking to bulky content
                 shrinker = None
-                if (
-                    component_name in ("params", "prompt", "result", "result_preview", "result_schema", "result_summary", "body") or
+                if not non_shrinkable and (
+                    component_name in ("params", "prompt", "result_summary", "body") or
                     (component_name == "content" and len(component_content) > 250)
                 ):
                     shrinker = "hmt"
@@ -4750,7 +4763,8 @@ def _get_unified_history_prompt(
                     component_name,
                     component_content,
                     weight=component_weight,
-                    shrinker=shrinker
+                    shrinker=shrinker,
+                    non_shrinkable=non_shrinkable,
                 )
 
     return fresh_tool_call_step_ids

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2187,7 +2187,7 @@ class PromptContextBuilderTests(TestCase):
         )
         self.assertNotIn(f"<parent_result_id>{parent_tool_call.pk}</parent_result_id>", content)
 
-    def test_tool_result_components_are_non_shrinkable_in_promptree(self):
+    def test_tool_result_lookup_components_are_non_shrinkable_in_promptree(self):
         from api.agent.core import promptree
 
         small_step = PersistentAgentStep.objects.create(
@@ -2204,18 +2204,29 @@ class PromptContextBuilderTests(TestCase):
             agent=self.agent,
             description="Tool call: http_request",
         )
-        PersistentAgentToolCall.objects.create(
+        parent_call = PersistentAgentToolCall.objects.create(
             step=large_step,
             tool_name="http_request",
             tool_params={"url": "https://example.test/data"},
             result=json.dumps({"content": "large-preview-result " * 3000}),
+        )
+        child_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Tool call: child_tool",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=child_step,
+            parent_tool_call=parent_call,
+            tool_name="child_tool",
+            tool_params={},
+            result=json.dumps({"status": "ok"}),
         )
 
         original_section_text = promptree._Node.section_text
         captured_tool_result_sections = []
 
         def capture_section_text(node, name, txt, **kwargs):
-            if name in {"result", "result_meta", "result_preview", "result_schema"}:
+            if name in {"parent_result_id", "result", "result_meta", "result_preview", "result_schema"}:
                 captured_tool_result_sections.append(
                     {
                         "name": name,
@@ -2237,9 +2248,14 @@ class PromptContextBuilderTests(TestCase):
         self.assertIn("result", captured_by_name)
         self.assertIn("result_meta", captured_by_name)
         self.assertIn("result_preview", captured_by_name)
-        for section in captured_tool_result_sections:
-            self.assertTrue(section["non_shrinkable"], section)
-            self.assertIsNone(section["shrinker"], section)
+        self.assertIn("parent_result_id", captured_by_name)
+
+        for name in ("parent_result_id", "result_meta"):
+            self.assertTrue(captured_by_name[name]["non_shrinkable"], captured_by_name[name])
+            self.assertIsNone(captured_by_name[name]["shrinker"], captured_by_name[name])
+        for name in ("result", "result_preview"):
+            self.assertFalse(captured_by_name[name]["non_shrinkable"], captured_by_name[name])
+            self.assertEqual(captured_by_name[name]["shrinker"], "hmt", captured_by_name[name])
 
     def test_completed_browser_tasks_use_unified_history_window_not_tool_history_limit(self):
         self._configure_unified_history_limits(

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2187,6 +2187,60 @@ class PromptContextBuilderTests(TestCase):
         )
         self.assertNotIn(f"<parent_result_id>{parent_tool_call.pk}</parent_result_id>", content)
 
+    def test_tool_result_components_are_non_shrinkable_in_promptree(self):
+        from api.agent.core import promptree
+
+        small_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Tool call: search_tools",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=small_step,
+            tool_name="search_tools",
+            tool_params={"query": "small"},
+            result=json.dumps({"status": "ok", "marker": "small-inline-result"}),
+        )
+        large_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Tool call: http_request",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=large_step,
+            tool_name="http_request",
+            tool_params={"url": "https://example.test/data"},
+            result=json.dumps({"content": "large-preview-result " * 3000}),
+        )
+
+        original_section_text = promptree._Node.section_text
+        captured_tool_result_sections = []
+
+        def capture_section_text(node, name, txt, **kwargs):
+            if name in {"result", "result_meta", "result_preview", "result_schema"}:
+                captured_tool_result_sections.append(
+                    {
+                        "name": name,
+                        "non_shrinkable": kwargs.get("non_shrinkable", False),
+                        "shrinker": kwargs.get("shrinker"),
+                    }
+                )
+            return original_section_text(node, name, txt, **kwargs)
+
+        with patch.object(promptree._Node, "section_text", new=capture_section_text), \
+             patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
+             patch('api.agent.core.prompt_context.ensure_comms_compacted'):
+            build_prompt_context(self.agent)
+
+        captured_by_name = {
+            section["name"]: section
+            for section in captured_tool_result_sections
+        }
+        self.assertIn("result", captured_by_name)
+        self.assertIn("result_meta", captured_by_name)
+        self.assertIn("result_preview", captured_by_name)
+        for section in captured_tool_result_sections:
+            self.assertTrue(section["non_shrinkable"], section)
+            self.assertIsNone(section["shrinker"], section)
+
     def test_completed_browser_tasks_use_unified_history_window_not_tool_history_limit(self):
         self._configure_unified_history_limits(
             tool_limit=2,


### PR DESCRIPTION
## Summary
- Mark tool result payload and lookup components as non-shrinkable in prompt context building
- Prevent a second HMT pass from stripping result IDs, previews, or schema details that upstream shaping already preserved
- Add coverage to verify tool result sections stay intact during promptree rendering

## Testing
- Added a unit test covering non-shrinkable handling for tool result sections