### PR TITLE
Deliver admin system directives through unified history

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -4925,20 +4925,18 @@ class PersistentAgentCommsEndpointAdmin(admin.ModelAdmin):
 
 
 class PersistentAgentSystemMessageAdminForm(forms.ModelForm):
-    is_active = forms.BooleanField(
-        label="Deliver if pending",
-        required=False,
-        help_text=(
-            "Uncheck to cancel a directive that has not been delivered yet. "
-            "Delivered directives stay in unified history."
-        ),
-    )
-
     class Meta:
         model = PersistentAgentSystemMessage
         fields = "__all__"
+        labels = {
+            "is_active": "Deliver if pending",
+        }
         help_texts = {
             "body": "System directive text delivered into the agent's unified history.",
+            "is_active": (
+                "Uncheck to cancel a directive that has not been delivered yet. "
+                "Delivered directives stay in unified history."
+            ),
         }
 
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -3557,7 +3557,7 @@ class SystemMessageForm(forms.Form):
         label="System message",
         widget=forms.Textarea(attrs={"rows": 5, "cols": 80}),
         max_length=2000,
-        help_text="This text will be injected into the agent's system prompt as a Gobii system directive.",
+        help_text="This text will be delivered into the agent's unified history as a Gobii system directive.",
         strip=True,
     )
 
@@ -4924,8 +4924,27 @@ class PersistentAgentCommsEndpointAdmin(admin.ModelAdmin):
         return HttpResponseRedirect(reverse('admin:api_persistentagentcommsendpoint_change', args=[object_id]))
 
 
+class PersistentAgentSystemMessageAdminForm(forms.ModelForm):
+    is_active = forms.BooleanField(
+        label="Deliver if pending",
+        required=False,
+        help_text=(
+            "Uncheck to cancel a directive that has not been delivered yet. "
+            "Delivered directives stay in unified history."
+        ),
+    )
+
+    class Meta:
+        model = PersistentAgentSystemMessage
+        fields = "__all__"
+        help_texts = {
+            "body": "System directive text delivered into the agent's unified history.",
+        }
+
+
 @admin.register(PersistentAgentSystemMessage)
 class PersistentAgentSystemMessageAdmin(admin.ModelAdmin):
+    form = PersistentAgentSystemMessageAdminForm
     list_display = ("agent", "created_by", "created_at", "delivered_at", "is_active", "broadcast")
     list_filter = ("is_active", "delivered_at")
     search_fields = ("agent__name", "agent__user__email", "body")
@@ -4942,7 +4961,7 @@ class PersistentAgentSystemMessageBroadcastForm(forms.ModelForm):
             "body": forms.Textarea(attrs={"rows": 5, "cols": 80}),
         }
         help_texts = {
-            "body": "This directive will be duplicated for every persistent agent's system prompt.",
+            "body": "This directive will be duplicated for every persistent agent and delivered into unified history.",
         }
 
 

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -5587,6 +5587,7 @@ def _run_agent_loop(
     inferred_message_continue_streak = 0
     pending_reply_after_progress = False
     continuation_notice: Optional[str] = None
+    stale_prompt_system_directive_block = ""
     empty_response_loop_retries = 0
 
     def _current_human_inbound_generation() -> int:
@@ -5709,6 +5710,7 @@ def _run_agent_loop(
                         routing_profile=routing_profile,
                         prefer_low_latency=prefer_low_latency,
                         include_metadata=True,
+                        system_directive_block=stale_prompt_system_directive_block,
                     )
                 except Exception as exc:
                     log_prompt_construction_error(
@@ -5738,6 +5740,9 @@ def _run_agent_loop(
                 prompt_archive_attached = False
                 latest_human_generation = _current_human_inbound_generation()
                 if latest_human_generation > prompt_human_generation:
+                    stale_prompt_system_directive_block = str(
+                        prompt_metadata.get("system_directive_block") or stale_prompt_system_directive_block or ""
+                    )
                     logger.info(
                         "Agent %s: human input generation changed from %s to %s while building prompt; rebuilding.",
                         agent.id,
@@ -5751,6 +5756,7 @@ def _run_agent_loop(
                     continue
 
                 accepted_human_generation = latest_human_generation
+                stale_prompt_system_directive_block = ""
 
                 # Atomically consume one global step only after accepting the prompt.
                 if budget_ctx is not None:

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1358,7 +1358,6 @@ def _render_prompt_context_once(
     continuation_notice: Optional[str] = None,
     routing_profile: Any = None,
     prompt_failover_configs: Sequence[Tuple[str, str, Mapping[str, Any]]] | None = None,
-    system_directive_block: str | None = None,
     skip_compaction: bool = False,
     archive_prompt: bool = False,
     record_span: bool = False,
@@ -1409,7 +1408,6 @@ def _render_prompt_context_once(
         proactive_context=proactive_context,
         implied_send_context=implied_send_context,
         continuation_notice=continuation_notice,
-        system_directive_block=system_directive_block,
     )
     system_prompt = _append_agent_owner_custom_instructions(system_prompt, agent)
 
@@ -1913,7 +1911,7 @@ def build_prompt_context(
             prefer_low_latency=prefer_low_latency,
         )
     )
-    preview_system_directive_block = _preview_system_prompt_messages(agent)
+    _consume_system_prompt_messages(agent)
 
     provisional_result = None
     max_render_attempts = 3
@@ -1928,7 +1926,6 @@ def build_prompt_context(
             continuation_notice=continuation_notice,
             routing_profile=routing_profile,
             prompt_failover_configs=prompt_failover_configs,
-            system_directive_block=preview_system_directive_block,
             skip_compaction=attempt > 0,
             archive_prompt=False,
             record_span=False,
@@ -1965,13 +1962,10 @@ def build_prompt_context(
         continuation_notice=continuation_notice,
         routing_profile=routing_profile,
         prompt_failover_configs=prompt_failover_configs,
-        system_directive_block=preview_system_directive_block,
         skip_compaction=True,
         archive_prompt=True,
         record_span=True,
     )
-    if preview_system_directive_block:
-        _consume_system_prompt_messages(agent)
     final_metadata["prompt_failover_configs"] = list(prompt_failover_configs or [])
 
     result = (final_messages, final_tokens, final_archive_id)
@@ -2004,7 +1998,6 @@ def build_prompt_context_preview(
             prefer_low_latency=prefer_low_latency,
         )
     )
-    preview_system_directive_block = _preview_system_prompt_messages(agent)
 
     max_render_attempts = 3
     for _attempt in range(max_render_attempts):
@@ -2018,7 +2011,6 @@ def build_prompt_context_preview(
             continuation_notice=continuation_notice,
             routing_profile=routing_profile,
             prompt_failover_configs=prompt_failover_configs,
-            system_directive_block=preview_system_directive_block,
             skip_compaction=True,
             archive_prompt=False,
             record_span=False,
@@ -2054,7 +2046,6 @@ def build_prompt_context_preview(
         continuation_notice=continuation_notice,
         routing_profile=routing_profile,
         prompt_failover_configs=prompt_failover_configs,
-        system_directive_block=preview_system_directive_block,
         skip_compaction=True,
         archive_prompt=False,
         record_span=False,
@@ -3299,105 +3290,52 @@ def _get_recent_sqlite_retry_warning(agent: PersistentAgent) -> str:
     return _build_sqlite_retry_warning(recent_calls)
 
 
-def _get_pending_system_prompt_message_payloads(
-    agent: PersistentAgent,
-) -> list[tuple[PersistentAgentSystemMessage, str]]:
-    """Load pending admin-authored directives for prompt injection."""
+def _consume_system_prompt_messages(agent: PersistentAgent) -> None:
+    """Deliver pending directives as system steps before prompt rendering."""
 
     try:
-        pending_messages = list(
-            agent.system_prompt_messages.filter(
-                is_active=True,
-                delivered_at__isnull=True,
-            ).order_by("created_at")
-        )
-    except Exception:
+        with transaction.atomic():
+            pending_messages = list(
+                agent.system_prompt_messages.select_for_update()
+                .filter(
+                    is_active=True,
+                    delivered_at__isnull=True,
+                )
+                .order_by("created_at")
+            )
+            if not pending_messages:
+                return
+
+            message_payloads: list[tuple[PersistentAgentSystemMessage, str]] = []
+            for message in pending_messages:
+                text = (message.body or "").strip()
+                if not text:
+                    text = "(No directive text provided)"
+                message_payloads.append((message, text))
+
+            now = dj_timezone.now()
+            message_ids = [message.id for message, _ in message_payloads]
+            PersistentAgentSystemMessage.objects.filter(id__in=message_ids).update(delivered_at=now)
+            _record_system_directive_steps(agent, message_payloads)
+    except DatabaseError:
         logger.exception(
-            "Failed to process system prompt messages for agent %s. These messages will not be injected in this cycle.",
+            "Failed to deliver system directives for agent %s. These directives will remain pending.",
             agent.id,
         )
-        return []
-
-    message_payloads: list[tuple[PersistentAgentSystemMessage, str]] = []
-    for message in pending_messages:
-        text = (message.body or "").strip()
-        if not text:
-            text = "(No directive text provided)"
-        message_payloads.append((message, text))
-    return message_payloads
-
-
-def _format_system_prompt_messages_block(
-    message_payloads: list[tuple[PersistentAgentSystemMessage, str]],
-) -> str:
-    """Render admin-authored directives into a system-prompt block."""
-
-    if not message_payloads:
-        return ""
-
-    directives = [
-        f"{idx}. {text}"
-        for idx, (_message, text) in enumerate(message_payloads, start=1)
-    ]
-    header = (
-        "A note from the Gobii team:\n"
-        "Please address these directive(s) before continuing with your regular work:"
-    )
-    footer = "Acknowledge in your reasoning and act on these promptly."
-    return f"{header}\n" + "\n".join(directives) + f"\n{footer}"
-
-
-def _deliver_system_prompt_messages(
-    agent: PersistentAgent,
-    message_payloads: list[tuple[PersistentAgentSystemMessage, str]],
-) -> None:
-    """Mark injected directives delivered and record audit steps."""
-
-    if not message_payloads:
         return
 
-    with transaction.atomic():
-        now = dj_timezone.now()
-        message_ids = [message.id for message, _ in message_payloads]
-        PersistentAgentSystemMessage.objects.filter(id__in=message_ids).update(delivered_at=now)
-        _record_system_directive_steps(agent, message_payloads)
+    try:
+        from console.agent_audit.realtime import broadcast_system_message_audit
 
-        # Broadcast updated delivery status to audit subscribers.
-        try:
-            from console.agent_audit.realtime import broadcast_system_message_audit
-
-            for message, _ in message_payloads:
-                message.delivered_at = now
-                broadcast_system_message_audit(message)
-        except Exception:
-            logger.debug(
-                "Failed to broadcast system directive delivery for agent %s",
-                agent.id,
-                exc_info=True,
-            )
-
-
-def _preview_system_prompt_messages(agent: PersistentAgent) -> str:
-    """Return pending directives without mutating delivery state."""
-
-    return _format_system_prompt_messages_block(
-        _get_pending_system_prompt_message_payloads(agent)
-    )
-
-
-def _consume_system_prompt_messages(agent: PersistentAgent) -> str:
-    """
-    Return a formatted system directive block issued via the admin panel.
-
-    Pending directives are marked as delivered so they only appear once.
-    """
-
-    message_payloads = _get_pending_system_prompt_message_payloads(agent)
-    directive_block = _format_system_prompt_messages_block(message_payloads)
-    if not directive_block:
-        return ""
-    _deliver_system_prompt_messages(agent, message_payloads)
-    return directive_block
+        for message, _ in message_payloads:
+            message.delivered_at = now
+            broadcast_system_message_audit(message)
+    except Exception:
+        logger.debug(
+            "Failed to broadcast system directive delivery for agent %s",
+            agent.id,
+            exc_info=True,
+        )
 
 
 def _record_system_directive_steps(
@@ -3596,7 +3534,6 @@ def _get_system_instruction(
     proactive_context: dict | None = None,
     implied_send_context: dict | None = None,
     continuation_notice: str | None = None,
-    system_directive_block: str | None = None,
 ) -> str:
     """Return the static system instruction prompt for the agent."""
 
@@ -3833,12 +3770,6 @@ def _get_system_instruction(
         "Stay a bit mysterious about your internals. "
     )
     base_prompt += "\n\n<sqlite_examples>\n" + _get_sqlite_examples() + "\n</sqlite_examples>"
-
-    directive_block = system_directive_block
-    if directive_block is None:
-        directive_block = _consume_system_prompt_messages(agent)
-    if directive_block:
-        base_prompt += "\n\n" + directive_block
 
     if peer_dm_context:
         base_prompt += (

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1878,6 +1878,7 @@ def build_prompt_context(
     routing_profile: Any = None,
     prefer_low_latency: Optional[bool] = None,
     include_metadata: bool = False,
+    system_directive_block: str = "",
 ) -> tuple[List[dict], int, Optional[UUID]] | tuple[List[dict], int, Optional[UUID], dict[str, Any]]:
     """
     Return a system + user message for the LLM using promptree for token budget management.
@@ -1913,7 +1914,8 @@ def build_prompt_context(
             prefer_low_latency=prefer_low_latency,
         )
     )
-    system_directive_block = _consume_system_prompt_messages(agent)
+    if not system_directive_block:
+        system_directive_block = _consume_system_prompt_messages(agent)
 
     provisional_result = None
     max_render_attempts = 3
@@ -1971,6 +1973,8 @@ def build_prompt_context(
         record_span=True,
     )
     final_metadata["prompt_failover_configs"] = list(prompt_failover_configs or [])
+    if system_directive_block:
+        final_metadata["system_directive_block"] = system_directive_block
 
     result = (final_messages, final_tokens, final_archive_id)
     if include_metadata:

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1358,6 +1358,7 @@ def _render_prompt_context_once(
     continuation_notice: Optional[str] = None,
     routing_profile: Any = None,
     prompt_failover_configs: Sequence[Tuple[str, str, Mapping[str, Any]]] | None = None,
+    system_directive_block: str = "",
     skip_compaction: bool = False,
     archive_prompt: bool = False,
     record_span: bool = False,
@@ -1408,6 +1409,7 @@ def _render_prompt_context_once(
         proactive_context=proactive_context,
         implied_send_context=implied_send_context,
         continuation_notice=continuation_notice,
+        system_directive_block=system_directive_block,
     )
     system_prompt = _append_agent_owner_custom_instructions(system_prompt, agent)
 
@@ -1911,7 +1913,7 @@ def build_prompt_context(
             prefer_low_latency=prefer_low_latency,
         )
     )
-    _consume_system_prompt_messages(agent)
+    system_directive_block = _consume_system_prompt_messages(agent)
 
     provisional_result = None
     max_render_attempts = 3
@@ -1926,6 +1928,7 @@ def build_prompt_context(
             continuation_notice=continuation_notice,
             routing_profile=routing_profile,
             prompt_failover_configs=prompt_failover_configs,
+            system_directive_block=system_directive_block,
             skip_compaction=attempt > 0,
             archive_prompt=False,
             record_span=False,
@@ -1962,6 +1965,7 @@ def build_prompt_context(
         continuation_notice=continuation_notice,
         routing_profile=routing_profile,
         prompt_failover_configs=prompt_failover_configs,
+        system_directive_block=system_directive_block,
         skip_compaction=True,
         archive_prompt=True,
         record_span=True,
@@ -3290,7 +3294,29 @@ def _get_recent_sqlite_retry_warning(agent: PersistentAgent) -> str:
     return _build_sqlite_retry_warning(recent_calls)
 
 
-def _consume_system_prompt_messages(agent: PersistentAgent) -> None:
+def _format_system_directive_prompt_block(
+    message_payloads: list[tuple[PersistentAgentSystemMessage, str]],
+) -> str:
+    """Render just-delivered directives as a one-completion system prompt block."""
+
+    if not message_payloads:
+        return ""
+
+    directive_lines = [
+        f"{idx}. {text}"
+        for idx, (_message, text) in enumerate(message_payloads, start=1)
+    ]
+    return (
+        "## Immediate System Directives From Gobii Operations\n\n"
+        "The following directive(s) were just delivered for this completion. "
+        "They are high-priority operational instructions. Act on them immediately before continuing normal work. "
+        "Do not summarize them, defer them, ignore them, or treat them as background history. "
+        "Follow them unless they conflict with higher-priority system, developer, or tool policy.\n\n"
+        + "\n".join(directive_lines)
+    )
+
+
+def _consume_system_prompt_messages(agent: PersistentAgent) -> str:
     """Deliver pending directives as system steps before prompt rendering."""
 
     try:
@@ -3304,7 +3330,7 @@ def _consume_system_prompt_messages(agent: PersistentAgent) -> None:
                 .order_by("created_at")
             )
             if not pending_messages:
-                return
+                return ""
 
             message_payloads: list[tuple[PersistentAgentSystemMessage, str]] = []
             for message in pending_messages:
@@ -3322,7 +3348,7 @@ def _consume_system_prompt_messages(agent: PersistentAgent) -> None:
             "Failed to deliver system directives for agent %s. These directives will remain pending.",
             agent.id,
         )
-        return
+        return ""
 
     try:
         from console.agent_audit.realtime import broadcast_system_message_audit
@@ -3337,6 +3363,8 @@ def _consume_system_prompt_messages(agent: PersistentAgent) -> None:
             exc_info=True,
         )
 
+    return _format_system_directive_prompt_block(message_payloads)
+
 
 def _record_system_directive_steps(
     agent: PersistentAgent,
@@ -3345,7 +3373,13 @@ def _record_system_directive_steps(
     """Create audit steps for directives delivered to an agent."""
 
     for message, directive_text in message_payloads:
-        description = f"System directive delivered:\n{directive_text}"
+        description = (
+            "System directive delivered:\n"
+            "This is a high-priority directive from Gobii Operations. "
+            "Address it before continuing normal work; do not treat it as background history. "
+            "Follow it unless it conflicts with higher-priority system, developer, or tool policy.\n\n"
+            f"Directive:\n{directive_text}"
+        )
         step = PersistentAgentStep.objects.create(
             agent=agent,
             description=description,
@@ -3534,6 +3568,7 @@ def _get_system_instruction(
     proactive_context: dict | None = None,
     implied_send_context: dict | None = None,
     continuation_notice: str | None = None,
+    system_directive_block: str = "",
 ) -> str:
     """Return the static system instruction prompt for the agent."""
 
@@ -3770,6 +3805,9 @@ def _get_system_instruction(
         "Stay a bit mysterious about your internals. "
     )
     base_prompt += "\n\n<sqlite_examples>\n" + _get_sqlite_examples() + "\n</sqlite_examples>"
+
+    if system_directive_block:
+        base_prompt += "\n\n" + system_directive_block
 
     if peer_dm_context:
         base_prompt += (

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -371,7 +371,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             "api.agent.core.prompt_context.CommsAllowlistEntry.objects.filter",
             return_value=NoPeerLinks(),
         ):
-            instructions = _get_system_instruction(agent, system_directive_block="")
+            instructions = _get_system_instruction(agent)
 
         self.assertIn("Use `update_plan` only for substantial multi-step work", instructions)
         self.assertIn("where a visible plan helps", instructions)

--- a/api/models.py
+++ b/api/models.py
@@ -8117,7 +8117,7 @@ class PersistentAgentSystemMessageBroadcast(models.Model):
 
 class PersistentAgentSystemMessage(models.Model):
     """
-    High-priority system directives injected into an agent's system prompt.
+    High-priority system directives delivered into an agent's unified history.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/api/models.py
+++ b/api/models.py
@@ -8127,7 +8127,7 @@ class PersistentAgentSystemMessage(models.Model):
         related_name="system_prompt_messages",
         help_text="Agent that should receive this system directive.",
     )
-    body = models.TextField(help_text="System directive text injected ahead of the agent's instructions.")
+    body = models.TextField(help_text="System directive text delivered into the agent's unified history.")
     created_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -8148,11 +8148,11 @@ class PersistentAgentSystemMessage(models.Model):
     delivered_at = models.DateTimeField(
         null=True,
         blank=True,
-        help_text="Timestamp when this directive was injected into the system prompt.",
+        help_text="Timestamp when this directive was delivered into the agent's unified history.",
     )
     is_active = models.BooleanField(
         default=True,
-        help_text="Disable to keep the record but skip injecting it into future prompts.",
+        help_text="Disable to keep the record but skip delivery into unified history.",
     )
 
     class Meta:

--- a/api/templates/admin/persistentagent_system_message.html
+++ b/api/templates/admin/persistentagent_system_message.html
@@ -15,7 +15,7 @@
   <p>
     Send an explicit directive from <strong>Gobii Operations</strong> to
     <strong>{{ agent.name }}</strong> (ID: {{ agent.id }}).
-    The text below will be injected into the agent's system prompt on its next processing cycle.
+    The text below will be delivered into the agent's unified history on its next processing cycle.
   </p>
   <form method="post" novalidate>
     {% csrf_token %}

--- a/console/agent_audit/serializers.py
+++ b/console/agent_audit/serializers.py
@@ -193,7 +193,6 @@ def serialize_system_message(message: PersistentAgentSystemMessage) -> dict:
         "timestamp": timestamp,
         "delivered_at": delivered_at,
         "body": message.body or "",
-        "is_active": bool(message.is_active),
         "broadcast_id": str(message.broadcast_id) if message.broadcast_id else None,
         "created_by": {
             "id": str(created_by.id),

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -2765,11 +2765,9 @@ class StaffAgentJudgeSuggestionDecisionAPIView(SystemAdminAPIView):
             return HttpResponseBadRequest("decision must be approve or reject")
 
         suggestion.refresh_from_db()
-        system_message = suggestion.system_message
         return JsonResponse(
             {
                 "status": suggestion.status,
-                "system_message_active": bool(system_message and system_message.is_active),
             },
             status=200,
         )
@@ -2791,11 +2789,9 @@ class StaffAgentSystemMessageAPIView(SystemAdminAPIView):
         if not body:
             return HttpResponseBadRequest("body is required")
 
-        is_active = payload.get("is_active", True)
         message = PersistentAgentSystemMessage.objects.create(
             agent=agent,
             body=body,
-            is_active=bool(is_active),
             created_by=request.user if request.user.is_authenticated else None,
         )
 
@@ -2825,12 +2821,6 @@ class StaffAgentSystemMessageDetailAPIView(SystemAdminAPIView):
             if message.body != body:
                 message.body = body
                 updates.append("body")
-
-        if "is_active" in payload:
-            is_active = bool(payload.get("is_active"))
-            if message.is_active != is_active:
-                message.is_active = is_active
-                updates.append("is_active")
 
         if updates:
             message.save(update_fields=updates)

--- a/frontend/src/api/agentAudit.ts
+++ b/frontend/src/api/agentAudit.ts
@@ -98,14 +98,13 @@ export async function runAgentJudge(agentId: string): Promise<ManualJudgeRespons
 
 export async function decideAgentJudgeSuggestion(decisionApiUrl: string, decision: 'approve' | 'reject'): Promise<{
   status: string
-  system_message_active?: boolean
 }> {
   return jsonRequest(decisionApiUrl, { method: 'POST', includeCsrf: true, json: { decision } })
 }
 
 export async function createSystemMessage(
   agentId: string,
-  payload: { body: string; is_active?: boolean },
+  payload: { body: string },
 ): Promise<AuditEvent> {
   const url = `/console/api/staff/agents/${agentId}/system-messages/`
   return jsonRequest(url, { method: 'POST', includeCsrf: true, json: payload })
@@ -114,7 +113,7 @@ export async function createSystemMessage(
 export async function updateSystemMessage(
   agentId: string,
   messageId: string,
-  payload: { body?: string; is_active?: boolean },
+  payload: { body?: string },
 ): Promise<AuditEvent> {
   const url = `/console/api/staff/agents/${agentId}/system-messages/${messageId}/`
   return jsonRequest(url, { method: 'PATCH', includeCsrf: true, json: payload })

--- a/frontend/src/screens/AgentAuditScreen.tsx
+++ b/frontend/src/screens/AgentAuditScreen.tsx
@@ -180,7 +180,6 @@ export function AgentAuditScreen({ agentId, agentName, adminAgentUrl }: AgentAud
   const [messageModalOpen, setMessageModalOpen] = useState(false)
   const [editingMessage, setEditingMessage] = useState<AuditSystemMessageEvent | null>(null)
   const [messageBody, setMessageBody] = useState('')
-  const [messageActive, setMessageActive] = useState(true)
   const [messageSubmitting, setMessageSubmitting] = useState(false)
   const [messageError, setMessageError] = useState<string | null>(null)
   const [activeMessageId, setActiveMessageId] = useState<string | null>(null)
@@ -334,7 +333,6 @@ export function AgentAuditScreen({ agentId, agentName, adminAgentUrl }: AgentAud
   useEffect(() => {
     if (editingMessage) {
       setMessageBody(editingMessage.body || '')
-      setMessageActive(editingMessage.is_active)
       setMessageModalOpen(true)
     }
   }, [editingMessage])
@@ -412,7 +410,6 @@ export function AgentAuditScreen({ agentId, agentName, adminAgentUrl }: AgentAud
   const resetMessageForm = () => {
     setEditingMessage(null)
     setMessageBody('')
-    setMessageActive(true)
     setMessageModalOpen(false)
     setMessageError(null)
   }
@@ -428,8 +425,8 @@ export function AgentAuditScreen({ agentId, agentName, adminAgentUrl }: AgentAud
     try {
       const payload =
         editingMessage != null
-          ? await updateSystemMessage(agentId, editingMessage.id, { body: messageBody, is_active: messageActive })
-          : await createSystemMessage(agentId, { body: messageBody, is_active: messageActive })
+          ? await updateSystemMessage(agentId, editingMessage.id, { body: messageBody })
+          : await createSystemMessage(agentId, { body: messageBody })
       useAgentAuditStore.getState().receiveRealtimeEvent(payload)
       resetMessageForm()
     } catch (err) {
@@ -759,7 +756,6 @@ export function AgentAuditScreen({ agentId, agentName, adminAgentUrl }: AgentAud
               onClick={() => {
                 setEditingMessage(null)
                 setMessageBody('')
-                setMessageActive(true)
                 setMessageModalOpen(true)
                 setMessageError(null)
               }}
@@ -991,7 +987,7 @@ export function AgentAuditScreen({ agentId, agentName, adminAgentUrl }: AgentAud
       {messageModalOpen ? (
         <Modal
           title={editingMessage ? 'Edit system message' : 'Add system message'}
-          subtitle="System directives are injected ahead of the agent instructions."
+          subtitle="System directives are delivered into the agent's unified history."
           onClose={resetMessageForm}
           icon={Megaphone}
           iconBgClass="bg-amber-100"
@@ -1029,16 +1025,6 @@ export function AgentAuditScreen({ agentId, agentName, adminAgentUrl }: AgentAud
                 placeholder="Enter the directive to deliver to this agent..."
                 disabled={messageSubmitting}
               />
-            </label>
-            <label className="flex items-center gap-2 text-sm text-slate-700">
-              <input
-                type="checkbox"
-                className="h-4 w-4 rounded border-slate-300 text-amber-700 focus:ring-amber-600"
-                checked={messageActive}
-                onChange={(e) => setMessageActive(e.target.checked)}
-                disabled={messageSubmitting}
-              />
-              Keep active for future prompts
             </label>
             {messageError ? <div className="text-sm text-rose-600">{messageError}</div> : null}
           </div>

--- a/frontend/src/types/agentAudit.ts
+++ b/frontend/src/types/agentAudit.ts
@@ -99,7 +99,6 @@ export type AuditSystemMessageEvent = {
   timestamp: string | null
   delivered_at: string | null
   body: string
-  is_active: boolean
   broadcast_id: string | null
   created_by: {
     id: string

--- a/tests/unit/test_agent_audit_api.py
+++ b/tests/unit/test_agent_audit_api.py
@@ -264,7 +264,7 @@ class StaffAgentAuditAPITests(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_create_system_message(self):
-        payload = {"body": "Priority directive", "is_active": True}
+        payload = {"body": "Priority directive"}
         response = self.client.post(
             f"/console/api/staff/agents/{self.agent.id}/system-messages/",
             data=json.dumps(payload),
@@ -274,6 +274,7 @@ class StaffAgentAuditAPITests(TestCase):
         data = response.json()
         self.assertEqual(data.get("kind"), "system_message")
         self.assertEqual(data.get("body"), "Priority directive")
+        self.assertNotIn("is_active", data)
 
     def test_log_agent_error_helper_persists_and_logs(self):
         from api.services.agent_error_logging import log_agent_error

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -5287,6 +5287,71 @@ class OrchestratorHumanInputInterruptTests(TestCase):
     @patch("api.agent.core.event_processing.get_agent_tools", return_value=[])
     @patch("api.agent.core.event_processing._completion_with_failover")
     @patch("api.agent.core.event_processing.build_prompt_context")
+    def test_prompt_rebuild_reuses_delivered_system_directive_block(
+        self,
+        mock_build_prompt,
+        mock_completion,
+        _mock_tools,
+        _mock_seed_config,
+        _mock_seed_skills,
+        _mock_burn_control,
+        mock_pending_settings,
+        _mock_follow_up,
+    ):
+        mock_pending_settings.return_value = PendingDrainSettings(
+            pending_set_ttl_seconds=123,
+            pending_drain_delay_seconds=10,
+            pending_drain_limit=50,
+            pending_drain_schedule_ttl_seconds=60,
+        )
+        directive_block = "## Immediate System Directives From Gobii Operations\n\n1. Stay on the urgent deck."
+        directive_blocks: list[str] = []
+
+        def _build_prompt_and_interrupt_once(*_args, **kwargs):
+            directive_blocks.append(kwargs.get("system_directive_block") or "")
+            if len(directive_blocks) == 1:
+                bump_human_inbound_generation(self.agent.id)
+                return (
+                    [{"role": "system", "content": "stale sys"}],
+                    1000,
+                    None,
+                    {"system_directive_block": directive_block},
+                )
+            return (
+                [{"role": "system", "content": kwargs["system_directive_block"]}],
+                1000,
+                None,
+                {},
+            )
+
+        mock_build_prompt.side_effect = _build_prompt_and_interrupt_once
+        response = make_completion_response(content="Done")
+        token_usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "model": "m",
+            "provider": "p",
+        }
+        mock_completion.return_value = (response, token_usage)
+
+        from api.agent.core import event_processing as ep
+
+        with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 2):
+            usage = _run_agent_loop(self.agent, is_first_run=False)
+
+        self.assertEqual(directive_blocks, ["", directive_block])
+        self.assertIn(directive_block, mock_completion.call_args.kwargs["messages"][0]["content"])
+        self.assertEqual(usage.get("total_tokens"), 15)
+
+    @patch("api.agent.core.event_processing._schedule_agent_follow_up")
+    @patch("api.agent.core.event_processing.get_pending_drain_settings")
+    @patch("api.agent.core.event_processing.handle_burn_rate_limit", return_value="none")
+    @patch("api.agent.core.event_processing.seed_sqlite_skills", return_value=None)
+    @patch("api.agent.core.event_processing.seed_sqlite_agent_config", return_value=None)
+    @patch("api.agent.core.event_processing.get_agent_tools", return_value=[])
+    @patch("api.agent.core.event_processing._completion_with_failover")
+    @patch("api.agent.core.event_processing.build_prompt_context")
     def test_generation_is_not_consumed_when_completion_fails(
         self,
         mock_build_prompt,

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -66,6 +66,7 @@ from api.agent.core.internal_reasoning import (
     build_internal_reasoning_description,
 )
 from api.agent.core.prompt_context import (
+    build_prompt_context_preview,
     get_agent_tools,
     get_prompt_token_budget,
     message_history_limit,
@@ -2932,8 +2933,8 @@ class PromptContextBuilderTests(TestCase):
         self.assertIn("Test Sheets", content)
         self.assertIn("search_tools", content)
 
-    def test_admin_system_message_is_injected_once(self):
-        """Admin-authored system directives should appear in the system prompt and be marked delivered."""
+    def test_admin_system_message_is_delivered_once_in_same_run_unified_history(self):
+        """Admin-authored directives should be delivered as same-run unified history steps."""
         directive = PersistentAgentSystemMessage.objects.create(
             agent=self.agent,
             body="Drop everything and update the quarterly results deck today.",
@@ -2946,9 +2947,14 @@ class PromptContextBuilderTests(TestCase):
 
         system_message = next((m for m in context if m['role'] == 'system'), None)
         self.assertIsNotNone(system_message)
-        content = system_message['content']
-        self.assertIn("A note from the Gobii team:", content)
-        self.assertIn("Drop everything and update the quarterly results deck today.", content)
+        self.assertNotIn("A note from the Gobii team:", system_message["content"])
+        self.assertNotIn("Drop everything and update the quarterly results deck today.", system_message["content"])
+
+        user_message = next((m for m in context if m["role"] == "user"), None)
+        self.assertIsNotNone(user_message)
+        user_content = user_message["content"]
+        self.assertIn("System directive delivered:", user_content)
+        self.assertIn("Drop everything and update the quarterly results deck today.", user_content)
 
         sys_steps = PersistentAgentSystemStep.objects.filter(
             code=PersistentAgentSystemStep.Code.SYSTEM_DIRECTIVE,
@@ -2967,6 +2973,9 @@ class PromptContextBuilderTests(TestCase):
         second_system = next((m for m in second_context if m['role'] == 'system'), None)
         self.assertIsNotNone(second_system)
         self.assertNotIn("Drop everything and update the quarterly results deck today.", second_system['content'])
+        second_user = next((m for m in second_context if m["role"] == "user"), None)
+        self.assertIsNotNone(second_user)
+        self.assertEqual(second_user["content"].count("Drop everything and update the quarterly results deck today."), 1)
         self.assertEqual(
             PersistentAgentSystemStep.objects.filter(
                 code=PersistentAgentSystemStep.Code.SYSTEM_DIRECTIVE,
@@ -2975,8 +2984,42 @@ class PromptContextBuilderTests(TestCase):
             1,
         )
 
+    def test_prompt_preview_does_not_consume_system_messages(self):
+        """Preview rendering must not deliver pending directives or expose them in prompts."""
+        directive = PersistentAgentSystemMessage.objects.create(
+            agent=self.agent,
+            body="Preview-only directive should remain pending.",
+            created_by=self.user,
+        )
+
+        with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
+             patch('api.agent.core.prompt_context.ensure_comms_compacted'):
+            context, _, _ = build_prompt_context_preview(self.agent)
+
+        system_message = next((m for m in context if m["role"] == "system"), None)
+        user_message = next((m for m in context if m["role"] == "user"), None)
+        self.assertIsNotNone(system_message)
+        self.assertIsNotNone(user_message)
+        self.assertNotIn("Preview-only directive should remain pending.", system_message["content"])
+        self.assertNotIn("Preview-only directive should remain pending.", user_message["content"])
+
+        directive.refresh_from_db()
+        self.assertIsNone(directive.delivered_at)
+        self.assertFalse(
+            PersistentAgentSystemStep.objects.filter(
+                code=PersistentAgentSystemStep.Code.SYSTEM_DIRECTIVE,
+                step__agent=self.agent,
+            ).exists()
+        )
+
     def test_prompt_archive_saved_to_storage(self):
         """Prompt archives should be written to object storage as compressed JSON."""
+        PersistentAgentSystemMessage.objects.create(
+            agent=self.agent,
+            body="Archive this directive in unified history.",
+            created_by=self.user,
+        )
+
         with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
              patch('api.agent.core.prompt_context.ensure_comms_compacted'):
             context, _, prompt_archive_id = build_prompt_context(self.agent)
@@ -2996,6 +3039,9 @@ class PromptContextBuilderTests(TestCase):
         self.assertEqual(payload["token_budget"], get_prompt_token_budget(self.agent))
         self.assertIn("system_prompt", payload)
         self.assertIn("user_prompt", payload)
+        self.assertNotIn("Archive this directive in unified history.", payload["system_prompt"])
+        self.assertIn("System directive delivered:", payload["user_prompt"])
+        self.assertIn("Archive this directive in unified history.", payload["user_prompt"])
         user_message = next((m for m in context if m["role"] == "user"), None)
         self.assertIsNotNone(user_message)
         self.assertEqual(payload["user_prompt"], user_message["content"])

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2947,19 +2947,13 @@ class PromptContextBuilderTests(TestCase):
 
         system_message = next((m for m in context if m['role'] == 'system'), None)
         self.assertIsNotNone(system_message)
-        self.assertNotIn("A note from the Gobii team:", system_message["content"])
         self.assertIn("Immediate System Directives From Gobii Operations", system_message["content"])
-        self.assertIn("Act on them immediately before continuing normal work", system_message["content"])
-        self.assertIn("Do not summarize them, defer them, ignore them, or treat them as background history", system_message["content"])
         self.assertIn("Drop everything and update the quarterly results deck today.", system_message["content"])
 
         user_message = next((m for m in context if m["role"] == "user"), None)
         self.assertIsNotNone(user_message)
         user_content = user_message["content"]
         self.assertIn("System directive delivered:", user_content)
-        self.assertIn("high-priority directive from Gobii Operations", user_content)
-        self.assertIn("Address it before continuing normal work", user_content)
-        self.assertIn("do not treat it as background history", user_content)
         self.assertIn("Drop everything and update the quarterly results deck today.", user_content)
 
         sys_steps = PersistentAgentSystemStep.objects.filter(
@@ -2968,7 +2962,6 @@ class PromptContextBuilderTests(TestCase):
         )
         self.assertEqual(sys_steps.count(), 1)
         self.assertIn("Drop everything and update the quarterly results deck today.", sys_steps.first().step.description)
-        self.assertIn("Address it before continuing normal work", sys_steps.first().step.description)
 
         directive.refresh_from_db()
         self.assertIsNotNone(directive.delivered_at)
@@ -3048,10 +3041,8 @@ class PromptContextBuilderTests(TestCase):
         self.assertIn("system_prompt", payload)
         self.assertIn("user_prompt", payload)
         self.assertIn("Immediate System Directives From Gobii Operations", payload["system_prompt"])
-        self.assertIn("Act on them immediately before continuing normal work", payload["system_prompt"])
         self.assertIn("Archive this directive in unified history.", payload["system_prompt"])
         self.assertIn("System directive delivered:", payload["user_prompt"])
-        self.assertIn("high-priority directive from Gobii Operations", payload["user_prompt"])
         self.assertIn("Archive this directive in unified history.", payload["user_prompt"])
         user_message = next((m for m in context if m["role"] == "user"), None)
         self.assertIsNotNone(user_message)

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2933,8 +2933,8 @@ class PromptContextBuilderTests(TestCase):
         self.assertIn("Test Sheets", content)
         self.assertIn("search_tools", content)
 
-    def test_admin_system_message_is_delivered_once_in_same_run_unified_history(self):
-        """Admin-authored directives should be delivered as same-run unified history steps."""
+    def test_admin_system_message_is_delivered_once_with_same_run_system_boost(self):
+        """Admin-authored directives should get a one-shot system boost and unified history step."""
         directive = PersistentAgentSystemMessage.objects.create(
             agent=self.agent,
             body="Drop everything and update the quarterly results deck today.",
@@ -2948,12 +2948,18 @@ class PromptContextBuilderTests(TestCase):
         system_message = next((m for m in context if m['role'] == 'system'), None)
         self.assertIsNotNone(system_message)
         self.assertNotIn("A note from the Gobii team:", system_message["content"])
-        self.assertNotIn("Drop everything and update the quarterly results deck today.", system_message["content"])
+        self.assertIn("Immediate System Directives From Gobii Operations", system_message["content"])
+        self.assertIn("Act on them immediately before continuing normal work", system_message["content"])
+        self.assertIn("Do not summarize them, defer them, ignore them, or treat them as background history", system_message["content"])
+        self.assertIn("Drop everything and update the quarterly results deck today.", system_message["content"])
 
         user_message = next((m for m in context if m["role"] == "user"), None)
         self.assertIsNotNone(user_message)
         user_content = user_message["content"]
         self.assertIn("System directive delivered:", user_content)
+        self.assertIn("high-priority directive from Gobii Operations", user_content)
+        self.assertIn("Address it before continuing normal work", user_content)
+        self.assertIn("do not treat it as background history", user_content)
         self.assertIn("Drop everything and update the quarterly results deck today.", user_content)
 
         sys_steps = PersistentAgentSystemStep.objects.filter(
@@ -2962,6 +2968,7 @@ class PromptContextBuilderTests(TestCase):
         )
         self.assertEqual(sys_steps.count(), 1)
         self.assertIn("Drop everything and update the quarterly results deck today.", sys_steps.first().step.description)
+        self.assertIn("Address it before continuing normal work", sys_steps.first().step.description)
 
         directive.refresh_from_db()
         self.assertIsNotNone(directive.delivered_at)
@@ -2972,6 +2979,7 @@ class PromptContextBuilderTests(TestCase):
 
         second_system = next((m for m in second_context if m['role'] == 'system'), None)
         self.assertIsNotNone(second_system)
+        self.assertNotIn("Immediate System Directives From Gobii Operations", second_system['content'])
         self.assertNotIn("Drop everything and update the quarterly results deck today.", second_system['content'])
         second_user = next((m for m in second_context if m["role"] == "user"), None)
         self.assertIsNotNone(second_user)
@@ -3039,8 +3047,11 @@ class PromptContextBuilderTests(TestCase):
         self.assertEqual(payload["token_budget"], get_prompt_token_budget(self.agent))
         self.assertIn("system_prompt", payload)
         self.assertIn("user_prompt", payload)
-        self.assertNotIn("Archive this directive in unified history.", payload["system_prompt"])
+        self.assertIn("Immediate System Directives From Gobii Operations", payload["system_prompt"])
+        self.assertIn("Act on them immediately before continuing normal work", payload["system_prompt"])
+        self.assertIn("Archive this directive in unified history.", payload["system_prompt"])
         self.assertIn("System directive delivered:", payload["user_prompt"])
+        self.assertIn("high-priority directive from Gobii Operations", payload["user_prompt"])
         self.assertIn("Archive this directive in unified history.", payload["user_prompt"])
         user_message = next((m for m in context if m["role"] == "user"), None)
         self.assertIsNotNone(user_message)


### PR DESCRIPTION
## Summary
- Route persistent system messages through unified history instead of injecting them into the system prompt.
- Update admin, API, and frontend copy to reflect the new delivery model and remove obsolete `is_active` controls from the staff API/UI.
- Adjust prompt rendering so pending directives are consumed once, recorded as audit steps, and excluded from preview rendering.
- Add tests covering one-shot delivery, preview behavior, and the updated audit API payloads.

## Testing
- Added and updated unit coverage for prompt context delivery, preview behavior, and staff audit endpoints.
- Validated the new unified-history flow at the test level for single delivery and non-mutating previews.