### PR TITLE
Refactor invite responses and modal handling

### DIFF
--- a/frontend/src/components/llmConfig/LlmConfigView.tsx
+++ b/frontend/src/components/llmConfig/LlmConfigView.tsx
@@ -9,7 +9,7 @@ import { actionKey, button } from './shared'
 import type { LlmConfigController } from './useLlmConfigController'
 
 export function LlmConfigView({ controller }: { controller: LlmConfigController }) {
-  const { data, feedback, modal, showModal, closeModal, statsCards, provider: providerState, routing } = controller
+  const { data, feedback, modal, showModal, statsCards, provider: providerState, routing } = controller
   const selectedProfile = data.selectedProfile
   const selectedProfileId = data.selectedProfileId
 
@@ -181,7 +181,6 @@ export function LlmConfigView({ controller }: { controller: LlmConfigController 
                 isBusy={feedback.isBusy}
                 testStatuses={providerState.endpointTestStatuses}
                 showModal={showModal}
-                closeModal={closeModal}
                 handlers={providerState.providerHandlers}
               />
             ))}

--- a/frontend/src/components/llmConfig/ProviderCard.tsx
+++ b/frontend/src/components/llmConfig/ProviderCard.tsx
@@ -1,10 +1,10 @@
-import { ChevronDown, Copy, KeyRound, Loader2, Plus, ShieldCheck, Trash2, X } from 'lucide-react'
+import { ChevronDown, Copy, KeyRound, Loader2, Plus, ShieldCheck, Trash2 } from 'lucide-react'
 import { useState, type ReactNode } from 'react'
-import { createPortal } from 'react-dom'
 import { Button as AriaButton, Dialog, DialogTrigger, ListBox, ListBoxItem, Popover, type Key, type Selection } from 'react-aria-components'
 
 import * as llmApi from '../../api/llmConfig'
 import { CheckboxField, FormField, SelectInput, TextInput } from '../common/FormControls'
+import { Modal } from '../common/Modal'
 import { actionKey, addEndpointOptions, button, type EndpointFormValues, type EndpointTestStatus, type ProviderCardData, type ProviderEndpointCard, reasoningEffortOptions } from './shared'
 
 export type ProviderCardHandlers = {
@@ -17,7 +17,7 @@ export type ProviderCardHandlers = {
   onTestEndpoint: (endpoint: ProviderEndpointCard) => Promise<void>
 }
 
-export function ProviderCard({ provider, handlers, isBusy, testStatuses, showModal, closeModal }: { provider: ProviderCardData; handlers: ProviderCardHandlers; isBusy: (key: string) => boolean; testStatuses: Record<string, EndpointTestStatus | undefined>; showModal: (renderer: (onClose: () => void) => ReactNode) => void; closeModal: () => void }) {
+export function ProviderCard({ provider, handlers, isBusy, testStatuses, showModal }: { provider: ProviderCardData; handlers: ProviderCardHandlers; isBusy: (key: string) => boolean; testStatuses: Record<string, EndpointTestStatus | undefined>; showModal: (renderer: (onClose: () => void) => ReactNode) => void }) {
   const [activeTab, setActiveTab] = useState<'endpoints' | 'settings'>('endpoints')
   const [editingEndpointId, setEditingEndpointId] = useState<string | null>(null)
   const rotateBusy = isBusy(actionKey('provider', provider.id, 'rotate'))
@@ -35,12 +35,12 @@ export function ProviderCard({ provider, handlers, isBusy, testStatuses, showMod
   }
 
   const openAddEndpointModal = (type: llmApi.ProviderEndpoint['type'], sourceEndpoint?: ProviderEndpointCard) => {
-    showModal((onClose) => createPortal(
+    showModal((onClose) => (
       <ProviderEndpointModal
         mode="create"
         providerName={provider.name}
         type={type}
-        sourceEndpoint={sourceEndpoint}
+        endpoint={sourceEndpoint}
         busy={creatingEndpoint}
         onClose={onClose}
         onSubmit={async (values) => {
@@ -51,8 +51,7 @@ export function ProviderCard({ provider, handlers, isBusy, testStatuses, showMod
             // feedback already shown
           }
         }}
-      />,
-      document.body,
+      />
     ))
   }
 
@@ -67,68 +66,29 @@ export function ProviderCard({ provider, handlers, isBusy, testStatuses, showMod
   }
 
   const openEndpointEditor = (endpoint: ProviderEndpointCard) => {
-    const isEditing = editingEndpointId === endpoint.id
-    if (isEditing) {
+    const closeEditor = (onClose: () => void) => {
       setEditingEndpointId(null)
-      closeModal()
-      return
+      onClose()
     }
     setEditingEndpointId(endpoint.id)
-    showModal((onClose) =>
-      createPortal(
-        <div className="fixed inset-0 z-[200] flex items-center justify-center bg-slate-900/60">
-          <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-2xl">
-            <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold">
-                {endpoint.type === 'persistent'
-                  ? 'Edit persistent endpoint'
-                  : endpoint.type === 'browser'
-                    ? 'Edit browser endpoint'
-                    : endpoint.type === 'file_handler'
-                      ? 'Edit file handler endpoint'
-                      : endpoint.type === 'image_generation'
-                        ? 'Edit image generation endpoint'
-                        : endpoint.type === 'video_generation'
-                          ? 'Edit video generation endpoint'
-                        : 'Edit embedding endpoint'}
-              </h3>
-              <button
-                onClick={() => {
-                  setEditingEndpointId(null)
-                  onClose()
-                }}
-                className={button.icon}
-              >
-                <X className="size-5" />
-              </button>
-            </div>
-            <p className="text-sm text-slate-500 mt-1">{provider.name}</p>
-            <div className="mt-4">
-              <ProviderEndpointForm
-                mode="edit"
-                endpoint={endpoint}
-                type={endpoint.type}
-                saving={isBusy(actionKey('endpoint', endpoint.id, 'update'))}
-                onCancel={() => {
-                  setEditingEndpointId(null)
-                  onClose()
-                }}
-                onSave={async (values) => {
-                  try {
-                    await handlers.onSaveEndpoint(endpoint, values)
-                    setEditingEndpointId(null)
-                    onClose()
-                  } catch {
-                    // feedback already shown
-                  }
-                }}
-              />
-            </div>
-          </div>
-        </div>,
-        document.body,
-      ),
-    )
+    showModal((onClose) => (
+      <ProviderEndpointModal
+        mode="edit"
+        providerName={provider.name}
+        type={endpoint.type}
+        endpoint={endpoint}
+        busy={isBusy(actionKey('endpoint', endpoint.id, 'update'))}
+        onClose={() => closeEditor(onClose)}
+        onSave={async (values) => {
+          try {
+            await handlers.onSaveEndpoint(endpoint, values)
+            closeEditor(onClose)
+          } catch {
+            // feedback already shown
+          }
+        }}
+      />
+    ))
   }
 
   return (
@@ -522,40 +482,36 @@ function ProviderEndpointForm({
 }
 
 type ProviderEndpointModalProps = {
-  mode: 'create'
+  mode: ProviderEndpointFormMode
   providerName: string
   type: llmApi.ProviderEndpoint['type']
-  sourceEndpoint?: ProviderEndpointCard
+  endpoint?: ProviderEndpointCard
   busy?: boolean
-  onSubmit: (values: EndpointFormValues & { key?: string }) => Promise<void> | void
+  onSubmit?: (values: EndpointFormValues & { key?: string }) => Promise<void> | void
+  onSave?: (values: EndpointFormValues) => Promise<void> | void
   onClose: () => void
 }
 
-function ProviderEndpointModal({ providerName, type, sourceEndpoint, onSubmit, onClose, busy }: ProviderEndpointModalProps) {
-  const title = sourceEndpoint ? `Clone ${endpointTypeLabels[type]} endpoint` : `Add ${endpointTypeLabels[type]} endpoint`
+function ProviderEndpointModal({ mode, providerName, type, endpoint, onSubmit, onSave, onClose, busy }: ProviderEndpointModalProps) {
+  const title = mode === 'edit'
+    ? `Edit ${endpointTypeLabels[type]} endpoint`
+    : endpoint
+      ? `Clone ${endpointTypeLabels[type]} endpoint`
+      : `Add ${endpointTypeLabels[type]} endpoint`
 
   return (
-    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-slate-900/60">
-      <div className="w-full max-w-xl rounded-2xl bg-white p-6 shadow-2xl">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold">{title}</h3>
-          <button onClick={onClose} className={button.icon}>
-            <X className="size-5" />
-          </button>
-        </div>
-        <p className="text-sm text-slate-500 mt-1">{providerName}</p>
-        <div className="mt-4 space-y-3">
-          <ProviderEndpointForm
-            mode="create"
-            type={type}
-            endpoint={sourceEndpoint}
-            saving={busy}
-            submitLabel={sourceEndpoint ? 'Clone endpoint' : 'Add endpoint'}
-            onClose={onClose}
-            onSubmit={onSubmit}
-          />
-        </div>
-      </div>
-    </div>
+    <Modal title={title} subtitle={providerName} onClose={onClose} icon={null} widthClass="sm:max-w-xl">
+      <ProviderEndpointForm
+        mode={mode}
+        type={type}
+        endpoint={endpoint}
+        saving={busy}
+        submitLabel={endpoint ? 'Clone endpoint' : 'Add endpoint'}
+        onClose={onClose}
+        onCancel={onClose}
+        onSubmit={onSubmit}
+        onSave={onSave}
+      />
+    </Modal>
   )
 }

--- a/frontend/src/components/llmConfig/modals.tsx
+++ b/frontend/src/components/llmConfig/modals.tsx
@@ -1,9 +1,10 @@
-import { AlertCircle, Loader2, Plus, X } from 'lucide-react'
+import { AlertCircle, Loader2, Plus } from 'lucide-react'
 import { useState, type FormEvent } from 'react'
 
 import * as llmApi from '../../api/llmConfig'
 import { HttpError } from '../../api/http'
 import { ActionConfirmDialog } from '../common/ActionConfirmDialog'
+import { Modal } from '../common/Modal'
 import { ModalForm } from '../common/ModalForm'
 import { button, type ConfirmDialogConfig, formatNullableNumber, type Tier, type TierScope } from './shared'
 
@@ -51,56 +52,13 @@ export function AddEndpointModal({
     }
   }
   return (
-    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-slate-900/60">
-      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold">Add endpoint to {tier.name}</h3>
-          <button onClick={onClose} className={button.icon}>
-            <X className="size-5" />
-          </button>
-        </div>
-        <div className="mt-4">
-          {endpoints.length === 0 ? (
-            <p className="text-sm text-slate-500">No endpoints available for this tier.</p>
-          ) : (
-            <>
-              <label className="text-sm font-medium text-slate-700">Endpoint</label>
-              <select
-                className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-                value={selected}
-                onChange={(event) => setSelected(event.target.value)}
-              >
-                {endpoints.map((endpoint) => (
-                  <option key={endpoint.id} value={endpoint.id}>
-                    {endpoint.label || endpoint.model}
-                  </option>
-                ))}
-              </select>
-              {scope === 'browser' ? (
-                <div className="mt-4 space-y-1">
-                  <label className="text-sm font-medium text-slate-700">Extraction endpoint (optional)</label>
-                  <select
-                    className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-                    value={extractionSelected}
-                    onChange={(event) => setExtractionSelected(event.target.value)}
-                  >
-                    <option value="">No separate extraction model</option>
-                    {endpoints.map((endpoint) => (
-                      <option key={endpoint.id} value={endpoint.id}>
-                        {endpoint.label || endpoint.model}
-                      </option>
-                    ))}
-                  </select>
-                  <p className="text-xs text-slate-500">If set, page extraction uses this endpoint; otherwise it falls back to the primary model.</p>
-                </div>
-              ) : null}
-            </>
-          )}
-        </div>
-        <div className="mt-6 flex justify-end gap-3">
-          <button type="button" className={button.secondary} onClick={onClose} disabled={isSubmitting}>
-            Cancel
-          </button>
+    <Modal
+      title={`Add endpoint to ${tier.name}`}
+      onClose={onClose}
+      icon={null}
+      widthClass="sm:max-w-md"
+      footer={(
+        <>
           <button
             type="button"
             className={button.primary}
@@ -109,9 +67,49 @@ export function AddEndpointModal({
           >
             {isSubmitting ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />} Add endpoint
           </button>
-        </div>
-      </div>
-    </div>
+          <button type="button" className={button.secondary} onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </button>
+        </>
+      )}
+    >
+      {endpoints.length === 0 ? (
+        <p className="text-sm text-slate-500">No endpoints available for this tier.</p>
+      ) : (
+        <>
+          <label className="text-sm font-medium text-slate-700">Endpoint</label>
+          <select
+            className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            value={selected}
+            onChange={(event) => setSelected(event.target.value)}
+          >
+            {endpoints.map((endpoint) => (
+              <option key={endpoint.id} value={endpoint.id}>
+                {endpoint.label || endpoint.model}
+              </option>
+            ))}
+          </select>
+          {scope === 'browser' ? (
+            <div className="mt-4 space-y-1">
+              <label className="text-sm font-medium text-slate-700">Extraction endpoint (optional)</label>
+              <select
+                className="mt-1 block w-full rounded-lg border-slate-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                value={extractionSelected}
+                onChange={(event) => setExtractionSelected(event.target.value)}
+              >
+                <option value="">No separate extraction model</option>
+                {endpoints.map((endpoint) => (
+                  <option key={endpoint.id} value={endpoint.id}>
+                    {endpoint.label || endpoint.model}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-slate-500">If set, page extraction uses this endpoint; otherwise it falls back to the primary model.</p>
+            </div>
+          ) : null}
+        </>
+      )}
+    </Modal>
   )
 }
 

--- a/frontend/src/components/llmConfig/useRoutingTierActions.tsx
+++ b/frontend/src/components/llmConfig/useRoutingTierActions.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState, type Dispatch, type ReactNode, type SetStateAction } from 'react'
-import { createPortal } from 'react-dom'
 
 import * as llmApi from '../../api/llmConfig'
 import { AddEndpointModal, CreateProfileModal, EditProfileModal } from './modals'
@@ -421,7 +420,7 @@ export function useRoutingTierActions({
     const useProfile = Boolean(
       selectedProfile && scope !== 'file_handler' && scope !== 'image_generation' && scope !== 'video_generation',
     )
-    showModal((onClose) => createPortal(
+    showModal((onClose) => (
       <AddEndpointModal
         tier={tier}
         scope={scope}
@@ -429,8 +428,7 @@ export function useRoutingTierActions({
         busy={isBusy(actionKey(useProfile ? 'profile' : scope, scope, tier.id, 'attach-endpoint'))}
         onAdd={(selection) => (useProfile ? submitProfileTierEndpoint(tier, scope, selection) : submitTierEndpoint(tier, scope, selection))}
         onClose={onClose}
-      />,
-      document.body,
+      />
     ))
   }
   

--- a/frontend/src/screens/agentCollaborators/AgentCollaboratorInviteResponsePage.tsx
+++ b/frontend/src/screens/agentCollaborators/AgentCollaboratorInviteResponsePage.tsx
@@ -1,38 +1,20 @@
-import { useEffect, useMemo, useState } from 'react'
-import { AlertTriangle, ArrowRight, CheckCircle2, LoaderCircle, XCircle } from 'lucide-react'
-
 import {
   acceptAgentCollaboratorInvite,
   declineAgentCollaboratorInvite,
   type AgentCollaboratorInviteResponseAction,
   type AgentCollaboratorInviteResponsePayload,
 } from '../../api/agentCollaboratorInvites'
-
-type InviteStatus = 'loading' | 'accepted' | 'declined' | 'issue' | 'error'
-
-type AgentCollaboratorInviteResponsePageProps = {
-  token: string
-  action: AgentCollaboratorInviteResponseAction
-  onNavigate: (path: string) => void
-}
+import { InviteResponsePage, type InviteResponseConfig } from '../invitations/InviteResponsePage'
 
 function issueTitle(issue: AgentCollaboratorInviteResponsePayload['issue']): string {
-  if (issue === 'expired') {
-    return 'Invite expired'
-  }
-  if (issue === 'wrong_account') {
-    return 'Wrong account'
-  }
-  if (issue === 'already_responded') {
-    return 'Invite already used'
-  }
+  if (issue === 'expired') return 'Invite expired'
+  if (issue === 'wrong_account') return 'Wrong account'
+  if (issue === 'already_responded') return 'Invite already used'
   return 'Invite unavailable'
 }
 
 function issueMessage(payload: AgentCollaboratorInviteResponsePayload | null): string {
-  if (payload?.message) {
-    return payload.message
-  }
+  if (payload?.message) return payload.message
   if (payload?.issue === 'wrong_account') {
     return payload.invitedEmail
       ? `This invite was sent to ${payload.invitedEmail}. Switch accounts to respond to it.`
@@ -51,116 +33,49 @@ function issueMessage(payload: AgentCollaboratorInviteResponsePayload | null): s
   return 'This invite link is invalid or no longer available.'
 }
 
+function buildConfig(action: AgentCollaboratorInviteResponseAction): InviteResponseConfig<AgentCollaboratorInviteResponsePayload> {
+  const accepted = action === 'accept'
+  return {
+    eyebrow: 'Agent Invite',
+    successStatus: accepted ? 'accepted' : 'declined',
+    request: accepted ? acceptAgentCollaboratorInvite : declineAgentCollaboratorInvite,
+    errorMessage: `Unable to ${action} this invite.`,
+    title: ({ status, payload }) => status === 'accepted'
+      ? `Joined ${payload?.agent?.name ?? 'agent'}`
+      : status === 'declined'
+        ? 'Invite declined'
+        : status === 'loading'
+          ? accepted ? 'Accepting invite' : 'Declining invite'
+          : status === 'issue' ? issueTitle(payload?.issue) : `Could not ${action} invite`,
+    message: ({ status, payload, errorMessage }) => status === 'accepted'
+      ? 'Opening the shared agent.'
+      : status === 'declined'
+        ? 'Returning to your agents.'
+        : status === 'loading'
+          ? accepted
+            ? 'Checking the invite and preparing the shared agent.'
+            : 'Checking the invite and recording your response.'
+          : status === 'issue' ? issueMessage(payload) : (errorMessage ?? `Unable to ${action} this invite.`),
+    actionPath: ({ status, payload }) => (status === 'accepted' || status === 'declined') && payload?.redirectUrl
+      ? payload.redirectUrl
+      : status === 'issue' && payload?.issue === 'wrong_account' ? '/app/profile' : '/app/agents',
+    actionLabel: ({ status }) => status === 'accepted' ? 'Open agent' : 'Continue',
+  }
+}
+
+const INVITE_CONFIGS = {
+  accept: buildConfig('accept'),
+  decline: buildConfig('decline'),
+}
+
 export function AgentCollaboratorInviteResponsePage({
   token,
   action,
   onNavigate,
-}: AgentCollaboratorInviteResponsePageProps) {
-  const [status, setStatus] = useState<InviteStatus>('loading')
-  const [payload, setPayload] = useState<AgentCollaboratorInviteResponsePayload | null>(null)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-
-  useEffect(() => {
-    let cancelled = false
-    let redirectTimer: number | undefined
-
-    const respondToInvite = async () => {
-      setStatus('loading')
-      setPayload(null)
-      setErrorMessage(null)
-      try {
-        const result = action === 'accept'
-          ? await acceptAgentCollaboratorInvite(token)
-          : await declineAgentCollaboratorInvite(token)
-        if (cancelled) {
-          return
-        }
-        setPayload(result)
-        if (!result.ok) {
-          setStatus('issue')
-          return
-        }
-        setStatus(action === 'accept' ? 'accepted' : 'declined')
-        if (result.redirectUrl) {
-          redirectTimer = window.setTimeout(() => onNavigate(result.redirectUrl as string), 650)
-        }
-      } catch (error) {
-        if (cancelled) {
-          return
-        }
-        setStatus('error')
-        setErrorMessage(error instanceof Error ? error.message : `Unable to ${action} this invite.`)
-      }
-    }
-
-    void respondToInvite()
-    return () => {
-      cancelled = true
-      if (redirectTimer) {
-        window.clearTimeout(redirectTimer)
-      }
-    }
-  }, [action, onNavigate, token])
-
-  const icon = useMemo(() => {
-    if (status === 'loading') {
-      return <LoaderCircle className="immersive-invite-card__icon-svg immersive-invite-card__icon-svg--spin" />
-    }
-    if (status === 'accepted') {
-      return <CheckCircle2 className="immersive-invite-card__icon-svg" />
-    }
-    if (status === 'declined') {
-      return <XCircle className="immersive-invite-card__icon-svg" />
-    }
-    return <AlertTriangle className="immersive-invite-card__icon-svg" />
-  }, [status])
-
-  const title = status === 'accepted'
-    ? `Joined ${payload?.agent?.name ?? 'agent'}`
-    : status === 'declined'
-      ? 'Invite declined'
-      : status === 'loading'
-        ? action === 'accept' ? 'Accepting invite' : 'Declining invite'
-        : status === 'issue'
-          ? issueTitle(payload?.issue)
-          : `Could not ${action} invite`
-
-  const message = status === 'accepted'
-    ? 'Opening the shared agent.'
-    : status === 'declined'
-      ? 'Returning to your agents.'
-      : status === 'loading'
-        ? action === 'accept'
-          ? 'Checking the invite and preparing the shared agent.'
-          : 'Checking the invite and recording your response.'
-        : status === 'issue'
-          ? issueMessage(payload)
-          : (errorMessage ?? `Unable to ${action} this invite.`)
-
-  const actionPath = (status === 'accepted' || status === 'declined') && payload?.redirectUrl
-    ? payload.redirectUrl
-    : status === 'issue' && payload?.issue === 'wrong_account'
-      ? '/app/profile'
-      : '/app/agents'
-
-  return (
-    <section className="immersive-invite-page">
-      <div className={`immersive-invite-card immersive-invite-card--${status}`}>
-        <div className="immersive-invite-card__icon">{icon}</div>
-        <p className="immersive-invite-card__eyebrow">Agent Invite</p>
-        <h1 className="immersive-invite-card__title">{title}</h1>
-        <p className="immersive-invite-card__message">{message}</p>
-        {status !== 'loading' ? (
-          <button
-            type="button"
-            className="immersive-invite-card__button"
-            onClick={() => onNavigate(actionPath)}
-          >
-            <span>{status === 'accepted' ? 'Open agent' : 'Continue'}</span>
-            <ArrowRight className="h-4 w-4" />
-          </button>
-        ) : null}
-      </div>
-    </section>
-  )
+}: {
+  token: string
+  action: AgentCollaboratorInviteResponseAction
+  onNavigate: (path: string) => void
+}) {
+  return <InviteResponsePage token={token} onNavigate={onNavigate} config={INVITE_CONFIGS[action]} />
 }

--- a/frontend/src/screens/invitations/InviteResponsePage.tsx
+++ b/frontend/src/screens/invitations/InviteResponsePage.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, ArrowRight, CheckCircle2, LoaderCircle, XCircle } from 'lucide-react'
+
+type InviteStatus = 'loading' | 'accepted' | 'declined' | 'issue' | 'error'
+
+export type InviteResponsePayload = {
+  ok: boolean
+  issue?: string
+  redirectUrl?: string
+}
+
+type InviteResponseContext<TPayload> = {
+  status: InviteStatus
+  payload: TPayload | null
+  errorMessage: string | null
+}
+
+export type InviteResponseConfig<TPayload extends InviteResponsePayload> = {
+  eyebrow: string
+  successStatus: 'accepted' | 'declined'
+  request: (token: string) => Promise<TPayload>
+  title: (context: InviteResponseContext<TPayload>) => string
+  message: (context: InviteResponseContext<TPayload>) => string
+  actionPath: (context: InviteResponseContext<TPayload>) => string
+  actionLabel: (context: InviteResponseContext<TPayload>) => string
+  errorMessage: string
+  onSuccess?: (payload: TPayload) => void
+}
+
+export function InviteResponsePage<TPayload extends InviteResponsePayload>({
+  token,
+  onNavigate,
+  config,
+}: {
+  token: string
+  onNavigate: (path: string) => void
+  config: InviteResponseConfig<TPayload>
+}) {
+  const [status, setStatus] = useState<InviteStatus>('loading')
+  const [payload, setPayload] = useState<TPayload | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    let redirectTimer: number | undefined
+
+    const respondToInvite = async () => {
+      setStatus('loading')
+      setPayload(null)
+      setErrorMessage(null)
+      try {
+        const result = await config.request(token)
+        if (cancelled) return
+        setPayload(result)
+        if (!result.ok) {
+          setStatus('issue')
+          return
+        }
+        setStatus(config.successStatus)
+        config.onSuccess?.(result)
+        if (result.redirectUrl) {
+          redirectTimer = window.setTimeout(() => onNavigate(result.redirectUrl as string), 650)
+        }
+      } catch (error) {
+        if (cancelled) return
+        setStatus('error')
+        setErrorMessage(error instanceof Error ? error.message : config.errorMessage)
+      }
+    }
+
+    void respondToInvite()
+    return () => {
+      cancelled = true
+      if (redirectTimer) window.clearTimeout(redirectTimer)
+    }
+  }, [config, onNavigate, token])
+
+  const icon = useMemo(() => {
+    if (status === 'loading') {
+      return <LoaderCircle className="immersive-invite-card__icon-svg immersive-invite-card__icon-svg--spin" />
+    }
+    if (status === 'accepted') return <CheckCircle2 className="immersive-invite-card__icon-svg" />
+    if (status === 'declined') return <XCircle className="immersive-invite-card__icon-svg" />
+    return <AlertTriangle className="immersive-invite-card__icon-svg" />
+  }, [status])
+  const context = { status, payload, errorMessage }
+
+  return (
+    <section className="immersive-invite-page">
+      <div className={`immersive-invite-card immersive-invite-card--${status}`}>
+        <div className="immersive-invite-card__icon">{icon}</div>
+        <p className="immersive-invite-card__eyebrow">{config.eyebrow}</p>
+        <h1 className="immersive-invite-card__title">{config.title(context)}</h1>
+        <p className="immersive-invite-card__message">{config.message(context)}</p>
+        {status !== 'loading' ? (
+          <button
+            type="button"
+            className="immersive-invite-card__button"
+            onClick={() => onNavigate(config.actionPath(context))}
+          >
+            <span>{config.actionLabel(context)}</span>
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/screens/invitations/InviteResponsePage.tsx
+++ b/frontend/src/screens/invitations/InviteResponsePage.tsx
@@ -36,6 +36,17 @@ export function InviteResponsePage<TPayload extends InviteResponsePayload>({
   onNavigate: (path: string) => void
   config: InviteResponseConfig<TPayload>
 }) {
+  const {
+    eyebrow,
+    successStatus,
+    request,
+    title,
+    message,
+    actionPath,
+    actionLabel,
+    errorMessage: configErrorMessage,
+    onSuccess,
+  } = config
   const [status, setStatus] = useState<InviteStatus>('loading')
   const [payload, setPayload] = useState<TPayload | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -49,22 +60,22 @@ export function InviteResponsePage<TPayload extends InviteResponsePayload>({
       setPayload(null)
       setErrorMessage(null)
       try {
-        const result = await config.request(token)
+        const result = await request(token)
         if (cancelled) return
         setPayload(result)
         if (!result.ok) {
           setStatus('issue')
           return
         }
-        setStatus(config.successStatus)
-        config.onSuccess?.(result)
+        setStatus(successStatus)
+        onSuccess?.(result)
         if (result.redirectUrl) {
           redirectTimer = window.setTimeout(() => onNavigate(result.redirectUrl as string), 650)
         }
       } catch (error) {
         if (cancelled) return
         setStatus('error')
-        setErrorMessage(error instanceof Error ? error.message : config.errorMessage)
+        setErrorMessage(error instanceof Error ? error.message : configErrorMessage)
       }
     }
 
@@ -73,7 +84,7 @@ export function InviteResponsePage<TPayload extends InviteResponsePayload>({
       cancelled = true
       if (redirectTimer) window.clearTimeout(redirectTimer)
     }
-  }, [config, onNavigate, token])
+  }, [configErrorMessage, onNavigate, onSuccess, request, successStatus, token])
 
   const icon = useMemo(() => {
     if (status === 'loading') {
@@ -89,16 +100,16 @@ export function InviteResponsePage<TPayload extends InviteResponsePayload>({
     <section className="immersive-invite-page">
       <div className={`immersive-invite-card immersive-invite-card--${status}`}>
         <div className="immersive-invite-card__icon">{icon}</div>
-        <p className="immersive-invite-card__eyebrow">{config.eyebrow}</p>
-        <h1 className="immersive-invite-card__title">{config.title(context)}</h1>
-        <p className="immersive-invite-card__message">{config.message(context)}</p>
+        <p className="immersive-invite-card__eyebrow">{eyebrow}</p>
+        <h1 className="immersive-invite-card__title">{title(context)}</h1>
+        <p className="immersive-invite-card__message">{message(context)}</p>
         {status !== 'loading' ? (
           <button
             type="button"
             className="immersive-invite-card__button"
-            onClick={() => onNavigate(config.actionPath(context))}
+            onClick={() => onNavigate(actionPath(context))}
           >
-            <span>{config.actionLabel(context)}</span>
+            <span>{actionLabel(context)}</span>
             <ArrowRight className="h-4 w-4" />
           </button>
         ) : null}

--- a/frontend/src/screens/organization/OrganizationInviteAcceptPage.tsx
+++ b/frontend/src/screens/organization/OrganizationInviteAcceptPage.tsx
@@ -1,22 +1,9 @@
-import { useEffect, useMemo, useState } from 'react'
-import { AlertTriangle, ArrowRight, CheckCircle2, LoaderCircle } from 'lucide-react'
-
 import { acceptOrganizationInvite, type OrganizationInviteAcceptPayload } from '../../api/organization'
-
-type InviteStatus = 'loading' | 'accepted' | 'issue' | 'error'
-
-type OrganizationInviteAcceptPageProps = {
-  token: string
-  onNavigate: (path: string) => void
-}
+import { InviteResponsePage, type InviteResponseConfig } from '../invitations/InviteResponsePage'
 
 function issueTitle(issue: OrganizationInviteAcceptPayload['issue']): string {
-  if (issue === 'expired') {
-    return 'Invite expired'
-  }
-  if (issue === 'wrong_account') {
-    return 'Wrong account'
-  }
+  if (issue === 'expired') return 'Invite expired'
+  if (issue === 'wrong_account') return 'Wrong account'
   return 'Invite unavailable'
 }
 
@@ -34,110 +21,43 @@ function issueMessage(payload: OrganizationInviteAcceptPayload | null): string {
   return 'This invite link is invalid or no longer available.'
 }
 
-export function OrganizationInviteAcceptPage({ token, onNavigate }: OrganizationInviteAcceptPageProps) {
-  const [status, setStatus] = useState<InviteStatus>('loading')
-  const [payload, setPayload] = useState<OrganizationInviteAcceptPayload | null>(null)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-
-  useEffect(() => {
-    let cancelled = false
-    let redirectTimer: number | undefined
-
-    const acceptInvite = async () => {
-      setStatus('loading')
-      setPayload(null)
-      setErrorMessage(null)
-      try {
-        const result = await acceptOrganizationInvite(token)
-        if (cancelled) {
-          return
-        }
-        setPayload(result)
-        if (!result.ok) {
-          setStatus('issue')
-          return
-        }
-        setStatus('accepted')
-        if (result.organization) {
-          window.dispatchEvent(new CustomEvent('gobii:console-context-updated', {
-            detail: {
-              type: 'organization',
-              id: result.organization.id,
-              name: result.organization.name,
-            },
-          }))
-        }
-        if (result.redirectUrl) {
-          redirectTimer = window.setTimeout(() => onNavigate(result.redirectUrl as string), 650)
-        }
-      } catch (error) {
-        if (cancelled) {
-          return
-        }
-        setStatus('error')
-        setErrorMessage(error instanceof Error ? error.message : 'Unable to accept this invite.')
-      }
-    }
-
-    void acceptInvite()
-    return () => {
-      cancelled = true
-      if (redirectTimer) {
-        window.clearTimeout(redirectTimer)
-      }
-    }
-  }, [onNavigate, token])
-
-  const icon = useMemo(() => {
-    if (status === 'loading') {
-      return <LoaderCircle className="immersive-invite-card__icon-svg immersive-invite-card__icon-svg--spin" />
-    }
-    if (status === 'accepted') {
-      return <CheckCircle2 className="immersive-invite-card__icon-svg" />
-    }
-    return <AlertTriangle className="immersive-invite-card__icon-svg" />
-  }, [status])
-
-  const title = status === 'accepted'
+const ORGANIZATION_INVITE_CONFIG: InviteResponseConfig<OrganizationInviteAcceptPayload> = {
+  eyebrow: 'Team Invite',
+  successStatus: 'accepted',
+  request: acceptOrganizationInvite,
+  errorMessage: 'Unable to accept this invite.',
+  title: ({ status, payload }) => status === 'accepted'
     ? `Joined ${payload?.organization?.name ?? 'team'}`
     : status === 'loading'
       ? 'Accepting invite'
-      : status === 'issue'
-        ? issueTitle(payload?.issue)
-        : 'Could not accept invite'
-
-  const message = status === 'accepted'
+      : status === 'issue' ? issueTitle(payload?.issue) : 'Could not accept invite',
+  message: ({ status, payload, errorMessage }) => status === 'accepted'
     ? 'Opening your team workspace.'
     : status === 'loading'
       ? 'Checking the invite and preparing your team workspace.'
-      : status === 'issue'
-        ? issueMessage(payload)
-        : (errorMessage ?? 'Unable to accept this invite.')
-
-  const actionPath = status === 'accepted' && payload?.redirectUrl
+      : status === 'issue' ? issueMessage(payload) : (errorMessage ?? 'Unable to accept this invite.'),
+  actionPath: ({ status, payload }) => status === 'accepted' && payload?.redirectUrl
     ? payload.redirectUrl
-    : status === 'issue' && payload?.issue === 'wrong_account'
-      ? '/app/profile'
-      : '/app/agents'
+    : status === 'issue' && payload?.issue === 'wrong_account' ? '/app/profile' : '/app/agents',
+  actionLabel: ({ status }) => status === 'accepted' ? 'Open organization' : 'Continue',
+  onSuccess: (payload) => {
+    if (!payload.organization) return
+    window.dispatchEvent(new CustomEvent('gobii:console-context-updated', {
+      detail: {
+        type: 'organization',
+        id: payload.organization.id,
+        name: payload.organization.name,
+      },
+    }))
+  },
+}
 
-  return (
-    <section className="immersive-invite-page">
-      <div className={`immersive-invite-card immersive-invite-card--${status}`}>
-        <div className="immersive-invite-card__icon">{icon}</div>
-        <p className="immersive-invite-card__eyebrow">Team Invite</p>
-        <h1 className="immersive-invite-card__title">{title}</h1>
-        <p className="immersive-invite-card__message">{message}</p>
-        {status !== 'loading' ? (
-          <button
-            type="button"
-            className="immersive-invite-card__button"
-            onClick={() => onNavigate(actionPath)}
-          >
-            <span>{status === 'accepted' ? 'Open organization' : 'Continue'}</span>
-            <ArrowRight className="h-4 w-4" />
-          </button>
-        ) : null}
-      </div>
-    </section>
-  )
+export function OrganizationInviteAcceptPage({
+  token,
+  onNavigate,
+}: {
+  token: string
+  onNavigate: (path: string) => void
+}) {
+  return <InviteResponsePage token={token} onNavigate={onNavigate} config={ORGANIZATION_INVITE_CONFIG} />
 }


### PR DESCRIPTION
**Summary**
- Consolidated invite response screens into a साझा reusable `InviteResponsePage` to remove duplicated loading, success, and error flow.
- Simplified the agent collaborator invite page and prepared organization invite handling to use the shared invite response config.
- Reworked LLM config and routing modals to use the shared `Modal` component instead of manual portal overlays.
- Trimmed a few now-unneeded props and imports in the LLM config UI.

**Testing**
- Not run (not requested)