### PR TITLE
Normalize MCP result payloads before serialization

### DIFF
--- a/api/agent/tools/mcp_manager.py
+++ b/api/agent/tools/mcp_manager.py
@@ -21,10 +21,12 @@ import contextvars
 import sys
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
+from decimal import Decimal
 from urllib.parse import urlparse
 from typing import Callable, Dict, Any, Iterable, List, Optional, Tuple
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta, UTC
+from dataclasses import asdict, dataclass, field, is_dataclass
+from datetime import date, datetime, time, timedelta, UTC
+from uuid import UUID
 
 import requests
 
@@ -1883,6 +1885,15 @@ class MCPToolManager:
     def _json_safe_mcp_data(cls, value: Any) -> Any:
         if value is None or isinstance(value, (str, int, float, bool)):
             return value
+
+        if isinstance(value, (datetime, date, time)):
+            return value.isoformat()
+
+        if isinstance(value, (Decimal, UUID)):
+            return str(value)
+
+        if is_dataclass(value) and not isinstance(value, type):
+            return cls._json_safe_mcp_data(asdict(value))
 
         model_dump = getattr(value, "model_dump", None)
         if callable(model_dump):

--- a/api/agent/tools/mcp_manager.py
+++ b/api/agent/tools/mcp_manager.py
@@ -19,6 +19,7 @@ import fnmatch
 import contextlib
 import contextvars
 import sys
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 from typing import Callable, Dict, Any, Iterable, List, Optional, Tuple
@@ -1878,12 +1879,39 @@ class MCPToolManager:
 
         return definitions
 
-    @staticmethod
-    def _extract_tool_result_content(result: Any) -> Any:
+    @classmethod
+    def _json_safe_mcp_data(cls, value: Any) -> Any:
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            try:
+                return cls._json_safe_mcp_data(model_dump(mode="json"))
+            except TypeError:
+                return cls._json_safe_mcp_data(model_dump())
+
+        dict_dump = getattr(value, "dict", None)
+        if callable(dict_dump):
+            return cls._json_safe_mcp_data(dict_dump())
+
+        if isinstance(value, Mapping):
+            return {
+                str(key): cls._json_safe_mcp_data(item)
+                for key, item in value.items()
+            }
+
+        if isinstance(value, (list, tuple, set)):
+            return [cls._json_safe_mcp_data(item) for item in value]
+
+        return value
+
+    @classmethod
+    def _extract_tool_result_content(cls, result: Any) -> Any:
         if isinstance(result, dict) and "result" in result:
             return result.get("result")
         if getattr(result, "data", None) is not None:
-            return result.data
+            return cls._json_safe_mcp_data(result.data)
         for block in getattr(result, "content", None) or []:
             if hasattr(block, "text"):
                 return block.text

--- a/api/agent/tools/tests/test_mcp_tool_cache.py
+++ b/api/agent/tools/tests/test_mcp_tool_cache.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 from django.test import SimpleTestCase, tag, override_settings
 from django.utils import timezone
+from pydantic import BaseModel
 
 from api.agent.tools.mcp_manager import (
     MCPServerRuntime,
@@ -415,6 +416,85 @@ class MCPToolCacheTests(SimpleTestCase):
 
         client.list_tools.assert_awaited_once()
         self.assertEqual([tool.full_name for tool in tools], ["google_sheets-add-row"])
+
+
+@tag("batch_mcp_tools")
+class MCPToolResultDataNormalizationTests(SimpleTestCase):
+    def test_pydantic_data_result_is_normalized_to_json_safe_primitives(self):
+        class Project(BaseModel):
+            description: str
+            location: str
+            name: str
+            owner: str
+            updated: str
+            url: str
+
+        class Root(BaseModel):
+            count: int
+            projects: list[Project]
+
+        manager = MCPToolManager()
+        raw_result = SimpleNamespace(
+            data=Root(
+                count=1,
+                projects=[
+                    Project(
+                        description="",
+                        location="",
+                        name="Product Manager",
+                        owner="",
+                        updated="",
+                        url="https://www.linkedin.com/talent/hire/2063754842/overview",
+                    )
+                ],
+            ),
+            content=[SimpleNamespace(text="fallback text should not be used")],
+        )
+
+        result = manager._finalize_mcp_result("linkedin-recruiter", "list-projects", raw_result)
+
+        self.assertEqual(
+            result["result"],
+            {
+                "count": 1,
+                "projects": [
+                    {
+                        "description": "",
+                        "location": "",
+                        "name": "Product Manager",
+                        "owner": "",
+                        "updated": "",
+                        "url": "https://www.linkedin.com/talent/hire/2063754842/overview",
+                    }
+                ],
+            },
+        )
+        serialized = json.dumps(result)
+        self.assertNotIn("Root(", serialized)
+        self.assertNotIn("Project(", serialized)
+
+    def test_nested_model_containers_are_normalized_recursively(self):
+        class Item(BaseModel):
+            name: str
+            rank: int
+
+        manager = MCPToolManager()
+        raw_result = SimpleNamespace(
+            data={
+                "primary": Item(name="alpha", rank=1),
+                "items": [Item(name="beta", rank=2)],
+                "tuple_items": (Item(name="gamma", rank=3),),
+                "set_items": {"delta"},
+            },
+        )
+
+        result = manager._finalize_mcp_result("example", "nested-data", raw_result)
+
+        self.assertEqual(result["result"]["primary"], {"name": "alpha", "rank": 1})
+        self.assertEqual(result["result"]["items"], [{"name": "beta", "rank": 2}])
+        self.assertEqual(result["result"]["tuple_items"], [{"name": "gamma", "rank": 3}])
+        self.assertEqual(sorted(result["result"]["set_items"]), ["delta"])
+        json.dumps(result)
 
 
 @tag("batch_mcp_tools")

--- a/api/agent/tools/tests/test_mcp_tool_cache.py
+++ b/api/agent/tools/tests/test_mcp_tool_cache.py
@@ -1,8 +1,11 @@
 import asyncio
 import json
-from dataclasses import replace
+from dataclasses import dataclass, replace
+from datetime import UTC, date, datetime, time
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
+from uuid import UUID
 
 from django.test import SimpleTestCase, tag, override_settings
 from django.utils import timezone
@@ -494,6 +497,46 @@ class MCPToolResultDataNormalizationTests(SimpleTestCase):
         self.assertEqual(result["result"]["items"], [{"name": "beta", "rank": 2}])
         self.assertEqual(result["result"]["tuple_items"], [{"name": "gamma", "rank": 3}])
         self.assertEqual(sorted(result["result"]["set_items"]), ["delta"])
+        json.dumps(result)
+
+    def test_standard_json_hostile_types_are_normalized(self):
+        @dataclass
+        class Event:
+            id: UUID
+            amount: Decimal
+            created_at: datetime
+            event_date: date
+            event_time: time
+
+        manager = MCPToolManager()
+        raw_result = SimpleNamespace(
+            data={
+                "event": Event(
+                    id=UUID("12345678-1234-5678-1234-567812345678"),
+                    amount=Decimal("10.50"),
+                    created_at=datetime(2026, 6, 26, 18, 35, 0, tzinfo=UTC),
+                    event_date=date(2026, 6, 26),
+                    event_time=time(18, 35, 0),
+                ),
+                "ids": {UUID("87654321-4321-8765-4321-876543218765")},
+                "amounts": [Decimal("1.25")],
+            },
+        )
+
+        result = manager._finalize_mcp_result("example", "standard-types", raw_result)
+
+        self.assertEqual(
+            result["result"]["event"],
+            {
+                "id": "12345678-1234-5678-1234-567812345678",
+                "amount": "10.50",
+                "created_at": "2026-06-26T18:35:00+00:00",
+                "event_date": "2026-06-26",
+                "event_time": "18:35:00",
+            },
+        )
+        self.assertEqual(result["result"]["amounts"], ["1.25"])
+        self.assertEqual(result["result"]["ids"], ["87654321-4321-8765-4321-876543218765"])
         json.dumps(result)
 
 


### PR DESCRIPTION
## Summary
- Normalize MCP `data` payloads into JSON-safe primitives before final result extraction.
- Add recursive handling for Pydantic models and nested containers so tool results serialize cleanly.
- Cover the normalization path with tests for model-heavy payloads and mixed nested data structures.

## Testing
- Added unit coverage for Pydantic-backed MCP results and recursive container normalization.
- Verified the finalized result can be JSON serialized without leaking model reprs or non-serializable objects.