### PR TITLE
Surface agent schedule metadata in timeline and processing state

### DIFF
--- a/console/agent_chat/signals.py
+++ b/console/agent_chat/signals.py
@@ -58,6 +58,7 @@ from .timeline import (
     is_chat_hidden_message,
     serialize_plan_event,
     serialize_message_event,
+    serialize_agent_schedule,
     serialize_processing_snapshot,
     serialize_thinking_event,
 )
@@ -106,6 +107,7 @@ def emit_agent_profile_update(
         "signup_preview_state": agent.signup_preview_state,
         "planning_state": agent.planning_state,
         "timestamp": timezone.now().isoformat(),
+        **serialize_agent_schedule(agent),
     }
     if processing_active is not None:
         normalized_processing_active = bool(processing_active)
@@ -554,6 +556,7 @@ def broadcast_agent_profile_update(sender, instance: PersistentAgent, created: b
         "avatar",
         "mini_description",
         "short_description",
+        "schedule",
     }
     update_fields = kwargs.get("update_fields")
     if not created and update_fields is not None:
@@ -565,7 +568,16 @@ def broadcast_agent_profile_update(sender, instance: PersistentAgent, created: b
         refreshed = (
             PersistentAgent.objects
             .filter(id=instance.id)
-            .only("id", "name", "avatar", "mini_description", "short_description")
+            .only(
+                "id",
+                "name",
+                "avatar",
+                "mini_description",
+                "short_description",
+                "schedule",
+                "is_active",
+                "life_state",
+            )
             .first()
         )
         if refreshed is None:
@@ -657,7 +669,10 @@ def broadcast_processing_state(sender, instance: BrowserUseAgentTask, **kwargs):
 
 def _broadcast_processing(agent):
     snapshot = build_processing_snapshot(agent)
-    payload = serialize_processing_snapshot(snapshot)
+    payload = {
+        **serialize_processing_snapshot(snapshot),
+        **serialize_agent_schedule(agent),
+    }
     _send(_group_name(agent.id), "processing_event", payload, agent_id=str(agent.id))
     emit_agent_usage_update(agent)
     _emit_processing_profile_update_if_changed(agent, snapshot.active)

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -1162,10 +1162,11 @@ def build_processing_snapshot(agent: PersistentAgent) -> ProcessingSnapshot:
     heartbeat_active = False
     try:
         redis_client = get_redis_client()
-        lock_active = any(
-            bool(redis_client.exists(key))
-            for key in processing_lock_storage_keys(agent.id)
-        )
+        lock_keys = processing_lock_storage_keys(agent.id)
+        try:
+            lock_active = bool(redis_client.exists(*lock_keys))
+        except TypeError:
+            lock_active = any(bool(redis_client.exists(key)) for key in lock_keys)
         queued_flag = is_processing_queued(agent.id, client=redis_client)
         heartbeat_active = bool(get_processing_heartbeat(agent.id, client=redis_client))
     except Exception:

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -18,7 +18,11 @@ from django.utils import timezone
 from django.utils.timesince import timesince
 from django.urls import reverse
 
-from api.agent.core.processing_flags import get_processing_heartbeat, is_processing_queued
+from api.agent.core.processing_flags import (
+    get_processing_heartbeat,
+    is_processing_queued,
+    processing_lock_storage_keys,
+)
 from api.agent.core.schedule_parser import ScheduleParser
 from api.agent.comms.chat_email_display_cache import (
     get_cached_chat_body_html,
@@ -1097,17 +1101,12 @@ def _coerce_schedule_eta_to_timedelta(eta: object) -> timedelta | None:
     return None
 
 
-def _compute_next_scheduled_run(agent: PersistentAgent, *, now: datetime | None = None) -> datetime | None:
-    """Return the next known scheduled wake-up for an agent."""
-
-    if not agent.is_active or agent.life_state != PersistentAgent.LifeState.ACTIVE:
-        return None
-
-    current_env = getattr(settings, "GOBII_RELEASE_ENV", "local")
-    if (agent.execution_environment or "local") != current_env:
-        return None
-
-    schedule_value = (agent.schedule or "").strip()
+def _compute_next_scheduled_run_for_schedule(
+    schedule_value: str | None,
+    *,
+    now: datetime | None = None,
+) -> datetime | None:
+    schedule_value = (schedule_value or "").strip()
     if not schedule_value:
         return None
 
@@ -1133,20 +1132,40 @@ def _compute_next_scheduled_run(agent: PersistentAgent, *, now: datetime | None 
     return current_time + delay
 
 
+def compute_agent_schedule_next_run(
+    agent: PersistentAgent,
+    *,
+    now: datetime | None = None,
+) -> datetime | None:
+    if not agent.is_active or agent.life_state != PersistentAgent.LifeState.ACTIVE:
+        return None
+    return _compute_next_scheduled_run_for_schedule(agent.schedule, now=now)
+
+
+def _compute_next_scheduled_run(agent: PersistentAgent, *, now: datetime | None = None) -> datetime | None:
+    """Return the next known scheduled wake-up for an agent in this release env."""
+
+    current_env = getattr(settings, "GOBII_RELEASE_ENV", "local")
+    if (agent.execution_environment or "local") != current_env:
+        return None
+    return compute_agent_schedule_next_run(agent, now=now)
+
+
 def build_processing_snapshot(agent: PersistentAgent) -> ProcessingSnapshot:
     """Compute current processing activity and active web tasks for an agent."""
 
-    # Check if the agent event processing lock is held
-    # Note: Redlock prefixes keys with "redlock:" internally
+    # Check if the agent event processing lock is held.
     from config.redis_client import get_redis_client
 
-    lock_key = f"redlock:agent-event-processing:{agent.id}"
     lock_active = False
     queued_flag = False
     heartbeat_active = False
     try:
         redis_client = get_redis_client()
-        lock_active = bool(redis_client.exists(lock_key))
+        lock_active = any(
+            bool(redis_client.exists(key))
+            for key in processing_lock_storage_keys(agent.id)
+        )
         queued_flag = is_processing_queued(agent.id, client=redis_client)
         heartbeat_active = bool(get_processing_heartbeat(agent.id, client=redis_client))
     except Exception:
@@ -1245,6 +1264,13 @@ def serialize_processing_snapshot(snapshot: ProcessingSnapshot) -> dict:
         "active": snapshot.active,
         "webTasks": snapshot.web_tasks,
         "nextScheduledAt": _format_timestamp(snapshot.next_scheduled_at),
+    }
+
+
+def serialize_agent_schedule(agent: PersistentAgent) -> dict:
+    return {
+        "agent_schedule": agent.schedule or "",
+        "agent_next_scheduled_at": _format_timestamp(compute_agent_schedule_next_run(agent)),
     }
 
 

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -6814,6 +6814,7 @@ class AgentProcessingStatusAPIView(LoginRequiredMixin, View):
                 "processing_snapshot": serialize_processing_snapshot(snapshot),
                 "signup_preview_state": agent.signup_preview_state,
                 "planning_state": agent.planning_state,
+                **serialize_agent_schedule(agent),
             }
         )
 
@@ -6872,6 +6873,7 @@ class AgentStopAPIView(ApiLoginRequiredMixin, View):
                 "cancelledWebTaskCount": cancelled_web_task_count,
                 "processing_active": snapshot.active,
                 "processing_snapshot": serialize_processing_snapshot(snapshot),
+                **serialize_agent_schedule(agent),
             }
         )
 

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -228,6 +228,7 @@ from console.agent_chat.timeline import (
     build_processing_snapshot,
     compute_processing_status,
     fetch_timeline_window,
+    serialize_agent_schedule,
     serialize_message_event,
     serialize_processing_snapshot,
 )
@@ -3780,6 +3781,7 @@ class AgentTimelineAPIView(LoginRequiredMixin, View):
             "agent_avatar_url": agent.get_avatar_thumbnail_url(),
             "signup_preview_state": agent.signup_preview_state,
             "planning_state": agent.planning_state,
+            **serialize_agent_schedule(agent),
             **_pending_action_payload(agent, request.user),
         }
         return JsonResponse(payload)

--- a/frontend/src/api/agentChat.ts
+++ b/frontend/src/api/agentChat.ts
@@ -677,6 +677,7 @@ export function resolveSpawnRequest(
 export type ProcessingStatusResponse = {
   processing_active: boolean
   processing_snapshot?: ProcessingSnapshot
+  agent_next_scheduled_at?: string | null
   signup_preview_state?: SignupPreviewState | null
   planning_state?: PlanningState | null
 }
@@ -686,6 +687,7 @@ export type StopAgentResponse = {
   cancelledWebTaskCount: number
   processing_active: boolean
   processing_snapshot?: ProcessingSnapshot
+  agent_next_scheduled_at?: string | null
 }
 
 export async function fetchProcessingStatus(agentId: string): Promise<ProcessingStatusResponse> {

--- a/frontend/src/api/agentChat.ts
+++ b/frontend/src/api/agentChat.ts
@@ -33,6 +33,8 @@ export type TimelineResponse = {
   processing_snapshot?: ProcessingSnapshot
   agent_name?: string | null
   agent_avatar_url?: string | null
+  agent_schedule?: string | null
+  agent_next_scheduled_at?: string | null
   signup_preview_state?: SignupPreviewState | null
   planning_state?: PlanningState | null
   pending_human_input_requests?: PendingHumanInputRequest[]

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -469,6 +469,7 @@ export function AgentChatLayout({
   const runtimeAwaitingResponse = runtimeSession.processing.awaitingResponse
   const runtimeProcessingWebTasks = runtimeSession.processing.processingWebTasks
   const runtimeNextScheduledAt = runtimeSession.processing.nextScheduledAt
+    ?? runtimeSession.identity.agentNextScheduledAt
   const runtimeStopProcessingRequested = runtimeSession.processing.stopProcessingRequested
   const runtimeSkipPlanningBusy = runtimeSession.processing.skipPlanningBusy
   const runtimeStreaming = runtimeSession.stream.streaming

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -681,6 +681,7 @@ export const AgentComposer = memo(function AgentComposer({
     ]
   }, [baseInsights, storeAgentEmail, storeAgentSms])
   const nextScheduledAt = activeSession.processing.nextScheduledAt
+    ?? activeSession.identity.agentNextScheduledAt
   const readyWakeTime = formatReadyWakeTime(nextScheduledAt)
   const readyWakeDuration = readyWakeTime?.startsWith('in ') ? readyWakeTime.slice(3) : readyWakeTime
   const readyWakeLabel = readyWakeTime?.startsWith('in ') ? 'Next wake-up in' : 'Next wake-up'

--- a/frontend/src/hooks/agentChatSocketMessageRouter.ts
+++ b/frontend/src/hooks/agentChatSocketMessageRouter.ts
@@ -17,6 +17,7 @@ type AgentIdentityUpdate = {
   agentId?: string | null
   agentName?: string | null
   agentAvatarUrl?: string | null
+  agentNextScheduledAt?: string | null
   signupPreviewState?: SignupPreviewState | null
   planningState?: PlanningState | null
 }
@@ -60,6 +61,11 @@ function buildAgentIdentityUpdate(payload: Record<string, unknown>): AgentIdenti
   }
   if (Object.prototype.hasOwnProperty.call(payload, 'planning_state')) {
     nextIdentity.planningState = normalizePlanningState(payload.planning_state)
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'agent_next_scheduled_at')) {
+    nextIdentity.agentNextScheduledAt = typeof payload.agent_next_scheduled_at === 'string'
+      ? payload.agent_next_scheduled_at
+      : null
   }
 
   return nextIdentity
@@ -123,12 +129,21 @@ export function routeAgentChatSocketMessage({
 
   if (messageType === 'processing' && message.payload) {
     const payloadAgentId = extractAgentChatSocketEnvelopeAgentId(message)
+    const processingRecord = message.payload as Record<string, unknown>
     const processingPayload = message.payload as ProcessingSnapshot
     if (payloadAgentId) {
       replaceProcessingSnapshotInCache(queryClient, payloadAgentId, processingPayload)
     }
     if (payloadAgentId === activeAgentId) {
       updateProcessing(processingPayload)
+      if (Object.prototype.hasOwnProperty.call(processingRecord, 'agent_next_scheduled_at')) {
+        updateAgentIdentity({
+          agentId: payloadAgentId,
+          agentNextScheduledAt: typeof processingRecord.agent_next_scheduled_at === 'string'
+            ? processingRecord.agent_next_scheduled_at
+            : null,
+        })
+      }
     }
     return { type: 'handled' }
   }

--- a/frontend/src/hooks/usePendingActionsBridge.ts
+++ b/frontend/src/hooks/usePendingActionsBridge.ts
@@ -39,13 +39,19 @@ export function usePendingActionsBridge(
 
     const name = initialPageResponse.agent_name ?? null
     const avatar = initialPageResponse.agent_avatar_url ?? null
+    const nextScheduledAt = initialPageResponse.agent_next_scheduled_at ?? null
+    const hasNextScheduledAt = Object.prototype.hasOwnProperty.call(
+      initialPageResponse,
+      'agent_next_scheduled_at',
+    )
     const signupPreviewState = normalizeSignupPreviewState(initialPageResponse.signup_preview_state)
     const planningState = normalizePlanningState(initialPageResponse.planning_state)
-    if (name || avatar || signupPreviewState !== 'none' || planningState !== 'skipped') {
+    if (name || avatar || hasNextScheduledAt || signupPreviewState !== 'none' || planningState !== 'skipped') {
       dispatch(chatActions.agentIdentityUpdated({
         agentId: activeAgentId,
         ...(name ? { agentName: name } : {}),
         ...(avatar ? { agentAvatarUrl: avatar } : {}),
+        ...(hasNextScheduledAt ? { agentNextScheduledAt: nextScheduledAt } : {}),
         signupPreviewState,
         planningState,
       }))

--- a/frontend/src/hooks/useTimelineCacheInjector.ts
+++ b/frontend/src/hooks/useTimelineCacheInjector.ts
@@ -230,10 +230,19 @@ export function replaceProcessingSnapshotInCache(
   agentId: string,
   processingSnapshot: ProcessingSnapshot,
 ) {
+  const processingPayload = processingSnapshot as ProcessingSnapshot & Record<string, unknown>
+  const hasNextScheduledAt = Object.prototype.hasOwnProperty.call(processingPayload, 'agent_next_scheduled_at')
   updateLatestTimelineRawInCache(queryClient, agentId, (current) => ({
     ...current,
     processing_active: processingSnapshot.active,
     processing_snapshot: processingSnapshot,
+    ...(hasNextScheduledAt
+      ? {
+          agent_next_scheduled_at: typeof processingPayload.agent_next_scheduled_at === 'string'
+            ? processingPayload.agent_next_scheduled_at
+            : null,
+        }
+      : {}),
   }))
 }
 
@@ -292,6 +301,15 @@ export function updateAgentIdentityInCache(
       const processingActive = Boolean(payload.processing_active)
       if (processingActive !== current.processing_active) {
         next.processing_active = processingActive
+        changed = true
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'agent_next_scheduled_at')) {
+      const agentNextScheduledAt = typeof payload.agent_next_scheduled_at === 'string'
+        ? payload.agent_next_scheduled_at
+        : null
+      if (agentNextScheduledAt !== (current.agent_next_scheduled_at ?? null)) {
+        next.agent_next_scheduled_at = agentNextScheduledAt
         changed = true
       }
     }

--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -42,6 +42,7 @@ export type AgentChatIdentityState = {
   agentMiniDescription: string | null
   agentEmail: string | null
   agentSms: string | null
+  agentNextScheduledAt: string | null
   auditUrl: string | null
   agentIsOrgOwned: boolean
   canManageAgent: boolean
@@ -106,6 +107,7 @@ type AgentIdentityUpdateInput = {
   agentMiniDescription?: string | null
   agentEmail?: string | null
   agentSms?: string | null
+  agentNextScheduledAt?: string | null
   auditUrl?: string | null
   agentIsOrgOwned?: boolean
   canManageAgent?: boolean
@@ -156,6 +158,7 @@ export function createInitialSession(): AgentChatSession {
       agentMiniDescription: null,
       agentEmail: null,
       agentSms: null,
+      agentNextScheduledAt: null,
       auditUrl: null,
       agentIsOrgOwned: false,
       canManageAgent: true,
@@ -241,6 +244,9 @@ function applyIdentityUpdate(session: AgentChatSession, update: AgentIdentityUpd
   }
   if (Object.prototype.hasOwnProperty.call(update ?? {}, 'agentSms')) {
     session.identity.agentSms = update?.agentSms ?? null
+  }
+  if (Object.prototype.hasOwnProperty.call(update ?? {}, 'agentNextScheduledAt')) {
+    session.identity.agentNextScheduledAt = update?.agentNextScheduledAt ?? null
   }
   if (Object.prototype.hasOwnProperty.call(update ?? {}, 'auditUrl')) {
     session.identity.auditUrl = update?.auditUrl ?? null

--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -532,11 +532,19 @@ export const refreshProcessing = createAsyncThunk<void, void, { state: RootState
     const agentId = getState().chat.activeAgentId
     if (!agentId) return
     try {
-      const { processing_active, processing_snapshot, signup_preview_state, planning_state } = await fetchProcessingStatus(agentId)
+      const status = await fetchProcessingStatus(agentId)
+      const {
+        processing_active,
+        processing_snapshot,
+        signup_preview_state,
+        planning_state,
+      } = status
       const snapshot = normalizeProcessingUpdate(processing_snapshot ?? { active: processing_active, webTasks: [] })
+      const hasNextScheduledAt = Object.prototype.hasOwnProperty.call(status, 'agent_next_scheduled_at')
       dispatch(chatActions.processingUpdated({ agentId, snapshot }))
       dispatch(chatActions.agentIdentityUpdated({
         agentId,
+        ...(hasNextScheduledAt ? { agentNextScheduledAt: status.agent_next_scheduled_at ?? null } : {}),
         signupPreviewState: signup_preview_state ?? undefined,
         planningState: planning_state ?? undefined,
       }))

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -68,10 +68,12 @@ from api.agent.core.processing_flags import (
     enqueue_pending_agent,
     is_agent_pending,
     is_processing_stop_requested,
+    processing_lock_storage_keys,
 )
 from api.agent.tools.web_chat_sender import execute_send_chat_message
 from api.services.pipedream_apps import get_owner_apps_state
 from api.services.web_sessions import heartbeat_web_session, start_web_session
+from config.redis_client import get_redis_client
 from console.agent_chat.plan_events import persist_plan_event
 from console.agent_chat.timeline import build_processing_snapshot
 from console.agent_chat.timeline import fetch_timeline_window
@@ -796,6 +798,26 @@ class AgentChatAPITests(TestCase):
         self.assertIn("active", snapshot)
         self.assertIn("webTasks", snapshot)
         self.assertIsInstance(snapshot.get("webTasks"), list)
+
+    @tag("batch_agent_chat")
+    @override_settings(GOBII_RELEASE_ENV="staging")
+    def test_timeline_includes_schedule_next_run_from_loaded_agent(self):
+        self.agent.schedule = "@hourly"
+        self.agent.execution_environment = "prod"
+        self.agent.is_active = True
+        self.agent.life_state = PersistentAgent.LifeState.ACTIVE
+        self.agent.save(
+            update_fields=["schedule", "execution_environment", "is_active", "life_state"],
+        )
+
+        response = self.client.get(f"/console/api/agents/{self.agent.id}/timeline/")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+
+        self.assertEqual(payload.get("agent_schedule"), "@hourly")
+        self.assertIsInstance(payload.get("agent_next_scheduled_at"), str)
+        snapshot = payload.get("processing_snapshot") or {}
+        self.assertIsNone(snapshot.get("nextScheduledAt"))
 
     @tag("batch_agent_chat")
     def test_timeline_includes_pending_action_requests_for_manager(self):
@@ -2578,6 +2600,22 @@ class AgentChatAPITests(TestCase):
             self.assertEqual(snapshot.get("webTasks"), [])
         finally:
             clear_processing_queued_flag(self.agent.id)
+
+    @tag("batch_agent_chat")
+    def test_processing_status_reports_active_for_processing_lock_storage_key(self):
+        redis_client = get_redis_client()
+        _, legacy_lock_key = processing_lock_storage_keys(self.agent.id)
+        redis_client.set(legacy_lock_key, "1", ex=60)
+        try:
+            response = self.client.get(f"/console/api/agents/{self.agent.id}/processing/")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertTrue(payload.get("processing_active"))
+
+            snapshot = payload.get("processing_snapshot") or {}
+            self.assertTrue(snapshot.get("active"))
+        finally:
+            redis_client.delete(legacy_lock_key)
 
     @tag("batch_agent_chat")
     def test_stop_endpoint_stops_processing_and_cancels_active_web_tasks(self):

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -2585,6 +2585,7 @@ class AgentChatAPITests(TestCase):
         snapshot = payload.get("processing_snapshot") or {}
 
         self.assertIsInstance(snapshot.get("nextScheduledAt"), str)
+        self.assertIsInstance(payload.get("agent_next_scheduled_at"), str)
 
     @tag("batch_agent_chat")
     def test_processing_status_reports_active_when_only_queued(self):

--- a/tests/unit/test_agent_chat_signals.py
+++ b/tests/unit/test_agent_chat_signals.py
@@ -840,6 +840,28 @@ class AgentChatSignalTests(TestCase):
         )
 
     @tag("batch_agent_chat")
+    def test_schedule_update_emits_agent_profile_event_with_next_scheduled_at(self):
+        self.agent.schedule = "@hourly"
+        with self.captureOnCommitCallbacks(execute=True):
+            self.agent.save(update_fields=["schedule"])
+
+        scheduled_profile_event = self._receive_with_timeout(self.owner_profile_channel_name)
+        scheduled_payload = scheduled_profile_event.get("payload", {})
+        self.assertEqual(scheduled_profile_event.get("type"), "agent_profile_event")
+        self.assertEqual(scheduled_payload.get("agent_schedule"), "@hourly")
+        self.assertIsInstance(scheduled_payload.get("agent_next_scheduled_at"), str)
+
+        self.agent.schedule = None
+        with self.captureOnCommitCallbacks(execute=True):
+            self.agent.save(update_fields=["schedule"])
+
+        cleared_profile_event = self._receive_with_timeout(self.owner_profile_channel_name)
+        cleared_payload = cleared_profile_event.get("payload", {})
+        self.assertEqual(cleared_profile_event.get("type"), "agent_profile_event")
+        self.assertEqual(cleared_payload.get("agent_schedule"), "")
+        self.assertIsNone(cleared_payload.get("agent_next_scheduled_at"))
+
+    @tag("batch_agent_chat")
     @patch("console.agent_chat.signals.build_processing_snapshot")
     def test_processing_broadcast_emits_agent_profile_event_with_processing_state(self, mock_build_processing_snapshot):
         mock_build_processing_snapshot.return_value = type(


### PR DESCRIPTION
## Summary
- Split schedule wake-up computation so agent schedule timing can be derived independently from release-environment filtering.
- Include the agent schedule and next scheduled run in the timeline API payload.
- Plumb the next scheduled run through chat identity state so the composer and layout can show it immediately.
- Broaden processing lock detection to cover all known storage keys.
- Add unit coverage for timeline schedule data and legacy processing-lock visibility.

## Testing
- Added targeted unit tests for timeline schedule serialization and processing status detection.
- Not run (not requested)