### PR TITLE
Persist console context across org changes

### DIFF
--- a/frontend/src/api/agentChat.test.ts
+++ b/frontend/src/api/agentChat.test.ts
@@ -2,12 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { resolveSpawnRequest } from './agentChat'
 import { jsonRequest } from './http'
-import { storeConsoleContext } from '../util/consoleContextStorage'
+import { clearStoredConsoleContext, storeConsoleContext } from '../util/consoleContextStorage'
 
 describe('resolveSpawnRequest', () => {
   beforeEach(() => {
     document.cookie = 'csrftoken=test-token'
     window.sessionStorage.clear()
+    clearStoredConsoleContext()
     window.history.replaceState(null, '', '/')
   })
 

--- a/frontend/src/screens/ImmersiveApp.tsx
+++ b/frontend/src/screens/ImmersiveApp.tsx
@@ -911,7 +911,6 @@ export function ImmersiveApp({
     onCreateAgent: handleNavigateToNewAgent,
     onAgentCreated: handleAgentCreated,
     showContextSwitcher: true,
-    persistContextSession: false,
     onContextSwitch: handleContextSwitch,
     selectionPage,
     selectionShellPanel,

--- a/frontend/src/util/consoleContextStorage.ts
+++ b/frontend/src/util/consoleContextStorage.ts
@@ -49,16 +49,40 @@ function getSessionStorage(): Storage | null {
   }
 }
 
+function safeGetItem(storage: Storage, key: string): string | null {
+  try {
+    return storage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeSetItem(storage: Storage, key: string, value: string): void {
+  try {
+    storage.setItem(key, value)
+  } catch {
+    // Storage can be available but blocked, e.g. private or locked-down browser modes.
+  }
+}
+
+function safeRemoveItem(storage: Storage, key: string): void {
+  try {
+    storage.removeItem(key)
+  } catch {
+    // Storage can be available but blocked, e.g. private or locked-down browser modes.
+  }
+}
+
 function readContextFromStorage(storage: Storage | null): StoredConsoleContext | null {
   if (!storage) {
     return null
   }
-  const type = storage.getItem(STORAGE_KEYS.type)
-  const id = storage.getItem(STORAGE_KEYS.id)
+  const type = safeGetItem(storage, STORAGE_KEYS.type)
+  const id = safeGetItem(storage, STORAGE_KEYS.id)
   if (!type || !id) {
     return null
   }
-  const name = storage.getItem(STORAGE_KEYS.name)
+  const name = safeGetItem(storage, STORAGE_KEYS.name)
   return {
     type,
     id,
@@ -70,12 +94,12 @@ function readLegacyContextFromStorage(storage: Storage | null): StoredConsoleCon
   if (!storage) {
     return null
   }
-  const type = storage.getItem(LEGACY_LOCAL_STORAGE_KEYS.type)
-  const id = storage.getItem(LEGACY_LOCAL_STORAGE_KEYS.id)
+  const type = safeGetItem(storage, LEGACY_LOCAL_STORAGE_KEYS.type)
+  const id = safeGetItem(storage, LEGACY_LOCAL_STORAGE_KEYS.id)
   if (!type || !id) {
     return null
   }
-  const name = storage.getItem(LEGACY_LOCAL_STORAGE_KEYS.name)
+  const name = safeGetItem(storage, LEGACY_LOCAL_STORAGE_KEYS.name)
   return {
     type,
     id,
@@ -87,12 +111,12 @@ function writeContextToStorage(storage: Storage | null, context: StoredConsoleCo
   if (!storage) {
     return
   }
-  storage.setItem(STORAGE_KEYS.type, context.type)
-  storage.setItem(STORAGE_KEYS.id, context.id)
+  safeSetItem(storage, STORAGE_KEYS.type, context.type)
+  safeSetItem(storage, STORAGE_KEYS.id, context.id)
   if (context.name) {
-    storage.setItem(STORAGE_KEYS.name, context.name)
+    safeSetItem(storage, STORAGE_KEYS.name, context.name)
   } else {
-    storage.removeItem(STORAGE_KEYS.name)
+    safeRemoveItem(storage, STORAGE_KEYS.name)
   }
 }
 
@@ -114,9 +138,9 @@ export function storeConsoleContext(context: StoredConsoleContext): void {
 export function clearStoredConsoleContext(): void {
   const sessionStorageRef = getSessionStorage()
   if (sessionStorageRef) {
-    sessionStorageRef.removeItem(STORAGE_KEYS.type)
-    sessionStorageRef.removeItem(STORAGE_KEYS.id)
-    sessionStorageRef.removeItem(STORAGE_KEYS.name)
+    safeRemoveItem(sessionStorageRef, STORAGE_KEYS.type)
+    safeRemoveItem(sessionStorageRef, STORAGE_KEYS.id)
+    safeRemoveItem(sessionStorageRef, STORAGE_KEYS.name)
   }
 
   const localStorageRef = getLocalStorage()
@@ -124,10 +148,10 @@ export function clearStoredConsoleContext(): void {
     return
   }
 
-  localStorageRef.removeItem(STORAGE_KEYS.type)
-  localStorageRef.removeItem(STORAGE_KEYS.id)
-  localStorageRef.removeItem(STORAGE_KEYS.name)
-  localStorageRef.removeItem(LEGACY_LOCAL_STORAGE_KEYS.type)
-  localStorageRef.removeItem(LEGACY_LOCAL_STORAGE_KEYS.id)
-  localStorageRef.removeItem(LEGACY_LOCAL_STORAGE_KEYS.name)
+  safeRemoveItem(localStorageRef, STORAGE_KEYS.type)
+  safeRemoveItem(localStorageRef, STORAGE_KEYS.id)
+  safeRemoveItem(localStorageRef, STORAGE_KEYS.name)
+  safeRemoveItem(localStorageRef, LEGACY_LOCAL_STORAGE_KEYS.type)
+  safeRemoveItem(localStorageRef, LEGACY_LOCAL_STORAGE_KEYS.id)
+  safeRemoveItem(localStorageRef, LEGACY_LOCAL_STORAGE_KEYS.name)
 }

--- a/frontend/src/util/consoleContextStorage.ts
+++ b/frontend/src/util/consoleContextStorage.ts
@@ -16,12 +16,22 @@ const LEGACY_LOCAL_STORAGE_KEYS = {
   name: 'contextName',
 }
 
+function isUsableStorage(storage: Storage | null): storage is Storage {
+  return Boolean(
+    storage
+    && typeof storage.getItem === 'function'
+    && typeof storage.setItem === 'function'
+    && typeof storage.removeItem === 'function'
+  )
+}
+
 function getLocalStorage(): Storage | null {
   if (typeof window === 'undefined') {
     return null
   }
   try {
-    return window.localStorage
+    const storage = window.localStorage
+    return isUsableStorage(storage) ? storage : null
   } catch {
     return null
   }
@@ -32,14 +42,14 @@ function getSessionStorage(): Storage | null {
     return null
   }
   try {
-    return window.sessionStorage
+    const storage = window.sessionStorage
+    return isUsableStorage(storage) ? storage : null
   } catch {
     return null
   }
 }
 
-export function readStoredConsoleContext(): StoredConsoleContext | null {
-  const storage = getSessionStorage()
+function readContextFromStorage(storage: Storage | null): StoredConsoleContext | null {
   if (!storage) {
     return null
   }
@@ -56,8 +66,24 @@ export function readStoredConsoleContext(): StoredConsoleContext | null {
   }
 }
 
-export function storeConsoleContext(context: StoredConsoleContext): void {
-  const storage = getSessionStorage()
+function readLegacyContextFromStorage(storage: Storage | null): StoredConsoleContext | null {
+  if (!storage) {
+    return null
+  }
+  const type = storage.getItem(LEGACY_LOCAL_STORAGE_KEYS.type)
+  const id = storage.getItem(LEGACY_LOCAL_STORAGE_KEYS.id)
+  if (!type || !id) {
+    return null
+  }
+  const name = storage.getItem(LEGACY_LOCAL_STORAGE_KEYS.name)
+  return {
+    type,
+    id,
+    name: name && name.trim() ? name : null,
+  }
+}
+
+function writeContextToStorage(storage: Storage | null, context: StoredConsoleContext): void {
   if (!storage) {
     return
   }
@@ -68,6 +94,21 @@ export function storeConsoleContext(context: StoredConsoleContext): void {
   } else {
     storage.removeItem(STORAGE_KEYS.name)
   }
+}
+
+export function readStoredConsoleContext(): StoredConsoleContext | null {
+  const sessionContext = readContextFromStorage(getSessionStorage())
+  if (sessionContext) {
+    return sessionContext
+  }
+
+  const localStorageRef = getLocalStorage()
+  return readContextFromStorage(localStorageRef) ?? readLegacyContextFromStorage(localStorageRef)
+}
+
+export function storeConsoleContext(context: StoredConsoleContext): void {
+  writeContextToStorage(getSessionStorage(), context)
+  writeContextToStorage(getLocalStorage(), context)
 }
 
 export function clearStoredConsoleContext(): void {


### PR DESCRIPTION
## Summary
- Keep the immersive app from opting out of persisted context so org/context selection survives navigation.
- Harden console context storage reads and writes to tolerate unavailable storage objects more safely.
- Add coverage for clearing stored context between tests to avoid cross-test leakage.

## Testing
- Updated unit test setup for agent chat context resolution.
- Not run (not requested).