### PR TITLE
Improve compact table layout in agent chat messages

### DIFF
--- a/frontend/src/components/agentChat/MessageContent.tsx
+++ b/frontend/src/components/agentChat/MessageContent.tsx
@@ -85,6 +85,14 @@ function wrapTablesForHorizontalScroll(value: string): string {
   document.body.querySelectorAll('table').forEach((table) => {
     if (table.parentElement?.classList.contains('chat-html-table-scroll')) return
 
+    const columnCount = Array.from(table.rows).reduce((maxColumns, row) => {
+      const rowColumns = Array.from(row.cells).reduce((total, cell) => total + cell.colSpan, 0)
+      return Math.max(maxColumns, rowColumns)
+    }, 0)
+    if (columnCount > 0 && columnCount <= 2) {
+      table.classList.add('chat-html-table--compact')
+    }
+
     const wrapper = document.createElement('div')
     wrapper.className = 'chat-html-table-scroll'
     table.before(wrapper)

--- a/frontend/src/components/agentChat/MessageContent.tsx
+++ b/frontend/src/components/agentChat/MessageContent.tsx
@@ -91,6 +91,9 @@ function wrapTablesForHorizontalScroll(value: string): string {
     }, 0)
     if (columnCount > 0 && columnCount <= 2) {
       table.classList.add('chat-html-table--compact')
+      if (columnCount === 2) {
+        table.classList.add('chat-html-table--2-cols')
+      }
     }
 
     const wrapper = document.createElement('div')

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3265,12 +3265,12 @@
 .chat-html-content .chat-html-table--compact td {
     min-width: 0;
 }
-.chat-html-content .chat-html-table--compact tr > :first-child {
+.chat-html-content .chat-html-table--2-cols tr > :first-child:not([colspan]) {
     width: clamp(8rem, 24%, 11rem);
     min-width: 8rem;
     overflow-wrap: normal;
 }
-.chat-html-content .chat-html-table--compact tr > :not(:first-child) {
+.chat-html-content .chat-html-table--2-cols tr > :not(:first-child) {
     overflow-wrap: anywhere;
 }
 .chat-bubble--user .chat-content {

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3249,6 +3249,9 @@
     font-size: 0.875rem;
     table-layout: auto;
 }
+.chat-html-content table.chat-html-table--compact {
+    width: 100%;
+}
 .chat-html-table-scroll table {
     margin: 0;
 }
@@ -3257,6 +3260,18 @@
     overflow-wrap: normal;
     word-break: normal;
     white-space: normal;
+}
+.chat-html-content .chat-html-table--compact th,
+.chat-html-content .chat-html-table--compact td {
+    min-width: 0;
+}
+.chat-html-content .chat-html-table--compact tr > :first-child {
+    width: clamp(8rem, 24%, 11rem);
+    min-width: 8rem;
+    overflow-wrap: normal;
+}
+.chat-html-content .chat-html-table--compact tr > :not(:first-child) {
+    overflow-wrap: anywhere;
 }
 .chat-bubble--user .chat-content {
     color: #334155;


### PR DESCRIPTION
## Summary
- Detect narrow chat tables with one or two columns and mark them for a compact layout.
- Make compact tables fill the available width while keeping the first column readable.
- Allow longer values in secondary cells to wrap more naturally and avoid awkward overflow.

## Testing
- Not run (not requested)