### PR TITLE
Handle MCP discovery failures without surfacing HTML errors

### DIFF
--- a/api/agent/tools/mcp_manager.py
+++ b/api/agent/tools/mcp_manager.py
@@ -954,8 +954,8 @@ class MCPToolManager:
                 prefer_cache=False,
                 sandbox_context=sandbox_context,
             )
-        except (ValueError, RuntimeError):
-            logger.exception("Failed to discover MCP tools for %s", config_id)
+        except (ValueError, RuntimeError, OSError, TimeoutError, httpx.HTTPError, ToolError) as exc:
+            logger.warning("MCP discovery failed for %s: %s", config_id, exc)
             return False
         return True
 

--- a/api/agent/tools/mcp_manager.py
+++ b/api/agent/tools/mcp_manager.py
@@ -954,7 +954,15 @@ class MCPToolManager:
                 prefer_cache=False,
                 sandbox_context=sandbox_context,
             )
-        except (ValueError, RuntimeError, OSError, TimeoutError, httpx.HTTPError, ToolError) as exc:
+        except (
+            ValueError,
+            RuntimeError,
+            OSError,
+            TimeoutError,
+            asyncio.TimeoutError,
+            httpx.HTTPError,
+            ToolError,
+        ) as exc:
             logger.warning("MCP discovery failed for %s: %s", config_id, exc)
             return False
         return True
@@ -1007,7 +1015,15 @@ class MCPToolManager:
                 prefer_cache=False,
                 sandbox_context=sandbox_context,
             )
-        except (ValueError, RuntimeError, OSError, TimeoutError, httpx.HTTPError, ToolError) as exc:
+        except (
+            ValueError,
+            RuntimeError,
+            OSError,
+            TimeoutError,
+            asyncio.TimeoutError,
+            httpx.HTTPError,
+            ToolError,
+        ) as exc:
             logger.warning("MCP test discovery failed for %s: %s", config_id, exc)
             return False, [], {
                 "phase": "discover_tools",

--- a/api/services/mcp_tool_discovery.py
+++ b/api/services/mcp_tool_discovery.py
@@ -1,6 +1,9 @@
 import logging
 from typing import Optional
 
+import httpx
+from fastmcp.exceptions import ToolError
+
 from api.models import PersistentAgent
 from api.services.sandbox_compute import (
     SandboxComputeService,
@@ -23,5 +26,13 @@ def schedule_mcp_tool_discovery(
     try:
         service = SandboxComputeService()
         service.discover_mcp_tools(config_id, reason=reason, agent=agent)
-    except (SandboxComputeUnavailable, ValueError, RuntimeError) as exc:
+    except (
+        SandboxComputeUnavailable,
+        ValueError,
+        RuntimeError,
+        OSError,
+        TimeoutError,
+        httpx.HTTPError,
+        ToolError,
+    ) as exc:
         logger.warning("Inline MCP tool discovery failed for %s: %s", config_id, exc)

--- a/frontend/src/api/safeErrorMessage.test.ts
+++ b/frontend/src/api/safeErrorMessage.test.ts
@@ -19,4 +19,16 @@ describe('safeErrorMessage', () => {
 
     expect(safeErrorMessage(error, 'Unable to save MCP server.')).toBe('Unable to save MCP server.')
   })
+
+  it('falls back to statusText when body is empty or not useful', () => {
+    const error = new HttpError(401, 'Unauthorized', null)
+
+    expect(safeErrorMessage(error, 'Fallback message.')).toBe('Unauthorized')
+  })
+
+  it('handles plain objects with a message property', () => {
+    const error = { message: 'Custom plain error message' }
+
+    expect(safeErrorMessage(error, 'Fallback message.')).toBe('Custom plain error message')
+  })
 })

--- a/frontend/src/api/safeErrorMessage.test.ts
+++ b/frontend/src/api/safeErrorMessage.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { HttpError } from './http'
+import { safeErrorMessage } from './safeErrorMessage'
+
+describe('safeErrorMessage', () => {
+  it('uses JSON error details when available', () => {
+    const error = new HttpError(400, 'Bad Request', { detail: 'Use a valid URL.' })
+
+    expect(safeErrorMessage(error, 'Unable to save MCP server.')).toBe('Use a valid URL.')
+  })
+
+  it('does not expose HTML error pages', () => {
+    const error = new HttpError(
+      500,
+      'Internal Server Error',
+      '<!doctype html><html><body>Internal error</body></html>',
+    )
+
+    expect(safeErrorMessage(error, 'Unable to save MCP server.')).toBe('Unable to save MCP server.')
+  })
+})

--- a/frontend/src/api/safeErrorMessage.ts
+++ b/frontend/src/api/safeErrorMessage.ts
@@ -1,6 +1,8 @@
 import { HttpError } from './http'
 
-export function safeErrorMessage(error: unknown): string {
+const DEFAULT_ERROR_MESSAGE = 'Request failed. Please try again.'
+
+export function safeErrorMessage(error: unknown, fallback = DEFAULT_ERROR_MESSAGE): string {
   if (error instanceof HttpError) {
     const body = error.body
     if (body && typeof body === 'object') {
@@ -14,13 +16,23 @@ export function safeErrorMessage(error: unknown): string {
       }
     }
     if (typeof body === 'string' && body.trim()) {
+      if (isHtmlResponse(body)) {
+        return fallback
+      }
       return body
     }
-    return 'Request failed. Please try again.'
+    return fallback
   }
   if (error instanceof Error && error.message) {
+    if (isHtmlResponse(error.message)) {
+      return fallback
+    }
     return error.message
   }
-  return 'Request failed. Please try again.'
+  return fallback
 }
 
+function isHtmlResponse(value: string): boolean {
+  const normalized = value.slice(0, 200).toLowerCase()
+  return normalized.includes('<!doctype') || normalized.includes('<html') || normalized.includes('<body')
+}

--- a/frontend/src/api/safeErrorMessage.ts
+++ b/frontend/src/api/safeErrorMessage.ts
@@ -19,13 +19,19 @@ export function safeErrorMessage(error: unknown, fallback = DEFAULT_ERROR_MESSAG
       }
       return body
     }
+    if (typeof error.statusText === 'string' && error.statusText.trim()) {
+      return error.statusText
+    }
     return fallback
   }
-  if (error instanceof Error && error.message) {
-    if (isHtmlResponse(error.message)) {
-      return fallback
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message: unknown }).message
+    if (typeof message === 'string' && message.trim()) {
+      if (isHtmlResponse(message)) {
+        return fallback
+      }
+      return message
     }
-    return error.message
   }
   return fallback
 }

--- a/frontend/src/api/safeErrorMessage.ts
+++ b/frontend/src/api/safeErrorMessage.ts
@@ -6,13 +6,11 @@ export function safeErrorMessage(error: unknown, fallback = DEFAULT_ERROR_MESSAG
   if (error instanceof HttpError) {
     const body = error.body
     if (body && typeof body === 'object') {
-      const maybeDetail = (body as { detail?: unknown }).detail
-      const maybeError = (body as { error?: unknown }).error
-      if (typeof maybeDetail === 'string' && maybeDetail.trim()) {
-        return maybeDetail
-      }
-      if (typeof maybeError === 'string' && maybeError.trim()) {
-        return maybeError
+      for (const key of ['message', 'detail', 'error']) {
+        const value = (body as Record<string, unknown>)[key]
+        if (typeof value === 'string' && value.trim()) {
+          return value
+        }
       }
     }
     if (typeof body === 'string' && body.trim()) {

--- a/frontend/src/components/mcp/AssignServerModal.tsx
+++ b/frontend/src/components/mcp/AssignServerModal.tsx
@@ -10,7 +10,7 @@ import {
   type McpServerAssignmentResponse,
 } from '../../api/mcp'
 import { ModalForm } from '../common/ModalForm'
-import { HttpError } from '../../api/http'
+import { safeErrorMessage } from '../../api/safeErrorMessage'
 
 type AssignServerModalProps = {
   server: McpServer
@@ -56,7 +56,7 @@ export function AssignServerModal({
       onClose()
     },
     onError: (error) => {
-      const message = resolveErrorMessage(error, 'Unable to update assignments.')
+      const message = safeErrorMessage(error, 'Unable to update assignments.')
       setStatusMessage(message)
       onError(message)
     },
@@ -122,7 +122,7 @@ export function AssignServerModal({
           </div>
         ) : isError ? (
           <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {resolveErrorMessage(error, 'Failed to load agents for this server.')}
+            {safeErrorMessage(error, 'Failed to load agents for this server.')}
           </div>
         ) : (
           <div className="space-y-5">
@@ -225,21 +225,6 @@ function useFilteredAgents(data: McpServerAssignmentResponse | undefined, search
       return name.includes(query) || description.includes(query)
     })
   }, [data, searchTerm])
-}
-
-function resolveErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof HttpError) {
-    if (typeof error.body === 'string' && error.body) {
-      return error.body
-    }
-    if (typeof error.statusText === 'string' && error.statusText) {
-      return error.statusText
-    }
-  }
-  if (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string') {
-    return (error as { message: string }).message
-  }
-  return fallback
 }
 
 function formatTimestamp(iso: string): string {

--- a/frontend/src/components/mcp/DeleteServerDialog.tsx
+++ b/frontend/src/components/mcp/DeleteServerDialog.tsx
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 import { Trash2 } from 'lucide-react'
 
 import { deleteMcpServer } from '../../api/mcp'
-import { HttpError } from '../../api/http'
+import { safeErrorMessage } from '../../api/safeErrorMessage'
 import { ActionConfirmDialog } from '../common/ActionConfirmDialog'
 
 type DeleteServerDialogProps = {
@@ -28,7 +28,7 @@ export function DeleteServerDialog({ serverName, deleteUrl, onClose, onDeleted, 
       onDeleted()
       onClose()
     } catch (error) {
-      const message = resolveErrorMessage(error, 'Failed to delete MCP server.')
+      const message = safeErrorMessage(error, 'Failed to delete MCP server.')
       setLocalError(message)
       onError(message)
     }
@@ -52,44 +52,4 @@ export function DeleteServerDialog({ serverName, deleteUrl, onClose, onDeleted, 
       </p>
     </ActionConfirmDialog>
   )
-}
-
-function resolveErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof HttpError) {
-    const bodyMessage = resolveBodyMessage(error.body)
-    if (bodyMessage) {
-      return bodyMessage
-    }
-    if (typeof error.statusText === 'string' && error.statusText) {
-      return error.statusText
-    }
-  }
-  if (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string') {
-    return (error as { message: string }).message
-  }
-  return fallback
-}
-
-function resolveBodyMessage(body: unknown): string | null {
-  if (typeof body === 'string') {
-    const trimmed = body.trim()
-    if (!trimmed) {
-      return null
-    }
-    return isHtmlResponse(trimmed) ? null : trimmed
-  }
-  if (body && typeof body === 'object') {
-    for (const key of ['message', 'detail', 'error']) {
-      const value = (body as Record<string, unknown>)[key]
-      if (typeof value === 'string' && value.trim()) {
-        return value
-      }
-    }
-  }
-  return null
-}
-
-function isHtmlResponse(body: string): boolean {
-  const normalized = body.slice(0, 200).toLowerCase()
-  return normalized.includes('<!doctype') || normalized.includes('<html') || normalized.includes('<body')
 }

--- a/frontend/src/components/mcp/McpServerFormModal.tsx
+++ b/frontend/src/components/mcp/McpServerFormModal.tsx
@@ -207,7 +207,7 @@ export function McpServerFormModal({
         }
       } else {
         const fallback = mode === 'create' ? 'Unable to save MCP server.' : 'Unable to update MCP server.'
-        const message = resolveErrorMessage(error, fallback)
+        const message = safeErrorMessage(error, fallback)
         setStatusMessage(message)
         onError(message)
       }
@@ -247,7 +247,7 @@ export function McpServerFormModal({
   }
 
   if (mode === 'edit' && detailQuery.error) {
-    const message = resolveErrorMessage(detailQuery.error, 'Failed to load MCP server details.')
+    const message = safeErrorMessage(detailQuery.error, 'Failed to load MCP server details.')
     return (
       <Modal
         title={formTitle}
@@ -1012,10 +1012,6 @@ function isErrorBody(payload: unknown): payload is { errors?: FormErrors; messag
   }
   const record = payload as Record<string, unknown>
   return 'errors' in record || 'message' in record
-}
-
-function resolveErrorMessage(error: unknown, fallback: string): string {
-  return safeErrorMessage(error, fallback)
 }
 
 function extractBearerToken(value: string): string | null {

--- a/frontend/src/components/mcp/McpServerFormModal.tsx
+++ b/frontend/src/components/mcp/McpServerFormModal.tsx
@@ -11,6 +11,7 @@ import {
   type McpServerPayload,
 } from '../../api/mcp'
 import { HttpError } from '../../api/http'
+import { safeErrorMessage } from '../../api/safeErrorMessage'
 import { useMcpOAuth } from '../../hooks/useMcpOAuth'
 import { Modal } from '../common/Modal'
 import { ModalForm } from '../common/ModalForm'
@@ -1014,18 +1015,7 @@ function isErrorBody(payload: unknown): payload is { errors?: FormErrors; messag
 }
 
 function resolveErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof HttpError) {
-    if (typeof error.body === 'string' && error.body) {
-      return error.body
-    }
-    if (typeof error.statusText === 'string' && error.statusText) {
-      return error.statusText
-    }
-  }
-  if (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string') {
-    return (error as { message: string }).message
-  }
-  return fallback
+  return safeErrorMessage(error, fallback)
 }
 
 function extractBearerToken(value: string): string | null {

--- a/frontend/src/components/mcp/McpServerTestModal.tsx
+++ b/frontend/src/components/mcp/McpServerTestModal.tsx
@@ -11,7 +11,7 @@ import {
   type McpServerTestResponse,
   type McpServerTestTool,
 } from '../../api/mcp'
-import { HttpError } from '../../api/http'
+import { safeErrorMessage } from '../../api/safeErrorMessage'
 import { Modal } from '../common/Modal'
 
 type McpServerTestModalProps = {
@@ -51,7 +51,7 @@ export function McpServerTestModal({
       }
     },
     onError: (error) => {
-      const message = resolveErrorMessage(error, 'Unable to test MCP server.')
+      const message = safeErrorMessage(error, 'Unable to test MCP server.')
       setStatusMessage(message)
       onError(message)
     },
@@ -111,7 +111,7 @@ export function McpServerTestModal({
               </div>
             ) : assignmentsQuery.isError ? (
               <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                {resolveErrorMessage(assignmentsQuery.error, 'Failed to load eligible agents.')}
+                {safeErrorMessage(assignmentsQuery.error, 'Failed to load eligible agents.')}
               </div>
             ) : (
               <>
@@ -290,19 +290,4 @@ function useFilteredTools(tools: McpServerTestTool[] | undefined, searchTerm: st
       return name.includes(query) || description.includes(query)
     })
   }, [tools, searchTerm])
-}
-
-function resolveErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof HttpError) {
-    if (typeof error.body === 'string' && error.body) {
-      return error.body
-    }
-    if (typeof error.statusText === 'string' && error.statusText) {
-      return error.statusText
-    }
-  }
-  if (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string') {
-    return (error as { message: string }).message
-  }
-  return fallback
 }

--- a/frontend/src/screens/AgentDetailScreen.tsx
+++ b/frontend/src/screens/AgentDetailScreen.tsx
@@ -45,6 +45,8 @@ import type {
   PendingCollaboratorAction,
 } from '../components/agentSettings/contactTypes'
 import { useModal } from '../hooks/useModal'
+import { HttpError } from '../api/http'
+import { safeErrorMessage } from '../api/safeErrorMessage'
 import { readStoredConsoleContext } from '../util/consoleContextStorage'
 import type { IntelligenceTierKey } from '../types/llmIntelligence'
 import type {
@@ -1661,12 +1663,12 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
         credentials: 'same-origin',
       })
       if (!response.ok) {
-        const message = (await response.text())?.trim()
-        throw new Error(message || 'Failed to delete agent. Please try again.')
+        const body = await response.text().catch(() => null)
+        throw new HttpError(response.status, response.statusText, body)
       }
       onDeleted?.()
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to delete agent. Please try again.'
+      const message = safeErrorMessage(error, 'Failed to delete agent. Please try again.')
       setDeleteError(message)
       throw error
     }

--- a/frontend/src/screens/AgentFilesScreen.tsx
+++ b/frontend/src/screens/AgentFilesScreen.tsx
@@ -4,6 +4,7 @@ import type { RowSelectionState } from '@tanstack/react-table'
 import { RefreshCw } from 'lucide-react'
 
 import { HttpError, getCsrfToken, jsonFetch, jsonRequest } from '../api/http'
+import { safeErrorMessage } from '../api/safeErrorMessage'
 import { CreateFolderForm } from '../components/agentFiles/CreateFolderForm'
 import { FileManagerBreadcrumbs } from '../components/agentFiles/FileManagerBreadcrumbs'
 import { FileManagerHeader } from '../components/agentFiles/FileManagerHeader'
@@ -35,21 +36,6 @@ type CreateFolderPayload = {
 type MovePayload = {
   nodeId: string
   parentId: string | null
-}
-
-function resolveErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof HttpError) {
-    if (typeof error.body === 'string' && error.body) {
-      return error.body
-    }
-    if (typeof error.statusText === 'string' && error.statusText) {
-      return error.statusText
-    }
-  }
-  if (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string') {
-    return (error as { message: string }).message
-  }
-  return fallback
 }
 
 async function uploadFiles(url: string, payload: UploadPayload): Promise<AgentFsNode[]> {
@@ -176,7 +162,7 @@ export function AgentFilesScreen({
       await queryClient.invalidateQueries({ queryKey: ['agent-files', initialData.agent.id] })
     },
     onError: (error) => {
-      setActionError(resolveErrorMessage(error, 'Failed to upload files.'))
+      setActionError(safeErrorMessage(error, 'Failed to upload files.'))
     },
     onSettled: () => {
       setUploadInfo(null)
@@ -196,7 +182,7 @@ export function AgentFilesScreen({
       await queryClient.invalidateQueries({ queryKey: ['agent-files', initialData.agent.id] })
     },
     onError: (error) => {
-      setActionError(resolveErrorMessage(error, 'Failed to delete files.'))
+      setActionError(safeErrorMessage(error, 'Failed to delete files.'))
     },
   })
 
@@ -209,7 +195,7 @@ export function AgentFilesScreen({
       await queryClient.invalidateQueries({ queryKey: ['agent-files', initialData.agent.id] })
     },
     onError: (error) => {
-      setActionError(resolveErrorMessage(error, 'Failed to create folder.'))
+      setActionError(safeErrorMessage(error, 'Failed to create folder.'))
     },
   })
 
@@ -221,7 +207,7 @@ export function AgentFilesScreen({
       await queryClient.invalidateQueries({ queryKey: ['agent-files', initialData.agent.id] })
     },
     onError: (error) => {
-      setActionError(resolveErrorMessage(error, 'Failed to move item.'))
+      setActionError(safeErrorMessage(error, 'Failed to move item.'))
     },
   })
 
@@ -406,7 +392,7 @@ export function AgentFilesScreen({
 
   const isBusy = uploadMutation.isPending || deleteMutation.isPending || createFolderMutation.isPending || moveMutation.isPending
   const errorMessage = filesQuery.isError
-    ? resolveErrorMessage(filesQuery.error, 'Unable to load agent files right now.')
+    ? safeErrorMessage(filesQuery.error, 'Unable to load agent files right now.')
     : null
 
   const handleRefresh = useCallback(() => {

--- a/tests/unit/test_console_mcp_servers.py
+++ b/tests/unit/test_console_mcp_servers.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import httpx
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings, tag
 from django.urls import reverse
@@ -221,6 +222,48 @@ class MCPServerCrudAPITests(TestCase):
         self.assertFalse(props["has_command"])
         self.assertTrue(props["is_active"])
         self.assertIsNone(track_kwargs.get("organization"))
+
+    @patch("api.services.mcp_tool_discovery.SandboxComputeService")
+    @patch("api.services.mcp_tool_discovery.sandbox_compute_enabled", return_value=True)
+    @patch("console.api_views._track_org_event_for_console")
+    @patch("console.api_views.get_mcp_manager")
+    def test_create_server_succeeds_when_inline_discovery_is_unauthorized(
+        self,
+        mock_get_mcp_manager,
+        mock_track_event,
+        _mock_schedule_enabled,
+        mock_sandbox_service,
+    ):
+        request = httpx.Request("GET", "https://api.example.com/mcp")
+        response = httpx.Response(401, request=request)
+        mock_sandbox_service.return_value.discover_mcp_tools.side_effect = httpx.HTTPStatusError(
+            "Unauthorized",
+            request=request,
+            response=response,
+        )
+
+        response = self.client.post(
+            reverse("console-mcp-server-list"),
+            data=json.dumps({
+                "display_name": "HTTP Server",
+                "url": "https://api.example.com/mcp",
+                "auth_method": MCPServerConfig.AuthMethod.NONE,
+                "is_active": True,
+                "headers": {},
+            }),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        server = MCPServerConfig.objects.get()
+        self.assertEqual(server.display_name, "HTTP Server")
+        mock_sandbox_service.return_value.discover_mcp_tools.assert_called_once_with(
+            str(server.id),
+            reason="config_changed",
+            agent=None,
+        )
+        mock_get_mcp_manager.return_value.refresh_server.assert_called_once_with(str(server.id))
+        mock_track_event.assert_called_once()
 
     @patch("console.api_views._track_org_event_for_console")
     @patch("console.api_views.get_mcp_manager")

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -11,6 +11,8 @@ from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch, MagicMock, AsyncMock, PropertyMock
+
+import httpx
 from django.test import TestCase, tag, override_settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -1248,6 +1250,14 @@ class MCPToolManagerTests(TestCase):
         self.assertTrue(ok)
         self.assertEqual(tools, [])
         self.assertEqual(details, {})
+
+    def test_discover_tools_for_server_handles_http_discovery_failure(self):
+        request = httpx.Request("GET", "https://example.com/mcp")
+        response = httpx.Response(401, request=request)
+        error = httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+        with patch.object(self.manager, "_register_server", side_effect=error):
+            self.assertFalse(self.manager.discover_tools_for_server(self.config_id))
         
     def test_get_tools_for_agent_registers_accessible_servers_only(self):
         """Ensure discovery runs only for servers the agent can access."""


### PR DESCRIPTION
## Summary
- Broaden MCP tool discovery error handling to treat network, timeout, and tool-level failures as non-fatal
- Switch frontend error messaging to a shared helper that prefers safe JSON details and ignores HTML error pages
- Add regression coverage for unauthorized discovery failures and safe error message extraction

## Testing
- Added unit coverage for MCP discovery failure handling and safe error message parsing
- Verified the updated server creation flow still succeeds when inline discovery returns an authorization error