### PR TITLE
Remove web session completion gating and retry path

### DIFF
--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -58,6 +58,7 @@ JUDGE_RUN_COOLDOWN_SECONDS = 60 * 45
 JUDGE_DAILY_RUN_LIMIT = 6
 REPORT_TOOL_NAME = "report_judge_suggestion"
 NO_ACTION = "no_action"
+JUDGE_FAILED_TOOL_TRIGGER_IGNORED_TOOL_NAMES = frozenset({"send_chat_message"})
 ALLOWED_SUGGESTION_TYPES = {
     PersistentAgentJudgeSuggestion.SuggestionType.INTELLIGENCE_UPGRADE,
     PersistentAgentJudgeSuggestion.SuggestionType.STONEWALL_REFRAME,
@@ -740,7 +741,12 @@ def _trigger_reasons(
     reasons: list[str] = []
     trigger_tool_calls = recent_tool_calls[:JUDGE_TRIGGER_TOOL_LIMIT]
     trigger_messages = recent_messages[:JUDGE_TRIGGER_MESSAGE_LIMIT]
-    recent_errors = [call for call in trigger_tool_calls if (call.status or "").lower() == "error"]
+    recent_errors = [
+        call
+        for call in trigger_tool_calls
+        if (call.status or "").lower() == "error"
+        and (call.tool_name or "") not in JUDGE_FAILED_TOOL_TRIGGER_IGNORED_TOOL_NAMES
+    ]
     if len(recent_errors) >= JUDGE_FAILED_TOOL_THRESHOLD:
         reasons.append("failed_tool_calls")
 

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -32,7 +32,6 @@ from django.conf import settings as django_settings
 from django.db import DatabaseError, transaction, close_old_connections
 from django.db.utils import OperationalError
 from django.utils import timezone as dj_timezone
-from waffle import switch_is_active
 
 from observability import mark_span_failed_with_exception
 from .budget import (
@@ -156,7 +155,7 @@ from ..tools.tool_manager import (
     should_skip_auto_substitution,
 )
 from ...services.tool_blacklist import is_tool_blacklisted_for_agent, tool_blacklist_error
-from ..tools.web_chat_sender import execute_send_chat_message, has_other_contact_channel
+from ..tools.web_chat_sender import execute_send_chat_message
 from ..tools.peer_dm import execute_send_agent_message
 from ..tools.webhook_sender import execute_send_webhook_event
 from ..tools.agent_variables import (
@@ -206,7 +205,6 @@ from api.services.web_sessions import (
     get_deliverable_web_sessions,
     has_deliverable_web_session,
 )
-from constants.feature_flags import AGENT_RETRY_COMPLETION_ON_WEB_SESSION_ACTIVATION
 from config import settings
 from config.redis_client import get_redis_client
 from util.analytics import Analytics, AnalyticsEvent, AnalyticsSource
@@ -3216,130 +3214,6 @@ def _finalize_tool_batch(
     )
 
 
-def _gate_send_chat_tool_for_delivery(
-    tools: List[dict],
-    agent: PersistentAgent,
-    *,
-    has_deliverable_web_target_now: Optional[bool] = None,
-) -> List[dict]:
-    """Hide send_chat_message only when no deliverable web target exists and non-web fallback channels are available."""
-    if has_deliverable_web_target_now is None:
-        has_deliverable_web_target_now = has_deliverable_web_session(agent)
-    if has_deliverable_web_target_now:
-        return tools
-    owner_user = getattr(agent, "user", None)
-    if owner_user and not has_other_contact_channel(agent, owner_user):
-        return tools
-
-    filtered = [
-        tool for tool in tools
-        if not (
-            isinstance(tool, dict)
-            and isinstance(tool.get("function"), dict)
-            and tool.get("function", {}).get("name") == "send_chat_message"
-        )
-    ]
-    return filtered if len(filtered) < len(tools) else tools
-
-
-def _track_post_completion_deliverable_web_session_activation(
-    agent: PersistentAgent,
-    *,
-    run_sequence_number: Optional[int],
-    iteration_index: int,
-    retry_switch_active: bool,
-    retry_performed: bool,
-) -> None:
-    """Emit analytics when a deliverable web session appears after completion returns."""
-    if not agent.user_id:
-        return
-
-    analytics_props: dict[str, Any] = {
-        "agent_id": str(agent.id),
-        "agent_name": agent.name,
-        "run_sequence_number": run_sequence_number,
-        "iteration": iteration_index,
-        "retry_reason": "web_session_activated_mid_completion",
-        "retry_strategy": "discard_and_rerun_once" if retry_performed else "none",
-        "retry_switch_active": retry_switch_active,
-        "retry_performed": retry_performed,
-        "had_deliverable_web_target_at_start": False,
-    }
-    props_with_org = Analytics.with_org_properties(
-        analytics_props,
-        organization=getattr(agent, "organization", None),
-    )
-    Analytics.track_event(
-        user_id=agent.user_id,
-        event=AnalyticsEvent.PERSISTENT_AGENT_WEB_SESSION_ACTIVATED_POST_COMPLETION,
-        source=AnalyticsSource.AGENT,
-        properties=props_with_org,
-    )
-
-
-def _should_retry_after_post_completion_deliverable_web_session_activation(
-    agent: PersistentAgent,
-    *,
-    run_sequence_number: Optional[int],
-    iteration_index: int,
-    max_remaining: int,
-    retry_used: bool,
-) -> bool:
-    """
-    Decide whether to retry once after a deliverable web session appears and emit analytics.
-
-    Returns True when the caller should discard current completion output and retry
-    on the next loop iteration.
-    """
-    retry_switch_active = False
-    try:
-        retry_switch_active = switch_is_active(
-            AGENT_RETRY_COMPLETION_ON_WEB_SESSION_ACTIVATION
-        )
-    except Exception:
-        logger.warning(
-            "Failed to evaluate switch %s; skipping mid-completion retry.",
-            AGENT_RETRY_COMPLETION_ON_WEB_SESSION_ACTIVATION,
-            exc_info=True,
-        )
-        retry_switch_active = False
-
-    has_iterations_remaining = iteration_index < max_remaining
-    retry_performed = (
-        retry_switch_active
-        and not retry_used
-        and has_iterations_remaining
-    )
-
-    try:
-        _track_post_completion_deliverable_web_session_activation(
-            agent,
-            run_sequence_number=run_sequence_number,
-            iteration_index=iteration_index,
-            retry_switch_active=retry_switch_active,
-            retry_performed=retry_performed,
-        )
-    except Exception:
-        logger.exception(
-            "Failed to emit analytics for post-completion deliverable web-session activation (agent=%s)",
-            agent.id,
-        )
-
-    if retry_performed:
-        logger.info(
-            "Agent %s: web session activated mid-completion; discarding completion output and retrying next iteration.",
-            agent.id,
-        )
-        return True
-
-    if retry_switch_active and not has_iterations_remaining:
-        logger.info(
-            "Agent %s: web session activated mid-completion but no iterations remain; processing current completion.",
-            agent.id,
-        )
-    return False
-
-
 def _get_latest_deliverable_web_session(agent: PersistentAgent):
     for session in get_deliverable_web_sessions(agent):
         if session.user_id is not None:
@@ -5666,7 +5540,6 @@ def _run_agent_loop(
     inferred_message_continue_streak = 0
     pending_reply_after_progress = False
     continuation_notice: Optional[str] = None
-    web_session_activation_retry_used = False
     empty_response_loop_retries = 0
 
     def _current_human_inbound_generation() -> int:
@@ -5754,11 +5627,7 @@ def _run_agent_loop(
                 if credit_snapshot is not None:
                     credit_snapshot["daily_state"] = daily_state
 
-                iteration_tools = _gate_send_chat_tool_for_delivery(
-                    tools,
-                    agent,
-                    has_deliverable_web_target_now=had_deliverable_web_target_at_start,
-                )
+                iteration_tools = tools
                 if is_daily_hard_limit_message_only_mode(daily_state):
                     iteration_tools = filter_tools_for_daily_limit_message_only_mode(iteration_tools)
                 iter_span.set_attribute("persistent_agent.tools.count", len(iteration_tools))
@@ -6088,23 +5957,6 @@ def _run_agent_loop(
                 # attach it to steps because PersistentAgentStep.save() would otherwise consume
                 # more task credits via completion billing.
                 _ensure_completion()
-
-                deliverable_web_session_activated_post_completion = (
-                    not had_deliverable_web_target_at_start and has_deliverable_web_session(agent)
-                )
-                if deliverable_web_session_activated_post_completion:
-                    if _should_retry_after_post_completion_deliverable_web_session_activation(
-                        agent,
-                        run_sequence_number=run_sequence_number,
-                        iteration_index=i + 1,
-                        max_remaining=max_remaining,
-                        retry_used=web_session_activation_retry_used,
-                    ):
-                        web_session_activation_retry_used = True
-                        continuation_notice = (
-                            "Web chat became active mid-run; rerunning once with updated tool availability."
-                        )
-                        continue
 
                 def _attach_completion(step_kwargs: dict) -> None:
                     if suppress_step_completion_billing:

--- a/api/migrations/0402_remove_agent_retry_completion_on_web_session_activation_switch.py
+++ b/api/migrations/0402_remove_agent_retry_completion_on_web_session_activation_switch.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+
+SWITCH_NAME = "agent_retry_completion_on_web_session_activation"
+
+
+def remove_switch(apps, schema_editor):
+    try:
+        Switch = apps.get_model("waffle", "Switch")
+    except LookupError:
+        return
+    Switch.objects.filter(name=SWITCH_NAME).delete()
+
+
+def restore_switch(apps, schema_editor):
+    try:
+        Switch = apps.get_model("waffle", "Switch")
+    except LookupError:
+        return
+    Switch.objects.update_or_create(
+        name=SWITCH_NAME,
+        defaults={"active": False},
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0401_merge_20260618_1848"),
+        ("waffle", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_switch, restore_switch),
+    ]

--- a/constants/feature_flags.py
+++ b/constants/feature_flags.py
@@ -150,11 +150,6 @@ MULTISEND_ENABLED = "multisend_enabled"
 # they can be added to an agent allowlist or requested by an agent.
 SMS_CONTACT_PURPOSE_REQUIRED = "sms_contact_purpose_required"
 
-# Retry one completion when web chat session becomes active mid-iteration.
-AGENT_RETRY_COMPLETION_ON_WEB_SESSION_ACTIVATION = (
-    "agent_retry_completion_on_web_session_activation"
-)
-
 # Owner-wide execution pause controls for billing lifecycle events.
 OWNER_EXECUTION_PAUSE_ON_BILLING_DELINQUENCY = (
     "owner_execution_pause_on_billing_delinquency"

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -14,7 +14,7 @@
       "planning_first_run": {
         "fitted_tokens": 3379,
         "system_bytes": 30850,
-        "tools_bytes": 11350,
+        "tools_bytes": 11760,
         "total_bytes": 57450,
         "user_bytes": 15600
       },

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,29 +1,29 @@
 {
-  "baseline_sha": "ac89a3f91ba1690d052fd5f29a9b600a1bc762e7",
+  "baseline_sha": "02ca37078fa554eb11efaede6f2c5b087bb0aa4d",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7486,
-        "system_bytes": 23802,
-        "tools_bytes": 20626,
-        "total_bytes": 55732,
-        "user_bytes": 11304
+        "fitted_tokens": 3434,
+        "system_bytes": 23900,
+        "tools_bytes": 22550,
+        "total_bytes": 62000,
+        "user_bytes": 15850
       },
       "planning_first_run": {
-        "fitted_tokens": 8818,
-        "system_bytes": 30834,
-        "tools_bytes": 11752,
-        "total_bytes": 53661,
-        "user_bytes": 11075
+        "fitted_tokens": 3379,
+        "system_bytes": 30850,
+        "tools_bytes": 11350,
+        "total_bytes": 57450,
+        "user_bytes": 15600
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 7618,
-        "system_bytes": 24279,
-        "tools_bytes": 20626,
-        "total_bytes": 56212,
-        "user_bytes": 11307
+        "fitted_tokens": 3442,
+        "system_bytes": 24350,
+        "tools_bytes": 23600,
+        "total_bytes": 63300,
+        "user_bytes": 15850
       }
     },
     "scenarios": {
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 834,
+    "file_count": 826,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 246339
+    "limit": 246850
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,29 +1,29 @@
 {
-  "baseline_sha": "02ca37078fa554eb11efaede6f2c5b087bb0aa4d",
+  "baseline_sha": "ac89a3f91ba1690d052fd5f29a9b600a1bc762e7",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 3434,
-        "system_bytes": 23900,
-        "tools_bytes": 22550,
-        "total_bytes": 62000,
-        "user_bytes": 15850
+        "fitted_tokens": 7486,
+        "system_bytes": 23802,
+        "tools_bytes": 20626,
+        "total_bytes": 55732,
+        "user_bytes": 11304
       },
       "planning_first_run": {
-        "fitted_tokens": 3379,
-        "system_bytes": 30850,
-        "tools_bytes": 11350,
-        "total_bytes": 57450,
-        "user_bytes": 15600
+        "fitted_tokens": 8818,
+        "system_bytes": 30834,
+        "tools_bytes": 11752,
+        "total_bytes": 53661,
+        "user_bytes": 11075
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 3442,
-        "system_bytes": 24350,
-        "tools_bytes": 23600,
-        "total_bytes": 63300,
-        "user_bytes": 15850
+        "fitted_tokens": 7618,
+        "system_bytes": 24279,
+        "tools_bytes": 20626,
+        "total_bytes": 56212,
+        "user_bytes": 11307
       }
     },
     "scenarios": {
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 826,
+    "file_count": 834,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 246850
+    "limit": 246339
   }
 }

--- a/scripts/check_complexity_budgets.py
+++ b/scripts/check_complexity_budgets.py
@@ -334,7 +334,6 @@ def _measure_prompt_scenario(
     planning: bool = False,
     web_session: bool = False,
 ) -> dict[str, int]:
-    from api.agent.core.event_processing import _gate_send_chat_tool_for_delivery
     from api.agent.core.prompt_context import build_prompt_context_preview, get_agent_tools
     from api.services.web_sessions import start_web_session
 
@@ -350,11 +349,7 @@ def _measure_prompt_scenario(
     )
     system_message = next(message["content"] for message in messages if message["role"] == "system")
     user_message = next(message["content"] for message in messages if message["role"] == "user")
-    tools = _gate_send_chat_tool_for_delivery(
-        get_agent_tools(agent),
-        agent,
-        has_deliverable_web_target_now=web_session,
-    )
+    tools = get_agent_tools(agent)
 
     system_bytes = _text_size(system_message)
     user_bytes = _text_size(user_message)

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -128,14 +128,14 @@ class AgentJudgeTests(TestCase):
                 description=f"Step {index}",
             )
 
-    def _add_error_tool_call(self, index: int) -> None:
+    def _add_error_tool_call(self, index: int, *, tool_name: str = "read_file") -> None:
         step = PersistentAgentStep.objects.create(
             agent=self.agent,
             description=f"Tool error {index}",
         )
         PersistentAgentToolCall.objects.create(
             step=step,
-            tool_name="read_file",
+            tool_name=tool_name,
             tool_params={"path": f"/tmp/{index}"},
             result='{"status":"error","message":"failed"}',
             status="error",
@@ -206,6 +206,23 @@ class AgentJudgeTests(TestCase):
 
         self.assertIsNotNone(trigger)
         self.assertIn("failed_tool_calls", trigger.reasons)
+
+    def test_failed_send_chat_message_tool_calls_do_not_trigger_judge(self):
+        for index in range(3):
+            self._add_error_tool_call(index, tool_name="send_chat_message")
+
+        trigger = build_judge_trigger(self.agent, tools=[])
+
+        self.assertIsNone(trigger)
+
+    def test_failed_send_chat_message_tool_calls_do_not_count_toward_failure_threshold(self):
+        self._add_error_tool_call(0, tool_name="send_chat_message")
+        self._add_error_tool_call(1, tool_name="read_file")
+        self._add_error_tool_call(2, tool_name="http_request")
+
+        trigger = build_judge_trigger(self.agent, tools=[])
+
+        self.assertIsNone(trigger)
 
     def test_negative_language_trigger_only_checks_latest_user_message(self):
         self._add_steps(1)

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2002,13 +2002,7 @@ class PromptContextBuilderTests(TestCase):
         self.assertNotIn("<implied_send_status>", combined)
         self.assertNotIn("implied_send_status", combined)
 
-    def test_agent_tools_include_send_chat_message_without_active_web_session_when_verified_fallback_exists(self):
-        EmailAddress.objects.create(
-            user=self.user,
-            email=self.user.email,
-            verified=True,
-            primary=True,
-        )
+    def test_agent_tools_include_send_chat_message(self):
         tools = get_agent_tools(self.agent)
         tool_names = [
             entry.get("function", {}).get("name")
@@ -3312,14 +3306,7 @@ class PromptContextBuilderTests(TestCase):
 
         self.assertEqual(mock_completion.call_count, 2, "Warning status should force a follow-up iteration.")
 
-    def test_agent_loop_includes_send_chat_message_without_active_web_session_when_verified_fallback_exists(self):
-        EmailAddress.objects.create(
-            user=self.user,
-            email=self.user.email,
-            verified=True,
-            primary=True,
-        )
-
+    def test_agent_loop_includes_send_chat_message(self):
         message_first = MagicMock()
         message_first.tool_calls = None
         message_first.function_call = None

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -15,7 +15,6 @@ from django.db import DatabaseError
 from django.test import RequestFactory, TestCase, tag, override_settings
 from django.utils import timezone
 from unittest.mock import patch, MagicMock, ANY
-from waffle.testutils import override_switch
 
 import zstandard as zstd
 from allauth.account.models import EmailAddress
@@ -30,7 +29,6 @@ from api.agent.core.event_processing import (
     _latest_inbound_message_needs_reply,
     _should_continue_for_pending_progress_reply,
     _should_continue_for_unanswered_inbound_after_tools,
-    _gate_send_chat_tool_for_delivery,
     _tool_definition_names_for_completion,
     _persist_tool_call_step,
     build_prompt_context,
@@ -2004,7 +2002,7 @@ class PromptContextBuilderTests(TestCase):
         self.assertNotIn("<implied_send_status>", combined)
         self.assertNotIn("implied_send_status", combined)
 
-    def test_session_tool_gating_excludes_send_chat_message_without_active_web_session_when_verified_fallback_exists(self):
+    def test_agent_tools_include_send_chat_message_without_active_web_session_when_verified_fallback_exists(self):
         EmailAddress.objects.create(
             user=self.user,
             email=self.user.email,
@@ -2012,31 +2010,9 @@ class PromptContextBuilderTests(TestCase):
             primary=True,
         )
         tools = get_agent_tools(self.agent)
-        gated_tools = _gate_send_chat_tool_for_delivery(tools, self.agent)
         tool_names = [
             entry.get("function", {}).get("name")
-            for entry in gated_tools
-            if isinstance(entry, dict)
-        ]
-        self.assertNotIn("send_chat_message", tool_names)
-
-    def test_session_tool_gating_includes_send_chat_message_without_active_web_session_when_no_verified_fallback(self):
-        tools = get_agent_tools(self.agent)
-        gated_tools = _gate_send_chat_tool_for_delivery(tools, self.agent)
-        tool_names = [
-            entry.get("function", {}).get("name")
-            for entry in gated_tools
-            if isinstance(entry, dict)
-        ]
-        self.assertIn("send_chat_message", tool_names)
-
-    def test_session_tool_gating_includes_send_chat_message_with_active_web_session(self):
-        start_web_session(self.agent, self.user)
-        tools = get_agent_tools(self.agent)
-        gated_tools = _gate_send_chat_tool_for_delivery(tools, self.agent)
-        tool_names = [
-            entry.get("function", {}).get("name")
-            for entry in gated_tools
+            for entry in tools
             if isinstance(entry, dict)
         ]
         self.assertIn("send_chat_message", tool_names)
@@ -3336,123 +3312,14 @@ class PromptContextBuilderTests(TestCase):
 
         self.assertEqual(mock_completion.call_count, 2, "Warning status should force a follow-up iteration.")
 
-    def test_web_session_activation_retry_discards_completion_and_retries_once(self):
-        """When switch is on and web session appears mid-iteration, discard and rerun once."""
+    def test_agent_loop_includes_send_chat_message_without_active_web_session_when_verified_fallback_exists(self):
         EmailAddress.objects.create(
             user=self.user,
             email=self.user.email,
             verified=True,
             primary=True,
         )
-        tool_call = MagicMock()
-        tool_call.function = MagicMock()
-        tool_call.function.name = "sqlite_batch"
-        tool_call.function.arguments = '{"sql":"SELECT 1","will_continue_work":false}'
 
-        message_first = MagicMock()
-        message_first.tool_calls = [tool_call]
-        message_first.function_call = None
-        message_first.content = None
-        response_first = MagicMock()
-        response_first.choices = [MagicMock(message=message_first)]
-        response_first.model_extra = {}
-
-        message_second = MagicMock()
-        message_second.tool_calls = None
-        message_second.function_call = None
-        message_second.content = None
-        response_second = MagicMock()
-        response_second.choices = [MagicMock(message=message_second)]
-        response_second.model_extra = {}
-
-        token_usage = {"model": "mock-model", "provider": "mock-provider"}
-        seen_tool_names = []
-
-        def completion_side_effect(*args, **kwargs):
-            names = [
-                entry.get("function", {}).get("name")
-                for entry in kwargs.get("tools", [])
-                if isinstance(entry, dict)
-            ]
-            seen_tool_names.append(names)
-            if len(seen_tool_names) == 1:
-                start_web_session(self.agent, self.user)
-                return response_first, token_usage
-            return response_second, token_usage
-
-        with override_switch("agent_retry_completion_on_web_session_activation", active=True):
-            with patch('api.agent.core.event_processing.build_prompt_context', return_value=([{"role": "system", "content": "sys"}], 1000, None)), \
-                 patch('api.agent.core.event_processing.get_llm_config_with_failover', return_value=[("mock", "mock-model", {})]), \
-                 patch('api.agent.core.event_processing._completion_with_failover', side_effect=completion_side_effect) as mock_completion, \
-                 patch('api.agent.core.event_processing.execute_enabled_tool', return_value={"status": "ok"}) as mock_execute_tool, \
-                 patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None}), \
-                 patch('api.agent.core.event_processing.Analytics.track_event') as mock_track_event:
-                from api.agent.core import event_processing as ep
-                with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 2):
-                    _run_agent_loop(self.agent, is_first_run=False)
-
-        self.assertEqual(mock_completion.call_count, 2)
-        self.assertEqual(mock_execute_tool.call_count, 0)
-        self.assertNotIn("send_chat_message", seen_tool_names[0])
-        self.assertIn("send_chat_message", seen_tool_names[1])
-        self.assertEqual(mock_track_event.call_count, 1)
-        self.assertEqual(
-            mock_track_event.call_args.kwargs["event"],
-            ep.AnalyticsEvent.PERSISTENT_AGENT_WEB_SESSION_ACTIVATED_POST_COMPLETION,
-        )
-        retry_props = mock_track_event.call_args.kwargs["properties"]
-        self.assertEqual(retry_props.get("retry_reason"), "web_session_activated_mid_completion")
-        self.assertEqual(retry_props.get("retry_strategy"), "discard_and_rerun_once")
-        self.assertEqual(retry_props.get("retry_switch_active"), True)
-        self.assertEqual(retry_props.get("retry_performed"), True)
-        self.assertEqual(retry_props.get("had_deliverable_web_target_at_start"), False)
-
-    def test_web_session_activation_retry_does_not_run_when_switch_off(self):
-        """When switch is off, completion output is processed normally."""
-        tool_call = MagicMock()
-        tool_call.function = MagicMock()
-        tool_call.function.name = "sqlite_batch"
-        tool_call.function.arguments = '{"sql":"SELECT 1","will_continue_work":false}'
-
-        message_first = MagicMock()
-        message_first.tool_calls = [tool_call]
-        message_first.function_call = None
-        message_first.content = None
-        response_first = MagicMock()
-        response_first.choices = [MagicMock(message=message_first)]
-        response_first.model_extra = {}
-
-        token_usage = {"model": "mock-model", "provider": "mock-provider"}
-
-        def completion_side_effect(*args, **kwargs):
-            start_web_session(self.agent, self.user)
-            return response_first, token_usage
-
-        with override_switch("agent_retry_completion_on_web_session_activation", active=False):
-            with patch('api.agent.core.event_processing.build_prompt_context', return_value=([{"role": "system", "content": "sys"}], 1000, None)), \
-                 patch('api.agent.core.event_processing.get_llm_config_with_failover', return_value=[("mock", "mock-model", {})]), \
-                 patch('api.agent.core.event_processing._completion_with_failover', side_effect=completion_side_effect) as mock_completion, \
-                 patch('api.agent.core.event_processing.execute_enabled_tool', return_value={"status": "ok", "auto_sleep_ok": True}) as mock_execute_tool, \
-                 patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None}), \
-                 patch('api.agent.core.event_processing.Analytics.track_event') as mock_track_event:
-                from api.agent.core import event_processing as ep
-                with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 2):
-                    _run_agent_loop(self.agent, is_first_run=False)
-
-        self.assertEqual(mock_completion.call_count, 1)
-        self.assertEqual(mock_execute_tool.call_count, 1)
-        self.assertEqual(mock_track_event.call_count, 1)
-        self.assertEqual(
-            mock_track_event.call_args.kwargs["event"],
-            ep.AnalyticsEvent.PERSISTENT_AGENT_WEB_SESSION_ACTIVATED_POST_COMPLETION,
-        )
-        retry_props = mock_track_event.call_args.kwargs["properties"]
-        self.assertEqual(retry_props.get("retry_strategy"), "none")
-        self.assertEqual(retry_props.get("retry_switch_active"), False)
-        self.assertEqual(retry_props.get("retry_performed"), False)
-
-    def test_web_session_activation_retry_emits_expected_analytics_event(self):
-        """Retry path should emit the dedicated analytics event with expected properties."""
         message_first = MagicMock()
         message_first.tool_calls = None
         message_first.function_call = None
@@ -3461,84 +3328,28 @@ class PromptContextBuilderTests(TestCase):
         response_first.choices = [MagicMock(message=message_first)]
         response_first.model_extra = {}
 
-        message_second = MagicMock()
-        message_second.tool_calls = None
-        message_second.function_call = None
-        message_second.content = None
-        response_second = MagicMock()
-        response_second.choices = [MagicMock(message=message_second)]
-        response_second.model_extra = {}
-
         token_usage = {"model": "mock-model", "provider": "mock-provider"}
+        seen_tool_names = []
 
         def completion_side_effect(*args, **kwargs):
-            if not hasattr(completion_side_effect, "called"):
-                completion_side_effect.called = True
-                start_web_session(self.agent, self.user)
-                return response_first, token_usage
-            return response_second, token_usage
-
-        with override_switch("agent_retry_completion_on_web_session_activation", active=True):
-            with patch('api.agent.core.event_processing.build_prompt_context', return_value=([{"role": "system", "content": "sys"}], 1000, None)), \
-                 patch('api.agent.core.event_processing.get_llm_config_with_failover', return_value=[("mock", "mock-model", {})]), \
-                 patch('api.agent.core.event_processing._completion_with_failover', side_effect=completion_side_effect), \
-                 patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None}), \
-                 patch('api.agent.core.event_processing.Analytics.track_event') as mock_track_event:
-                from api.agent.core import event_processing as ep
-                with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 2):
-                    _run_agent_loop(self.agent, is_first_run=False, run_sequence_number=7)
-
-        self.assertEqual(mock_track_event.call_count, 1)
-        kwargs = mock_track_event.call_args.kwargs
-        self.assertEqual(
-            kwargs["event"],
-            ep.AnalyticsEvent.PERSISTENT_AGENT_WEB_SESSION_ACTIVATED_POST_COMPLETION,
-        )
-        self.assertEqual(kwargs["source"], ep.AnalyticsSource.AGENT)
-        props = kwargs["properties"]
-        self.assertEqual(props.get("agent_id"), str(self.agent.id))
-        self.assertEqual(props.get("agent_name"), self.agent.name)
-        self.assertEqual(props.get("run_sequence_number"), 7)
-        self.assertEqual(props.get("iteration"), 1)
-        self.assertEqual(props.get("retry_reason"), "web_session_activated_mid_completion")
-        self.assertEqual(props.get("retry_strategy"), "discard_and_rerun_once")
-        self.assertEqual(props.get("retry_switch_active"), True)
-        self.assertEqual(props.get("retry_performed"), True)
-        self.assertEqual(props.get("had_deliverable_web_target_at_start"), False)
-
-    def test_web_session_activation_retry_skips_when_no_iterations_remaining(self):
-        """If no loop iteration remains, process current completion instead of dropping it."""
-        tool_call = MagicMock()
-        tool_call.function = MagicMock()
-        tool_call.function.name = "sqlite_batch"
-        tool_call.function.arguments = '{"sql":"SELECT 1","will_continue_work":false}'
-
-        message_first = MagicMock()
-        message_first.tool_calls = [tool_call]
-        message_first.function_call = None
-        message_first.content = None
-        response_first = MagicMock()
-        response_first.choices = [MagicMock(message=message_first)]
-        response_first.model_extra = {}
-
-        token_usage = {"model": "mock-model", "provider": "mock-provider"}
-
-        def completion_side_effect(*args, **kwargs):
-            start_web_session(self.agent, self.user)
+            seen_tool_names.append([
+                entry.get("function", {}).get("name")
+                for entry in kwargs.get("tools", [])
+                if isinstance(entry, dict)
+            ])
             return response_first, token_usage
 
-        with override_switch("agent_retry_completion_on_web_session_activation", active=True):
-            with patch('api.agent.core.event_processing.build_prompt_context', return_value=([{"role": "system", "content": "sys"}], 1000, None)), \
-                 patch('api.agent.core.event_processing.get_llm_config_with_failover', return_value=[("mock", "mock-model", {})]), \
-                 patch('api.agent.core.event_processing._completion_with_failover', side_effect=completion_side_effect) as mock_completion, \
-                 patch('api.agent.core.event_processing.execute_enabled_tool', return_value={"status": "ok"}) as mock_execute_tool, \
-                 patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None}):
-                from api.agent.core import event_processing as ep
-                with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 1):
-                    _run_agent_loop(self.agent, is_first_run=False)
+        with patch('api.agent.core.event_processing.build_prompt_context', return_value=([{"role": "system", "content": "sys"}], 1000, None)), \
+             patch('api.agent.core.event_processing.get_llm_config_with_failover', return_value=[("mock", "mock-model", {})]), \
+             patch('api.agent.core.event_processing._completion_with_failover', side_effect=completion_side_effect) as mock_completion, \
+             patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None}):
+            from api.agent.core import event_processing as ep
+            with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 1):
+                _run_agent_loop(self.agent, is_first_run=False)
 
         self.assertEqual(mock_completion.call_count, 1)
-        self.assertEqual(mock_execute_tool.call_count, 1)
+        self.assertTrue(seen_tool_names)
+        self.assertIn("send_chat_message", seen_tool_names[0])
 
 
 @tag("batch_event_processing")

--- a/util/analytics.py
+++ b/util/analytics.py
@@ -137,7 +137,6 @@ class AnalyticsEvent(StrEnum):
     PERSISTENT_AGENT_SOFT_EXPIRED = 'Persistent Agent Soft Expired'
     PERSISTENT_AGENT_SOFT_LIMIT_EXCEEDED = 'Persistent Agent Soft Limit Exceeded'
     PERSISTENT_AGENT_HARD_LIMIT_EXCEEDED = 'Persistent Agent Hard Limit Exceeded'
-    PERSISTENT_AGENT_WEB_SESSION_ACTIVATED_POST_COMPLETION = 'Persistent Agent Web Session Activated Post Completion'
     PERSISTENT_AGENT_BROWSER_DAILY_LIMIT_REACHED = 'Persistent Agent Browser Daily Limit Reached'
     PERSISTENT_AGENT_BURN_RATE_LIMIT_REACHED = 'Persistent Agent Burn Rate Limit Reached'
     PERSISTENT_AGENT_BURN_RATE_RUNTIME_TIER_STEPPED_DOWN = 'Persistent Agent Burn Rate Runtime Tier Stepped Down'


### PR DESCRIPTION
## Summary
- Remove the `send_chat_message` tool gating that hid web chat from completions when no deliverable session was active.
- حذف the mid-completion retry logic, related feature flag constant, analytics event, and migration cleanup for the retired switch.
- Update prompt-complexity measurement and unit tests to reflect that web chat tools remain available regardless of session state.

## Testing
- Updated unit coverage for prompt context and agent loop behavior.
- Not run (not requested).