### PR TITLE
Allow bulk folder deletion in agent files

### DIFF
--- a/console/api_views.py
+++ b/console/api_views.py
@@ -4990,18 +4990,23 @@ class AgentFsNodeBulkDeleteAPIView(LoginRequiredMixin, View):
             return HttpResponseBadRequest("node_ids must be a non-empty list")
 
         filespace = get_or_create_default_filespace(agent)
-        nodes = (
+        nodes = list(
             AgentFsNode.objects.alive()
             .filter(
                 filespace=filespace,
                 id__in=node_ids,
-                node_type=AgentFsNode.NodeType.FILE,
             )
+            .order_by("path")
         )
 
         deleted = 0
-        for node in nodes:
+        deleted_prefixes: list[str] = []
+        for node in sorted(nodes, key=lambda item: item.path.count("/")):
+            if any(node.path == prefix or node.path.startswith(f"{prefix}/") for prefix in deleted_prefixes):
+                continue
             deleted += node.trash_subtree()
+            if node.node_type == AgentFsNode.NodeType.DIR:
+                deleted_prefixes.append(node.path.rstrip("/"))
 
         try:
             Analytics.track_event(

--- a/frontend/src/components/agentFiles/FileTable.tsx
+++ b/frontend/src/components/agentFiles/FileTable.tsx
@@ -133,7 +133,7 @@ export function FileTable({
             }}
             onChange={table.getToggleAllRowsSelectedHandler()}
             className={selectionInputClassName}
-            aria-label="Select all files"
+            aria-label="Select all items"
           />
         ),
         cell: ({ row }) => (
@@ -204,24 +204,36 @@ export function FileTable({
           const node = row.original
           if (node.nodeType === 'dir') {
             return (
-              <label
-                htmlFor={uploadInputId}
-                role="button"
-                tabIndex={isBusy ? -1 : 0}
-                aria-disabled={isBusy}
-                className={folderUploadButtonClassName}
-                onPointerDown={(event) => {
-                  if (isBusy) {
-                    event.preventDefault()
-                    return
-                  }
-                  onRequestUpload(node.id)
-                }}
-                onKeyDown={(event) => handleUploadKeyDown(node.id, event)}
-              >
-                <UploadCloud className="h-3.5 w-3.5" />
-                Upload here
-              </label>
+              <div className="flex flex-wrap items-center gap-2">
+                <label
+                  htmlFor={uploadInputId}
+                  role="button"
+                  tabIndex={isBusy ? -1 : 0}
+                  aria-disabled={isBusy}
+                  className={folderUploadButtonClassName}
+                  onPointerDown={(event) => {
+                    if (isBusy) {
+                      event.preventDefault()
+                      return
+                    }
+                    onRequestUpload(node.id)
+                  }}
+                  onKeyDown={(event) => handleUploadKeyDown(node.id, event)}
+                >
+                  <UploadCloud className="h-3.5 w-3.5" />
+                  Upload here
+                </label>
+                {canManage && (
+                  <button
+                    type="button"
+                    className={deleteButtonClassName}
+                    onClick={() => onDeleteNode(node)}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    Delete
+                  </button>
+                )}
+              </div>
             )
           }
 
@@ -260,7 +272,7 @@ export function FileTable({
     onRowSelectionChange,
     getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.id,
-    enableRowSelection: canManage ? (row) => row.original.nodeType === 'file' : false,
+    enableRowSelection: canManage,
   })
 
   return (

--- a/frontend/src/screens/AgentFilesScreen.tsx
+++ b/frontend/src/screens/AgentFilesScreen.tsx
@@ -243,6 +243,11 @@ export function AgentFilesScreen({
     return Object.keys(rowSelection).filter((key) => rowSelection[key])
   }, [rowSelection])
   const selectedRows = selectedNodes.length
+  const selectedNodeRecords = useMemo(() => {
+    return selectedNodes
+      .map((nodeId) => nodeMap.get(nodeId))
+      .filter((node): node is AgentFsNode => Boolean(node))
+  }, [nodeMap, selectedNodes])
 
   const handleBulkDelete = useCallback(async () => {
     if (!canManage) {
@@ -251,7 +256,12 @@ export function AgentFilesScreen({
     if (!selectedNodes.length) {
       return
     }
-    const confirmed = window.confirm(`Delete ${selectedNodes.length} file${selectedNodes.length === 1 ? '' : 's'}?`)
+    const hasFolder = selectedNodeRecords.some((node) => node.nodeType === 'dir')
+    const confirmed = window.confirm(
+      hasFolder
+        ? `Delete ${selectedNodes.length} selected item${selectedNodes.length === 1 ? '' : 's'}? Folders and their contents will also be deleted.`
+        : `Delete ${selectedNodes.length} file${selectedNodes.length === 1 ? '' : 's'}?`,
+    )
     if (!confirmed) {
       return
     }
@@ -260,13 +270,17 @@ export function AgentFilesScreen({
     } catch {
       // Errors are surfaced via mutation callbacks.
     }
-  }, [canManage, deleteMutation, selectedNodes])
+  }, [canManage, deleteMutation, selectedNodeRecords, selectedNodes])
 
   const handleSingleDelete = useCallback(async (node: AgentFsNode) => {
     if (!canManage) {
       return
     }
-    const confirmed = window.confirm(`Delete ${node.name}?`)
+    const confirmed = window.confirm(
+      node.nodeType === 'dir'
+        ? `Delete folder "${node.name}" and all contents?`
+        : `Delete "${node.name}"?`,
+    )
     if (!confirmed) {
       return
     }

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -19,7 +19,7 @@ from django.utils import timezone
 from waffle.testutils import override_flag, override_switch
 
 from api.agent.files.attachment_helpers import resolve_filespace_attachments
-from api.agent.files.filespace_service import write_bytes_to_dir
+from api.agent.files.filespace_service import get_or_create_default_filespace, write_bytes_to_dir
 from api.agent.comms.imap_adapter import ImapEmailAdapter
 from api.agent.comms.adapters import ParsedMessage
 from api.agent.comms.chat_email_display_cache import merge_chat_body_html_cache
@@ -885,6 +885,132 @@ class AgentChatAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"nodes": []})
         self.assertEqual(AgentFileSpaceAccess.objects.filter(agent=self.agent).count(), access_count)
+
+    @tag("batch_agent_chat")
+    def test_agent_files_delete_file_still_soft_deletes_file(self):
+        write_bytes_to_dir(
+            self.agent,
+            b"hello",
+            "/reports/summary.txt",
+            "text/plain",
+        )
+        node = AgentFsNode.objects.get(path="/reports/summary.txt")
+
+        response = self.client.post(
+            reverse("console_agent_fs_delete", kwargs={"agent_id": self.agent.id}),
+            data=json.dumps({"nodeIds": [str(node.id)]}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"deleted": 1})
+        node.refresh_from_db()
+        self.assertTrue(node.is_deleted)
+
+    @tag("batch_agent_chat")
+    def test_agent_files_delete_empty_folder_soft_deletes_folder(self):
+        filespace = get_or_create_default_filespace(self.agent)
+        folder = AgentFsNode.objects.create(
+            filespace=filespace,
+            parent=None,
+            node_type=AgentFsNode.NodeType.DIR,
+            name="empty",
+        )
+
+        response = self.client.post(
+            reverse("console_agent_fs_delete", kwargs={"agent_id": self.agent.id}),
+            data=json.dumps({"nodeIds": [str(folder.id)]}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"deleted": 1})
+        folder.refresh_from_db()
+        self.assertTrue(folder.is_deleted)
+
+    @tag("batch_agent_chat")
+    def test_agent_files_delete_folder_soft_deletes_subtree(self):
+        write_bytes_to_dir(
+            self.agent,
+            b"notes",
+            "/docs/notes.txt",
+            "text/plain",
+        )
+        write_bytes_to_dir(
+            self.agent,
+            b"report",
+            "/docs/sub/report.txt",
+            "text/plain",
+        )
+        folder = AgentFsNode.objects.get(path="/docs")
+
+        response = self.client.post(
+            reverse("console_agent_fs_delete", kwargs={"agent_id": self.agent.id}),
+            data=json.dumps({"nodeIds": [str(folder.id)]}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"deleted": 4})
+        self.assertFalse(AgentFsNode.objects.alive().filter(path__startswith="/docs").exists())
+
+    @tag("batch_agent_chat")
+    def test_agent_files_delete_folder_and_child_does_not_double_count(self):
+        write_bytes_to_dir(
+            self.agent,
+            b"notes",
+            "/docs/notes.txt",
+            "text/plain",
+        )
+        write_bytes_to_dir(
+            self.agent,
+            b"report",
+            "/docs/sub/report.txt",
+            "text/plain",
+        )
+        folder = AgentFsNode.objects.get(path="/docs")
+        child = AgentFsNode.objects.get(path="/docs/sub/report.txt")
+
+        response = self.client.post(
+            reverse("console_agent_fs_delete", kwargs={"agent_id": self.agent.id}),
+            data=json.dumps({"nodeIds": [str(folder.id), str(child.id)]}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"deleted": 4})
+        self.assertFalse(AgentFsNode.objects.alive().filter(path__startswith="/docs").exists())
+
+    @tag("batch_agent_chat")
+    def test_agent_files_delete_folder_forbidden_for_collaborator(self):
+        write_bytes_to_dir(
+            self.agent,
+            b"notes",
+            "/docs/notes.txt",
+            "text/plain",
+        )
+        folder = AgentFsNode.objects.get(path="/docs")
+        collaborator = get_user_model().objects.create_user(
+            username="files-delete-collaborator",
+            email="files-delete-collaborator@example.com",
+            password="password123",
+        )
+        AgentCollaborator.objects.create(
+            agent=self.agent,
+            user=collaborator,
+            invited_by=self.user,
+        )
+        self.client.force_login(collaborator)
+
+        response = self.client.post(
+            reverse("console_agent_fs_delete", kwargs={"agent_id": self.agent.id}),
+            data=json.dumps({"nodeIds": [str(folder.id)]}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        folder.refresh_from_db()
+        self.assertFalse(folder.is_deleted)
 
     @tag("batch_agent_chat")
     def test_timeline_filters_manager_only_pending_actions_for_collaborator(self):


### PR DESCRIPTION
**Summary**
- Allow bulk delete to accept folders as well as files, while avoiding double-deletion when a parent folder and child node are both selected.
- Update the files UI to let managers select folders for bulk actions and show delete affordances on folder rows.
- Improve confirmation copy so folder deletions clearly warn that contents will be removed too.
- Add backend coverage for deleting files, empty folders, nested folder subtrees, duplicate parent/child selections, and collaborator permission checks.

**Testing**
- Added unit tests covering the updated bulk delete semantics and permission behavior.
- Updated frontend behavior for folder selection and delete confirmations.
- Not run (not requested)