### PR TITLE
Remove unneeded feature flags and simplify shell rendering

### DIFF
--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -9,10 +9,8 @@ from datetime import timedelta
 from typing import Any
 
 from django.core.cache import cache
-from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db import DatabaseError, IntegrityError, transaction
 from django.utils import timezone
-from waffle import get_waffle_flag_model
 
 from api.agent.core.llm_config import (
     INPUT_TOKEN_HEADROOM,
@@ -40,7 +38,6 @@ from api.models import (
     PersistentAgentSystemStep,
     PersistentAgentToolCall,
 )
-from constants.feature_flags import PERSISTENT_AGENT_LLM_JUDGE
 from util.analytics import Analytics, AnalyticsEvent, AnalyticsSource
 
 logger = logging.getLogger(__name__)
@@ -706,32 +703,7 @@ def _agent_judge_endpoint_max_input_tokens() -> int | None:
 
 
 def is_agent_judge_enabled_for_agent(agent: PersistentAgent) -> bool:
-    if not getattr(agent, "user_id", None):
-        return False
-
-    try:
-        Flag = get_waffle_flag_model()
-        flag = Flag.objects.get(name=PERSISTENT_AGENT_LLM_JUDGE)
-    except ObjectDoesNotExist:
-        return False
-    except (DatabaseError, ImproperlyConfigured):
-        logger.exception(
-            "Failed loading waffle flag '%s' when evaluating judge eligibility for agent %s",
-            PERSISTENT_AGENT_LLM_JUDGE,
-            getattr(agent, "id", None),
-        )
-        return False
-
-    try:
-        return bool(flag.is_active_for_user(agent.user))
-    except (DatabaseError, ImproperlyConfigured, AttributeError):
-        logger.exception(
-            "Error evaluating waffle flag '%s' for user %s (agent %s)",
-            PERSISTENT_AGENT_LLM_JUDGE,
-            getattr(agent, "user_id", None),
-            getattr(agent, "id", None),
-        )
-        return False
+    return bool(getattr(agent, "user_id", None))
 
 
 def _trigger_reasons(

--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -703,7 +703,7 @@ def _agent_judge_endpoint_max_input_tokens() -> int | None:
 
 
 def is_agent_judge_enabled_for_agent(agent: PersistentAgent) -> bool:
-    return bool(getattr(agent, "user_id", None))
+    return bool(agent.user_id)
 
 
 def _trigger_reasons(

--- a/api/migrations/0407_remove_always_on_waffle_rows.py
+++ b/api/migrations/0407_remove_always_on_waffle_rows.py
@@ -1,0 +1,39 @@
+from django.db import migrations
+
+
+FLAG_NAMES = (
+    "pricing_free_oss_plan",
+    "persistent_agent_llm_judge",
+    "persistent_agent_planning_mode",
+    "personal_agent_signup_starter_charter",
+    "fish_homepage",
+    "fish_upper_left",
+    "multiplayer_agents",
+)
+
+SWITCH_NAMES = (
+    "fish_collateral",
+)
+
+
+def remove_obsolete_waffle_rows(apps, schema_editor):
+    Flag = apps.get_model("waffle", "Flag")
+    Switch = apps.get_model("waffle", "Switch")
+
+    Flag.objects.filter(name__in=FLAG_NAMES).delete()
+    Switch.objects.filter(name__in=SWITCH_NAMES).delete()
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0406_persistentagentcompletion_time_to_first_token_ms"),
+        ("waffle", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_obsolete_waffle_rows, noop),
+    ]

--- a/api/services/persistent_agents.py
+++ b/api/services/persistent_agents.py
@@ -6,13 +6,11 @@ from typing import Optional
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
-from django.http import HttpRequest
 from django.utils.crypto import get_random_string
 
 from agent_namer import AgentNameGenerator
 from agents.services import PretrainedWorkerTemplateService, AgentService
 
-from constants.feature_flags import PERSISTENT_AGENT_PLANNING_MODE
 from api.agent.core.llm_config import resolve_intelligence_tier_for_owner
 from api.agent.avatar import maybe_schedule_agent_avatar
 from api.agent.short_description import (
@@ -36,7 +34,6 @@ from api.services.daily_credit_limits import (
     get_tier_credit_multiplier,
 )
 from api.services.daily_credit_settings import get_daily_credit_settings_for_owner
-from util.waffle_flags import is_waffle_flag_active
 
 
 logger = logging.getLogger(__name__)
@@ -62,11 +59,7 @@ class PersistentAgentProvisioningService:
 
     @staticmethod
     def _default_planning_state(user) -> str:
-        request = HttpRequest()
-        request.user = user
-        if is_waffle_flag_active(PERSISTENT_AGENT_PLANNING_MODE, request, default=True):
-            return PersistentAgent.PlanningState.PLANNING
-        return PersistentAgent.PlanningState.SKIPPED
+        return PersistentAgent.PlanningState.PLANNING
 
     @classmethod
     def generate_unique_name(cls, user, *, max_attempts: int | None = None) -> str:

--- a/config/settings.py
+++ b/config/settings.py
@@ -455,7 +455,6 @@ TEMPLATES = [
                 "pages.context_processors.environment_info",
                 "pages.context_processors.show_signup_tracking",
                 "pages.context_processors.mini_mode",
-                "pages.context_processors.fish_collateral",
                 "pages.context_processors.analytics",
                 "pages.context_processors.llm_bootstrap",
                 "pages.context_processors.canonical_url",

--- a/console/templates/console/react_shell_base.html
+++ b/console/templates/console/react_shell_base.html
@@ -8,15 +8,9 @@
   <meta name="csrf-cookie-name" content="{{ settings.CSRF_COOKIE_NAME|default:'csrftoken' }}">
   {% include "partials/_csrf_helpers.html" %}
   <title>{% block page_title %}Gobii Console{% endblock %}</title>
-  {% if fish_collateral_enabled %}
-    <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/gobii_fish_favicon_32.png' %}" />
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/gobii_fish_favicon_16.png' %}" />
-    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/gobii_fish_apple_touch_180.png' %}" />
-  {% else %}
-    <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/favicon-32x32.png' %}" />
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/favicon-16x16.png' %}" />
-    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/apple-touch-icon.png' %}" />
-  {% endif %}
+  <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/gobii_fish_favicon_32.png' %}" />
+  <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/gobii_fish_favicon_16.png' %}" />
+  <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/gobii_fish_apple_touch_180.png' %}" />
   <link rel="preconnect" href="https://cdnjs.cloudflare.com">
   {% if settings.GOBII_PROPRIETARY_MODE %}
   <link rel="preconnect" href="https://js.stripe.com">
@@ -28,11 +22,7 @@
   {% if settings.GOBII_PROPRIETARY_MODE %}
   <script async src="https://js.stripe.com/dahlia/stripe.js"></script>
   {% endif %}
-  {% if fish_collateral_enabled %}
-    <link rel="preload" as="image" href="{% static 'images/gobii_fish.png' %}" />
-  {% else %}
-    <link rel="preload" as="image" href="{% static 'images/noBgBlue.png' %}" />
-  {% endif %}
+  <link rel="preload" as="image" href="{% static 'images/gobii_fish.png' %}" />
   <link rel="stylesheet" href="{% static 'css/custom_fonts.css' %}">
   <link rel="stylesheet" href="{% static 'css/pygments.css' %}">
   <link rel="stylesheet" href="{% static 'css/globals.css' %}">

--- a/constants/feature_flags.py
+++ b/constants/feature_flags.py
@@ -1,7 +1,6 @@
 # constants/feature_flags.py
 PERSISTENT_AGENTS = "persistent_agents"
 ORGANIZATIONS = "organizations"
-MULTIPLAYER_AGENTS = "multiplayer_agents"
 
 # Soft-expiration for free-plan agents that go inactive
 AGENT_SOFT_EXPIRATION = "agent_soft_expiration"
@@ -12,9 +11,6 @@ AGENT_CRON_THROTTLE = "agent_cron_throttle"
 # Route /support form submissions to Intercom-style email intake.
 SUPPORT_INTERCOM = "support_intercom"
 
-
-# Controls favicon/logo collateral assets across templates and app shell
-FISH_COLLATERAL = "fish_collateral"
 
 # Controls whether the pricing upgrade modal renders in an almost full-screen layout.
 PRICING_MODAL_ALMOST_FULL_SCREEN = "pricing_modal_almost_full_screen"
@@ -38,9 +34,6 @@ CTA_CONTINUE_AGENT_BTN = "cta_continue_agent_btn"
 # Controls whether pricing trial CTA helper text emphasizes no charge during the trial.
 CTA_NO_CHARGE_DURING_TRIAL = "cta_no_charge_during_trial"
 
-# Controls whether /pricing shows the open-source self-serve Free option.
-PRICING_FREE_OSS_PLAN = "pricing_free_oss_plan"
-
 # Controls whether anonymous marketing CTA flows go to signup before continuing.
 CTA_SIGNUP_FIRST = "cta_signup_first"
 
@@ -49,10 +42,6 @@ CTA_SIGNUP_MODAL = "cta_signup_modal"
 
 # Controls crawlable related links on dedicated /solutions/* marketing pages.
 SOLUTION_CRAWLABLE_LINKS = "solution_crawlable_links"
-
-# Controls whether personal no-plan users get a built-in starter charter when
-# entering immersive new-agent flow without saved draft state.
-PERSONAL_AGENT_SIGNUP_STARTER_CHARTER = "personal_agent_signup_starter_charter"
 
 # Controls whether personal no-plan users see the signup preview UI in immersive
 # chat instead of the pricing modal / standard composer flow.
@@ -141,9 +130,8 @@ STRIPE_CHECKOUT_TOS_CONSENT_REQUIRED = "stripe_checkout_tos_consent_required"
 # defers non-critical animation setup.
 HOMEPAGE_PERF_MOTION_REDUCTION = "homepage_perf_motion_reduction"
 
-# Are we allow to send to multiple comm points at once - NOTE THIS IS NOT THE SAME AS MULTIPLAYER_AGENTS
-# This is a switch to send to multiple comms points at once, such as email and sms, or multiple emails. has to be a
-# switch not flag
+# This is a switch to send to multiple comms points at once, such as email and sms, or multiple emails. It has to be a
+# switch, not a flag.
 MULTISEND_ENABLED = "multisend_enabled"
 
 # Requires additional SMS contacts to declare compliance metadata before
@@ -161,9 +149,3 @@ OWNER_EXECUTION_PAUSE_ON_TRIAL_CONVERSION_FAILED = (
 # iMessage-style simplified chat UI — collapses non-message events into compact pills
 SIMPLIFIED_CHAT_UI = "simplified_chat_ui"
 SIMPLIFIED_CHAT_DEFAULT_CONVERSATIONAL = "simplified_chat_default_conversational"
-
-# Controls whether newly provisioned persistent agents start in prompt-led planning mode.
-PERSISTENT_AGENT_PLANNING_MODE = "persistent_agent_planning_mode"
-
-# Controls whether persistent agents run the advisory LLM trajectory judge.
-PERSISTENT_AGENT_LLM_JUDGE = "persistent_agent_llm_judge"

--- a/frontend/src/components/agentChat/ChatSidebar.tsx
+++ b/frontend/src/components/agentChat/ChatSidebar.tsx
@@ -195,15 +195,8 @@ export const ChatSidebar = memo(function ChatSidebar({
     }
   }, [createAgentDisabled, isMobile, onBlockedCreateAgent, onCreateAgent])
 
-  const fishCollateralEnabled = useMemo(() => {
-    if (typeof document === 'undefined') {
-      return true
-    }
-    const mountNode = document.getElementById('gobii-frontend-root')
-    return mountNode?.dataset.fishCollateralEnabled !== 'false'
-  }, [])
-  const sidebarLogoSrc = fishCollateralEnabled ? '/static/images/gobii_fish.png' : '/static/images/noBgWhite.png'
-  const sidebarLogoAlt = fishCollateralEnabled ? 'Gobii Fish' : 'Gobii'
+  const sidebarLogoSrc = '/static/images/gobii_fish.png'
+  const sidebarLogoAlt = 'Gobii Fish'
 
   const activeAgent = useMemo(
     () => agents.find((agent) => agent.id === activeAgentId) ?? null,

--- a/middleware/app_shell.py
+++ b/middleware/app_shell.py
@@ -12,7 +12,6 @@ from django.urls import reverse
 from api.services.system_settings import get_max_file_size
 from config.vite import ViteManifestError, get_vite_asset
 from util.integrations import pipedream_status
-from util.fish_collateral import is_fish_collateral_enabled
 
 APP_PATH_PREFIX = "/app"
 APP_PROTECTED_PATH_PREFIX = f"{APP_PATH_PREFIX}/agents"
@@ -182,7 +181,7 @@ def _format_pixel_loaders() -> str:
     return "\n  ".join(snippets) if snippets else ""
 
 
-def _build_shell_html(*, fish_collateral_enabled: bool) -> str:
+def _build_shell_html() -> str:
     vite_tags = _format_vite_tags()
     segment_snippet = _format_segment_snippet()
     pixel_loaders = _format_pixel_loaders()
@@ -190,8 +189,7 @@ def _build_shell_html(*, fish_collateral_enabled: bool) -> str:
     segment_bootstrap_js = static("js/segment_bootstrap.js")
     analytics_js = static("js/gobii_analytics.js")
     signup_tracking_js = static("js/signup_tracking.js")
-    icon_url = static("images/gobii_fish.png") if fish_collateral_enabled else static("images/noBgBlue.png")
-    fish_collateral_data_attr = "true" if fish_collateral_enabled else "false"
+    icon_url = static("images/gobii_fish.png")
     fonts_css = static("css/custom_fonts.css")
     pygments_css = static("css/pygments.css")
     globals_css = static("css/globals.css")
@@ -242,7 +240,7 @@ def _build_shell_html(*, fish_collateral_enabled: bool) -> str:
   {vite_tags}
 </head>
 <body class="min-h-screen bg-white">
-  <div id="gobii-frontend-root" data-app="immersive-app" data-fish-collateral-enabled="{fish_collateral_data_attr}"{max_chat_upload_size_attr}{native_integrations_attr}{pipedream_attrs}></div>
+  <div id="gobii-frontend-root" data-app="immersive-app"{max_chat_upload_size_attr}{native_integrations_attr}{pipedream_attrs}></div>
 </body>
 </html>"""
 
@@ -254,7 +252,6 @@ class AppShellMiddleware:
         self.get_response = get_response
         self._cached_shell = None
         self._cached_etag = None
-        self._cached_fish_collateral_enabled = None
 
     def __call__(self, request):
         if request.method in {"GET", "HEAD"}:
@@ -283,16 +280,10 @@ class AppShellMiddleware:
 
             process_billing_return(request)
 
-        fish_collateral_enabled = is_fish_collateral_enabled()
-        if (
-            self._cached_shell is None
-            or settings.DEBUG
-            or self._cached_fish_collateral_enabled != fish_collateral_enabled
-        ):
-            self._cached_shell = _build_shell_html(fish_collateral_enabled=fish_collateral_enabled)
+        if self._cached_shell is None or settings.DEBUG:
+            self._cached_shell = _build_shell_html()
             digest = hashlib.sha256(self._cached_shell.encode("utf-8")).hexdigest()
             self._cached_etag = f"\"{digest}\""
-            self._cached_fish_collateral_enabled = fish_collateral_enabled
 
         request_etag = request.headers.get("If-None-Match")
         if self._etag_matches(request_etag):

--- a/pages/context_processors.py
+++ b/pages/context_processors.py
@@ -20,7 +20,6 @@ from pages.account_info_cache import (
 from pages.mini_mode import is_mini_mode_enabled
 from tasks.services import TaskCreditService
 from util.analytics import AnalyticsEvent, AnalyticsCTAs, Analytics
-from util.fish_collateral import is_fish_collateral_enabled
 from util.subscription_helper import (
     reconcile_user_plan_from_stripe,
     get_user_api_rate_limit,
@@ -199,12 +198,6 @@ def mini_mode(request):
     return {
         "mini_mode_enabled": mini_mode_enabled,
         "mini_mode_solutions_header": mini_mode_enabled and request.path.startswith("/solutions/"),
-    }
-
-
-def fish_collateral(request):
-    return {
-        "fish_collateral_enabled": is_fish_collateral_enabled(),
     }
 
 

--- a/pages/templates/home.html
+++ b/pages/templates/home.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load vite_tags %}
-{% load waffle_tags %}
 {% load cta_tags %}
 {% block title %}{{ home_meta_title }}{% endblock %}
 {% block canonical_link %}

--- a/pages/views.py
+++ b/pages/views.py
@@ -139,7 +139,7 @@ from util.attribution_referrers import (
     decode_attribution_value,
 )
 from util.waffle_flags import is_waffle_flag_active, is_waffle_switch_active
-from util.fish_collateral import build_web_manifest_payload, is_fish_collateral_enabled
+from util.fish_collateral import build_web_manifest_payload
 from api.services.pipedream_apps import (
     PipedreamCatalogError,
     PipedreamCatalogService,
@@ -1623,11 +1623,7 @@ class PretrainedWorkerDetailView(ProprietaryPretrainedWorkerOnlyMixin, TemplateV
             reverse('pages:pretrained_worker_detail', kwargs={'slug': self.employee.code})
         )
         home_url = self.request.build_absolute_uri(reverse('pages:home'))
-        default_image_path = (
-            "images/gobii_fish_social_1280x640.png"
-            if is_fish_collateral_enabled()
-            else "images/noBgBlue.png"
-        )
+        default_image_path = "images/gobii_fish_social_1280x640.png"
         default_social_image_url = self.request.build_absolute_uri(static(default_image_path))
         seo_description = (self.employee.description or self.employee.tagline or "").strip()
         social_title = f"{self.employee.display_name} AI Agent Template"
@@ -2589,9 +2585,7 @@ def health_check(request):
 
 class WebManifestView(View):
     def get(self, request, *args, **kwargs):
-        payload = build_web_manifest_payload(
-            fish_collateral_enabled=is_fish_collateral_enabled(),
-        )
+        payload = build_web_manifest_payload()
         response = JsonResponse(payload, content_type="application/manifest+json")
         response["Cache-Control"] = "public, max-age=3600"
         session = getattr(request, "session", None)

--- a/proprietary/templates/home/_hero.html
+++ b/proprietary/templates/home/_hero.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% load waffle_tags %}
 
 {% if settings.GOBII_PROPRIETARY_MODE %}
 <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 md:gap-6 mb-6 lg:max-w-3xl mx-auto">
@@ -15,15 +14,11 @@
     <p class="mt-4 text-lg text-gray-500 md:max-w-md">Email&nbsp;them <i data-lucide="mail" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>. Text&nbsp;them <i data-lucide="message-square" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>. They work <span class="font-medium text-violet-600">24/7</span>.</p>
   </div>
   <div class="flex justify-center md:block flex-shrink-0 order-first md:order-last">
-    {% flag "fish_homepage" %}
-      <div class="gobii-hero-fish-cursor" data-gobii-fish-cursor>
-        <div class="gobii-hero-fish" role="img" aria-label="Gobii AI mascot, an animated fish, swimming on the homepage">
-          {% include "home/_gobii_fish.svg" %}
-        </div>
+    <div class="gobii-hero-fish-cursor" data-gobii-fish-cursor>
+      <div class="gobii-hero-fish" role="img" aria-label="Gobii AI mascot, an animated fish, swimming on the homepage">
+        {% include "home/_gobii_fish.svg" %}
       </div>
-    {% else %}
-      <img src="{% static 'images/undraw/texting.svg' %}" alt="A person texting their AI agent" width="784" height="582" class="w-[140px] sm:w-[180px] md:w-[220px] lg:w-[280px]" loading="lazy">
-    {% endflag %}
+    </div>
   </div>
 </div>
 {% else %}

--- a/proprietary/templates/pricing.html
+++ b/proprietary/templates/pricing.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load static %}
-{% load waffle_tags %}
 {% load cta_tags %}
 {% block title %}Pricing - Gobii{% endblock %}
 {% block head_extras %}

--- a/proprietary/views.py
+++ b/proprietary/views.py
@@ -12,6 +12,7 @@ from django.template.loader import render_to_string
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import strip_tags, escape
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 from django.core.mail import send_mail, BadHeaderError, EmailMultiAlternatives
 
@@ -422,27 +423,27 @@ class PricingView(ProprietaryModeRequiredMixin, TemplateView):
             0,
             {
                 "code": "free_oss",
-                "name": "Free",
+                "name": _("Free"),
                 "price": 0,
                 "price_label": "$0",
                 "price_prefix": "$",
                 "price_amount": 0,
-                "desc": "Self-Hosted Agents",
+                "desc": _("Self-Hosted Agents"),
                 "tasks": None,
-                "pricing_model": "Self-hosted, open source",
+                "pricing_model": _("Self-hosted, open source"),
                 "highlight": False,
-                "badge": "Open source",
+                "badge": _("Open source"),
                 "disabled": False,
                 "cta_disabled": False,
                 "current_plan": False,
                 "trial_cancel_text": None,
                 "features": [
-                    "Run on your own computer or server",
-                    "Bring your own AI models",
-                    "Always-on agents with browser automation",
-                    "Open source and MIT licensed",
+                    _("Run on your own computer or server"),
+                    _("Bring your own AI models"),
+                    _("Always-on agents with browser automation"),
+                    _("Open source and MIT licensed"),
                 ],
-                "cta": "View on GitHub",
+                "cta": _("View on GitHub"),
                 "cta_url": "https://github.com/gobii-ai/gobii-platform",
                 "cta_icon": "github",
                 "cta_variant": "outline",

--- a/proprietary/views.py
+++ b/proprietary/views.py
@@ -25,13 +25,11 @@ from api.services.trial_abuse import (
     evaluate_user_trial_eligibility,
     user_has_prior_individual_history,
 )
-from util.fish_collateral import is_fish_collateral_enabled
 from constants.feature_flags import (
     CTA_NO_CHARGE_DURING_TRIAL,
     CTA_PRICING_CANCEL_TEXT_UNDER_BTN,
     CTA_START_FREE_TRIAL,
     CTA_UNLOCK_AGENT_COPY,
-    PRICING_FREE_OSS_PLAN,
     SUPPORT_INTERCOM,
 )
 from util.trial_eligibility import (
@@ -239,12 +237,6 @@ class PricingView(ProprietaryModeRequiredMixin, TemplateView):
             self.request,
             default=False,
         )
-        show_free_oss_plan = is_waffle_flag_active(
-            PRICING_FREE_OSS_PLAN,
-            self.request,
-            default=False,
-        )
-
         def _trial_cta(days: int, label: str) -> str:
             if days > 0 and trial_eligible:
                 if cta_unlock_agent_copy:
@@ -426,44 +418,43 @@ class PricingView(ProprietaryModeRequiredMixin, TemplateView):
             },
         ]
 
-        if show_free_oss_plan:
-            pricing_plans.insert(
-                0,
-                {
-                    "code": "free_oss",
-                    "name": "Free",
-                    "price": 0,
-                    "price_label": "$0",
-                    "price_prefix": "$",
-                    "price_amount": 0,
-                    "desc": "Self-Hosted Agents",
-                    "tasks": None,
-                    "pricing_model": "Self-hosted, open source",
-                    "highlight": False,
-                    "badge": "Open source",
-                    "disabled": False,
-                    "cta_disabled": False,
-                    "current_plan": False,
-                    "trial_cancel_text": None,
-                    "features": [
-                        "Run on your own computer or server",
-                        "Bring your own AI models",
-                        "Always-on agents with browser automation",
-                        "Open source and MIT licensed",
-                    ],
-                    "cta": "View on GitHub",
-                    "cta_url": "https://github.com/gobii-ai/gobii-platform",
-                    "cta_icon": "github",
-                    "cta_variant": "outline",
-                    "external": True,
-                    "signup_modal": False,
-                    "analytics_cta_id": "pricing_free_oss_plan",
-                    "analytics_intent": "view_open_source",
-                },
-            )
+        pricing_plans.insert(
+            0,
+            {
+                "code": "free_oss",
+                "name": "Free",
+                "price": 0,
+                "price_label": "$0",
+                "price_prefix": "$",
+                "price_amount": 0,
+                "desc": "Self-Hosted Agents",
+                "tasks": None,
+                "pricing_model": "Self-hosted, open source",
+                "highlight": False,
+                "badge": "Open source",
+                "disabled": False,
+                "cta_disabled": False,
+                "current_plan": False,
+                "trial_cancel_text": None,
+                "features": [
+                    "Run on your own computer or server",
+                    "Bring your own AI models",
+                    "Always-on agents with browser automation",
+                    "Open source and MIT licensed",
+                ],
+                "cta": "View on GitHub",
+                "cta_url": "https://github.com/gobii-ai/gobii-platform",
+                "cta_icon": "github",
+                "cta_variant": "outline",
+                "external": True,
+                "signup_modal": False,
+                "analytics_cta_id": "pricing_free_oss_plan",
+                "analytics_intent": "view_open_source",
+            },
+        )
 
         context["pricing_plans"] = pricing_plans
-        context["pricing_grid_has_free_oss_plan"] = show_free_oss_plan
+        context["pricing_grid_has_free_oss_plan"] = True
 
         # Plan limits pulled from plan configuration to keep the table in sync
         max_contacts_per_agent = [
@@ -859,12 +850,8 @@ class BlogIndexView(ProprietaryModeRequiredMixin, TemplateView):
         )
 
         canonical_url = self.request.build_absolute_uri(self.request.path)
-        if is_fish_collateral_enabled():
-            brand_logo_path = "images/gobii_fish.png"
-            default_image_path = "images/gobii_fish_social_1280x640.png"
-        else:
-            brand_logo_path = "images/noBgBlue.png"
-            default_image_path = "images/noBgBlue.png"
+        brand_logo_path = "images/gobii_fish.png"
+        default_image_path = "images/gobii_fish_social_1280x640.png"
         brand_logo_url = self.request.build_absolute_uri(static(brand_logo_path))
         default_image_url = self.request.build_absolute_uri(static(default_image_path))
 
@@ -953,12 +940,8 @@ class BlogPostView(ProprietaryModeRequiredMixin, TemplateView):
 
         context = super().get_context_data(**kwargs)
         canonical_url = self.request.build_absolute_uri(self.request.path)
-        if is_fish_collateral_enabled():
-            brand_logo_path = "images/gobii_fish.png"
-            default_image_path = "images/gobii_fish_social_1280x640.png"
-        else:
-            brand_logo_path = "images/noBgBlue.png"
-            default_image_path = "images/noBgBlue.png"
+        brand_logo_path = "images/gobii_fish.png"
+        default_image_path = "images/gobii_fish_social_1280x640.png"
         default_image_alt = "Gobii logo"
         brand_logo_url = self.request.build_absolute_uri(static(brand_logo_path))
         default_image_url = self.request.build_absolute_uri(static(default_image_path))

--- a/setup/templates/setup/wizard.html
+++ b/setup/templates/setup/wizard.html
@@ -56,11 +56,7 @@
     <main class="relative mx-auto max-w-6xl px-4 py-12 sm:px-8 sm:py-16 lg:px-12 lg:py-20">
       <div class="rounded-[2.5rem] border border-white/70 bg-white/95 p-8 shadow-panel ring-1 ring-brand-50/50 backdrop-blur-xl sm:p-12 lg:p-14">
         <header class="mb-12 space-y-6">
-          {% if fish_collateral_enabled %}
-            <img src="{% static 'images/gobii_fish_with_text_purple_nav.png' %}" alt="Gobii Fish" class="h-9 w-auto">
-          {% else %}
-            <img src="{% static 'images/noBgBlue.png' %}" alt="Gobii" class="h-9 w-auto">
-          {% endif %}
+          <img src="{% static 'images/gobii_fish_with_text_purple_nav.png' %}" alt="Gobii Fish" class="h-9 w-auto">
           <div class="space-y-2">
             <p class="text-[11px] font-medium uppercase tracking-[0.32em] text-brand-400">First-run setup</p>
             <h1 class="text-3xl font-medium tracking-tight text-slate-900/90 sm:text-[2.5rem]">Welcome to Gobii</h1>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,6 @@
 {% load static %}
 {% load django_htmx %}
 {% load analytics_tags %}
-{% load waffle_tags %}
 <!doctype html>
 <html lang="en">
 <head>
@@ -33,17 +32,10 @@
   <title>{% block title %}Gobii{% endblock %}</title>
 {% endif %}
   <!-- Favicon -->
-  {% if fish_collateral_enabled %}
-    <link rel="icon" href="{% static 'images/gobii_fish_favicon.ico' %}?v=5" sizes="any">
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/gobii_fish_favicon_16.png' %}?v=5">
-    <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/gobii_fish_favicon_32.png' %}?v=5">
-    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/gobii_fish_apple_touch_180.png' %}?v=5">
-  {% else %}
-    <link rel="icon" href="{% static 'images/favicon.ico' %}?v=4" sizes="any">
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/favicon-16x16.png' %}?v=4">
-    <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/favicon-32x32.png' %}?v=4">
-    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/apple-touch-icon.png' %}?v=4">
-  {% endif %}
+  <link rel="icon" href="{% static 'images/gobii_fish_favicon.ico' %}?v=5" sizes="any">
+  <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/gobii_fish_favicon_16.png' %}?v=5">
+  <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/gobii_fish_favicon_32.png' %}?v=5">
+  <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/gobii_fish_apple_touch_180.png' %}?v=5">
 
   <meta name="twitter:site"        content="@gobii_ai">
 
@@ -282,15 +274,11 @@
 
   {% endif %}
   <!-- Preload logo to prevent flicker -->
-  {% flag "fish_upper_left" %}
-    <link rel="preload"
-          as="image"
-          type="image/webp"
-          href="{% static 'images/gobii_fish_with_text_purple_nav_2x.webp' %}"
-          imagesrcset="{% static 'images/gobii_fish_with_text_purple_nav_1x.webp' %} 1x, {% static 'images/gobii_fish_with_text_purple_nav_2x.webp' %} 2x, {% static 'images/gobii_fish_with_text_purple_nav_3x.webp' %} 3x">
-  {% else %}
-    <link rel="preload" as="image" href="{% static 'images/noBgIndigo600.png' %}" />
-  {% endflag %}
+  <link rel="preload"
+        as="image"
+        type="image/webp"
+        href="{% static 'images/gobii_fish_with_text_purple_nav_2x.webp' %}"
+        imagesrcset="{% static 'images/gobii_fish_with_text_purple_nav_1x.webp' %} 1x, {% static 'images/gobii_fish_with_text_purple_nav_2x.webp' %} 2x, {% static 'images/gobii_fish_with_text_purple_nav_3x.webp' %} 3x">
   
   <style>
     [x-cloak] { display: none !important; }

--- a/templates/includes/_header_logo_image.html
+++ b/templates/includes/_header_logo_image.html
@@ -1,23 +1,11 @@
 {% load static %}
-{% load waffle_tags %}
 
-{% flag "fish_upper_left" %}
-  <img src="{% static 'images/gobii_fish_with_text_purple_nav_2x.webp' %}"
-       srcset="{% static 'images/gobii_fish_with_text_purple_nav_1x.webp' %} 1x, {% static 'images/gobii_fish_with_text_purple_nav_2x.webp' %} 2x, {% static 'images/gobii_fish_with_text_purple_nav_3x.webp' %} 3x"
-       alt="Gobii Fish Wordmark"
-       class="h-10 w-auto"
-       width="108"
-       height="40"
-       loading="eager"
-       decoding="async"
-       fetchpriority="high">
-{% else %}
-  <img src="{% static 'images/noBgIndigo600.png' %}"
-       alt="Gobii Wordmark"
-       class="h-10 w-auto"
-       width="120"
-       height="40"
-       loading="eager"
-       decoding="async"
-       fetchpriority="high">
-{% endflag %}
+<img src="{% static 'images/gobii_fish_with_text_purple_nav_2x.webp' %}"
+     srcset="{% static 'images/gobii_fish_with_text_purple_nav_1x.webp' %} 1x, {% static 'images/gobii_fish_with_text_purple_nav_2x.webp' %} 2x, {% static 'images/gobii_fish_with_text_purple_nav_3x.webp' %} 3x"
+     alt="Gobii Fish Wordmark"
+     class="h-10 w-auto"
+     width="108"
+     height="40"
+     loading="eager"
+     decoding="async"
+     fetchpriority="high">

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -7,7 +7,6 @@ from django.contrib.auth import get_user_model
 from django.db import DatabaseError
 from django.test import TestCase, tag
 from django.utils import timezone
-from waffle.models import Flag
 
 from api.agent.core.agent_judge import (
     JUDGE_DAILY_RUN_LIMIT,
@@ -47,7 +46,6 @@ from api.models import (
     UserQuota,
 )
 from console.agent_chat.pending_actions import list_pending_action_requests
-from constants.feature_flags import PERSISTENT_AGENT_LLM_JUDGE
 from util.analytics import AnalyticsEvent
 
 
@@ -84,17 +82,6 @@ class AgentJudgeTests(TestCase):
         quota, _ = UserQuota.objects.get_or_create(user=cls.user)
         quota.agent_limit = 50
         quota.save()
-        Flag.objects.update_or_create(
-            name=PERSISTENT_AGENT_LLM_JUDGE,
-            defaults={
-                "everyone": True,
-                "percent": 0,
-                "superusers": False,
-                "staff": False,
-                "authenticated": False,
-            },
-        )
-
     def setUp(self):
         browser_agent = BrowserUseAgent.objects.create(
             user=self.user,
@@ -161,39 +148,7 @@ class AgentJudgeTests(TestCase):
 
         self.assertIsNone(trigger)
 
-    def test_disabled_waffle_flag_blocks_judge(self):
-        Flag.objects.update_or_create(
-            name=PERSISTENT_AGENT_LLM_JUDGE,
-            defaults={
-                "everyone": False,
-                "percent": 0,
-                "superusers": False,
-                "staff": False,
-                "authenticated": False,
-            },
-        )
-        self._add_steps(40)
-
-        self.assertFalse(is_agent_judge_enabled_for_agent(self.agent))
-        self.assertIsNone(build_judge_trigger(self.agent, tools=[]))
-
-        with patch("api.agent.core.agent_judge.get_agent_judge_llm_config") as config_mock:
-            maybe_run_agent_judge(self.agent, tools=[])
-
-        config_mock.assert_not_called()
-
-    def test_user_specific_waffle_flag_enables_judge(self):
-        flag, _ = Flag.objects.update_or_create(
-            name=PERSISTENT_AGENT_LLM_JUDGE,
-            defaults={
-                "everyone": None,
-                "percent": 0,
-                "superusers": False,
-                "staff": False,
-                "authenticated": False,
-            },
-        )
-        flag.users.add(self.user)
+    def test_agent_with_user_is_judge_enabled(self):
         self._add_failed_tool_trigger()
 
         self.assertTrue(is_agent_judge_enabled_for_agent(self.agent))

--- a/tests/unit/test_agent_planning_mode.py
+++ b/tests/unit/test_agent_planning_mode.py
@@ -4,7 +4,6 @@ from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings, tag
 from django.urls import reverse
-from waffle.testutils import override_flag
 
 from api.agent.core.processing_flags import get_human_inbound_generation
 from api.agent.core.prompt_context import _get_system_instruction, build_prompt_context
@@ -12,7 +11,6 @@ from api.agent.tools.planning import execute_end_planning
 from api.agent.tools.schedule_updater import execute_update_schedule
 from api.agent.tools.static_tools import PLANNING_MODE_DISABLED_TOOL_NAMES, get_static_tool_definitions
 from api.agent.tools.tool_runtime import execute_runtime_tool_call
-from constants.feature_flags import PERSISTENT_AGENT_PLANNING_MODE
 from api.models import (
     BrowserUseAgent,
     CommsChannel,
@@ -80,24 +78,13 @@ class PersistentAgentPlanningModeTests(TestCase):
 
         self.assertEqual(result.agent.planning_state, PersistentAgent.PlanningState.PLANNING)
 
-    def test_provisioning_skips_planning_when_flag_off(self):
-        with override_flag(PERSISTENT_AGENT_PLANNING_MODE, active=False):
-            result = PersistentAgentProvisioningService.provision(
-                user=self.user,
-                name="Provisioned Nonplanning Agent",
-                charter="Research product leads",
-            )
-
-        self.assertEqual(result.agent.planning_state, PersistentAgent.PlanningState.SKIPPED)
-
     def test_explicit_planning_state_overrides_planning_flag(self):
-        with override_flag(PERSISTENT_AGENT_PLANNING_MODE, active=True):
-            result = PersistentAgentProvisioningService.provision(
-                user=self.user,
-                name="Explicitly Skipped Planning Agent",
-                charter="Research product leads",
-                planning_state=PersistentAgent.PlanningState.SKIPPED,
-            )
+        result = PersistentAgentProvisioningService.provision(
+            user=self.user,
+            name="Explicitly Skipped Planning Agent",
+            charter="Research product leads",
+            planning_state=PersistentAgent.PlanningState.SKIPPED,
+        )
 
         self.assertEqual(result.agent.planning_state, PersistentAgent.PlanningState.SKIPPED)
 

--- a/tests/unit/test_agent_planning_mode.py
+++ b/tests/unit/test_agent_planning_mode.py
@@ -78,7 +78,7 @@ class PersistentAgentPlanningModeTests(TestCase):
 
         self.assertEqual(result.agent.planning_state, PersistentAgent.PlanningState.PLANNING)
 
-    def test_explicit_planning_state_overrides_planning_flag(self):
+    def test_explicit_planning_state_overrides_default(self):
         result = PersistentAgentProvisioningService.provision(
             user=self.user,
             name="Explicitly Skipped Planning Agent",

--- a/tests/unit/test_blog_seo.py
+++ b/tests/unit/test_blog_seo.py
@@ -70,7 +70,7 @@ class BlogSeoTests(TestCase):
         og_image = soup.find("meta", property="og:image")["content"]
         og_image_alt = soup.find("meta", property="og:image:alt")["content"]
 
-        self.assertTrue(og_image.endswith("/static/images/noBgBlue.png"))
+        self.assertTrue(og_image.endswith("/static/images/gobii_fish_social_1280x640.png"))
         self.assertEqual(og_image_alt, "Gobii logo")
         self.assertEqual(
             soup.find("meta", attrs={"name": "twitter:image:alt"})["content"],

--- a/tests/unit/test_google_analytics_pages.py
+++ b/tests/unit/test_google_analytics_pages.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings, tag
 from django.urls import reverse
-from waffle.testutils import override_switch
 
 
 User = get_user_model()
@@ -155,21 +154,8 @@ class GoogleAnalyticsRenderingTests(TestCase):
         self.assertIn("enabled: false,", content)
 
     @tag("batch_pages_signals")
-    def test_base_template_uses_legacy_collateral_when_switch_is_off(self):
-        with override_switch("fish_collateral", active=False):
-            response = self.client.get(reverse("pages:home"))
-        self.assertEqual(response.status_code, 200)
-        content = response.content.decode("utf-8")
-        self.assertIn('/static/images/favicon.ico?v=4', content)
-        self.assertIn('/static/images/favicon-16x16.png?v=4', content)
-        self.assertIn('/static/images/favicon-32x32.png?v=4', content)
-        self.assertIn('/static/images/apple-touch-icon.png?v=4', content)
-        self.assertIn('rel="manifest" href="/manifest.json"', content)
-
-    @tag("batch_pages_signals")
-    def test_base_template_uses_fish_collateral_when_switch_is_on(self):
-        with override_switch("fish_collateral", active=True):
-            response = self.client.get(reverse("pages:home"))
+    def test_base_template_uses_fish_assets(self):
+        response = self.client.get(reverse("pages:home"))
         self.assertEqual(response.status_code, 200)
         content = response.content.decode("utf-8")
         self.assertIn('/static/images/gobii_fish_favicon.ico?v=5', content)
@@ -179,23 +165,11 @@ class GoogleAnalyticsRenderingTests(TestCase):
 
     @tag("batch_pages_signals")
     @override_settings(DEBUG=False, GA_MEASUREMENT_ID="G-TEST123", GOBII_PROPRIETARY_MODE=True)
-    def test_app_shell_uses_legacy_icon_when_switch_is_off(self):
-        with override_switch("fish_collateral", active=False):
-            response = self.client.get("/app")
-        self.assertEqual(response.status_code, 200)
-        content = response.content.decode("utf-8")
-        self.assertIn('href="/static/images/noBgBlue.png"', content)
-        self.assertIn('data-fish-collateral-enabled="false"', content)
-
-    @tag("batch_pages_signals")
-    @override_settings(DEBUG=False, GA_MEASUREMENT_ID="G-TEST123", GOBII_PROPRIETARY_MODE=True)
-    def test_app_shell_uses_fish_icon_when_switch_is_on(self):
-        with override_switch("fish_collateral", active=True):
-            response = self.client.get("/app")
+    def test_app_shell_uses_fish_icon(self):
+        response = self.client.get("/app")
         self.assertEqual(response.status_code, 200)
         content = response.content.decode("utf-8")
         self.assertIn('href="/static/images/gobii_fish.png"', content)
-        self.assertIn('data-fish-collateral-enabled="true"', content)
 
 
 @tag("batch_pages_signals")
@@ -226,20 +200,8 @@ class WebManifestRenderingTests(TestCase):
         self.assertNotIn(settings.FBP_COOKIE_NAME, response.cookies)
         self.assertNotIn(settings.SESSION_COOKIE_NAME, response.cookies)
 
-    def test_manifest_uses_legacy_icons_when_switch_is_off(self):
-        with override_switch("fish_collateral", active=False):
-            response = self.client.get(reverse("pages:web_manifest"))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "application/manifest+json")
-        payload = response.json()
-        self.assertEqual(payload["icons"][0]["src"], "/static/images/favicon-16x16.png")
-        self.assertEqual(payload["icons"][1]["src"], "/static/images/favicon-32x32.png")
-        self.assertEqual(payload["icons"][2]["src"], "/static/images/favicon-192x192.png")
-        self.assertEqual(payload["icons"][3]["src"], "/static/images/gobii_swoosh_white_on_blue_512.png")
-
-    def test_manifest_uses_fish_icons_when_switch_is_on(self):
-        with override_switch("fish_collateral", active=True):
-            response = self.client.get(reverse("pages:web_manifest"))
+    def test_manifest_uses_fish_icons(self):
+        response = self.client.get(reverse("pages:web_manifest"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/manifest+json")
         payload = response.json()

--- a/tests/unit/test_pages.py
+++ b/tests/unit/test_pages.py
@@ -425,20 +425,8 @@ class HomePageTests(TestCase):
         self.assertContains(response, "turnstile/v0/api.js?render=explicit")
 
     @override_settings(GOBII_PROPRIETARY_MODE=True)
-    def test_home_page_uses_legacy_hero_illustration_when_fish_homepage_is_off(self):
-        with override_flag("fish_homepage", active=False):
-            response = self.client.get("/")
-
-        self.assertEqual(response.status_code, 200)
-        soup = BeautifulSoup(response.content.decode("utf-8"), "html.parser")
-        legacy_hero_image = soup.find("img", {"src": "/static/images/undraw/texting.svg"})
-        self.assertIsNotNone(legacy_hero_image)
-        self.assertIsNone(soup.select_one("[data-gobii-fish-cursor]"))
-
-    @override_settings(GOBII_PROPRIETARY_MODE=True)
-    def test_home_page_uses_fish_hero_animation_when_fish_homepage_is_on(self):
-        with override_flag("fish_homepage", active=True):
-            response = self.client.get("/")
+    def test_home_page_uses_fish_hero_animation(self):
+        response = self.client.get("/")
 
         self.assertEqual(response.status_code, 200)
         soup = BeautifulSoup(response.content.decode("utf-8"), "html.parser")
@@ -1530,7 +1518,11 @@ class RecruitingContactPageTests(TestCase):
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response["Location"], "/")
 
-    @override_settings(PUBLIC_CONTACT_EMAIL="hello@gobii.test", SUPPORT_EMAIL="support@gobii.test")
+    @override_settings(
+        PUBLIC_CONTACT_EMAIL="hello@gobii.test",
+        SUPPORT_EMAIL="support@gobii.test",
+        TURNSTILE_ENABLED=False,
+    )
     @patch("pages.views._track_web_event_for_request")
     @patch("pages.views.send_mail")
     def test_recruiting_contact_request_sends_distinct_lead_email(self, mock_send_mail, mock_track_event):
@@ -1881,6 +1873,7 @@ class RobotsTxtTests(TestCase):
 
 @tag("batch_pages")
 class LlmsTxtTests(TestCase):
+    @override_settings(GOBII_PROPRIETARY_MODE=False)
     def test_llms_txt_is_served_from_root_in_community_mode(self):
         response = self.client.get("/llms.txt")
 
@@ -1911,6 +1904,7 @@ class LlmsTxtTests(TestCase):
         self.assertNotContains(response, "http://testserver/pretrained-workers/")
         self.assertNotContains(response, "http://testserver/library/")
 
+    @override_settings(GOBII_PROPRIETARY_MODE=False)
     def test_llms_full_txt_is_served_from_root_in_community_mode(self):
         response = self.client.get("/llms-full.txt")
 
@@ -3153,7 +3147,6 @@ class AgentSpawnIntentApiTests(TestCase):
         self.client.force_login(user)
 
         with (
-            override_flag("personal_agent_signup_starter_charter", active=True),
             override_flag("personal_agent_signup_preview_processing_limit", active=True),
             patch("util.personal_signup_preview.can_user_use_personal_agents_and_api", return_value=False),
         ):
@@ -4457,6 +4450,10 @@ class ProprietaryPricingTrialCopyTests(TestCase):
         view.setup(request)
         return view.get_context_data()
 
+    @staticmethod
+    def _plan_by_id(plans, plan_id):
+        return next(plan for plan in plans if plan["code"] == plan_id)
+
     @patch("proprietary.views.get_user_plan", return_value={"id": PlanNames.FREE})
     @patch("proprietary.views.evaluate_user_trial_eligibility", return_value=SimpleNamespace(decision="no_trial"))
     @patch("proprietary.views.get_stripe_settings")
@@ -4479,8 +4476,8 @@ class ProprietaryPricingTrialCopyTests(TestCase):
 
         context = self._get_pricing_context_for_user(user)
         plans = context["pricing_plans"]
-        self.assertEqual(plans[0]["cta"], "Subscribe to Pro")
-        self.assertEqual(plans[1]["cta"], "Subscribe to Scale")
+        self.assertEqual(self._plan_by_id(plans, PlanNames.STARTUP)["cta"], "Subscribe to Pro")
+        self.assertEqual(self._plan_by_id(plans, PlanNames.SCALE)["cta"], "Subscribe to Scale")
 
     @patch("proprietary.views.get_user_plan", return_value={"id": PlanNames.FREE})
     @patch("proprietary.views.evaluate_user_trial_eligibility", return_value=SimpleNamespace(decision="eligible"))
@@ -4504,8 +4501,8 @@ class ProprietaryPricingTrialCopyTests(TestCase):
 
         context = self._get_pricing_context_for_user(user)
         plans = context["pricing_plans"]
-        self.assertEqual(plans[0]["cta"], "Start 7-day Free Trial")
-        self.assertEqual(plans[1]["cta"], "Start 14-day Free Trial")
+        self.assertEqual(self._plan_by_id(plans, PlanNames.STARTUP)["cta"], "Start 7-day Free Trial")
+        self.assertEqual(self._plan_by_id(plans, PlanNames.SCALE)["cta"], "Start 14-day Free Trial")
 
     @patch("proprietary.views.get_user_plan", return_value={"id": PlanNames.FREE})
     @patch("proprietary.views.evaluate_user_trial_eligibility", return_value=SimpleNamespace(decision="eligible"))
@@ -4531,8 +4528,8 @@ class ProprietaryPricingTrialCopyTests(TestCase):
             context = self._get_pricing_context_for_user(user)
 
         plans = context["pricing_plans"]
-        self.assertEqual(plans[0]["cta"], "Start Free Trial")
-        self.assertEqual(plans[1]["cta"], "Start Free Trial")
+        self.assertEqual(self._plan_by_id(plans, PlanNames.STARTUP)["cta"], "Start Free Trial")
+        self.assertEqual(self._plan_by_id(plans, PlanNames.SCALE)["cta"], "Start Free Trial")
 
 
 @tag("batch_pages")

--- a/tests/unit/test_proprietary_pricing_view.py
+++ b/tests/unit/test_proprietary_pricing_view.py
@@ -7,7 +7,6 @@ from django.urls import reverse
 from waffle.testutils import override_flag
 
 from api.models import EntitlementDefinition, Plan, PlanVersion, PlanVersionEntitlement
-from constants.feature_flags import PRICING_FREE_OSS_PLAN
 from constants.plans import PLAN_SLUG_BY_LEGACY_CODE, PlanNames
 from pages.models import CallToAction
 
@@ -144,7 +143,7 @@ class PricingPageCtaCopyTests(TestCase):
 
     @override_settings(GOBII_PROPRIETARY_MODE=True)
     @patch("proprietary.views.get_stripe_settings")
-    def test_pricing_page_omits_free_oss_plan_when_flag_disabled(
+    def test_pricing_page_renders_free_oss_plan(
         self,
         mock_get_stripe_settings,
     ):
@@ -153,32 +152,7 @@ class PricingPageCtaCopyTests(TestCase):
             scale_trial_days=14,
         )
 
-        with override_flag(PRICING_FREE_OSS_PLAN, active=False):
-            response = self.client.get(reverse("proprietary:pricing"))
-
-        self.assertEqual(response.status_code, 200)
-        plan_codes = [
-            plan["code"]
-            for plan in response.context["pricing_plans"]
-        ]
-        self.assertEqual(plan_codes, [PlanNames.STARTUP, PlanNames.SCALE])
-        self.assertFalse(response.context["pricing_grid_has_free_oss_plan"])
-        self.assertNotContains(response, "View on GitHub")
-        self.assertNotContains(response, 'data-analytics-cta-id="pricing_free_oss_plan"')
-
-    @override_settings(GOBII_PROPRIETARY_MODE=True)
-    @patch("proprietary.views.get_stripe_settings")
-    def test_pricing_page_renders_free_oss_plan_when_flag_enabled(
-        self,
-        mock_get_stripe_settings,
-    ):
-        mock_get_stripe_settings.return_value = SimpleNamespace(
-            startup_trial_days=7,
-            scale_trial_days=14,
-        )
-
-        with override_flag(PRICING_FREE_OSS_PLAN, active=True):
-            response = self.client.get(reverse("proprietary:pricing"))
+        response = self.client.get(reverse("proprietary:pricing"))
 
         self.assertEqual(response.status_code, 200)
         plans = response.context["pricing_plans"]

--- a/tests/unit/test_signup_email_blocklist.py
+++ b/tests/unit/test_signup_email_blocklist.py
@@ -313,8 +313,7 @@ class TrialOnboardingAdapterTests(TestCase):
         middleware.process_request(request)
         request.session.save()
 
-        with override_flag("personal_agent_signup_starter_charter", active=True):
-            redirect_url = get_login_redirect_url(request, signup=True)
+        redirect_url = get_login_redirect_url(request, signup=True)
 
         parsed = urlparse(redirect_url)
         self.assertEqual(parsed.path, f"{IMMERSIVE_APP_BASE_PATH}/agents/new")
@@ -339,9 +338,8 @@ class TrialOnboardingAdapterTests(TestCase):
         middleware.process_request(request)
         request.session.save()
 
-        with override_flag("personal_agent_signup_starter_charter", active=True):
-            context.request = request
-            self.addCleanup(lambda: setattr(context, "request", None))
-            redirect_url = get_login_redirect_url(request, signup=True)
+        context.request = request
+        self.addCleanup(lambda: setattr(context, "request", None))
+        redirect_url = get_login_redirect_url(request, signup=True)
 
         self.assertEqual(redirect_url, next_url)

--- a/util/fish_collateral.py
+++ b/util/fish_collateral.py
@@ -1,17 +1,3 @@
-from django.core.exceptions import ImproperlyConfigured
-from django.db import DatabaseError
-
-from constants.feature_flags import FISH_COLLATERAL
-from waffle import switch_is_active
-
-
-LEGACY_MANIFEST_ICONS = (
-    {"src": "/static/images/favicon-16x16.png", "sizes": "16x16", "type": "image/png"},
-    {"src": "/static/images/favicon-32x32.png", "sizes": "32x32", "type": "image/png"},
-    {"src": "/static/images/favicon-192x192.png", "sizes": "192x192", "type": "image/png"},
-    {"src": "/static/images/gobii_swoosh_white_on_blue_512.png", "sizes": "512x512", "type": "image/png"},
-)
-
 FISH_MANIFEST_ICONS = (
     {"src": "/static/images/gobii_fish_favicon_16.png", "sizes": "16x16", "type": "image/png"},
     {"src": "/static/images/gobii_fish_favicon_32.png", "sizes": "32x32", "type": "image/png"},
@@ -20,14 +6,7 @@ FISH_MANIFEST_ICONS = (
 )
 
 
-def is_fish_collateral_enabled(*, default: bool = False) -> bool:
-    try:
-        return switch_is_active(FISH_COLLATERAL)
-    except (DatabaseError, ImproperlyConfigured):
-        return default
-
-
-def build_web_manifest_payload(*, fish_collateral_enabled: bool) -> dict:
+def build_web_manifest_payload() -> dict:
     return {
         "name": "Gobii",
         "short_name": "Gobii",
@@ -36,5 +15,5 @@ def build_web_manifest_payload(*, fish_collateral_enabled: bool) -> dict:
         "display": "standalone",
         "background_color": "#ffffff",
         "theme_color": "#0ea5e9",
-        "icons": list(FISH_MANIFEST_ICONS if fish_collateral_enabled else LEGACY_MANIFEST_ICONS),
+        "icons": list(FISH_MANIFEST_ICONS),
     }

--- a/util/personal_signup_preview.py
+++ b/util/personal_signup_preview.py
@@ -6,7 +6,6 @@ from django.http import HttpRequest
 from constants.feature_flags import (
     PERSONAL_AGENT_SIGNUP_PREVIEW_PROCESSING_LIMIT,
     PERSONAL_AGENT_SIGNUP_PREVIEW_UI,
-    PERSONAL_AGENT_SIGNUP_STARTER_CHARTER,
 )
 from util.onboarding import clear_trial_onboarding_intent, get_trial_onboarding_state
 from util.trial_enforcement import can_user_use_personal_agents_and_api
@@ -24,7 +23,7 @@ SIGNUP_PREVIEW_EXISTING_AGENT_MESSAGE = (
 class PersonalSignupPreviewConfig:
     current_context_is_personal: bool
     eligible_user: bool
-    starter_charter_flag_enabled: bool
+    starter_charter_available: bool
     ui_flag_enabled: bool
     processing_limit_flag_enabled: bool
 
@@ -34,7 +33,7 @@ class PersonalSignupPreviewConfig:
 
     @property
     def starter_charter_enabled(self) -> bool:
-        return self.current_context_is_eligible and self.starter_charter_flag_enabled
+        return self.current_context_is_eligible and self.starter_charter_available
 
     @property
     def ui_enabled(self) -> bool:
@@ -77,13 +76,6 @@ def is_personal_signup_preview_feature_enabled(
     return is_waffle_flag_active(flag_name, request, default=False)
 
 
-def is_personal_signup_starter_charter_enabled(request: HttpRequest | None = None) -> bool:
-    return is_personal_signup_preview_feature_enabled(
-        PERSONAL_AGENT_SIGNUP_STARTER_CHARTER,
-        request,
-    )
-
-
 def is_personal_signup_preview_ui_enabled(request: HttpRequest | None = None) -> bool:
     return is_personal_signup_preview_feature_enabled(
         PERSONAL_AGENT_SIGNUP_PREVIEW_UI,
@@ -117,7 +109,7 @@ def resolve_personal_signup_preview(
     return PersonalSignupPreviewConfig(
         current_context_is_personal=current_context_type == "personal",
         eligible_user=can_use_personal_signup_preview(user),
-        starter_charter_flag_enabled=is_personal_signup_starter_charter_enabled(request),
+        starter_charter_available=True,
         ui_flag_enabled=is_personal_signup_preview_ui_enabled(request),
         processing_limit_flag_enabled=is_personal_signup_preview_processing_limit_enabled(request),
     )


### PR DESCRIPTION
## Summary
- Remove stale always-on Waffle rows and related flag checks from agent, persistent agent, and shell rendering paths
- Simplify page and template logic around app shell, home, pricing, setup, and header/logo rendering
- Update related utilities and unit coverage to match the reduced flag surface and new behavior

## Testing
- Updated and ran targeted unit coverage for agent judgment, planning mode, pages, pricing, signup blocklist, SEO, and analytics behavior
- Verified the impacted template and view paths through the existing test suite for the changed areas