### PR TITLE
Move email OAuth callback to the app shell and add a standalone OAuth callback layout

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -363,7 +363,12 @@ urlpatterns = [
     path("console/secrets/", LegacyConsoleRedirectView.as_view(), name="console-secrets"),
     path("console/advanced/mcp-servers/", MCPServerManagementView.as_view(), name="console-mcp-servers"),
     path("console/mcp/oauth/callback/", MCPOAuthCallbackPageView.as_view(), name="console-mcp-oauth-callback-view"),
-    path("console/email/oauth/callback/", AgentEmailOAuthCallbackPageView.as_view(), name="console-email-oauth-callback-view"),
+    path(
+        "console/email/oauth/callback/",
+        RedirectView.as_view(pattern_name="app-email-oauth-callback-view", permanent=False, query_string=True),
+        name="console-email-oauth-callback-view",
+    ),
+    path("app/email/oauth/callback/", AgentEmailOAuthCallbackPageView.as_view(), name="app-email-oauth-callback-view"),
     path(
         "integrations/oauth/callback/",
         NativeIntegrationOAuthCallbackPageView.as_view(),

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -8094,7 +8094,7 @@ class AgentEmailOAuthStartView(LoginRequiredMixin, View):
         state = str(body.get("state") or secrets.token_urlsafe(32))
 
         callback_url = body.get("redirect_uri") or request.build_absolute_uri(
-            reverse("console-email-oauth-callback-view")
+            reverse("app-email-oauth-callback-view")
         )
 
         manual_client_id = str(body.get("client_id") or "")
@@ -8261,7 +8261,7 @@ class AgentEmailOAuthCallbackView(LoginRequiredMixin, View):
         client_id = body.get("client_id") or session.client_id or ""
         client_secret = body.get("client_secret") or session.client_secret or ""
         redirect_uri = body.get("redirect_uri") or session.redirect_uri or request.build_absolute_uri(
-            reverse("console-email-oauth-callback-view")
+            reverse("app-email-oauth-callback-view")
         )
         headers = body.get("headers") or {}
         if headers and not isinstance(headers, dict):

--- a/console/email_settings/views.py
+++ b/console/email_settings/views.py
@@ -575,7 +575,7 @@ def _serialize_agent_email_settings(
         "provider": credential.provider if credential else "",
         "scope": credential.scope if credential else "",
         "expiresAt": credential.expires_at.isoformat() if credential and credential.expires_at else None,
-        "callbackPath": reverse("console-email-oauth-callback-view"),
+        "callbackPath": reverse("app-email-oauth-callback-view"),
         "startUrl": reverse("console-email-oauth-start"),
         "statusUrl": reverse("console-email-oauth-status", args=[account.pk]) if account else None,
         "revokeUrl": reverse("console-email-oauth-revoke", args=[account.pk]) if account else None,

--- a/console/templates/console/agent_email_oauth_callback.html
+++ b/console/templates/console/agent_email_oauth_callback.html
@@ -1,19 +1,11 @@
-{% extends "console_page.html" %}
+{% extends "console/oauth_callback_shell.html" %}
 {% load static %}
 
-{% block console_content %}
-<div class="max-w-xl mx-auto px-6 py-8">
-  <div class="bg-white/80 backdrop-blur-sm shadow-xl rounded-xl overflow-hidden">
-    <div class="px-6 py-5">
-      <h1 class="text-lg font-semibold text-slate-900">Finishing Email OAuth Connection</h1>
-      <p id="email-oauth-status" class="text-sm text-slate-700 mt-2">Completing authorization...</p>
-      <pre id="email-oauth-error" class="hidden rounded-lg bg-red-50 border border-red-200 px-3 py-2 mt-3 text-xs text-red-700 whitespace-pre-wrap"></pre>
-    </div>
-  </div>
-</div>
-{% endblock %}
-
-{% block extra_js %}
-  {{ block.super }}
+{% block oauth_callback_title %}Finishing Email OAuth Connection - Gobii{% endblock %}
+{% block oauth_callback_icon %}<span class="text-lg font-semibold" aria-hidden="true">@</span>{% endblock %}
+{% block oauth_callback_heading %}Finishing email connection{% endblock %}
+{% block oauth_callback_status_id %}email-oauth-status{% endblock %}
+{% block oauth_callback_error_id %}email-oauth-error{% endblock %}
+{% block oauth_callback_script %}
   <script type="module" src="{% static 'js/agent_email_oauth_callback.js' %}"></script>
 {% endblock %}

--- a/console/templates/console/native_integration_oauth_callback.html
+++ b/console/templates/console/native_integration_oauth_callback.html
@@ -1,36 +1,8 @@
+{% extends "console/oauth_callback_shell.html" %}
 {% load static %}
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="csrf-cookie-name" content="{{ settings.CSRF_COOKIE_NAME|default:'csrftoken' }}">
-  <title>Finishing Connection - Gobii</title>
-  <link rel="stylesheet" href="{% static 'css/tailwind.css' %}">
-  <link rel="stylesheet" href="{% static 'css/custom_fonts.css' %}">
-  <script defer src="https://unpkg.com/lucide@0.546.0"></script>
-</head>
-<body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
-  <main class="flex min-h-screen items-center justify-center px-4 py-8">
-    <section class="w-full max-w-sm space-y-4 text-center">
-      <div class="mx-auto flex h-11 w-11 items-center justify-center rounded-lg border border-sky-300/25 bg-sky-950/45 text-sky-100">
-        <i data-lucide="plug" class="h-5 w-5"></i>
-      </div>
-      <div class="space-y-1">
-        <h1 class="text-base font-semibold">Finishing connection</h1>
-        <p id="native-oauth-status" class="text-sm text-slate-300">Completing authorization...</p>
-      </div>
-      <pre id="native-oauth-error" class="hidden rounded-lg border border-rose-300/25 bg-rose-950/30 px-3 py-2 text-left text-xs text-rose-100 whitespace-pre-wrap"></pre>
-      <p class="text-xs text-slate-500">This tab will close automatically if your browser allows it.</p>
-    </section>
-  </main>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      if (window.lucide) {
-        window.lucide.createIcons({ nameAttr: 'data-lucide' });
-      }
-    });
-  </script>
+
+{% block oauth_callback_status_id %}native-oauth-status{% endblock %}
+{% block oauth_callback_error_id %}native-oauth-error{% endblock %}
+{% block oauth_callback_script %}
   <script type="module" src="{% static 'js/native_integration_oauth_callback.js' %}"></script>
-</body>
-</html>
+{% endblock %}

--- a/console/templates/console/oauth_callback_shell.html
+++ b/console/templates/console/oauth_callback_shell.html
@@ -1,0 +1,41 @@
+{% load static %}
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="csrf-cookie-name" content="{{ settings.CSRF_COOKIE_NAME|default:'csrftoken' }}">
+  {% include "partials/_csrf_helpers.html" %}
+  <title>{% block oauth_callback_title %}Finishing Connection - Gobii{% endblock %}</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/gobii_fish_favicon_32.png' %}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/gobii_fish_favicon_16.png' %}">
+  <link rel="stylesheet" href="{% static 'css/tailwind.css' %}">
+  <link rel="stylesheet" href="{% static 'css/custom_fonts.css' %}">
+  <script defer src="https://unpkg.com/lucide@0.546.0"></script>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100 antialiased">
+  <main class="flex min-h-screen items-center justify-center px-4 py-8">
+    <section class="w-full max-w-sm space-y-3 text-center">
+      <div class="mx-auto flex h-11 w-11 items-center justify-center rounded-lg border border-sky-300/25 bg-sky-950/45 text-sky-100">
+        {% block oauth_callback_icon %}
+          <i data-lucide="plug" class="h-5 w-5"></i>
+        {% endblock %}
+      </div>
+      <div class="space-y-1">
+        <h1 class="text-base font-semibold">{% block oauth_callback_heading %}Finishing connection{% endblock %}</h1>
+        <p id="{% block oauth_callback_status_id %}oauth-status{% endblock %}" class="text-sm text-slate-300">Completing authorization...</p>
+      </div>
+      <pre id="{% block oauth_callback_error_id %}oauth-error{% endblock %}" class="hidden rounded-lg border border-rose-300/25 bg-rose-950/30 px-3 py-2 text-left text-xs text-rose-100 whitespace-pre-wrap"></pre>
+      <p class="text-xs text-slate-500">{% block oauth_callback_hint %}This tab will close automatically if your browser allows it.{% endblock %}</p>
+    </section>
+  </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.lucide) {
+        window.lucide.createIcons({ nameAttr: 'data-lucide' });
+      }
+    });
+  </script>
+  {% block oauth_callback_script %}{% endblock %}
+</body>
+</html>

--- a/middleware/app_shell.py
+++ b/middleware/app_shell.py
@@ -14,6 +14,9 @@ from config.vite import ViteManifestError, get_vite_asset
 from util.integrations import pipedream_status
 
 APP_PATH_PREFIX = "/app"
+APP_SHELL_BYPASS_PATHS = (
+    f"{APP_PATH_PREFIX}/email/oauth/callback/",
+)
 APP_PROTECTED_PATH_PREFIX = f"{APP_PATH_PREFIX}/agents"
 APP_BILLING_PATH_PREFIX = f"{APP_PATH_PREFIX}/billing"
 APP_API_KEYS_PATH_PREFIX = f"{APP_PATH_PREFIX}/api-keys"
@@ -319,6 +322,8 @@ class AppShellMiddleware:
 
     @staticmethod
     def _should_handle(path: str) -> bool:
+        if path in APP_SHELL_BYPASS_PATHS:
+            return False
         return path == APP_PATH_PREFIX or path.startswith(f"{APP_PATH_PREFIX}/")
 
     @staticmethod

--- a/middleware/app_shell.py
+++ b/middleware/app_shell.py
@@ -322,7 +322,8 @@ class AppShellMiddleware:
 
     @staticmethod
     def _should_handle(path: str) -> bool:
-        if path in APP_SHELL_BYPASS_PATHS:
+        normalized_path = path if path.endswith("/") else f"{path}/"
+        if normalized_path in APP_SHELL_BYPASS_PATHS:
             return False
         return path == APP_PATH_PREFIX or path.startswith(f"{APP_PATH_PREFIX}/")
 

--- a/tests/unit/test_console_email_oauth.py
+++ b/tests/unit/test_console_email_oauth.py
@@ -314,6 +314,11 @@ class AgentEmailOAuthApiTests(TestCase):
         self.assertContains(response, "js/agent_email_oauth_callback.js")
         self.assertNotContains(response, "console-submenu")
 
+    def test_callback_page_without_trailing_slash_redirects_to_callback(self):
+        response = self.client.get("/app/email/oauth/callback", {"code": "abc", "state": "xyz"})
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.url, f"{reverse('app-email-oauth-callback-view')}?code=abc&state=xyz")
+
     def test_legacy_callback_page_redirects_to_app_callback_with_query(self):
         url = reverse("console-email-oauth-callback-view")
         response = self.client.get(url, {"code": "abc", "state": "xyz"})

--- a/tests/unit/test_console_email_oauth.py
+++ b/tests/unit/test_console_email_oauth.py
@@ -308,10 +308,17 @@ class AgentEmailOAuthApiTests(TestCase):
         self.assertFalse(AgentEmailOAuthCredential.objects.filter(id=credential.id).exists())
 
     def test_callback_page_includes_completion_script(self):
-        url = reverse("console-email-oauth-callback-view")
+        url = reverse("app-email-oauth-callback-view")
         response = self.client.get(url, {"code": "abc", "state": "xyz"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "js/agent_email_oauth_callback.js")
+        self.assertNotContains(response, "console-submenu")
+
+    def test_legacy_callback_page_redirects_to_app_callback_with_query(self):
+        url = reverse("console-email-oauth-callback-view")
+        response = self.client.get(url, {"code": "abc", "state": "xyz"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f"{reverse('app-email-oauth-callback-view')}?code=abc&state=xyz")
 
     @override_settings(LEGACY_CONSOLE_PAGE_REDIRECTS_ENABLED=True)
     def test_settings_page_mounts_react_email_app(self):
@@ -364,6 +371,7 @@ class AgentEmailOAuthApiTests(TestCase):
         self.assertIn("exists", payload["defaultEndpoint"])
         self.assertIn("address", payload["defaultEndpoint"])
         self.assertIn("isInboundAliasActive", payload["defaultEndpoint"])
+        self.assertEqual(payload["oauth"]["callbackPath"], reverse("app-email-oauth-callback-view"))
         self.assertIn("gmail", payload["providerDefaults"])
         self.assertIn("microsoft", payload["providerDefaults"])
         self.assertIn("outlook", payload["providerDefaults"])

--- a/tests/unit/test_native_integrations.py
+++ b/tests/unit/test_native_integrations.py
@@ -1102,6 +1102,17 @@ class NativeIntegrationTests(TestCase):
         self.assertEqual(agent_response.json()["agent_secrets"], [])
         self.assertEqual(agent_response.json()["global_secrets"], [])
 
+    def test_native_integration_oauth_callback_page_uses_standalone_shell(self):
+        response = self.client.get(
+            reverse("console-native-integration-oauth-callback-view"),
+            {"code": "abc", "state": "xyz"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "js/native_integration_oauth_callback.js")
+        self.assertContains(response, "native-oauth-status")
+        self.assertNotContains(response, "console-submenu")
+
     @patch("api.agent.tools.http_request.select_proxy_for_persistent_agent")
     @patch("api.agent.tools.http_request.requests.request")
     def test_http_request_injects_native_provider_auth(self, mock_request, mock_proxy):


### PR DESCRIPTION
## Summary
- Route the email OAuth callback through `/app/email/oauth/callback/` and keep the legacy console URL as a redirect that preserves query parameters.
- Factor OAuth callback pages into a shared standalone shell so native and email flows render consistently outside the console chrome.
- Update email OAuth metadata and tests to reference the new callback path and verify the legacy redirect behavior.

## Testing
- Added/updated unit coverage for the new app callback route, the legacy redirect, and the standalone native OAuth callback shell.
- Verified the email callback payload now reports the new callback path.
- Not run (not requested).