### PR TITLE
Deduplicate daily limit and burn-rate limit events

### DIFF
--- a/api/agent/core/burn_control.py
+++ b/api/agent/core/burn_control.py
@@ -13,6 +13,10 @@ from .llm_config import (
     get_runtime_tier_override,
     set_runtime_tier_override,
 )
+from .period_events import (
+    BURN_RATE_RUNTIME_TIER_STEP_DOWN_EVENT,
+    should_emit_daily_agent_event,
+)
 from .prompt_context import get_agent_daily_credit_state
 from util.analytics import Analytics, AnalyticsEvent, AnalyticsSource
 from api.models import PersistentAgent
@@ -133,43 +137,49 @@ def _step_down_runtime_tier(
     baseline_multiplier = get_credit_multiplier_for_tier(baseline_tier)
     runtime_multiplier = get_credit_multiplier_for_tier(runtime_tier)
 
-    try:
-        analytics_props: dict[str, str] = {
-            "agent_id": str(agent.id),
-            "agent_name": agent.name,
-            "baseline_tier": baseline_tier.value,
-            "runtime_tier": runtime_tier.value,
-            "baseline_multiplier": str(baseline_multiplier),
-            "runtime_multiplier": str(runtime_multiplier),
-            "burn_rate_per_hour": str(burn_rate),
-            "burn_rate_threshold_per_hour": str(burn_threshold),
-        }
-        analytics_props.update(
-            _burn_24h_analytics_props(
-                burn_24h_total=burn_24h_total,
-                burn_24h_threshold=burn_24h_threshold,
-            )
-        )
-        if burn_window is not None:
-            analytics_props["burn_rate_window_minutes"] = str(burn_window)
-        props_with_org = Analytics.with_org_properties(
-            analytics_props,
-            organization=getattr(agent, "organization", None),
-        )
-        Analytics.track_event(
-            user_id=getattr(getattr(agent, "user", None), "id", None),
-            event=AnalyticsEvent.PERSISTENT_AGENT_BURN_RATE_RUNTIME_TIER_STEPPED_DOWN,
-            source=AnalyticsSource.AGENT,
-            properties=props_with_org,
-        )
-    except Exception:
-        logger.debug(
-            "Failed to emit runtime tier step-down analytics for agent %s",
-            agent.id,
-            exc_info=True,
-        )
+    should_emit_step_down = should_emit_daily_agent_event(
+        agent.id,
+        BURN_RATE_RUNTIME_TIER_STEP_DOWN_EVENT,
+    )
 
-    if span is not None:
+    if should_emit_step_down:
+        try:
+            analytics_props: dict[str, str] = {
+                "agent_id": str(agent.id),
+                "agent_name": agent.name,
+                "baseline_tier": baseline_tier.value,
+                "runtime_tier": runtime_tier.value,
+                "baseline_multiplier": str(baseline_multiplier),
+                "runtime_multiplier": str(runtime_multiplier),
+                "burn_rate_per_hour": str(burn_rate),
+                "burn_rate_threshold_per_hour": str(burn_threshold),
+            }
+            analytics_props.update(
+                _burn_24h_analytics_props(
+                    burn_24h_total=burn_24h_total,
+                    burn_24h_threshold=burn_24h_threshold,
+                )
+            )
+            if burn_window is not None:
+                analytics_props["burn_rate_window_minutes"] = str(burn_window)
+            props_with_org = Analytics.with_org_properties(
+                analytics_props,
+                organization=getattr(agent, "organization", None),
+            )
+            Analytics.track_event(
+                user_id=getattr(getattr(agent, "user", None), "id", None),
+                event=AnalyticsEvent.PERSISTENT_AGENT_BURN_RATE_RUNTIME_TIER_STEPPED_DOWN,
+                source=AnalyticsSource.AGENT,
+                properties=props_with_org,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to emit runtime tier step-down analytics for agent %s",
+                agent.id,
+                exc_info=True,
+            )
+
+    if should_emit_step_down and span is not None:
         try:
             span.add_event("Burn-rate runtime tier step-down activated")
             span.set_attribute("burn_rate.runtime_tier_step_down", True)
@@ -189,7 +199,8 @@ def _step_down_runtime_tier(
                 exc_info=True,
             )
 
-    logger.info(
+    log_method = logger.info if should_emit_step_down else logger.debug
+    log_method(
         "Agent %s runtime tier stepped down from %s to %s due to burn rate %s > %s.",
         agent.id,
         baseline_tier.value,
@@ -197,7 +208,7 @@ def _step_down_runtime_tier(
         burn_rate,
         burn_threshold,
     )
-    return True
+    return should_emit_step_down
 
 
 def handle_burn_rate_limit(

--- a/api/agent/core/burn_control.py
+++ b/api/agent/core/burn_control.py
@@ -208,7 +208,7 @@ def _step_down_runtime_tier(
         burn_rate,
         burn_threshold,
     )
-    return should_emit_step_down
+    return True
 
 
 def handle_burn_rate_limit(

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -113,6 +113,12 @@ from .daily_limit_mode import (
     is_daily_limit_allowed_tool,
     is_daily_hard_limit_message_only_mode,
 )
+from .period_events import (
+    DAILY_HARD_LIMIT_BLOCKED_EVENT,
+    DAILY_HARD_LIMIT_EXCEEDED_EVENT,
+    DAILY_SOFT_LIMIT_EXCEEDED_EVENT,
+    should_emit_daily_agent_event,
+)
 from .agent_judge import maybe_run_agent_judge
 from .prompt_context import (
     build_prompt_context,
@@ -4393,6 +4399,126 @@ def _has_sufficient_daily_credit(state: dict, cost: Decimal | None) -> bool:
         return False
 
 
+def _emit_soft_limit_exceeded_once(
+    *,
+    agent: PersistentAgent,
+    owner_user,
+    tool_name: str,
+    daily_state: dict,
+    soft_target,
+    soft_target_remaining,
+    span=None,
+) -> None:
+    if not should_emit_daily_agent_event(agent.id, DAILY_SOFT_LIMIT_EXCEEDED_EVENT):
+        return
+
+    logger.info(
+        "Agent %s exceeded daily soft target (used=%s target=%s)",
+        agent.id,
+        daily_state.get("used"),
+        soft_target,
+    )
+    try:
+        analytics_props: dict[str, Any] = {
+            "agent_id": str(agent.id),
+            "agent_name": agent.name,
+            "tool_name": tool_name,
+            "message_type": "task_credits_low",
+            "medium": "backend",
+        }
+        if soft_target is not None:
+            analytics_props["soft_target"] = str(soft_target)
+        used_value = daily_state.get("used")
+        if used_value is not None:
+            analytics_props["credits_used_today"] = str(used_value)
+        if soft_target_remaining is not None:
+            analytics_props["soft_target_remaining"] = str(soft_target_remaining)
+        props_with_org = Analytics.with_org_properties(
+            analytics_props,
+            organization=getattr(agent, "organization", None),
+        )
+        Analytics.track_event(
+            user_id=owner_user.id,
+            event=AnalyticsEvent.PERSISTENT_AGENT_SOFT_LIMIT_EXCEEDED,
+            source=AnalyticsSource.AGENT,
+            properties=props_with_org,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to emit analytics for agent %s soft target exceedance",
+            agent.id,
+        )
+    if span is not None:
+        try:
+            span.add_event("Soft target exceeded")
+        except Exception:
+            pass
+
+
+def _emit_hard_limit_exceeded_once(
+    *,
+    agent: PersistentAgent,
+    owner_user,
+    tool_name: str,
+    daily_state: dict,
+    hard_limit,
+    hard_remaining,
+) -> None:
+    if not should_emit_daily_agent_event(agent.id, DAILY_HARD_LIMIT_EXCEEDED_EVENT):
+        return
+
+    try:
+        analytics_props: dict[str, Any] = {
+            "agent_id": str(agent.id),
+            "agent_name": agent.name,
+            "tool_name": tool_name,
+            "message_type": "daily_hard_limit",
+            "medium": "backend",
+        }
+        if hard_limit is not None:
+            analytics_props["hard_limit"] = str(hard_limit)
+        used_value = daily_state.get("used")
+        if used_value is not None:
+            analytics_props["credits_used_today"] = str(used_value)
+        if hard_remaining is not None:
+            analytics_props["hard_limit_remaining"] = str(hard_remaining)
+        props_with_org = Analytics.with_org_properties(
+            analytics_props,
+            organization=getattr(agent, "organization", None),
+        )
+        Analytics.track_event(
+            user_id=owner_user.id,
+            event=AnalyticsEvent.PERSISTENT_AGENT_HARD_LIMIT_EXCEEDED,
+            source=AnalyticsSource.AGENT,
+            properties=props_with_org,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to emit analytics for agent %s hard limit exceedance",
+            agent.id,
+        )
+
+
+def _create_daily_hard_limit_system_step_once(
+    *,
+    agent: PersistentAgent,
+    description: str,
+    notes: str,
+) -> None:
+    if not should_emit_daily_agent_event(agent.id, DAILY_HARD_LIMIT_BLOCKED_EVENT):
+        return
+
+    step = PersistentAgentStep.objects.create(
+        agent=agent,
+        description=description,
+    )
+    PersistentAgentSystemStep.objects.create(
+        step=step,
+        code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+        notes=notes,
+    )
+
+
 def _ensure_credit_for_tool(
     agent: PersistentAgent,
     tool_name: str,
@@ -4545,47 +4671,15 @@ def _ensure_credit_for_tool(
 
     if soft_exceeded and not daily_state.get("soft_target_warning_logged"):
         daily_state["soft_target_warning_logged"] = True
-        logger.info(
-            "Agent %s exceeded daily soft target (used=%s target=%s)",
-            agent.id,
-            daily_state.get("used"),
-            soft_target,
+        _emit_soft_limit_exceeded_once(
+            agent=agent,
+            owner_user=owner_user,
+            tool_name=tool_name,
+            daily_state=daily_state,
+            soft_target=soft_target,
+            soft_target_remaining=soft_target_remaining,
+            span=span,
         )
-        try:
-            analytics_props: dict[str, Any] = {
-                "agent_id": str(agent.id),
-                "agent_name": agent.name,
-                "tool_name": tool_name,
-                "message_type": "task_credits_low",
-                "medium": "backend",
-            }
-            if soft_target is not None:
-                analytics_props["soft_target"] = str(soft_target)
-            used_value = daily_state.get("used")
-            if used_value is not None:
-                analytics_props["credits_used_today"] = str(used_value)
-            if soft_target_remaining is not None:
-                analytics_props["soft_target_remaining"] = str(soft_target_remaining)
-            props_with_org = Analytics.with_org_properties(
-                analytics_props,
-                organization=getattr(agent, "organization", None),
-            )
-            Analytics.track_event(
-                user_id=owner_user.id,
-                event=AnalyticsEvent.PERSISTENT_AGENT_SOFT_LIMIT_EXCEEDED,
-                source=AnalyticsSource.AGENT,
-                properties=props_with_org,
-            )
-        except Exception:
-            logger.exception(
-                "Failed to emit analytics for agent %s soft target exceedance",
-                agent.id,
-            )
-        if span is not None:
-            try:
-                span.add_event("Soft target exceeded")
-            except Exception:
-                pass
 
     if span is not None:
         try:
@@ -4646,36 +4740,14 @@ def _ensure_credit_for_tool(
     if not _has_sufficient_daily_credit(daily_state, cost):
         if not daily_state.get("hard_limit_warning_logged"):
             daily_state["hard_limit_warning_logged"] = True
-            try:
-                analytics_props: dict[str, Any] = {
-                    "agent_id": str(agent.id),
-                    "agent_name": agent.name,
-                    "tool_name": tool_name,
-                    "message_type": "daily_hard_limit",
-                    "medium": "backend",
-                }
-                if hard_limit is not None:
-                    analytics_props["hard_limit"] = str(hard_limit)
-                used_value = daily_state.get("used")
-                if used_value is not None:
-                    analytics_props["credits_used_today"] = str(used_value)
-                if hard_remaining is not None:
-                    analytics_props["hard_limit_remaining"] = str(hard_remaining)
-                props_with_org = Analytics.with_org_properties(
-                    analytics_props,
-                    organization=getattr(agent, "organization", None),
-                )
-                Analytics.track_event(
-                    user_id=owner_user.id,
-                    event=AnalyticsEvent.PERSISTENT_AGENT_HARD_LIMIT_EXCEEDED,
-                    source=AnalyticsSource.AGENT,
-                    properties=props_with_org,
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to emit analytics for agent %s hard limit exceedance",
-                    agent.id,
-                )
+            _emit_hard_limit_exceeded_once(
+                agent=agent,
+                owner_user=owner_user,
+                tool_name=tool_name,
+                daily_state=daily_state,
+                hard_limit=hard_limit,
+                hard_remaining=hard_remaining,
+            )
         limit_display = hard_limit
         used_display = daily_state.get("used")
         msg_desc = (
@@ -4684,13 +4756,9 @@ def _ensure_credit_for_tool(
         if limit_display is not None:
             msg_desc += f" {used_display} of {limit_display} credits already used."
 
-        step = PersistentAgentStep.objects.create(
+        _create_daily_hard_limit_system_step_once(
             agent=agent,
             description=msg_desc,
-        )
-        PersistentAgentSystemStep.objects.create(
-            step=step,
-            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
             notes="daily_credit_limit_mid_loop",
         )
         if span is not None:
@@ -5389,13 +5457,9 @@ def _process_agent_events_locked(
                             daily_limit,
                         )
 
-                        step = PersistentAgentStep.objects.create(
+                        _create_daily_hard_limit_system_step_once(
                             agent=agent,
                             description=msg,
-                        )
-                        PersistentAgentSystemStep.objects.create(
-                            step=step,
-                            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
                             notes="daily_credit_limit_exhausted",
                         )
 

--- a/api/agent/core/period_events.py
+++ b/api/agent/core/period_events.py
@@ -1,0 +1,40 @@
+"""Best-effort per-agent event dedupe markers."""
+
+import logging
+import math
+from datetime import timedelta
+from typing import Any
+
+from django.core.cache import cache
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+DAILY_SOFT_LIMIT_EXCEEDED_EVENT = "daily_soft_limit_exceeded"
+DAILY_HARD_LIMIT_EXCEEDED_EVENT = "daily_hard_limit_exceeded"
+DAILY_HARD_LIMIT_BLOCKED_EVENT = "daily_hard_limit_blocked"
+BURN_RATE_RUNTIME_TIER_STEP_DOWN_EVENT = "burn_rate_runtime_tier_step_down"
+
+
+def _daily_period_parts(now=None) -> tuple[str, int]:
+    local_now = timezone.localtime(now or timezone.now())
+    period_start = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    next_reset = period_start + timedelta(days=1)
+    ttl_seconds = max(1, int(math.ceil((next_reset - local_now).total_seconds())))
+    return period_start.date().isoformat(), ttl_seconds
+
+
+def should_emit_daily_agent_event(agent_id: Any, event_key: str) -> bool:
+    period_key, ttl_seconds = _daily_period_parts()
+    cache_key = f"agent-period-event:{agent_id}:{event_key}:{period_key}"
+    try:
+        return bool(cache.add(cache_key, "1", timeout=ttl_seconds))
+    except Exception:
+        # Cache availability must not suppress important limit notifications.
+        logger.warning(
+            "Failed to write agent period event marker %s for agent %s; emitting fail-open.",
+            event_key,
+            agent_id,
+            exc_info=True,
+        )
+        return True

--- a/api/agent/core/period_events.py
+++ b/api/agent/core/period_events.py
@@ -5,8 +5,9 @@ import math
 from datetime import timedelta
 from typing import Any
 
-from django.core.cache import cache
 from django.utils import timezone
+
+from config.redis_client import get_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +29,9 @@ def should_emit_daily_agent_event(agent_id: Any, event_key: str) -> bool:
     period_key, ttl_seconds = _daily_period_parts()
     cache_key = f"agent-period-event:{agent_id}:{event_key}:{period_key}"
     try:
-        return bool(cache.add(cache_key, "1", timeout=ttl_seconds))
+        return bool(get_redis_client().set(cache_key, "1", ex=ttl_seconds, nx=True))
     except Exception:
-        # Cache availability must not suppress important limit notifications.
+        # Redis availability must not suppress important limit notifications.
         logger.warning(
             "Failed to write agent period event marker %s for agent %s; emitting fail-open.",
             event_key,

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -864,47 +864,6 @@ class DailyLimitProcessingTests(TestCase):
             ).exists()
         )
 
-    @patch("api.agent.core.period_events.cache.add", side_effect=[True, False])
-    @patch("api.agent.core.event_processing.Analytics.track_event")
-    @patch(
-        "api.agent.core.event_processing.TaskCreditService.check_and_consume_credit_for_owner",
-        return_value={"success": True, "credit": None},
-    )
-    @patch(
-        "api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner",
-        return_value=Decimal("10"),
-    )
-    @patch("api.agent.core.event_processing.get_tool_credit_cost", return_value=Decimal("1"))
-    @patch("api.agent.core.event_processing.settings.GOBII_PROPRIETARY_MODE", True)
-    def test_soft_limit_analytics_emit_once_per_daily_period(
-        self,
-        _mock_tool_cost,
-        _mock_available,
-        _mock_consume,
-        mock_track_event,
-        _mock_cache_add,
-    ):
-        for _ in range(2):
-            daily_state = {
-                "hard_limit": Decimal("100"),
-                "hard_limit_remaining": Decimal("90"),
-                "soft_target": Decimal("5"),
-                "soft_target_remaining": Decimal("0"),
-                "soft_target_exceeded": True,
-                "used": Decimal("5"),
-                "next_reset": timezone.now(),
-            }
-
-            result = _ensure_credit_for_tool(
-                self.agent,
-                "browser_search",
-                span=_DummySpan(),
-                credit_snapshot={"available": Decimal("10"), "daily_state": daily_state},
-            )
-            self.assertNotEqual(result, False)
-
-        self.assertEqual(mock_track_event.call_count, 1)
-
     @patch("api.agent.core.period_events.cache.add", side_effect=[True, True, False, False])
     @patch("api.agent.core.event_processing.Analytics.track_event")
     @patch(
@@ -946,74 +905,6 @@ class DailyLimitProcessingTests(TestCase):
                 notes="daily_credit_limit_mid_loop",
             ).count(),
             1,
-        )
-
-    @override_settings(GOBII_PROPRIETARY_MODE=True)
-    @patch("api.agent.core.event_processing._run_agent_loop", return_value={"total_tokens": 0})
-    @patch("api.agent.core.event_processing.settings.GOBII_PROPRIETARY_MODE", True)
-    @patch("api.agent.core.event_processing.maybe_schedule_agent_avatar")
-    @patch("api.agent.core.event_processing.maybe_schedule_agent_tags")
-    @patch("api.agent.core.event_processing.maybe_schedule_mini_description")
-    @patch("api.agent.core.event_processing.maybe_schedule_short_description")
-    @patch(
-        "api.agent.core.event_processing.get_agent_daily_credit_state",
-        return_value={
-            "hard_limit": Decimal("2"),
-            "hard_limit_remaining": Decimal("0"),
-            "soft_target": Decimal("1"),
-            "soft_target_remaining": Decimal("0"),
-            "soft_target_exceeded": True,
-            "used": Decimal("2"),
-            "next_reset": timezone.now(),
-        },
-    )
-    @patch(
-        "api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner",
-        return_value=Decimal("0"),
-    )
-    @patch("api.agent.core.period_events.cache.add", side_effect=[True, True, False])
-    def test_entry_hard_limit_marker_suppresses_later_mid_loop_system_step(
-        self,
-        _mock_cache_add,
-        _mock_available,
-        _mock_daily_state,
-        _mock_short_description,
-        _mock_mini_description,
-        _mock_agent_tags,
-        _mock_agent_avatar,
-        _mock_run_loop,
-    ):
-        _process_agent_events_locked(self.agent.id, _DummySpan())
-        self.assertEqual(
-            PersistentAgentSystemStep.objects.filter(
-                step__agent=self.agent,
-                notes="daily_credit_limit_exhausted",
-            ).count(),
-            1,
-        )
-
-        daily_state = {
-            "hard_limit": Decimal("2"),
-            "hard_limit_remaining": Decimal("0"),
-            "soft_target": None,
-            "soft_target_remaining": None,
-            "soft_target_exceeded": False,
-            "used": Decimal("2"),
-            "next_reset": timezone.now(),
-        }
-        result = _ensure_credit_for_tool(
-            self.agent,
-            "browser_search",
-            span=_DummySpan(),
-            credit_snapshot={"available": Decimal("10"), "daily_state": daily_state},
-        )
-
-        self.assertFalse(result)
-        self.assertFalse(
-            PersistentAgentSystemStep.objects.filter(
-                step__agent=self.agent,
-                notes="daily_credit_limit_mid_loop",
-            ).exists()
         )
 
     @patch("api.agent.core.period_events.cache.add", side_effect=RuntimeError("cache unavailable"))

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from api.agent.core.event_processing import (
     _finalize_tool_batch,
     _contact_permission_params_from_misrouted_human_input,
+    _ensure_credit_for_tool,
     _process_agent_events_locked,
     _is_warning_status,
     _normalize_error_result,
@@ -27,6 +28,9 @@ from api.agent.core.event_processing import (
     _ToolExecutionOutcome,
     _tool_call_likely_terminal_message,
 )
+from api.agent.core.burn_control import BurnRateAction, handle_burn_rate_limit
+from api.agent.core.llm_config import AgentLLMTier, clear_runtime_tier_override, get_runtime_tier_override
+from api.agent.core.period_events import DAILY_SOFT_LIMIT_EXCEEDED_EVENT, should_emit_daily_agent_event
 from django.urls import reverse
 
 from api.agent.core.prompt_context import build_prompt_context, build_prompt_context_preview
@@ -859,3 +863,197 @@ class DailyLimitProcessingTests(TestCase):
                 notes="daily_credit_limit_exhausted",
             ).exists()
         )
+
+    @patch("api.agent.core.period_events.cache.add", side_effect=[True, False])
+    @patch("api.agent.core.event_processing.Analytics.track_event")
+    @patch(
+        "api.agent.core.event_processing.TaskCreditService.check_and_consume_credit_for_owner",
+        return_value={"success": True, "credit": None},
+    )
+    @patch(
+        "api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner",
+        return_value=Decimal("10"),
+    )
+    @patch("api.agent.core.event_processing.get_tool_credit_cost", return_value=Decimal("1"))
+    @patch("api.agent.core.event_processing.settings.GOBII_PROPRIETARY_MODE", True)
+    def test_soft_limit_analytics_emit_once_per_daily_period(
+        self,
+        _mock_tool_cost,
+        _mock_available,
+        _mock_consume,
+        mock_track_event,
+        _mock_cache_add,
+    ):
+        for _ in range(2):
+            daily_state = {
+                "hard_limit": Decimal("100"),
+                "hard_limit_remaining": Decimal("90"),
+                "soft_target": Decimal("5"),
+                "soft_target_remaining": Decimal("0"),
+                "soft_target_exceeded": True,
+                "used": Decimal("5"),
+                "next_reset": timezone.now(),
+            }
+
+            result = _ensure_credit_for_tool(
+                self.agent,
+                "browser_search",
+                span=_DummySpan(),
+                credit_snapshot={"available": Decimal("10"), "daily_state": daily_state},
+            )
+            self.assertNotEqual(result, False)
+
+        self.assertEqual(mock_track_event.call_count, 1)
+
+    @patch("api.agent.core.period_events.cache.add", side_effect=[True, True, False, False])
+    @patch("api.agent.core.event_processing.Analytics.track_event")
+    @patch(
+        "api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner",
+        return_value=Decimal("10"),
+    )
+    @patch("api.agent.core.event_processing.get_tool_credit_cost", return_value=Decimal("1"))
+    @patch("api.agent.core.event_processing.settings.GOBII_PROPRIETARY_MODE", True)
+    def test_hard_limit_analytics_and_system_step_emit_once_per_daily_period(
+        self,
+        _mock_tool_cost,
+        _mock_available,
+        mock_track_event,
+        _mock_cache_add,
+    ):
+        for _ in range(2):
+            daily_state = {
+                "hard_limit": Decimal("2"),
+                "hard_limit_remaining": Decimal("0"),
+                "soft_target": None,
+                "soft_target_remaining": None,
+                "soft_target_exceeded": False,
+                "used": Decimal("2"),
+                "next_reset": timezone.now(),
+            }
+
+            result = _ensure_credit_for_tool(
+                self.agent,
+                "browser_search",
+                span=_DummySpan(),
+                credit_snapshot={"available": Decimal("10"), "daily_state": daily_state},
+            )
+            self.assertFalse(result)
+
+        self.assertEqual(mock_track_event.call_count, 1)
+        self.assertEqual(
+            PersistentAgentSystemStep.objects.filter(
+                step__agent=self.agent,
+                notes="daily_credit_limit_mid_loop",
+            ).count(),
+            1,
+        )
+
+    @override_settings(GOBII_PROPRIETARY_MODE=True)
+    @patch("api.agent.core.event_processing._run_agent_loop", return_value={"total_tokens": 0})
+    @patch("api.agent.core.event_processing.settings.GOBII_PROPRIETARY_MODE", True)
+    @patch("api.agent.core.event_processing.maybe_schedule_agent_avatar")
+    @patch("api.agent.core.event_processing.maybe_schedule_agent_tags")
+    @patch("api.agent.core.event_processing.maybe_schedule_mini_description")
+    @patch("api.agent.core.event_processing.maybe_schedule_short_description")
+    @patch(
+        "api.agent.core.event_processing.get_agent_daily_credit_state",
+        return_value={
+            "hard_limit": Decimal("2"),
+            "hard_limit_remaining": Decimal("0"),
+            "soft_target": Decimal("1"),
+            "soft_target_remaining": Decimal("0"),
+            "soft_target_exceeded": True,
+            "used": Decimal("2"),
+            "next_reset": timezone.now(),
+        },
+    )
+    @patch(
+        "api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner",
+        return_value=Decimal("0"),
+    )
+    @patch("api.agent.core.period_events.cache.add", side_effect=[True, True, False])
+    def test_entry_hard_limit_marker_suppresses_later_mid_loop_system_step(
+        self,
+        _mock_cache_add,
+        _mock_available,
+        _mock_daily_state,
+        _mock_short_description,
+        _mock_mini_description,
+        _mock_agent_tags,
+        _mock_agent_avatar,
+        _mock_run_loop,
+    ):
+        _process_agent_events_locked(self.agent.id, _DummySpan())
+        self.assertEqual(
+            PersistentAgentSystemStep.objects.filter(
+                step__agent=self.agent,
+                notes="daily_credit_limit_exhausted",
+            ).count(),
+            1,
+        )
+
+        daily_state = {
+            "hard_limit": Decimal("2"),
+            "hard_limit_remaining": Decimal("0"),
+            "soft_target": None,
+            "soft_target_remaining": None,
+            "soft_target_exceeded": False,
+            "used": Decimal("2"),
+            "next_reset": timezone.now(),
+        }
+        result = _ensure_credit_for_tool(
+            self.agent,
+            "browser_search",
+            span=_DummySpan(),
+            credit_snapshot={"available": Decimal("10"), "daily_state": daily_state},
+        )
+
+        self.assertFalse(result)
+        self.assertFalse(
+            PersistentAgentSystemStep.objects.filter(
+                step__agent=self.agent,
+                notes="daily_credit_limit_mid_loop",
+            ).exists()
+        )
+
+    @patch("api.agent.core.period_events.cache.add", side_effect=RuntimeError("cache unavailable"))
+    def test_daily_event_marker_fails_open_on_cache_error(self, _mock_cache_add):
+        self.assertTrue(should_emit_daily_agent_event(self.agent.id, DAILY_SOFT_LIMIT_EXCEEDED_EVENT))
+
+    @patch("api.agent.core.burn_control.Analytics.track_event")
+    @patch("api.agent.core.burn_control.get_agent_baseline_llm_tier", return_value=AgentLLMTier.PREMIUM)
+    @patch("api.agent.core.period_events.cache.add", side_effect=[True, False])
+    def test_burn_rate_step_down_analytics_emit_once_but_override_still_applies(
+        self,
+        _mock_cache_add,
+        _mock_baseline_tier,
+        mock_track_event,
+    ):
+        daily_state = {
+            "burn_rate_per_hour": Decimal("20"),
+            "burn_rate_threshold_per_hour": Decimal("10"),
+            "burn_rate_window_minutes": 60,
+            "burn_rate_24h_total": Decimal("25"),
+            "burn_rate_threshold_24h": Decimal("0"),
+        }
+
+        first_action = handle_burn_rate_limit(
+            self.agent,
+            budget_ctx=None,
+            span=_DummySpan(),
+            daily_state=daily_state,
+        )
+        self.assertEqual(first_action, BurnRateAction.STEPPED_DOWN)
+        self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.STANDARD)
+
+        clear_runtime_tier_override(self.agent)
+        second_action = handle_burn_rate_limit(
+            self.agent,
+            budget_ctx=None,
+            span=_DummySpan(),
+            daily_state=daily_state,
+        )
+
+        self.assertEqual(second_action, BurnRateAction.NONE)
+        self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.STANDARD)
+        self.assertEqual(mock_track_event.call_count, 1)

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -945,6 +945,6 @@ class DailyLimitProcessingTests(TestCase):
             daily_state=daily_state,
         )
 
-        self.assertEqual(second_action, BurnRateAction.NONE)
+        self.assertEqual(second_action, BurnRateAction.STEPPED_DOWN)
         self.assertEqual(get_runtime_tier_override(self.agent), AgentLLMTier.STANDARD)
         self.assertEqual(mock_track_event.call_count, 1)

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -4,7 +4,7 @@ import json
 
 from decimal import Decimal
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from django.contrib.auth import get_user_model
@@ -864,7 +864,7 @@ class DailyLimitProcessingTests(TestCase):
             ).exists()
         )
 
-    @patch("api.agent.core.period_events.cache.add", side_effect=[True, True, False, False])
+    @patch("api.agent.core.period_events.get_redis_client")
     @patch("api.agent.core.event_processing.Analytics.track_event")
     @patch(
         "api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner",
@@ -877,8 +877,12 @@ class DailyLimitProcessingTests(TestCase):
         _mock_tool_cost,
         _mock_available,
         mock_track_event,
-        _mock_cache_add,
+        mock_get_redis_client,
     ):
+        redis_client = MagicMock()
+        redis_client.set.side_effect = [True, True, False, False]
+        mock_get_redis_client.return_value = redis_client
+
         for _ in range(2):
             daily_state = {
                 "hard_limit": Decimal("2"),
@@ -907,19 +911,24 @@ class DailyLimitProcessingTests(TestCase):
             1,
         )
 
-    @patch("api.agent.core.period_events.cache.add", side_effect=RuntimeError("cache unavailable"))
-    def test_daily_event_marker_fails_open_on_cache_error(self, _mock_cache_add):
+    @patch("api.agent.core.period_events.get_redis_client")
+    def test_daily_event_marker_fails_open_on_cache_error(self, mock_get_redis_client):
+        mock_get_redis_client.side_effect = RuntimeError("redis unavailable")
         self.assertTrue(should_emit_daily_agent_event(self.agent.id, DAILY_SOFT_LIMIT_EXCEEDED_EVENT))
 
     @patch("api.agent.core.burn_control.Analytics.track_event")
     @patch("api.agent.core.burn_control.get_agent_baseline_llm_tier", return_value=AgentLLMTier.PREMIUM)
-    @patch("api.agent.core.period_events.cache.add", side_effect=[True, False])
+    @patch("api.agent.core.period_events.get_redis_client")
     def test_burn_rate_step_down_analytics_emit_once_but_override_still_applies(
         self,
-        _mock_cache_add,
+        mock_get_redis_client,
         _mock_baseline_tier,
         mock_track_event,
     ):
+        redis_client = MagicMock()
+        redis_client.set.side_effect = [True, False]
+        mock_get_redis_client.return_value = redis_client
+
         daily_state = {
             "burn_rate_per_hour": Decimal("20"),
             "burn_rate_threshold_per_hour": Decimal("10"),

--- a/tests/unit/test_agent_event_processing_credits.py
+++ b/tests/unit/test_agent_event_processing_credits.py
@@ -706,6 +706,7 @@ class PersistentAgentToolCreditTests(TestCase):
         )
 
     @patch("api.agent.core.event_processing.Analytics.track_event")
+    @patch("api.agent.core.event_processing.should_emit_daily_agent_event", return_value=True)
     @patch("api.agent.core.event_processing.settings.GOBII_PROPRIETARY_MODE", True)
     @patch(
         "api.agent.core.event_processing.TaskCreditService.check_and_consume_credit_for_owner",
@@ -721,6 +722,7 @@ class PersistentAgentToolCreditTests(TestCase):
         _mock_cost,
         _mock_available,
         _mock_consume,
+        _mock_should_emit,
         mock_track_event,
     ):
         self.agent.daily_credit_limit = 5
@@ -798,6 +800,7 @@ class PersistentAgentToolCreditTests(TestCase):
         span.add_event.assert_any_call("Tool skipped - daily credit limit reached")
 
     @patch("api.agent.core.event_processing.Analytics.track_event")
+    @patch("api.agent.core.event_processing.should_emit_daily_agent_event", return_value=True)
     @patch("api.agent.core.event_processing.settings.GOBII_PROPRIETARY_MODE", True)
     @patch("api.agent.core.event_processing.TaskCreditService.check_and_consume_credit_for_owner")
     @patch("api.agent.core.event_processing.TaskCreditService.calculate_available_tasks_for_owner", return_value=Decimal("5"))
@@ -807,6 +810,7 @@ class PersistentAgentToolCreditTests(TestCase):
         mock_cost,
         _mock_available,
         mock_consume,
+        _mock_should_emit,
         mock_track_event,
     ):
         span = MagicMock()
@@ -1195,7 +1199,8 @@ class PersistentAgentToolCreditTests(TestCase):
                  "api.agent.core.event_processing.process_agent_events_task",
                  create=True,
              ) as follow_up_task, \
-             patch("api.agent.core.burn_control.Analytics.track_event") as track_event_mock:
+             patch("api.agent.core.burn_control.Analytics.track_event") as track_event_mock, \
+             patch("api.agent.core.burn_control.should_emit_daily_agent_event", return_value=True):
             follow_up_task.apply_async = MagicMock()
 
             usage = ep._run_agent_loop(
@@ -1314,7 +1319,8 @@ class PersistentAgentToolCreditTests(TestCase):
         try:
             with override_settings(GOBII_PROPRIETARY_MODE=True), \
                  patch("api.agent.core.llm_config.get_owner_plan", return_value={"id": "pro"}), \
-                 patch("api.agent.core.burn_control.Analytics.track_event") as track_event_mock:
+                 patch("api.agent.core.burn_control.Analytics.track_event") as track_event_mock, \
+                 patch("api.agent.core.burn_control.should_emit_daily_agent_event", return_value=True):
                 stepped = bc.maybe_step_down_runtime_tier_for_burn_rate(
                     self.agent,
                     daily_state=burn_state,


### PR DESCRIPTION
## Summary
- Add per-agent daily event markers to suppress duplicate soft limit, hard limit, hard-block, and burn-rate step-down emissions within the same day.
- Keep core limit enforcement and runtime tier overrides intact while reducing repeated analytics, system-step, and log noise.
- Extract shared helpers so the dedupe behavior is centralized and easier to apply consistently.

## Testing
- Added unit coverage for once-per-day emission behavior across hard-limit enforcement and burn-rate step-down paths.
- Added coverage for cache fail-open behavior when the dedupe marker cannot be written.