### PR TITLE
Include the tasks package in setuptools discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,5 +152,5 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where   = ["."]
-include = ["config", "console*", "api*", "pages*"]
+include = ["config", "console*", "api*", "pages*", "tasks*"]
 exclude = ["*/tests*", "*/static*", "*/templates*"]

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Task credit services package."""


### PR DESCRIPTION
## Summary
- Add `tasks*` to the setuptools package discovery list so the task credit services package is included in builds.
- Introduce the `tasks` package initializer to make the package importable.

## Testing
- Not run (not requested)