### PR TITLE
Persist agent chat drafts across composer transitions

### DIFF
--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, ClipboardEvent, FormEvent, KeyboardEvent, Ref } from 'react'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components'
 import { ArrowUp, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Gauge, KeyRound, Loader2, Mail, MessageSquare, MessageSquareQuote, OctagonAlert, Paperclip, Plus, Rocket, Sparkles, TriangleAlert, Zap, X } from 'lucide-react'
 
@@ -1204,7 +1204,7 @@ export const AgentComposer = memo(function AgentComposer({
     submitShortcutHint,
   ].filter(Boolean).join(' · ')
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (activeHumanInputUsesMainComposer) {
       return
     }
@@ -1456,7 +1456,7 @@ export const AgentComposer = memo(function AgentComposer({
     }
   }, [busyHumanInputRequestId, disabled, isSending, onDismissHumanInput, syncDraftHumanInputResponses])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!activeHumanInputUsesMainComposer || !activeHumanInputRequest) {
       return
     }
@@ -1781,19 +1781,11 @@ export const AgentComposer = memo(function AgentComposer({
     if (!item) {
       return
     }
-    const leavingMainComposerHumanInput = activeHumanInputUsesMainComposer
-      && (
-        item.kind !== 'human_input'
-        || item.requestId !== activeHumanInputRequest?.id
-      )
     setActivePendingActionId(item.actionId)
     if (item.kind === 'human_input') {
       setActiveHumanInputRequestId(item.requestId)
     } else {
       setActiveHumanInputRequestId(null)
-    }
-    if (leavingMainComposerHumanInput) {
-      restoreMessageDraft()
     }
   }
 

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -22,6 +22,11 @@ import { track, AnalyticsEvent } from '../../util/analytics'
 import { formatBytes } from '../../util/formatBytes'
 import { appendReturnTo } from '../../util/returnTo'
 import { sanitizeHtml } from '../../util/sanitize'
+import {
+  clearAgentChatMessageDraft,
+  readAgentChatMessageDraft,
+  writeAgentChatMessageDraft,
+} from '../../util/agentChatDraftStorage'
 import type { LlmIntelligenceConfig } from '../../types/llmIntelligence'
 import type { PlanningState } from '../../types/agentRoster'
 import { useModal } from '../../hooks/useModal'
@@ -551,7 +556,7 @@ export const AgentComposer = memo(function AgentComposer({
   compact = false,
   externalShellRef,
 }: AgentComposerProps) {
-  const [body, setBody] = useState('')
+  const [body, setBody] = useState(() => readAgentChatMessageDraft(agentId))
   const [attachments, setAttachments] = useState<File[]>([])
   const [attachmentError, setAttachmentError] = useState<string | null>(null)
   const [isSending, setIsSending] = useState(false)
@@ -1002,6 +1007,33 @@ export const AgentComposer = memo(function AgentComposer({
     [MAX_COMPOSER_HEIGHT],
   )
 
+  const moveTextareaCursorToEnd = useCallback((bodyLength?: number) => {
+    const node = textareaRef.current
+    if (!node) {
+      return
+    }
+    const cursorPosition = bodyLength ?? node.value.length
+    try {
+      node.setSelectionRange(cursorPosition, cursorPosition)
+    } catch {
+      // Selection updates are best-effort because the draft itself is already restored.
+    }
+  }, [])
+
+  const restoreMessageDraft = useCallback(() => {
+    const draft = readAgentChatMessageDraft(agentId)
+    setBody(draft)
+    requestAnimationFrame(() => {
+      adjustTextareaHeight(true)
+      moveTextareaCursorToEnd(draft.length)
+    })
+  }, [adjustTextareaHeight, agentId, moveTextareaCursorToEnd])
+
+  const updateMessageDraft = useCallback((nextBody: string) => {
+    setBody(nextBody)
+    writeAgentChatMessageDraft(agentId, nextBody)
+  }, [agentId])
+
   useEffect(() => {
     adjustTextareaHeight()
   }, [body, adjustTextareaHeight])
@@ -1108,9 +1140,10 @@ export const AgentComposer = memo(function AgentComposer({
     // Use a small delay to ensure the DOM is ready after navigation
     const timer = setTimeout(() => {
       textareaRef.current?.focus()
+      moveTextareaCursorToEnd()
     }, 100)
     return () => clearTimeout(timer)
-  }, [autoFocus, focusKey])
+  }, [autoFocus, focusKey, moveTextareaCursorToEnd])
 
   useEffect(() => {
     const node = shellRef.current
@@ -1171,14 +1204,12 @@ export const AgentComposer = memo(function AgentComposer({
     submitShortcutHint,
   ].filter(Boolean).join(' · ')
 
-  const wasUsingMainComposerHumanInputRef = useRef(false)
   useEffect(() => {
-    if (wasUsingMainComposerHumanInputRef.current && !activeHumanInputUsesMainComposer) {
-      setBody('')
-      requestAnimationFrame(() => adjustTextareaHeight(true))
+    if (activeHumanInputUsesMainComposer) {
+      return
     }
-    wasUsingMainComposerHumanInputRef.current = activeHumanInputUsesMainComposer
-  }, [activeHumanInputUsesMainComposer, adjustTextareaHeight])
+    restoreMessageDraft()
+  }, [activeHumanInputUsesMainComposer, agentId, restoreMessageDraft])
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -1505,6 +1536,7 @@ export const AgentComposer = memo(function AgentComposer({
         setIsSending(true)
         await onSubmit(trimmed, attachmentsSnapshot)
         setBody('')
+        clearAgentChatMessageDraft(agentId)
         setAttachments([])
         setAttachmentError(null)
         if (fileInputRef.current) {
@@ -1518,6 +1550,7 @@ export const AgentComposer = memo(function AgentComposer({
       }
     } else {
       setBody('')
+      clearAgentChatMessageDraft(agentId)
       setAttachments([])
       setAttachmentError(null)
       if (fileInputRef.current) {
@@ -1527,6 +1560,7 @@ export const AgentComposer = memo(function AgentComposer({
     }
   }, [
     adjustTextareaHeight,
+    agentId,
     attachments,
     body,
     disabled,
@@ -1759,8 +1793,7 @@ export const AgentComposer = memo(function AgentComposer({
       setActiveHumanInputRequestId(null)
     }
     if (leavingMainComposerHumanInput) {
-      setBody('')
-      requestAnimationFrame(() => adjustTextareaHeight(true))
+      restoreMessageDraft()
     }
   }
 
@@ -2128,9 +2161,11 @@ export const AgentComposer = memo(function AgentComposer({
                   value={body}
                   onChange={(event) => {
                     const nextValue = event.target.value
-                    setBody(nextValue)
                     if (activeHumanInputUsesMainComposer && activeHumanInputRequest) {
+                      setBody(nextValue)
                       handleDraftHumanInputFreeTextChange(activeHumanInputRequest.id, nextValue)
+                    } else {
+                      updateMessageDraft(nextValue)
                     }
                   }}
                   onKeyDown={handleKeyDown}

--- a/frontend/src/util/agentChatDraftStorage.ts
+++ b/frontend/src/util/agentChatDraftStorage.ts
@@ -1,0 +1,70 @@
+const MESSAGE_DRAFT_STORAGE_PREFIX = 'gobii:agent-chat:message-draft:'
+
+function isUsableStorage(storage: Storage | null): storage is Storage {
+  return Boolean(
+    storage
+    && typeof storage.getItem === 'function'
+    && typeof storage.setItem === 'function'
+    && typeof storage.removeItem === 'function'
+  )
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const storage = window.localStorage
+    return isUsableStorage(storage) ? storage : null
+  } catch {
+    return null
+  }
+}
+
+function getMessageDraftStorageKey(agentId: string): string {
+  return `${MESSAGE_DRAFT_STORAGE_PREFIX}${agentId}`
+}
+
+export function readAgentChatMessageDraft(agentId: string | null | undefined): string {
+  if (!agentId) {
+    return ''
+  }
+
+  const storage = getLocalStorage()
+  if (!storage) {
+    return ''
+  }
+
+  try {
+    return storage.getItem(getMessageDraftStorageKey(agentId)) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function writeAgentChatMessageDraft(agentId: string | null | undefined, draft: string): void {
+  if (!agentId) {
+    return
+  }
+
+  const storage = getLocalStorage()
+  if (!storage) {
+    return
+  }
+
+  try {
+    const key = getMessageDraftStorageKey(agentId)
+    if (draft === '') {
+      storage.removeItem(key)
+    } else {
+      storage.setItem(key, draft)
+    }
+  } catch {
+    // Storage can be blocked or quota-limited; drafts should never break chat.
+  }
+}
+
+export function clearAgentChatMessageDraft(agentId: string | null | undefined): void {
+  writeAgentChatMessageDraft(agentId, '')
+}


### PR DESCRIPTION
## Summary
- Store agent chat composer text drafts in local storage per agent
- Restore drafts when switching back into an agent composer or after leaving human-input mode
- Clear saved drafts after successful send to avoid stale message recovery
- Preserve cursor position and textarea sizing when restoring content

## Testing
- Not run (not requested)