### PR TITLE
Clarify inline CSS requirements for agent email sending

### DIFF
--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -161,6 +161,7 @@ def get_send_email_tool() -> Dict[str, Any]:
             "name": "send_email",
             "description": (
                 "Send rich body-only HTML email without <html>/<head>/<body>; avoid Markdown. "
+                "Do not use <style> blocks or CSS classes; put CSS directly on each element with inline style attrs. "
                 "For reports/dashboards, avoid bare HTML: use inline style attrs on sections, tables/cells, and highlighted values. Do NOT leave report metrics in plain lists. Do NOT use Markdown pipe tables."
             ),
             "parameters": {

--- a/tests/unit/test_email_sender_db_connections.py
+++ b/tests/unit/test_email_sender_db_connections.py
@@ -109,6 +109,7 @@ class EmailSenderDbConnectionTests(TransactionTestCase):
         properties = tool["function"]["parameters"]["properties"]
 
         self.assertIn("body-only HTML", description)
+        self.assertIn("Do not use <style> blocks or CSS classes", description)
         self.assertIn("inline style attrs", description)
         self.assertIn("tables/cells", description)
         self.assertIn("Do NOT leave report metrics in plain lists", description)


### PR DESCRIPTION
## Summary
- Tighten the `send_email` tool guidance to require inline styles on every element.
- Explicitly forbid `<style>` blocks and CSS classes so HTML email output stays compatible and predictable.
- Add a unit test to lock the updated tool description.

## Testing
- Added/updated unit coverage for the email sender tool description.
- Not run (not requested).