### PR TITLE
Add provider creation and endpoint cloning to LLM config console

### DIFF
--- a/console/api_views.py
+++ b/console/api_views.py
@@ -1875,6 +1875,14 @@ def _json_ok(**extra):
     return JsonResponse(payload)
 
 
+def _coerce_provider_browser_backend(value: Any) -> str:
+    backend = str(value or LLMProvider.BrowserBackend.OPENAI).strip()
+    if backend not in LLMProvider.BrowserBackend.values:
+        allowed = ", ".join(LLMProvider.BrowserBackend.values)
+        raise ValueError(f"browser_backend must be one of: {allowed}")
+    return backend
+
+
 _REASONING_EFFORT_VALUES = set(PersistentModelEndpoint.ReasoningEffort.values)
 
 
@@ -5551,13 +5559,18 @@ class LLMProviderListCreateAPIView(SystemAdminAPIView):
         if LLMProvider.objects.filter(key=key).exists():
             return HttpResponseBadRequest("Provider key already exists")
 
+        try:
+            browser_backend = _coerce_provider_browser_backend(payload.get("browser_backend"))
+        except ValueError as exc:
+            return HttpResponseBadRequest(str(exc))
+
         provider = LLMProvider(
             display_name=display_name,
             key=key,
             enabled=_coerce_bool(payload.get("enabled", True)),
             env_var_name=(payload.get("env_var_name") or "").strip(),
             model_prefix=(payload.get("model_prefix") or "").strip(),
-            browser_backend=payload.get("browser_backend") or LLMProvider.BrowserBackend.OPENAI,
+            browser_backend=browser_backend,
             supports_safety_identifier=_coerce_bool(payload.get("supports_safety_identifier", False)),
             vertex_project=(payload.get("vertex_project") or "").strip(),
             vertex_location=(payload.get("vertex_location") or "").strip(),
@@ -5595,6 +5608,11 @@ class LLMProviderDetailAPIView(SystemAdminAPIView):
                     value = value.strip()
                 if model_field == "supports_safety_identifier":
                     value = _coerce_bool(value)
+                if model_field == "browser_backend":
+                    try:
+                        value = _coerce_provider_browser_backend(value)
+                    except ValueError as exc:
+                        return HttpResponseBadRequest(str(exc))
                 setattr(provider, model_field, value)
 
         if "enabled" in payload:

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -5578,6 +5578,10 @@ class LLMProviderListCreateAPIView(SystemAdminAPIView):
         api_key_value = payload.get("api_key")
         if api_key_value:
             provider.api_key_encrypted = SecretsEncryption.encrypt_value(api_key_value)
+        try:
+            provider.full_clean()
+        except ValidationError as exc:
+            return HttpResponseBadRequest(_format_validation_error(exc))
         provider.save()
         return _json_ok(provider_id=str(provider.id))
 

--- a/console/llm_serializers.py
+++ b/console/llm_serializers.py
@@ -260,6 +260,7 @@ def build_llm_overview() -> dict[str, Any]:
                 "key": provider.key,
                 "enabled": bool(provider.enabled),
                 "env_var": provider.env_var_name,
+                "model_prefix": provider.model_prefix,
                 "browser_backend": provider.browser_backend,
                 "supports_safety_identifier": provider.supports_safety_identifier,
                 "vertex_project": provider.vertex_project,

--- a/frontend/src/api/llmConfig.ts
+++ b/frontend/src/api/llmConfig.ts
@@ -54,12 +54,28 @@ export type Provider = {
   key: string
   enabled: boolean
   env_var: string
+  model_prefix: string
   browser_backend: string
   supports_safety_identifier: boolean
   vertex_project: string
   vertex_location: string
   status: string
   endpoints: ProviderEndpoint[]
+}
+
+export type ProviderBrowserBackend = 'OPENAI' | 'ANTHROPIC' | 'GOOGLE' | 'OPENAI_COMPAT'
+
+export type ProviderCreatePayload = {
+  display_name: string
+  key: string
+  api_key?: string
+  env_var_name?: string
+  model_prefix?: string
+  browser_backend: ProviderBrowserBackend
+  supports_safety_identifier: boolean
+  vertex_project?: string
+  vertex_location?: string
+  enabled: boolean
 }
 
 export type TierEndpoint = {
@@ -181,6 +197,10 @@ function withCsrf(json?: unknown, method: string = 'POST') {
 
 export function updateProvider(providerId: string, payload: Record<string, unknown>) {
   return jsonRequest(`${base}/providers/${providerId}/`, withCsrf(payload, 'PATCH'))
+}
+
+export function createProvider(payload: ProviderCreatePayload) {
+  return jsonRequest(`${base}/providers/`, withCsrf(payload))
 }
 
 const endpointPaths = {

--- a/frontend/src/components/llmConfig/LlmConfigView.tsx
+++ b/frontend/src/components/llmConfig/LlmConfigView.tsx
@@ -23,6 +23,7 @@ import {
 import { SectionCard } from './SectionCard'
 import { StatCard } from './StatCard'
 import { ProviderCard } from './ProviderCard'
+import { ProviderFormModal } from './ProviderFormModal'
 import { ActivityDock, RangeSection, TierCard, TierGroupSection } from './RoutingSections'
 import { PerformanceTestingPanel } from './PerformanceTestingPanel'
 import { actionKey, button } from './shared'
@@ -182,6 +183,23 @@ export function LlmConfigView({ controller }: { controller: LlmConfigController 
         <SectionCard
           title="Provider inventory"
           description="Toggle providers on/off, rotate keys, and review exposed endpoints."
+          actions={
+            <button
+              type="button"
+              className={button.primary}
+              onClick={() => showModal((onClose) => (
+                <ProviderFormModal
+                  onCreate={providerState.onCreateProvider}
+                  onClose={onClose}
+                  busy={feedback.isBusy(actionKey('provider', 'create'))}
+                />
+              ))}
+              disabled={feedback.isBusy(actionKey('provider', 'create'))}
+            >
+              <Plus className="size-4" />
+              Add provider
+            </button>
+          }
         >
           <div className="grid gap-4 md:grid-cols-1 lg:grid-cols-2">
             {data.providers.map((provider) => (

--- a/frontend/src/components/llmConfig/ProviderCard.tsx
+++ b/frontend/src/components/llmConfig/ProviderCard.tsx
@@ -232,7 +232,7 @@ export function ProviderCard({ provider, handlers, isBusy, testStatuses, showMod
                         <button type="button" className={button.secondary} onClick={() => handlers.onTestEndpoint(endpoint).catch(() => {})} disabled={testBusy}>
                           {testBusy ? <Loader2 className="size-4 animate-spin" /> : 'Test'}
                         </button>
-                        <button className={button.secondary} onClick={() => openAddEndpointModal(endpoint.type, endpoint)} disabled={creatingEndpoint}>
+                        <button type="button" className={button.secondary} onClick={() => openAddEndpointModal(endpoint.type, endpoint)} disabled={creatingEndpoint}>
                           {creatingEndpoint ? <Loader2 className="size-4 animate-spin" /> : <Copy className="size-4" />}
                           Clone
                         </button>

--- a/frontend/src/components/llmConfig/ProviderCard.tsx
+++ b/frontend/src/components/llmConfig/ProviderCard.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, KeyRound, Loader2, Plus, ShieldCheck, Trash2, X } from 'lucide-react'
+import { ChevronDown, Copy, KeyRound, Loader2, Plus, ShieldCheck, Trash2, X } from 'lucide-react'
 import { useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import {
@@ -51,12 +51,13 @@ export function ProviderCard({ provider, handlers, isBusy, testStatuses, showMod
     }
   }
 
-  const openAddEndpointModal = (type: llmApi.ProviderEndpoint['type']) => {
+  const openAddEndpointModal = (type: llmApi.ProviderEndpoint['type'], sourceEndpoint?: ProviderEndpointCard) => {
     showModal((onClose) => createPortal(
       <ProviderEndpointModal
         mode="create"
         providerName={provider.name}
         type={type}
+        sourceEndpoint={sourceEndpoint}
         busy={creatingEndpoint}
         onClose={onClose}
         onSubmit={async (values) => {
@@ -231,6 +232,10 @@ export function ProviderCard({ provider, handlers, isBusy, testStatuses, showMod
                         <button type="button" className={button.secondary} onClick={() => handlers.onTestEndpoint(endpoint).catch(() => {})} disabled={testBusy}>
                           {testBusy ? <Loader2 className="size-4 animate-spin" /> : 'Test'}
                         </button>
+                        <button className={button.secondary} onClick={() => openAddEndpointModal(endpoint.type, endpoint)} disabled={creatingEndpoint}>
+                          {creatingEndpoint ? <Loader2 className="size-4 animate-spin" /> : <Copy className="size-4" />}
+                          Clone
+                        </button>
                         <button className={button.secondary} onClick={() => openEndpointEditor(endpoint)}>
                           {isEditing ? 'Close' : 'Edit'}
                         </button>
@@ -275,6 +280,10 @@ export function ProviderCard({ provider, handlers, isBusy, testStatuses, showMod
         {activeTab === 'settings' && (
           <div className="space-y-4 text-sm text-slate-600">
             <div>
+              <p className="font-semibold text-slate-900/90">Provider key</p>
+              <p className="text-xs text-slate-500 break-all">{provider.key}</p>
+            </div>
+            <div>
               <p className="font-semibold text-slate-900/90">Environment fallback</p>
               <p className="text-xs text-slate-500 break-all">{provider.fallback}</p>
             </div>
@@ -282,6 +291,10 @@ export function ProviderCard({ provider, handlers, isBusy, testStatuses, showMod
               <div>
                 <p className="text-xs text-slate-500 uppercase">Backend</p>
                 <p className="font-medium text-slate-900/90">{provider.backend}</p>
+              </div>
+              <div>
+                <p className="text-xs text-slate-500 uppercase">Model prefix</p>
+                <p className="font-medium text-slate-900/90">{provider.modelPrefix || '—'}</p>
               </div>
               <div>
                 <p className="text-xs text-slate-500 uppercase">Safety identifiers</p>
@@ -330,6 +343,7 @@ type ProviderEndpointFormProps = {
   type: llmApi.ProviderEndpoint['type']
   endpoint?: ProviderEndpointCard
   saving?: boolean
+  submitLabel?: string
   onSave?: (values: EndpointFormValues) => Promise<void> | void
   onSubmit?: (values: EndpointFormValues & { key?: string }) => Promise<void> | void
   onCancel?: () => void
@@ -345,9 +359,10 @@ function ProviderEndpointForm({
   onCancel,
   onClose,
   saving,
+  submitLabel,
 }: ProviderEndpointFormProps) {
   const isCreate = mode === 'create'
-  const [key, setKey] = useState('')
+  const [key, setKey] = useState(isCreate && endpoint?.key ? `${endpoint.key}-copy` : '')
   const [model, setModel] = useState(endpoint?.name ?? '')
   const [pricingModel, setPricingModel] = useState(endpoint?.litellm_pricing_model ?? '')
   const [temperature, setTemperature] = useState(endpoint?.temperature?.toString() ?? '')
@@ -360,8 +375,8 @@ function ProviderEndpointForm({
   const [supportsVision, setSupportsVision] = useState(Boolean(endpoint?.supports_vision))
   const [supportsImageToImage, setSupportsImageToImage] = useState(Boolean(endpoint?.supports_image_to_image))
   const [supportsImageToVideo, setSupportsImageToVideo] = useState(Boolean(endpoint?.supports_image_to_video))
-  const [supportsToolChoice, setSupportsToolChoice] = useState(isCreate ? true : Boolean(endpoint?.supports_tool_choice))
-  const [parallelTools, setParallelTools] = useState(isCreate ? true : Boolean(endpoint?.use_parallel_tool_calls))
+  const [supportsToolChoice, setSupportsToolChoice] = useState(endpoint?.supports_tool_choice ?? true)
+  const [parallelTools, setParallelTools] = useState(endpoint?.use_parallel_tool_calls ?? true)
   const [allowImpliedSend, setAllowImpliedSend] = useState(endpoint?.allow_implied_send ?? true)
   const [supportsReasoning, setSupportsReasoning] = useState(Boolean(endpoint?.supports_reasoning))
   const [reasoningEffort, setReasoningEffort] = useState(endpoint?.reasoning_effort ?? '')
@@ -565,7 +580,7 @@ function ProviderEndpointForm({
         <button className={button.secondary} onClick={onCancel || onClose} disabled={isSubmitting}>Cancel</button>
         <button className={button.primary} onClick={handleSubmit} disabled={isCreate ? (!key || !model || isSubmitting) : isSubmitting}>
           {isSubmitting ? <Loader2 className="size-4 animate-spin" aria-hidden /> : isCreate ? <Plus className="size-4" /> : null}
-          {isCreate ? 'Add endpoint' : 'Save changes'}
+          {isCreate ? (submitLabel ?? 'Add endpoint') : 'Save changes'}
         </button>
       </div>
     </div>
@@ -576,13 +591,14 @@ type ProviderEndpointModalProps = {
   mode: 'create'
   providerName: string
   type: llmApi.ProviderEndpoint['type']
+  sourceEndpoint?: ProviderEndpointCard
   busy?: boolean
   onSubmit: (values: EndpointFormValues & { key?: string }) => Promise<void> | void
   onClose: () => void
 }
 
-function ProviderEndpointModal({ providerName, type, onSubmit, onClose, busy }: ProviderEndpointModalProps) {
-  const title = `Add ${endpointTypeLabels[type]} endpoint`
+function ProviderEndpointModal({ providerName, type, sourceEndpoint, onSubmit, onClose, busy }: ProviderEndpointModalProps) {
+  const title = sourceEndpoint ? `Clone ${endpointTypeLabels[type]} endpoint` : `Add ${endpointTypeLabels[type]} endpoint`
 
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-slate-900/60">
@@ -598,7 +614,9 @@ function ProviderEndpointModal({ providerName, type, onSubmit, onClose, busy }: 
           <ProviderEndpointForm
             mode="create"
             type={type}
+            endpoint={sourceEndpoint}
             saving={busy}
+            submitLabel={sourceEndpoint ? 'Clone endpoint' : 'Add endpoint'}
             onClose={onClose}
             onSubmit={onSubmit}
           />

--- a/frontend/src/components/llmConfig/ProviderFormModal.tsx
+++ b/frontend/src/components/llmConfig/ProviderFormModal.tsx
@@ -84,8 +84,9 @@ export function ProviderFormModal({ onCreate, onClose, busy }: ProviderFormModal
         <label className="block">
           <span className="text-sm font-medium text-slate-700">Provider key</span>
           <input
+            type="text"
             value={key}
-            onChange={(event) => setKey(event.currentTarget.value)}
+            onChange={(event) => setKey(event.currentTarget.value.toLowerCase().replace(/[^a-z0-9_-]/g, ''))}
             className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
             placeholder="openrouter"
           />

--- a/frontend/src/components/llmConfig/ProviderFormModal.tsx
+++ b/frontend/src/components/llmConfig/ProviderFormModal.tsx
@@ -1,0 +1,175 @@
+import { PlugZap } from 'lucide-react'
+import { useState, type FormEvent } from 'react'
+
+import * as llmApi from '../../api/llmConfig'
+import { ModalForm } from '../common/ModalForm'
+
+const backendOptions: Array<{ value: llmApi.ProviderBrowserBackend; label: string }> = [
+  { value: 'OPENAI', label: 'OpenAI' },
+  { value: 'ANTHROPIC', label: 'Anthropic' },
+  { value: 'GOOGLE', label: 'Google' },
+  { value: 'OPENAI_COMPAT', label: 'OpenAI-compatible' },
+]
+
+type ProviderFormModalProps = {
+  onCreate: (payload: llmApi.ProviderCreatePayload) => Promise<void>
+  onClose: () => void
+  busy?: boolean
+}
+
+export function ProviderFormModal({ onCreate, onClose, busy }: ProviderFormModalProps) {
+  const [displayName, setDisplayName] = useState('')
+  const [key, setKey] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [envVarName, setEnvVarName] = useState('')
+  const [modelPrefix, setModelPrefix] = useState('')
+  const [browserBackend, setBrowserBackend] = useState<llmApi.ProviderBrowserBackend>('OPENAI')
+  const [supportsSafetyIdentifier, setSupportsSafetyIdentifier] = useState(false)
+  const [vertexProject, setVertexProject] = useState('')
+  const [vertexLocation, setVertexLocation] = useState('')
+  const [enabled, setEnabled] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const isSubmitting = Boolean(busy || submitting)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSubmitting(true)
+    try {
+      await onCreate({
+        display_name: displayName.trim(),
+        key: key.trim(),
+        api_key: apiKey.trim(),
+        env_var_name: envVarName.trim(),
+        model_prefix: modelPrefix.trim(),
+        browser_backend: browserBackend,
+        supports_safety_identifier: supportsSafetyIdentifier,
+        vertex_project: vertexProject.trim(),
+        vertex_location: vertexLocation.trim(),
+        enabled,
+      })
+      onClose()
+    } catch {
+      // The shared feedback dock shows API errors; keep the dialog open for correction.
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <ModalForm
+      id="llm-provider-create-form"
+      title="Add provider"
+      subtitle="Configure provider credentials and runtime defaults."
+      icon={PlugZap}
+      onClose={onClose}
+      onSubmit={handleSubmit}
+      submitLabel="Add provider"
+      submittingLabel="Adding provider..."
+      submitting={isSubmitting}
+      submitDisabled={!displayName.trim() || !key.trim()}
+      widthClass="sm:max-w-2xl"
+      autoComplete="off"
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">Display name</span>
+          <input
+            value={displayName}
+            onChange={(event) => setDisplayName(event.currentTarget.value)}
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="OpenRouter"
+            autoFocus
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">Provider key</span>
+          <input
+            value={key}
+            onChange={(event) => setKey(event.currentTarget.value)}
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="openrouter"
+          />
+        </label>
+        <label className="block sm:col-span-2">
+          <span className="text-sm font-medium text-slate-700">Admin API key</span>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(event) => setApiKey(event.currentTarget.value)}
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="Optional"
+            autoComplete="new-password"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">Environment fallback</span>
+          <input
+            value={envVarName}
+            onChange={(event) => setEnvVarName(event.currentTarget.value)}
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="OPENROUTER_API_KEY"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">Model prefix</span>
+          <input
+            value={modelPrefix}
+            onChange={(event) => setModelPrefix(event.currentTarget.value)}
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="openrouter/"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">Browser backend</span>
+          <select
+            value={browserBackend}
+            onChange={(event) => setBrowserBackend(event.currentTarget.value as llmApi.ProviderBrowserBackend)}
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+          >
+            {backendOptions.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">Vertex project</span>
+          <input
+            value={vertexProject}
+            onChange={(event) => setVertexProject(event.currentTarget.value)}
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="Optional"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">Vertex location</span>
+          <input
+            value={vertexLocation}
+            onChange={(event) => setVertexLocation(event.currentTarget.value)}
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            placeholder="us-east4"
+          />
+        </label>
+      </div>
+      <div className="flex flex-wrap gap-4 text-sm text-slate-700">
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(event) => setEnabled(event.currentTarget.checked)}
+            className="rounded border-slate-300 text-blue-600 shadow-sm"
+          />
+          Enabled
+        </label>
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={supportsSafetyIdentifier}
+            onChange={(event) => setSupportsSafetyIdentifier(event.currentTarget.checked)}
+            className="rounded border-slate-300 text-blue-600 shadow-sm"
+          />
+          Supports safety identifiers
+        </label>
+      </div>
+    </ModalForm>
+  )
+}

--- a/frontend/src/components/llmConfig/shared.tsx
+++ b/frontend/src/components/llmConfig/shared.tsx
@@ -129,6 +129,7 @@ export type TokenRange = {
 
 export type ProviderEndpointCard = {
   id: string
+  key: string
   name: string
   enabled: boolean
   litellm_pricing_model?: string | null
@@ -155,11 +156,13 @@ export type ProviderEndpointCard = {
 export type ProviderCardData = {
   id: string
   name: string
+  key: string
   status: string
   backend: string
   fallback: string
   enabled: boolean
   envVar?: string
+  modelPrefix: string
   supportsSafety: boolean
   vertexProject: string
   vertexLocation: string
@@ -461,6 +464,22 @@ export type AsyncFeedback = {
   dismissNotice: (id: string) => void
 }
 
+function feedbackErrorMessage(error: unknown) {
+  if (error instanceof HttpError) {
+    if (typeof error.body === 'string' && error.body.trim()) {
+      return error.body
+    }
+    if (typeof error.body === 'object' && error.body && 'message' in error.body) {
+      return String((error.body as { message?: unknown }).message || error.message)
+    }
+    if (typeof error.body === 'object' && error.body && 'error' in error.body) {
+      return String((error.body as { error?: unknown }).error || error.message)
+    }
+    return error.message
+  }
+  return error instanceof Error ? error.message : 'Request failed'
+}
+
 export function useAsyncFeedback(): AsyncFeedback {
   const [busyCounts, setBusyCounts] = useState<Record<string, number>>({})
   const [labelCounts, setLabelCounts] = useState<Record<string, number>>({})
@@ -506,7 +525,7 @@ export function useAsyncFeedback(): AsyncFeedback {
       }
       return result
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Request failed'
+      const message = feedbackErrorMessage(error)
       const notice: ActivityNotice = {
         id: `notice-${noticeSeqRef.current += 1}`,
         intent: 'error',
@@ -903,16 +922,19 @@ export function mapProviders(input: llmApi.Provider[] = []): ProviderCardData[] 
   return input.map((provider) => ({
     id: provider.id,
     name: provider.name,
+    key: provider.key,
     status: provider.status,
     backend: provider.browser_backend,
     fallback: provider.env_var || 'Not configured',
     envVar: provider.env_var,
+    modelPrefix: provider.model_prefix,
     supportsSafety: provider.supports_safety_identifier,
     vertexProject: provider.vertex_project,
     vertexLocation: provider.vertex_location,
     enabled: provider.enabled,
     endpoints: provider.endpoints.map((endpoint) => ({
       id: endpoint.id,
+      key: endpoint.key,
       name: endpoint.model,
       enabled: endpoint.enabled,
       litellm_pricing_model: endpoint.litellm_pricing_model ?? null,

--- a/frontend/src/components/llmConfig/useProviderEndpointActions.tsx
+++ b/frontend/src/components/llmConfig/useProviderEndpointActions.tsx
@@ -141,6 +141,19 @@ export function useProviderEndpointActions({
       },
     )
   }
+
+  const handleProviderCreate = (payload: llmApi.ProviderCreatePayload) => {
+    return runMutation(
+      () => llmApi.createProvider(payload),
+      {
+        successMessage: 'Provider added',
+        label: 'Adding provider...',
+        busyKey: actionKey('provider', 'create'),
+        context: payload.display_name,
+        rethrow: true,
+      },
+    )
+  }
   
   const handleProviderAddEndpoint = (
     provider: ProviderCardData,
@@ -319,5 +332,5 @@ export function useProviderEndpointActions({
     onTestEndpoint: handleProviderTestEndpoint,
   }
 
-  return { endpointTestStatuses, providerHandlers }
+  return { endpointTestStatuses, providerHandlers, onCreateProvider: handleProviderCreate }
 }

--- a/tests/unit/test_console_llm_providers.py
+++ b/tests/unit/test_console_llm_providers.py
@@ -65,6 +65,17 @@ class ConsoleLLMProviderTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn(b"Provider key already exists", response.content)
 
+    def test_create_provider_rejects_invalid_key_slug(self):
+        response = self.client.post(
+            reverse("console_llm_providers"),
+            data=json.dumps({"display_name": "Bad Key", "key": "bad key"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"Enter a valid", response.content)
+        self.assertFalse(LLMProvider.objects.filter(display_name="Bad Key").exists())
+
     def test_create_provider_rejects_invalid_browser_backend(self):
         response = self.client.post(
             reverse("console_llm_providers"),

--- a/tests/unit/test_console_llm_providers.py
+++ b/tests/unit/test_console_llm_providers.py
@@ -1,0 +1,113 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase, tag
+from django.urls import reverse
+
+from api.models import LLMProvider
+from console.llm_serializers import build_llm_overview
+
+
+@tag("batch_console_api")
+class ConsoleLLMProviderTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_user(
+            username="admin-llm-provider@example.com",
+            email="admin-llm-provider@example.com",
+            password="pass1234",
+            is_staff=True,
+        )
+        self.client = Client()
+        self.client.force_login(self.admin)
+
+    def test_staff_can_create_provider_with_full_fields(self):
+        response = self.client.post(
+            reverse("console_llm_providers"),
+            data=json.dumps(
+                {
+                    "display_name": "Test Router",
+                    "key": "test-router",
+                    "api_key": "secret-value",
+                    "env_var_name": "TEST_ROUTER_API_KEY",
+                    "model_prefix": "test-router/",
+                    "browser_backend": LLMProvider.BrowserBackend.OPENAI_COMPAT,
+                    "supports_safety_identifier": True,
+                    "vertex_project": "vertex-project",
+                    "vertex_location": "us-east4",
+                    "enabled": True,
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        provider = LLMProvider.objects.get(key="test-router")
+        self.assertEqual(provider.display_name, "Test Router")
+        self.assertEqual(provider.env_var_name, "TEST_ROUTER_API_KEY")
+        self.assertEqual(provider.model_prefix, "test-router/")
+        self.assertEqual(provider.browser_backend, LLMProvider.BrowserBackend.OPENAI_COMPAT)
+        self.assertTrue(provider.supports_safety_identifier)
+        self.assertEqual(provider.vertex_project, "vertex-project")
+        self.assertEqual(provider.vertex_location, "us-east4")
+        self.assertTrue(provider.enabled)
+        self.assertTrue(provider.api_key_encrypted)
+
+    def test_create_provider_rejects_duplicate_key(self):
+        LLMProvider.objects.create(key="existing", display_name="Existing")
+
+        response = self.client.post(
+            reverse("console_llm_providers"),
+            data=json.dumps({"display_name": "Duplicate", "key": "existing"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"Provider key already exists", response.content)
+
+    def test_create_provider_rejects_invalid_browser_backend(self):
+        response = self.client.post(
+            reverse("console_llm_providers"),
+            data=json.dumps(
+                {
+                    "display_name": "Invalid Backend",
+                    "key": "invalid-backend",
+                    "browser_backend": "NOT_A_BACKEND",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"browser_backend must be one of", response.content)
+        self.assertFalse(LLMProvider.objects.filter(key="invalid-backend").exists())
+
+    def test_update_provider_rejects_invalid_browser_backend(self):
+        provider = LLMProvider.objects.create(
+            key="patch-backend",
+            display_name="Patch Backend",
+            browser_backend=LLMProvider.BrowserBackend.OPENAI,
+        )
+
+        response = self.client.patch(
+            reverse("console_llm_provider_detail", args=[provider.id]),
+            data=json.dumps({"browser_backend": "NOT_A_BACKEND"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b"browser_backend must be one of", response.content)
+        provider.refresh_from_db()
+        self.assertEqual(provider.browser_backend, LLMProvider.BrowserBackend.OPENAI)
+
+    def test_overview_includes_provider_model_prefix(self):
+        provider = LLMProvider.objects.create(
+            key="prefixed",
+            display_name="Prefixed",
+            model_prefix="prefixed/",
+        )
+
+        overview = build_llm_overview()
+        provider_payload = next(entry for entry in overview["providers"] if entry["id"] == str(provider.id))
+
+        self.assertEqual(provider_payload["model_prefix"], "prefixed/")


### PR DESCRIPTION
## Summary
- Add a console flow to create LLM providers with browser backend, model prefix, and safety settings.
- Surface provider keys and model prefixes in the provider UI and overview payload.
- Add endpoint cloning from an existing provider endpoint with sensible copied defaults.
- Harden provider browser backend validation on create and update, and improve API error surfacing in the UI.

## Testing
- Added unit coverage for provider creation, invalid backend rejection, overview serialization, and update validation.
- Not run (not requested)