### PR TITLE
Update homepage sourcing hero copy

### DIFF
--- a/pages/templates/home.html
+++ b/pages/templates/home.html
@@ -224,6 +224,31 @@
       }
     }
 
+    #create-agent-form textarea[name="charter"],
+    #charter-ghost {
+      line-height: 1.6;
+    }
+
+    #create-agent-form textarea[name="charter"] {
+      min-height: 6.75rem;
+      padding: 1rem 1.25rem;
+    }
+
+    #charter-ghost {
+      padding: 1rem 1.25rem;
+    }
+
+    @media (min-width: 640px) {
+      #create-agent-form textarea[name="charter"] {
+        min-height: 6.5rem;
+        padding: 1.125rem 1.5rem;
+      }
+
+      #charter-ghost {
+        padding: 1.125rem 1.5rem;
+      }
+    }
+
     {% if homepage_perf_motion_reduction_enabled %}
     @media (pointer: coarse), (max-width: 767px) {
       .gobii-hero-fish-cursor,
@@ -471,7 +496,7 @@
 
       <!-- Agent Spawn Form -->
       {% if not user.is_authenticated or account.usage.agents_unlimited is True or account.usage.agents_available > 0 %}
-      <div class="max-w-4xl mx-auto relative z-20">
+      <div class="max-w-3xl mx-auto relative z-20">
           <form method="post" name="create-agent-form" id="create-agent-form" action="{% url 'pages:home_agent_spawn' %}" data-authenticated="{{ user.is_authenticated|yesno:'true,false' }}" data-requires-trial="{{ home_spawn_requires_trial|yesno:'true,false' }}" data-immersive-form data-lazy-csrf data-analytics-cta-id="home_hero" data-analytics-placement="hero" data-analytics-intent="spawn_agent">
             <input type="hidden" name="return_to" id="agent-return-to" value="">
             <input type="hidden" name="embed" id="agent-embed" value="{% if user.is_authenticated %}1{% else %}0{% endif %}">
@@ -491,10 +516,10 @@
               <!-- Unified input + button container -->
               <div class="backdrop-blur-2xl bg-white/50 border border-white/60 focus-within:border-indigo-500 rounded-2xl overflow-visible relative shadow-xl transition-all duration-300">
                 <!-- Typing prompt overlay -->
-                <div id="charter-ghost" class="pointer-events-none absolute inset-0 flex px-5 py-4 text-base leading-relaxed text-slate-500 transition-opacity duration-200">
+                <div id="charter-ghost" class="pointer-events-none absolute inset-0 flex text-base leading-relaxed text-slate-500 transition-opacity duration-200">
                   <div>
                     <span>I want my Gobii to</span>
-                    <span id="charter-ghost-text"> find 200 ideal customers and their emails.</span>
+                    <span id="charter-ghost-text"> source qualified leads and companies for my ICP every Monday.</span>
                   </div>
                 </div>
 
@@ -639,13 +664,9 @@
 
                     <button
                       type="submit"
-                      class="magic-cta group inline-flex items-center justify-center gap-x-2 bg-gradient-to-r from-violet-600 to-purple-500 hover:from-violet-700 hover:to-purple-600 border border-transparent text-white text-sm font-semibold rounded-xl focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 py-3 px-4 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-[1.02]"
+                      class="magic-cta group inline-flex items-center justify-center gap-x-2 bg-gradient-to-r from-violet-600 to-purple-500 hover:from-violet-700 hover:to-purple-600 border border-transparent text-white text-sm font-semibold rounded-xl focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 py-3 px-5 shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-[1.02]"
                     >
-                      {% if not user.is_authenticated or home_spawn_requires_trial %}
-                        {% cta_text "cta_homepage_launch_btn_unauth" fallback="Start Free Trial" %}
-                      {% else %}
-                        {% cta_text "cta_homepage_launch_btn_auth" fallback="Spawn Agent" %}
-                      {% endif %}
+                      {% cta_text "cta_homepage_sourcing_btn" fallback="Start Sourcing" %}
                       <svg class="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 18l6-6-6-6"></path>
                       </svg>
@@ -661,6 +682,9 @@
                   </svg>
                   {{ agent_charter_form.charter.errors.0 }}
                 </div>
+              {% endif %}
+              {% if not user.is_authenticated or home_spawn_requires_trial %}
+                <p class="mt-3 text-center text-sm font-medium text-slate-500">7-day free trial.</p>
               {% endif %}
             </div>
 
@@ -1047,22 +1071,16 @@
 
       const homePerf = window.GobiiHomePerf;
       const baseScenarios = [
-        ' find 200 ideal customers and their emails.',
-        ' keep my Salesforce pipeline clean every day.',
-        ' watch new YC and seed startups and add founders to my sheet weekly.',
-        ' track competitor pricing and plan changes daily.',
-        ' pull fresh contacts from company sites and press releases each night.',
-        ' monitor RFP portals for AI and automation opportunities to bid on.',
-        " watch job boards for 'Senior Data Engineer' roles and auto-apply with my profile.",
-        ' track vendor status pages and alert me when SLAs slip.',
-        ' collect buyer intent posts on LinkedIn and Reddit and draft outreach.',
-        ' watch competitor changelogs and docs and summarize product moves weekly.',
-        ' track ecommerce competitors for stock and price changes daily.',
-        ' monitor fintech and regulatory sites and summarize what affects us.',
-        ' help me find a new place to rent.',
-        ' help me find a vacation house.',
-        ' watch for price drops on my wishlist items.',
-        " track flights to my destination and alert me when they're cheap."
+        ' source qualified leads and companies for my ICP every Monday.',
+        ' find candidates with Python and healthcare AI experience each week.',
+        ' monitor RFP portals and surface opportunities worth bidding on.',
+        ' build a weekly list of companies hiring RevOps leaders.',
+        ' enrich prospect accounts with decision makers and buying signals.',
+        ' find seed-stage fintech founders and add verified contacts to my sheet.',
+        ' source product managers from healthcare startups and rank them by fit.',
+        ' watch competitor customer pages and surface expansion opportunities.',
+        ' track new job posts that suggest companies need data tooling.',
+        ' monitor partner directories for agencies that match our ideal profile.'
       ];
 
       function toggleGhostVisibility() {

--- a/proprietary/templates/home/_hero.html
+++ b/proprietary/templates/home/_hero.html
@@ -8,11 +8,10 @@
       {% if landing_hero_text %}
         <span class="font-light">{{ landing_hero_text|safe }}</span>
       {% else %}
-        Your Gobii AI team,<br class="hidden sm:inline">
-        <span class="font-normal bg-gradient-to-r from-violet-700 to-purple-600 bg-clip-text text-transparent">always on</span>
+        Delegate <span class="font-normal bg-gradient-to-r from-violet-700 to-purple-600 bg-clip-text text-transparent">qualified sourcing</span> to AI employees
       {% endif %}
     </h1>
-    <p class="mt-4 text-lg text-gray-500 md:max-w-md">Email&nbsp;them <i data-lucide="mail" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>. Text&nbsp;them <i data-lucide="message-square" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>. They work <span class="font-medium text-violet-600">24/7</span>.</p>
+    <p class="mt-4 text-lg text-gray-500 md:max-w-md">Find leads <i aria-hidden="true" data-lucide="user-plus" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>, candidates, companies <i aria-hidden="true" data-lucide="building-2" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>, and opportunities on schedule <i aria-hidden="true" data-lucide="calendar-clock" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>.</p>
   </div>
   <div class="flex justify-center md:block flex-shrink-0 order-first md:order-last">
     {% flag "fish_homepage" %}
@@ -32,10 +31,9 @@
     {% if landing_hero_text %}
       <span class="font-light">{{ landing_hero_text|safe }}</span>
     {% else %}
-      <span class="font-light">Your AI team,</span>
-      <span class="font-normal bg-gradient-to-r from-violet-700 to-purple-600 bg-clip-text text-transparent">always on</span>
+      Delegate <span class="font-normal bg-gradient-to-r from-violet-700 to-purple-600 bg-clip-text text-transparent">qualified sourcing</span> to AI employees
     {% endif %}
   </h1>
-  <p class="mt-5 text-base sm:text-lg text-gray-500 max-w-2xl mx-auto leading-relaxed">Gobii agents are virtual coworkers with their own identity, memory, and&nbsp;tools. Email&nbsp;them <i data-lucide="mail" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>. Text&nbsp;them <i data-lucide="message-square" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>. They work <span class="font-medium text-violet-600">24/7</span>.</p>
+  <p class="mt-5 text-base sm:text-lg text-gray-500 max-w-2xl mx-auto leading-relaxed">Find leads <i aria-hidden="true" data-lucide="user-plus" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>, candidates, companies <i aria-hidden="true" data-lucide="building-2" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>, and opportunities on schedule <i aria-hidden="true" data-lucide="calendar-clock" class="inline-block w-[0.9em] h-[0.9em] text-violet-500 -translate-y-[1px]"></i>.</p>
 </div>
 {% endif %}

--- a/tests/unit/test_pages.py
+++ b/tests/unit/test_pages.py
@@ -819,7 +819,7 @@ class HomePageTests(TestCase):
         )
 
     @override_settings(GOBII_PROPRIETARY_MODE=True, PERSONAL_FREE_TRIAL_ENFORCEMENT_ENABLED=False)
-    def test_home_cta_text_changes_for_authenticated_users(self):
+    def test_home_cta_text_for_authenticated_users(self):
         unauth_response = self.client.get("/")
         self.assertEqual(unauth_response.status_code, 200)
         unauth_soup = BeautifulSoup(unauth_response.content, "html.parser")
@@ -827,7 +827,8 @@ class HomePageTests(TestCase):
         self.assertIsNotNone(unauth_hero_form)
         unauth_hero_button = unauth_hero_form.find("button", {"type": "submit"})
         self.assertIsNotNone(unauth_hero_button)
-        self.assertEqual(self._normalized_button_text(unauth_hero_button), "Start Free Trial")
+        self.assertEqual(self._normalized_button_text(unauth_hero_button), "Start Sourcing")
+        self.assertIn("7-day free trial.", unauth_hero_form.find_parent("div").get_text(" ", strip=True))
 
         unauth_card_source = unauth_soup.find(
             "input",
@@ -854,7 +855,7 @@ class HomePageTests(TestCase):
         self.assertIsNotNone(auth_hero_form)
         auth_hero_button = auth_hero_form.find("button", {"type": "submit"})
         self.assertIsNotNone(auth_hero_button)
-        self.assertEqual(self._normalized_button_text(auth_hero_button), "Spawn Agent")
+        self.assertEqual(self._normalized_button_text(auth_hero_button), "Start Sourcing")
 
         auth_card_source = auth_soup.find(
             "input",
@@ -901,8 +902,14 @@ class HomePageTests(TestCase):
         soup = BeautifulSoup(response.content, "html.parser")
         page_text = soup.get_text(" ")
         normalized_page_text = re.sub(r"\s+", " ", page_text)
-        normalized_page_text = normalized_page_text.replace(" ,", ",").replace(" ?", "?")
-        self.assertIn("Your Gobii AI team, always on", normalized_page_text)
+        normalized_page_text = (
+            normalized_page_text.replace(" ,", ",").replace(" ?", "?").replace(" .", ".")
+        )
+        self.assertIn("Delegate qualified sourcing to AI employees", normalized_page_text)
+        self.assertIn(
+            "Find leads, candidates, companies, and opportunities on schedule.",
+            normalized_page_text,
+        )
         self.assertIn(
             "Gobii is an AI agent platform that gives businesses always-on virtual coworkers "
             "capable of browser automation, web research, data collection, and workflow execution.",
@@ -924,7 +931,8 @@ class HomePageTests(TestCase):
         self.assertEqual(hero_form.get("data-analytics-intent"), "spawn_agent")
         hero_button = hero_form.find("button", {"type": "submit"})
         self.assertIsNotNone(hero_button)
-        self.assertEqual(self._normalized_button_text(hero_button), "Start Free Trial")
+        self.assertEqual(self._normalized_button_text(hero_button), "Start Sourcing")
+        self.assertIn("7-day free trial.", normalized_page_text)
         self.assertIsNone(hero_form.find("a", {"data-analytics-cta-id": "home_linkedin_recruiter_sales"}))
         self.assertIsNone(soup.find("a", {"data-analytics-cta-id": "home_linkedin_recruiter_sales"}))
         response_text = response.content.decode("utf-8")
@@ -941,8 +949,10 @@ class HomePageTests(TestCase):
             response,
             "I want my Gobii to",
         )
-        self.assertContains(response, " find 200 ideal customers and their emails.")
-        self.assertContains(response, "keep my Salesforce pipeline clean every day.")
+        self.assertContains(response, " source qualified leads and companies for my ICP every Monday.")
+        self.assertContains(response, "find candidates with Python and healthcare AI experience each week.")
+        self.assertNotContains(response, "find 200 ideal customers and their emails")
+        self.assertNotContains(response, "keep my Salesforce pipeline clean every day")
         self.assertNotContains(response, "Paste a role brief")
         self.assertNotContains(response, " parse this job description")
         self.assertNotContains(response, " build a qualified shortlist")
@@ -983,7 +993,8 @@ class HomePageTests(TestCase):
         self.assertEqual(hero_form.get("data-requires-trial"), "true")
         hero_button = hero_form.find("button", {"type": "submit"})
         self.assertIsNotNone(hero_button)
-        self.assertEqual(self._normalized_button_text(hero_button), "Start Free Trial")
+        self.assertEqual(self._normalized_button_text(hero_button), "Start Sourcing")
+        self.assertIn("7-day free trial.", hero_form.find_parent("div").get_text(" ", strip=True))
 
         card_source = soup.find(
             "input",
@@ -997,7 +1008,7 @@ class HomePageTests(TestCase):
         self.assertEqual(self._normalized_button_text(card_button), "Start Free Trial")
 
     @override_settings(GOBII_PROPRIETARY_MODE=True, PERSONAL_FREE_TRIAL_ENFORCEMENT_ENABLED=True)
-    def test_home_cta_text_stays_spawn_for_grandfathered_user(self):
+    def test_home_cta_text_stays_sourcing_for_grandfathered_user(self):
         user = get_user_model().objects.create_user(
             username="home_cta_grandfathered@example.com",
             email="home_cta_grandfathered@example.com",
@@ -1015,7 +1026,8 @@ class HomePageTests(TestCase):
         self.assertEqual(hero_form.get("data-requires-trial"), "false")
         hero_button = hero_form.find("button", {"type": "submit"})
         self.assertIsNotNone(hero_button)
-        self.assertEqual(self._normalized_button_text(hero_button), "Spawn Agent")
+        self.assertEqual(self._normalized_button_text(hero_button), "Start Sourcing")
+        self.assertNotIn("7-day free trial.", hero_form.find_parent("div").get_text(" ", strip=True))
 
         card_source = soup.find(
             "input",


### PR DESCRIPTION
## Summary
- update the homepage hero headline to focus on delegated qualified sourcing
- replace the subhead with sourcing-oriented copy and inline icons for leads, companies, and scheduling

## Tests
- uv run python manage.py test tests.unit.test_pages.HomePageTests --settings=config.test_settings