### PR TITLE
Fix default web chat recipient selection

### DIFF
--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db.models import Max
 from django.utils import timezone
 
 from ..comms.message_service import _get_or_create_conversation, _ensure_participant
@@ -29,7 +30,7 @@ from ...models import (
     parse_web_user_address,
 )
 from ...services.email_verification import has_verified_email
-from ...services.web_sessions import get_deliverable_web_session
+from ...services.web_sessions import get_deliverable_web_session, get_deliverable_web_sessions
 from .outbound_duplicate_guard import detect_recent_duplicate_message
 
 _PROGRESS_PREFIX_RE = re.compile(
@@ -219,6 +220,31 @@ def has_other_contact_channel(agent: PersistentAgent, recipient_user) -> bool:
     return False
 
 
+def _resolve_default_web_chat_address(agent: PersistentAgent) -> str:
+    if agent.preferred_contact_endpoint and agent.preferred_contact_endpoint.channel == CommsChannel.WEB:
+        return agent.preferred_contact_endpoint.address
+
+    for session in get_deliverable_web_sessions(agent):
+        if session.user_id is not None:
+            return build_web_user_address(session.user_id, agent.id)
+
+    web_conversations = agent.owned_conversations.filter(channel=CommsChannel.WEB)
+    latest_conversation = (
+        web_conversations.filter(messages__isnull=False)
+        .annotate(latest_message_at=Max("messages__timestamp"))
+        .order_by("-latest_message_at", "-id")
+        .first()
+    )
+    if latest_conversation:
+        return latest_conversation.address
+
+    owner_user = getattr(agent, "user", None)
+    if owner_user and not web_conversations.exists() and not has_other_contact_channel(agent, owner_user):
+        return build_web_user_address(owner_user.id, agent.id)
+
+    return ""
+
+
 def get_send_chat_tool() -> Dict[str, Any]:
     """Definition for the send_chat_message tool exposed to the agent."""
 
@@ -326,18 +352,7 @@ def execute_send_chat_message(agent: PersistentAgent, params: Dict[str, Any]) ->
     to_address = (params.get("to_address") or "").strip()
 
     if not to_address:
-        # Prefer explicit preferred endpoint configured for web chat
-        if agent.preferred_contact_endpoint and agent.preferred_contact_endpoint.channel == CommsChannel.WEB:
-            to_address = agent.preferred_contact_endpoint.address
-        else:
-            latest_conversation = agent.owned_conversations.filter(channel=CommsChannel.WEB).order_by("-id").first()
-            if latest_conversation:
-                to_address = latest_conversation.address
-            else:
-                owner_user = getattr(agent, "user", None)
-                if owner_user and not has_other_contact_channel(agent, owner_user):
-                    # When web chat is the only channel, default to the owner's web address.
-                    to_address = build_web_user_address(owner_user.id, agent.id)
+        to_address = _resolve_default_web_chat_address(agent)
 
     if not to_address:
         return {

--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -226,17 +226,23 @@ def _resolve_default_web_chat_address(agent: PersistentAgent) -> str:
 
     for session in get_deliverable_web_sessions(agent):
         if session.user_id is not None:
-            return build_web_user_address(session.user_id, agent.id)
+            session_address = build_web_user_address(session.user_id, agent.id)
+            if agent.is_recipient_whitelisted(CommsChannel.WEB, session_address):
+                return session_address
 
     web_conversations = agent.owned_conversations.filter(channel=CommsChannel.WEB)
-    latest_conversation = (
+    messaged_conversations = (
         web_conversations.filter(messages__isnull=False)
         .annotate(latest_message_at=Max("messages__timestamp"))
         .order_by("-latest_message_at", "-id")
-        .first()
     )
-    if latest_conversation:
-        return latest_conversation.address
+    for conversation in messaged_conversations:
+        if agent.is_recipient_whitelisted(CommsChannel.WEB, conversation.address):
+            return conversation.address
+
+    for conversation in web_conversations.order_by("-id"):
+        if agent.is_recipient_whitelisted(CommsChannel.WEB, conversation.address):
+            return conversation.address
 
     owner_user = getattr(agent, "user", None)
     if owner_user and not web_conversations.exists() and not has_other_contact_channel(agent, owner_user):

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -3279,6 +3279,64 @@ class AgentChatAPITests(TestCase):
         self.assertEqual(message.to_endpoint.address, recent_address)
 
     @tag("batch_agent_chat")
+    def test_send_chat_tool_without_to_address_skips_unauthorized_deliverable_web_session(self):
+        agent = PersistentAgent.objects.create(
+            user=self.user,
+            name="Default Recipient Authorization Tester",
+            charter="Test web chat authorization routing",
+            browser_use_agent=BrowserUseAgent.objects.create(
+                user=self.user,
+                name="Default Recipient Authorization Browser",
+            ),
+        )
+        removed_user = get_user_model().objects.create_user(
+            username="removed-web-user",
+            email="removed-web-user@example.com",
+            password="password123",
+        )
+        active_user = get_user_model().objects.create_user(
+            username="authorized-web-user",
+            email="authorized-web-user@example.com",
+            password="password123",
+        )
+        removed_collaborator = AgentCollaborator.objects.create(agent=agent, user=removed_user)
+        AgentCollaborator.objects.create(agent=agent, user=active_user)
+
+        start_web_session(agent, active_user)
+        start_web_session(agent, removed_user)
+        removed_collaborator.delete()
+
+        result = execute_send_chat_message(agent, {"body": "Ping"})
+
+        self.assertEqual(result["status"], "ok")
+        message = PersistentAgentMessage.objects.get(owner_agent=agent, is_outbound=True, body="Ping")
+        self.assertEqual(message.to_endpoint.address, build_web_user_address(active_user.id, agent.id))
+
+    @tag("batch_agent_chat")
+    def test_send_chat_tool_without_to_address_falls_back_to_web_conversation_without_messages(self):
+        agent = PersistentAgent.objects.create(
+            user=self.user,
+            name="Default Recipient Empty Conversation Tester",
+            charter="Test empty web conversation routing",
+            browser_use_agent=BrowserUseAgent.objects.create(
+                user=self.user,
+                name="Default Recipient Empty Conversation Browser",
+            ),
+        )
+        owner_address = build_web_user_address(self.user.id, agent.id)
+        PersistentAgentConversation.objects.create(
+            owner_agent=agent,
+            channel=CommsChannel.WEB,
+            address=owner_address,
+        )
+
+        result = execute_send_chat_message(agent, {"body": "Ping"})
+
+        self.assertEqual(result["status"], "ok")
+        message = PersistentAgentMessage.objects.get(owner_agent=agent, is_outbound=True, body="Ping")
+        self.assertEqual(message.to_endpoint.address, owner_address)
+
+    @tag("batch_agent_chat")
     @patch("api.agent.tasks.enqueue_interactive_process_agent_events")
     def test_message_post_creates_console_message(self, mock_enqueue):
         body = "Run weekly summary"

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -3091,6 +3091,194 @@ class AgentChatAPITests(TestCase):
         self.assertEqual(message.to_endpoint.address, self.user_address)
 
     @tag("batch_agent_chat")
+    def test_send_chat_tool_without_to_address_prefers_deliverable_web_session_over_uuid_order(self):
+        agent = PersistentAgent.objects.create(
+            user=self.user,
+            name="Default Recipient Session Tester",
+            charter="Test web chat default routing",
+            browser_use_agent=BrowserUseAgent.objects.create(
+                user=self.user,
+                name="Default Recipient Session Browser",
+            ),
+        )
+        stale_user = get_user_model().objects.create_user(
+            username="stale-web-user",
+            email="stale-web-user@example.com",
+            password="password123",
+        )
+        active_user = get_user_model().objects.create_user(
+            username="active-web-user",
+            email="active-web-user@example.com",
+            password="password123",
+        )
+        AgentCollaborator.objects.create(agent=agent, user=stale_user)
+        AgentCollaborator.objects.create(agent=agent, user=active_user)
+
+        PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=agent,
+            channel=CommsChannel.EMAIL,
+            address="default-recipient-session@example.com",
+            is_primary=True,
+        )
+        EmailAddress.objects.create(
+            user=stale_user,
+            email=stale_user.email,
+            verified=True,
+            primary=True,
+        )
+        EmailAddress.objects.create(
+            user=active_user,
+            email=active_user.email,
+            verified=True,
+            primary=True,
+        )
+
+        agent_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=agent,
+            channel=CommsChannel.WEB,
+            address=build_web_agent_address(agent.id),
+            is_primary=True,
+        )
+        stale_address = build_web_user_address(stale_user.id, agent.id)
+        active_address = build_web_user_address(active_user.id, agent.id)
+        stale_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=None,
+            channel=CommsChannel.WEB,
+            address=stale_address,
+        )
+        active_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=None,
+            channel=CommsChannel.WEB,
+            address=active_address,
+        )
+        stale_conversation = PersistentAgentConversation.objects.create(
+            id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+            owner_agent=agent,
+            channel=CommsChannel.WEB,
+            address=stale_address,
+        )
+        active_conversation = PersistentAgentConversation.objects.create(
+            id="00000000-0000-0000-0000-000000000001",
+            owner_agent=agent,
+            channel=CommsChannel.WEB,
+            address=active_address,
+        )
+        stale_message = PersistentAgentMessage.objects.create(
+            is_outbound=False,
+            from_endpoint=stale_endpoint,
+            to_endpoint=agent_endpoint,
+            conversation=stale_conversation,
+            body="Older chat",
+            owner_agent=agent,
+        )
+        active_message = PersistentAgentMessage.objects.create(
+            is_outbound=False,
+            from_endpoint=active_endpoint,
+            to_endpoint=agent_endpoint,
+            conversation=active_conversation,
+            body="Recent chat",
+            owner_agent=agent,
+        )
+        PersistentAgentMessage.objects.filter(pk=stale_message.pk).update(
+            timestamp=timezone.now() - timedelta(days=1)
+        )
+        PersistentAgentMessage.objects.filter(pk=active_message.pk).update(timestamp=timezone.now())
+        start_web_session(agent, active_user)
+
+        uuid_selected = agent.owned_conversations.filter(channel=CommsChannel.WEB).order_by("-id").first()
+        self.assertEqual(uuid_selected.address, stale_address)
+
+        result = execute_send_chat_message(agent, {"body": "Ping"})
+
+        self.assertEqual(result["status"], "ok")
+        message = PersistentAgentMessage.objects.get(owner_agent=agent, is_outbound=True, body="Ping")
+        self.assertEqual(message.to_endpoint.address, active_address)
+
+    @tag("batch_agent_chat")
+    def test_send_chat_tool_without_to_address_falls_back_to_latest_web_conversation_by_message_time(self):
+        agent = PersistentAgent.objects.create(
+            user=self.user,
+            name="Default Recipient Conversation Tester",
+            charter="Test web chat conversation recency routing",
+            browser_use_agent=BrowserUseAgent.objects.create(
+                user=self.user,
+                name="Default Recipient Conversation Browser",
+            ),
+        )
+        older_user = get_user_model().objects.create_user(
+            username="older-web-user",
+            email="older-web-user@example.com",
+            password="password123",
+        )
+        recent_user = get_user_model().objects.create_user(
+            username="recent-web-user",
+            email="recent-web-user@example.com",
+            password="password123",
+        )
+        AgentCollaborator.objects.create(agent=agent, user=older_user)
+        AgentCollaborator.objects.create(agent=agent, user=recent_user)
+
+        agent_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=agent,
+            channel=CommsChannel.WEB,
+            address=build_web_agent_address(agent.id),
+            is_primary=True,
+        )
+        older_address = build_web_user_address(older_user.id, agent.id)
+        recent_address = build_web_user_address(recent_user.id, agent.id)
+        older_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=None,
+            channel=CommsChannel.WEB,
+            address=older_address,
+        )
+        recent_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=None,
+            channel=CommsChannel.WEB,
+            address=recent_address,
+        )
+        older_conversation = PersistentAgentConversation.objects.create(
+            id="ffffffff-ffff-ffff-ffff-fffffffffffe",
+            owner_agent=agent,
+            channel=CommsChannel.WEB,
+            address=older_address,
+        )
+        recent_conversation = PersistentAgentConversation.objects.create(
+            id="00000000-0000-0000-0000-000000000002",
+            owner_agent=agent,
+            channel=CommsChannel.WEB,
+            address=recent_address,
+        )
+        older_message = PersistentAgentMessage.objects.create(
+            is_outbound=False,
+            from_endpoint=older_endpoint,
+            to_endpoint=agent_endpoint,
+            conversation=older_conversation,
+            body="Older chat",
+            owner_agent=agent,
+        )
+        recent_message = PersistentAgentMessage.objects.create(
+            is_outbound=False,
+            from_endpoint=recent_endpoint,
+            to_endpoint=agent_endpoint,
+            conversation=recent_conversation,
+            body="Recent chat",
+            owner_agent=agent,
+        )
+        PersistentAgentMessage.objects.filter(pk=older_message.pk).update(
+            timestamp=timezone.now() - timedelta(days=1)
+        )
+        PersistentAgentMessage.objects.filter(pk=recent_message.pk).update(timestamp=timezone.now())
+
+        uuid_selected = agent.owned_conversations.filter(channel=CommsChannel.WEB).order_by("-id").first()
+        self.assertEqual(uuid_selected.address, older_address)
+
+        result = execute_send_chat_message(agent, {"body": "Ping"})
+
+        self.assertEqual(result["status"], "ok")
+        message = PersistentAgentMessage.objects.get(owner_agent=agent, is_outbound=True, body="Ping")
+        self.assertEqual(message.to_endpoint.address, recent_address)
+
+    @tag("batch_agent_chat")
     @patch("api.agent.tasks.enqueue_interactive_process_agent_events")
     def test_message_post_creates_console_message(self, mock_enqueue):
         body = "Run weekly summary"


### PR DESCRIPTION
## Summary
- Resolve `send_chat_message` default routing to prefer an active deliverable web session before falling back to conversation history.
- Select the most recent web conversation by message timestamp instead of raw conversation ID ordering.
- Preserve the existing owner web-address fallback when web chat is the only available channel.

## Testing
- Added unit coverage for session-preferred routing and timestamp-based conversation fallback.
- Validated the existing send-chat path still creates outbound messages with the expected web recipient.