### PR TITLE
Route homepage agent spawn through app context

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -76,7 +76,24 @@ function resolvePathname(input: RequestInfo | URL): string | null {
 
 function shouldApplyConsoleContextHeaders(input: RequestInfo | URL): boolean {
   const requestPathname = resolvePathname(input)
+  if (requestHasExplicitConsoleContext(input)) {
+    return false
+  }
   return !requestPathname || !isMarketingContextHeaderPath(requestPathname)
+}
+
+function requestHasExplicitConsoleContext(input: RequestInfo | URL): boolean {
+  try {
+    const url = input instanceof URL
+      ? input
+      : new URL(
+          typeof Request !== 'undefined' && input instanceof Request ? input.url : String(input),
+          typeof window !== 'undefined' ? window.location.href : 'http://localhost/',
+        )
+    return Boolean(url.searchParams.get('context_type') && url.searchParams.get('context_id'))
+  } catch {
+    return false
+  }
 }
 
 export function buildLoginUrl(nextUrl?: string): string {

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -90,7 +90,9 @@ function requestHasExplicitConsoleContext(input: RequestInfo | URL): boolean {
           typeof Request !== 'undefined' && input instanceof Request ? input.url : String(input),
           typeof window !== 'undefined' ? window.location.href : 'http://localhost/',
         )
-    return Boolean(url.searchParams.get('context_type') && url.searchParams.get('context_id'))
+    const type = url.searchParams.get('context_type')
+    const id = url.searchParams.get('context_id')
+    return Boolean(id && (type === 'personal' || type === 'organization'))
   } catch {
     return false
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { I18nProvider } from 'react-aria-components'
 import { Loader2 } from 'lucide-react'
 import type { LibraryAgentsPayload } from './api/library'
 import { initializeSubscriptionStore } from './stores/subscriptionStore'
+import { storeConsoleContextFromUrlSearch } from './util/consoleContextStorage'
 import './index.css'
 import './styles/consoleShell.css'
 
@@ -36,6 +37,8 @@ if (!mountNode) {
 const rootNode = mountNode
 const appName = mountNode.dataset.app ?? 'immersive-app'
 const shouldInitializeSubscriptionStore = appName !== 'library'
+
+storeConsoleContextFromUrlSearch()
 
 if (shouldInitializeSubscriptionStore) {
   // Initialize subscription state from data attributes

--- a/frontend/src/util/consoleContextStorage.ts
+++ b/frontend/src/util/consoleContextStorage.ts
@@ -135,6 +135,19 @@ export function storeConsoleContext(context: StoredConsoleContext): void {
   writeContextToStorage(getLocalStorage(), context)
 }
 
+export function storeConsoleContextFromUrlSearch(search?: string): StoredConsoleContext | null {
+  const rawSearch = search ?? (typeof window === 'undefined' ? '' : window.location.search)
+  const params = new URLSearchParams(rawSearch)
+  const type = (params.get('context_type') || '').trim()
+  const id = (params.get('context_id') || '').trim()
+  if ((type !== 'personal' && type !== 'organization') || !id) {
+    return null
+  }
+  const context = { type, id, name: null }
+  storeConsoleContext(context)
+  return context
+}
+
 export function clearStoredConsoleContext(): void {
   const sessionStorageRef = getSessionStorage()
   if (sessionStorageRef) {

--- a/pages/templates/home.html
+++ b/pages/templates/home.html
@@ -478,6 +478,8 @@
             <input type="hidden" name="source_page" value="home_hero">
             <input type="hidden" name="trial_onboarding" value="1">
             <input type="hidden" name="trial_onboarding_target" value="agent_ui">
+            <input type="hidden" name="context_type" id="agent-context-type" value="{{ current_context.type|default:'personal' }}">
+            <input type="hidden" name="context_id" id="agent-context-id" value="{{ current_context.id|default:user.id }}">
             <div id="homepage-integrations-selected-fields">
               {% for app_slug in homepage_integrations_initial_selected_app_slugs %}
                 <input type="hidden" name="selected_pipedream_app_slugs" value="{{ app_slug }}" />
@@ -1632,6 +1634,46 @@
     </script>
 
     {% include "partials/_immersive_overlay.html" %}
+
+    <script>
+      (function () {
+        const STORAGE_KEYS = {
+          type: 'gobii:console:context-type',
+          id: 'gobii:console:context-id',
+        };
+        const LEGACY_KEYS = {
+          type: 'contextType',
+          id: 'contextId',
+        };
+
+        function readStoredContextValue(key) {
+          try {
+            return window.sessionStorage.getItem(STORAGE_KEYS[key])
+              || window.localStorage.getItem(STORAGE_KEYS[key])
+              || window.localStorage.getItem(LEGACY_KEYS[key])
+              || '';
+          } catch (error) {
+            return '';
+          }
+        }
+
+        document.addEventListener('submit', function (event) {
+          const form = event.target;
+          if (!(form instanceof HTMLFormElement) || form.id !== 'create-agent-form') {
+            return;
+          }
+          const contextTypeInput = form.querySelector('#agent-context-type');
+          const contextIdInput = form.querySelector('#agent-context-id');
+          const contextType = readStoredContextValue('type');
+          const contextId = readStoredContextValue('id');
+          if (!contextType || !contextId || !contextTypeInput || !contextIdInput) {
+            return;
+          }
+          contextTypeInput.value = contextType;
+          contextIdInput.value = contextId;
+        }, true);
+      })();
+    </script>
 
     <script>
       (function () {

--- a/pages/views.py
+++ b/pages/views.py
@@ -1441,7 +1441,15 @@ class HomeAgentSpawnView(TemplateView):
                 redirect_params["context_id"] = resolved_context.current_context.id
 
             if request.user.is_authenticated:
-                if trial_onboarding_requested and not can_user_use_personal_agents_and_api(request.user):
+                in_personal_context = (
+                    resolved_context is None
+                    or resolved_context.current_context.type == "personal"
+                )
+                if (
+                    trial_onboarding_requested
+                    and in_personal_context
+                    and not can_user_use_personal_agents_and_api(request.user)
+                ):
                     set_trial_onboarding_intent(
                         request,
                         target=trial_onboarding_target,

--- a/pages/views.py
+++ b/pages/views.py
@@ -10,6 +10,7 @@ from django.http.response import JsonResponse
 from django.views.generic import TemplateView, RedirectView, View
 from django.http import HttpResponse, Http404
 from django.core import signing
+from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
 from django.contrib import messages
 from django.utils.decorators import method_decorator
@@ -148,6 +149,7 @@ from api.services.native_integrations import list_native_integration_providers
 from api.pipedream_app_utils import normalize_app_slugs
 from marketing_events.custom_events import ConfiguredCustomEvent, emit_configured_custom_capi_event
 from middleware.utm_capture import UTMTrackingMiddleware
+from console.context_helpers import build_console_context, resolve_console_context
 from pages.mini_mode import set_mini_mode_cookie
 from .utils_markdown import (
     render_public_template_markdown,
@@ -1364,6 +1366,27 @@ class HomeAgentSpawnView(TemplateView):
             request.POST.get("trial_onboarding_target"),
             default=TRIAL_ONBOARDING_TARGET_AGENT_UI,
         )
+        resolved_context = None
+        if request.user.is_authenticated:
+            context_type = (request.POST.get("context_type") or "").strip()
+            context_id = (request.POST.get("context_id") or "").strip()
+            context_override = (
+                {"type": context_type, "id": context_id}
+                if context_type and context_id
+                else None
+            )
+            try:
+                resolved_context = (
+                    resolve_console_context(
+                        request.user,
+                        request.session,
+                        override=context_override,
+                    )
+                    if context_override
+                    else build_console_context(request)
+                )
+            except PermissionDenied:
+                resolved_context = build_console_context(request)
         
         if form.is_valid():
             return_to = normalize_return_to(request, request.POST.get("return_to"))
@@ -1372,6 +1395,10 @@ class HomeAgentSpawnView(TemplateView):
             embed = (request.POST.get("embed") or "").lower() in {"1", "true", "yes", "on"}
             if return_to:
                 request.session[IMMERSIVE_RETURN_TO_SESSION_KEY] = return_to
+            if resolved_context is not None:
+                request.session["context_type"] = resolved_context.current_context.type
+                request.session["context_id"] = resolved_context.current_context.id
+                request.session["context_name"] = resolved_context.current_context.name
 
             # Clear any previously selected pretrained worker so we treat this as a fresh custom charter
             request.session.pop(PretrainedWorkerTemplateService.TEMPLATE_SESSION_KEY, None)
@@ -1404,18 +1431,28 @@ class HomeAgentSpawnView(TemplateView):
                     }
                 )
             
-            next_url = reverse('agent_quick_spawn')
             redirect_params = {}
             if return_to:
                 redirect_params["return_to"] = return_to
             if embed:
                 redirect_params["embed"] = "1"
-            if redirect_params:
-                next_url = f"{next_url}?{urlencode(redirect_params)}"
+            if resolved_context is not None:
+                redirect_params["context_type"] = resolved_context.current_context.type
+                redirect_params["context_id"] = resolved_context.current_context.id
 
             if request.user.is_authenticated:
-                # User is already logged in, go directly to agent creation
-                return redirect(next_url)
+                if trial_onboarding_requested and not can_user_use_personal_agents_and_api(request.user):
+                    set_trial_onboarding_intent(
+                        request,
+                        target=trial_onboarding_target,
+                    )
+                    set_trial_onboarding_requires_plan_selection(request, required=True)
+                app_redirect_params = {**redirect_params, "spawn": "1"}
+                app_next_url = append_query_params(
+                    f"{IMMERSIVE_APP_BASE_PATH}/agents/new",
+                    app_redirect_params,
+                )
+                return redirect(app_next_url)
             _track_web_event_for_request(
                 request,
                 event=AnalyticsEvent.PERSISTENT_AGENT_CHARTER_SUBMIT,

--- a/tests/unit/test_pages.py
+++ b/tests/unit/test_pages.py
@@ -1155,6 +1155,53 @@ class HomePageTests(TestCase):
         self.assertEqual(session.get("context_id"), str(user.id))
         self.assertEqual(session.get("agent_charter"), "Custom charter")
 
+    @override_settings(PERSONAL_FREE_TRIAL_ENFORCEMENT_ENABLED=True)
+    def test_authenticated_home_spawn_does_not_set_personal_trial_state_for_org_context(self):
+        user = get_user_model().objects.create_user(
+            username="home_spawn_org_context@example.com",
+            email="home_spawn_org_context@example.com",
+            password="password123",
+        )
+        organization = Organization.objects.create(
+            name="Homepage Spawn Org",
+            slug="homepage-spawn-org",
+            created_by=user,
+        )
+        OrganizationMembership.objects.create(
+            org=organization,
+            user=user,
+            role=OrganizationMembership.OrgRole.OWNER,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+        self.client.force_login(user)
+
+        response = self.client.post(
+            reverse("pages:home_agent_spawn"),
+            {
+                "charter": "Create an org-owned agent",
+                "context_type": "organization",
+                "context_id": str(organization.id),
+                "trial_onboarding": "1",
+                "trial_onboarding_target": TRIAL_ONBOARDING_TARGET_AGENT_UI,
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        parsed = urlparse(response["Location"])
+        self.assertEqual(parsed.path, "/app/agents/new")
+        params = parse_qs(parsed.query)
+        self.assertEqual(params.get("spawn"), ["1"])
+        self.assertEqual(params.get("context_type"), ["organization"])
+        self.assertEqual(params.get("context_id"), [str(organization.id)])
+
+        session = self.client.session
+        self.assertEqual(session.get("context_type"), "organization")
+        self.assertEqual(session.get("context_id"), str(organization.id))
+        self.assertEqual(session.get("agent_charter"), "Create an org-owned agent")
+        self.assertNotIn(TRIAL_ONBOARDING_PENDING_SESSION_KEY, session)
+        self.assertNotIn(TRIAL_ONBOARDING_TARGET_SESSION_KEY, session)
+        self.assertNotIn(TRIAL_ONBOARDING_REQUIRES_PLAN_SELECTION_SESSION_KEY, session)
+
     def test_home_spawn_redirects_to_login(self):
         session = self.client.session
         session["utm_querystring"] = "utm_source=newsletter"

--- a/tests/unit/test_pages.py
+++ b/tests/unit/test_pages.py
@@ -20,6 +20,8 @@ from waffle.testutils import override_flag, override_switch
 from api.models import (
     BrowserUseAgent,
     MCPServerConfig,
+    Organization,
+    OrganizationMembership,
     PersistentAgent,
     PersistentAgentTemplate,
     UserBilling,
@@ -1062,6 +1064,96 @@ class HomePageTests(TestCase):
         self.assertNotIn(PretrainedWorkerTemplateService.TEMPLATE_SESSION_KEY, session)
         self.assertEqual(session["agent_charter_source"], "user")
         self.assertEqual(session["agent_charter"], "Custom charter")
+
+    @override_settings(PERSONAL_FREE_TRIAL_ENFORCEMENT_ENABLED=False)
+    def test_authenticated_home_spawn_redirects_to_app_spawn_flow(self):
+        user = get_user_model().objects.create_user(
+            username="home_spawn_auth@example.com",
+            email="home_spawn_auth@example.com",
+            password="password123",
+        )
+        self.client.force_login(user)
+
+        response = self.client.post(
+            reverse("pages:home_agent_spawn"),
+            {
+                "charter": "Custom charter",
+                "preferred_llm_tier": "premium",
+                "selected_pipedream_app_slugs": ["slack", "trello", "slack"],
+                "return_to": "/",
+                "embed": "1",
+                "trial_onboarding": "1",
+                "trial_onboarding_target": TRIAL_ONBOARDING_TARGET_AGENT_UI,
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        parsed = urlparse(response["Location"])
+        self.assertEqual(parsed.path, "/app/agents/new")
+        params = parse_qs(parsed.query)
+        self.assertEqual(params.get("spawn"), ["1"])
+        self.assertEqual(params.get("return_to"), ["/"])
+        self.assertEqual(params.get("embed"), ["1"])
+        self.assertEqual(params.get("context_type"), ["personal"])
+        self.assertEqual(params.get("context_id"), [str(user.id)])
+
+        session = self.client.session
+        self.assertEqual(session.get("agent_charter"), "Custom charter")
+        self.assertEqual(session.get("agent_charter_source"), "user")
+        self.assertEqual(session.get("context_type"), "personal")
+        self.assertEqual(session.get("context_id"), str(user.id))
+        self.assertEqual(session.get(page_views.PREFERRED_LLM_TIER_SESSION_KEY), "premium")
+        self.assertEqual(
+            session.get(page_views.AGENT_SELECTED_PIPEDREAM_APP_SLUGS_SESSION_KEY),
+            ["slack", "trello"],
+        )
+
+    @override_settings(PERSONAL_FREE_TRIAL_ENFORCEMENT_ENABLED=False)
+    def test_authenticated_home_spawn_respects_posted_personal_context(self):
+        user = get_user_model().objects.create_user(
+            username="home_spawn_context@example.com",
+            email="home_spawn_context@example.com",
+            password="password123",
+        )
+        organization = Organization.objects.create(
+            name="Homepage Context Org",
+            slug="homepage-context-org",
+            created_by=user,
+        )
+        OrganizationMembership.objects.create(
+            org=organization,
+            user=user,
+            role=OrganizationMembership.OrgRole.OWNER,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+        self.client.force_login(user)
+        session = self.client.session
+        session["context_type"] = "organization"
+        session["context_id"] = str(organization.id)
+        session["context_name"] = organization.name
+        session.save()
+
+        response = self.client.post(
+            reverse("pages:home_agent_spawn"),
+            {
+                "charter": "Custom charter",
+                "context_type": "personal",
+                "context_id": str(user.id),
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        parsed = urlparse(response["Location"])
+        self.assertEqual(parsed.path, "/app/agents/new")
+        params = parse_qs(parsed.query)
+        self.assertEqual(params.get("spawn"), ["1"])
+        self.assertEqual(params.get("context_type"), ["personal"])
+        self.assertEqual(params.get("context_id"), [str(user.id)])
+
+        session = self.client.session
+        self.assertEqual(session.get("context_type"), "personal")
+        self.assertEqual(session.get("context_id"), str(user.id))
+        self.assertEqual(session.get("agent_charter"), "Custom charter")
 
     def test_home_spawn_redirects_to_login(self):
         session = self.client.session


### PR DESCRIPTION
## Summary
- Preserve explicit console context when spawning an agent from the homepage.
- Store the resolved context in session and pass it through the app spawn redirect.
- Keep the homepage form and frontend URL handling aligned so authenticated users land in the app with the intended context.
- Add coverage for authenticated spawn redirects and posted context overrides.

## Testing
- Added focused unit tests for authenticated homepage spawn redirect behavior and context persistence.
- Not run (not requested)