### PR TITLE
Restrict SMS exposure to agents with active SMS endpoints

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -2280,16 +2280,9 @@ def _recent_contact_records_for_prompt(
 
 
 def _allowed_communication_channels(
-    agent: PersistentAgent,
     agent_endpoints: Sequence[PersistentAgentCommsEndpoint],
 ) -> list[str]:
-    channels = {
-        endpoint.channel
-        for endpoint in agent_endpoints
-        if endpoint.channel and not (
-            endpoint.channel == CommsChannel.SMS and agent.sms_disabled
-        )
-    }
+    channels = {endpoint.channel for endpoint in agent_endpoints if endpoint.channel}
     return sorted(channels)
 
 
@@ -2327,11 +2320,14 @@ def _build_contacts_block(
             non_shrinkable=True,
         )
 
-    # Agent endpoints (all, highlight primary)
-    agent_eps = (
+    # Agent endpoints currently available for outbound communication (highlight primary)
+    agent_eps_qs = (
         PersistentAgentCommsEndpoint.objects.filter(owner_agent=agent)
         .order_by("channel", "address")
     )
+    if agent.sms_disabled:
+        agent_eps_qs = agent_eps_qs.exclude(channel=CommsChannel.SMS)
+    agent_eps = list(agent_eps_qs)
     if agent_eps:
         agent_lines = ["As the agent, these are *YOUR* endpoints, i.e. the addresses you are sending messages *FROM*."]
         for ep in agent_eps:
@@ -2651,7 +2647,7 @@ def _build_contacts_block(
     )
     
     # Explicitly list allowed communication channels
-    allowed_channels = _allowed_communication_channels(agent, agent_eps)
+    allowed_channels = _allowed_communication_channels(agent_eps)
 
     if allowed_channels:
         contacts_group.section_text(

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -2280,15 +2280,16 @@ def _recent_contact_records_for_prompt(
 
 
 def _allowed_communication_channels(
+    agent: PersistentAgent,
     agent_endpoints: Sequence[PersistentAgentCommsEndpoint],
-    contact_records: Sequence[ContactSQLiteRecord],
 ) -> list[str]:
-    channels = {endpoint.channel for endpoint in agent_endpoints if endpoint.channel}
-    channels.update(
-        record.channel
-        for record in contact_records
-        if record.channel and record.status == "allowed" and record.allow_outbound
-    )
+    channels = {
+        endpoint.channel
+        for endpoint in agent_endpoints
+        if endpoint.channel and not (
+            endpoint.channel == CommsChannel.SMS and agent.sms_disabled
+        )
+    }
     return sorted(channels)
 
 
@@ -2650,7 +2651,7 @@ def _build_contacts_block(
     )
     
     # Explicitly list allowed communication channels
-    allowed_channels = _allowed_communication_channels(agent_eps, contact_records)
+    allowed_channels = _allowed_communication_channels(agent, agent_eps)
 
     if allowed_channels:
         contacts_group.section_text(

--- a/api/agent/tools/static_tools.py
+++ b/api/agent/tools/static_tools.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, Set
 
 from django.db.models import Q
 
-from api.models import AgentPeerLink, PersistentAgent
+from api.models import AgentPeerLink, CommsChannel, PersistentAgent
 from api.services.tool_blacklist import get_agent_tool_blacklist
 from .custom_tool_names import CREATE_CUSTOM_TOOL_NAME
 
@@ -85,7 +85,11 @@ def get_static_tool_definitions(agent: Optional[PersistentAgent]) -> List[dict]:
         get_update_plan_tool(),
         get_send_email_tool(),
     ]
-    if not agent or not agent.sms_disabled:
+    if (
+        agent
+        and not agent.sms_disabled
+        and agent.comms_endpoints.filter(channel=CommsChannel.SMS).exists()
+    ):
         static_tools.append(get_send_sms_tool())
     static_tools.extend([
         get_send_chat_tool(),

--- a/api/agent/tools/static_tools.py
+++ b/api/agent/tools/static_tools.py
@@ -64,6 +64,17 @@ def _get_sleep_tool() -> Dict[str, object]:
     }
 
 
+def _agent_has_sms_endpoint(agent: Optional[PersistentAgent]) -> bool:
+    if not agent or agent.sms_disabled:
+        return False
+
+    has_sms_endpoint = getattr(agent, "_has_sms_endpoint", None)
+    if has_sms_endpoint is None:
+        has_sms_endpoint = agent.comms_endpoints.filter(channel=CommsChannel.SMS).exists()
+        agent._has_sms_endpoint = has_sms_endpoint
+    return has_sms_endpoint
+
+
 def get_static_tool_definitions(agent: Optional[PersistentAgent]) -> List[dict]:
     """Return static (always-present) tool definitions for an agent."""
     from .apply_patch import get_apply_patch_tool
@@ -85,11 +96,7 @@ def get_static_tool_definitions(agent: Optional[PersistentAgent]) -> List[dict]:
         get_update_plan_tool(),
         get_send_email_tool(),
     ]
-    if (
-        agent
-        and not agent.sms_disabled
-        and agent.comms_endpoints.filter(channel=CommsChannel.SMS).exists()
-    ):
+    if _agent_has_sms_endpoint(agent):
         static_tools.append(get_send_sms_tool())
     static_tools.extend([
         get_send_chat_tool(),

--- a/tests/unit/test_agent_planning_mode.py
+++ b/tests/unit/test_agent_planning_mode.py
@@ -9,7 +9,11 @@ from api.agent.core.processing_flags import get_human_inbound_generation
 from api.agent.core.prompt_context import _get_system_instruction, build_prompt_context
 from api.agent.tools.planning import execute_end_planning
 from api.agent.tools.schedule_updater import execute_update_schedule
-from api.agent.tools.static_tools import PLANNING_MODE_DISABLED_TOOL_NAMES, get_static_tool_definitions
+from api.agent.tools.static_tools import (
+    PLANNING_MODE_DISABLED_TOOL_NAMES,
+    _agent_has_sms_endpoint,
+    get_static_tool_definitions,
+)
 from api.agent.tools.tool_runtime import execute_runtime_tool_call
 from api.models import (
     BrowserUseAgent,
@@ -123,6 +127,18 @@ class PersistentAgentPlanningModeTests(TestCase):
         names = _tool_names(get_static_tool_definitions(self.agent))
 
         self.assertIn("send_sms", names)
+
+    def test_sms_endpoint_check_is_cached_on_agent_instance(self):
+        PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.SMS,
+            address="+15555550123",
+            is_primary=True,
+        )
+
+        with self.assertNumQueries(1):
+            self.assertTrue(_agent_has_sms_endpoint(self.agent))
+            self.assertTrue(_agent_has_sms_endpoint(self.agent))
 
     def test_sms_disabled_agents_with_sms_endpoint_do_not_receive_send_sms_tool(self):
         PersistentAgentCommsEndpoint.objects.create(

--- a/tests/unit/test_agent_planning_mode.py
+++ b/tests/unit/test_agent_planning_mode.py
@@ -101,7 +101,36 @@ class PersistentAgentPlanningModeTests(TestCase):
         self.assertIn("send_chat_message", names)
         self.assertTrue(PLANNING_MODE_DISABLED_TOOL_NAMES.isdisjoint(names))
 
-    def test_sms_disabled_agents_do_not_receive_send_sms_tool(self):
+    def test_agents_without_sms_endpoint_do_not_receive_send_sms_tool(self):
+        names = _tool_names(get_static_tool_definitions(self.agent))
+
+        self.assertIn("send_email", names)
+        self.assertNotIn("send_sms", names)
+
+    def test_static_tools_without_agent_do_not_include_send_sms(self):
+        names = _tool_names(get_static_tool_definitions(None))
+
+        self.assertNotIn("send_sms", names)
+
+    def test_sms_enabled_agents_with_sms_endpoint_receive_send_sms_tool(self):
+        PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.SMS,
+            address="+15555550123",
+            is_primary=True,
+        )
+
+        names = _tool_names(get_static_tool_definitions(self.agent))
+
+        self.assertIn("send_sms", names)
+
+    def test_sms_disabled_agents_with_sms_endpoint_do_not_receive_send_sms_tool(self):
+        PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.SMS,
+            address="+15555550123",
+            is_primary=True,
+        )
         self.agent.sms_disabled = True
         self.agent.save(update_fields=["sms_disabled", "updated_at"])
 

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -9,6 +9,7 @@ from api.models import (
     CommsChannel,
     PersistentAgent,
     PersistentAgentCommsEndpoint,
+    UserPhoneNumber,
 )
 
 
@@ -127,7 +128,7 @@ class PromptContextContactsGuidanceTests(TestCase):
         self.assertNotIn("person-00@example.com", allowed_contacts)
         self.assertIn("status='allowed' AND allow_outbound=1", allowed_contacts)
 
-    def test_allowed_channels_include_outbound_allowed_contact_channels(self):
+    def test_allowed_contact_channels_do_not_imply_sending_channels(self):
         PersistentAgentCommsEndpoint.objects.create(
             owner_agent=self.agent,
             channel=CommsChannel.WEB,
@@ -166,5 +167,67 @@ class PromptContextContactsGuidanceTests(TestCase):
         )
 
         allowed_channels = collector.sections["allowed_channels"]
-        self.assertIn("You can communicate via: email, web.", allowed_channels)
+        self.assertIn("You can communicate via: web.", allowed_channels)
+        self.assertNotIn("email", allowed_channels)
         self.assertNotIn("sms", allowed_channels)
+
+    def test_verified_owner_phone_does_not_advertise_sms_without_agent_endpoint(self):
+        PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="agent@example.test",
+        )
+        UserPhoneNumber.objects.create(
+            user=self.user,
+            phone_number="+15555550123",
+            is_verified=True,
+        )
+        collector = _PromptSectionCollector()
+        config_authority = prompt_context._ConfigAuthorityResolver(self.agent)
+        contact_records = prompt_context.build_contacts_snapshot_records(
+            self.agent,
+            display_name_for_user=prompt_context._build_user_display_name,
+            user_can_configure=config_authority.user_can_configure,
+        )
+
+        prompt_context._build_contacts_block(
+            self.agent,
+            collector,
+            _NoopSpan(),
+            config_authority,
+            contact_records,
+        )
+
+        allowed_channels = collector.sections["allowed_channels"]
+        self.assertIn("You can communicate via: email.", allowed_channels)
+        self.assertNotIn("sms", allowed_channels)
+
+    def test_sms_endpoint_is_advertised_only_when_sms_is_enabled(self):
+        PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="agent@example.test",
+        )
+        PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.SMS,
+            address="+15555550124",
+        )
+
+        self.assertEqual(
+            prompt_context._allowed_communication_channels(
+                self.agent,
+                list(self.agent.comms_endpoints.all()),
+            ),
+            [CommsChannel.EMAIL, CommsChannel.SMS],
+        )
+
+        self.agent.sms_disabled = True
+
+        self.assertEqual(
+            prompt_context._allowed_communication_channels(
+                self.agent,
+                list(self.agent.comms_endpoints.all()),
+            ),
+            [CommsChannel.EMAIL],
+        )

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -214,20 +214,34 @@ class PromptContextContactsGuidanceTests(TestCase):
             address="+15555550124",
         )
 
-        self.assertEqual(
-            prompt_context._allowed_communication_channels(
-                self.agent,
-                list(self.agent.comms_endpoints.all()),
-            ),
-            [CommsChannel.EMAIL, CommsChannel.SMS],
+        config_authority = prompt_context._ConfigAuthorityResolver(self.agent)
+        contact_records = prompt_context.build_contacts_snapshot_records(
+            self.agent,
+            display_name_for_user=prompt_context._build_user_display_name,
+            user_can_configure=config_authority.user_can_configure,
         )
+        collector = _PromptSectionCollector()
+        prompt_context._build_contacts_block(
+            self.agent,
+            collector,
+            _NoopSpan(),
+            config_authority,
+            contact_records,
+        )
+
+        self.assertIn("- sms: +15555550124", collector.sections["agent_endpoints"])
+        self.assertIn("You can communicate via: email, sms.", collector.sections["allowed_channels"])
 
         self.agent.sms_disabled = True
-
-        self.assertEqual(
-            prompt_context._allowed_communication_channels(
-                self.agent,
-                list(self.agent.comms_endpoints.all()),
-            ),
-            [CommsChannel.EMAIL],
+        collector = _PromptSectionCollector()
+        prompt_context._build_contacts_block(
+            self.agent,
+            collector,
+            _NoopSpan(),
+            config_authority,
+            contact_records,
         )
+
+        self.assertNotIn("sms", collector.sections["agent_endpoints"])
+        self.assertIn("You can communicate via: email.", collector.sections["allowed_channels"])
+        self.assertNotIn("sms", collector.sections["allowed_channels"])


### PR DESCRIPTION
## Summary
- Stop advertising SMS in prompt guidance unless the agent has an SMS endpoint and SMS is enabled.
- Tighten static tool exposure so `send_sms` only appears for eligible agents.
- Add coverage for SMS-enabled, SMS-disabled, and endpoint-missing cases.

## Testing
- Added unit tests for prompt-context channel guidance and static tool selection.
- Verified SMS is omitted when disabled or when no SMS endpoint exists.