### PR TITLE
Restore full HTML for legacy Mailgun forwarded emails

### DIFF
--- a/api/agent/comms/adapters.py
+++ b/api/agent/comms/adapters.py
@@ -11,7 +11,7 @@ import json
 from django.http.request import QueryDict
 from opentelemetry import trace
 from dataclasses import dataclass
-from typing import Any, List, MutableMapping, Optional, Tuple
+from typing import Any, List, MutableMapping, Optional
 from django.http import HttpRequest
 from api.models import CommsChannel
 import  logging
@@ -19,145 +19,16 @@ import re
 
 from config.settings import EMAIL_STRIP_REPLIES
 from api.agent.comms.chat_email_display_cache import merge_chat_body_html_cache
+from api.agent.comms.email_forwarding import (
+    extract_forward_sections as _extract_forward_sections,
+    is_forward_like as _is_forward_like,
+)
 from api.services.system_settings import get_max_file_size
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer('gobii.utils')
 
 EMAIL_BODY_HTML_PAYLOAD_KEY = "body_html"
-
-
-# Optional quote prefix pattern - matches "> " or "> > " etc. at start of line
-# This handles forwarded content that's been quoted (e.g., when replying to a forward)
-# Also allows leading whitespace (e.g., from copy-paste or email client indentation)
-_QUOTE_PREFIX = r"\s*(?:>\s*)*"
-
-# Markers that definitively indicate a forward (not used in replies)
-FORWARD_ONLY_MARKERS = [
-    r"^" + _QUOTE_PREFIX + r"Begin forwarded message:",  # Apple Mail
-    r"^" + _QUOTE_PREFIX + r"-{2,}\s*Forwarded message\s*-{2,}$",  # Gmail
-]
-# Markers that are ambiguous - used by Outlook for both forwards AND replies
-AMBIGUOUS_QUOTE_MARKERS = [
-    r"^" + _QUOTE_PREFIX + r"-----Original Message-----$",
-    r"^" + _QUOTE_PREFIX + r"-{3,}\s*Original Message\s*-{3,}$",
-    r"^" + _QUOTE_PREFIX + r"_{10,}$",  # Outlook web underscore separators
-]
-FORWARD_ONLY_MARKERS_RE = re.compile("|".join(FORWARD_ONLY_MARKERS), re.IGNORECASE | re.MULTILINE)
-AMBIGUOUS_QUOTE_MARKERS_RE = re.compile("|".join(AMBIGUOUS_QUOTE_MARKERS), re.IGNORECASE | re.MULTILINE)
-SUBJECT_FWD_RE = re.compile(r"^\s*(fwd?|fw|wg|tr|rv)\s*:", re.IGNORECASE)
-SUBJECT_REPLY_RE = re.compile(r"^\s*re\s*:", re.IGNORECASE)
-# Pattern to match individual header lines in forwarded content (with optional quote prefix)
-FORWARDED_HEADER_LINE_RE = re.compile(
-    r"^" + _QUOTE_PREFIX + r"(From|Date|Sent|Subject|To):\s*.+",
-    re.IGNORECASE | re.MULTILINE,
-)
-
-
-def _has_forwarded_header_block(text: str) -> bool:
-    """Check if text contains a clustered block of email headers (indicating forwarded content).
-
-    This is more flexible than a strict regex - it looks for at least 3 of the typical
-    forwarded email headers (From, Date/Sent, Subject, To) within an 8-line window,
-    regardless of their order. Different email clients arrange these headers differently.
-    """
-    if not text:
-        return False
-    lines = text.split('\n')
-    for i in range(len(lines)):
-        window = '\n'.join(lines[i:i + 8])
-        matches = FORWARDED_HEADER_LINE_RE.findall(window)
-        # Normalize and dedupe (e.g., "From" and "from" count as one)
-        unique_headers = set(m.lower() for m in matches)
-        # "Sent" and "Date" are equivalent (different clients use different names)
-        if "sent" in unique_headers:
-            unique_headers.add("date")
-        if len(unique_headers) >= 3:
-            return True
-    return False
-
-
-def _is_forward_like(subject: str, body_text: str, attachments: list[dict]) -> bool:
-    # Embedded message/rfc822 attachment is a definitive forward
-    if any((a.get("ContentType", "") or "").lower() == "message/rfc822" for a in (attachments or [])):
-        return True
-    # Explicit forward subject prefix
-    if SUBJECT_FWD_RE.search(subject or ""):
-        return True
-    # Definitive forward-only markers (e.g., "Begin forwarded message:")
-    if FORWARD_ONLY_MARKERS_RE.search(body_text or ""):
-        return True
-
-    # For ambiguous markers and header blocks, skip if subject indicates a reply.
-    # Outlook uses "-----Original Message-----" and underscore separators for BOTH
-    # forwards and replies, so we can't rely on these alone.
-    is_reply = bool(SUBJECT_REPLY_RE.search(subject or ""))
-    if is_reply:
-        return False
-
-    # Ambiguous markers (only count as forward if not a reply)
-    if AMBIGUOUS_QUOTE_MARKERS_RE.search(body_text or ""):
-        return True
-    # Header block detection (only if not a reply)
-    if _has_forwarded_header_block(body_text):
-        return True
-    return False
-
-
-def _find_header_block_start(text: str) -> int | None:
-    """Find the start index of a forwarded header block in the text.
-
-    Returns the character index where the first header line of the block begins,
-    or None if no header block is found.
-    """
-    if not text:
-        return None
-    lines = text.split('\n')
-    line_starts = []
-    pos = 0
-    for line in lines:
-        line_starts.append(pos)
-        pos += len(line) + 1  # +1 for newline
-
-    for i in range(len(lines)):
-        window_lines = lines[i:i + 8]
-        window = '\n'.join(window_lines)
-        matches = FORWARDED_HEADER_LINE_RE.findall(window)
-        unique_headers = set(m.lower() for m in matches)
-        if "sent" in unique_headers:
-            unique_headers.add("date")
-        if len(unique_headers) >= 3:
-            # Find the first actual header line within this window
-            for j, line in enumerate(window_lines):
-                if FORWARDED_HEADER_LINE_RE.match(line):
-                    return line_starts[i + j]
-            # Fallback (shouldn't happen if we found matches)
-            return line_starts[i]
-    return None
-
-
-def _extract_forward_sections(body_text: str) -> Tuple[str, str]:
-    """
-    Returns (preamble, forwarded_block). If no marker found, returns (body_text, "").
-    """
-    if not body_text:
-        return "", ""
-    starts = []
-    # Check both forward-only and ambiguous markers for extraction
-    # (by the time we call this, we've already determined it's a forward)
-    m1 = FORWARD_ONLY_MARKERS_RE.search(body_text)
-    if m1:
-        starts.append(m1.start())
-    m2 = AMBIGUOUS_QUOTE_MARKERS_RE.search(body_text)
-    if m2:
-        starts.append(m2.start())
-    header_start = _find_header_block_start(body_text)
-    if header_start is not None:
-        starts.append(header_start)
-    if not starts:
-        return body_text.strip(), ""
-    idx = min(starts)
-    return body_text[:idx].strip(), body_text[idx:].strip()
 
 
 def _html_to_text(html: str) -> str:
@@ -443,12 +314,13 @@ class MailgunEmailAdapter(EmailAdapter):
         # Get the full unstripped body for forward detection and extraction
         # Mailgun's stripped-text removes quoted content, which we need for forwards
         body_plain_raw = _first_value(payload_dict.get("body-plain")) or ""
-        html_body = (
-            _first_value(payload_dict.get("stripped-html"))
-            or _first_value(payload_dict.get("body-html"))
+        stripped_html_body = _first_value(payload_dict.get("stripped-html")) or ""
+        full_html_body = (
+            _first_value(payload_dict.get("body-html"))
             or _first_value(payload_dict.get("html"))
             or ""
         )
+        html_body = stripped_html_body or full_html_body
 
         # For non-forwards, prefer stripped content; for forwards, we'll use body-plain
         stripped_text = _first_value(payload_dict.get("stripped-text")) or ""
@@ -493,7 +365,7 @@ class MailgunEmailAdapter(EmailAdapter):
 
         if is_forward:
             # For forwards, use body-plain to preserve the quoted/forwarded content
-            forward_text = body_plain_raw or _html_to_text(html_body) or working_text
+            forward_text = body_plain_raw or _html_to_text(full_html_body or html_body) or working_text
             preamble, forwarded = _extract_forward_sections(forward_text)
             if forwarded and preamble:
                 body = f"{preamble}\n\n{forwarded}"
@@ -537,12 +409,13 @@ class MailgunEmailAdapter(EmailAdapter):
             or ""
         ).strip()
 
+        chat_html_body = full_html_body if is_forward and full_html_body else html_body
         normalized_payload = _normalize_inbound_email_raw_payload(payload_dict)
-        if body or html_body:
+        if body or chat_html_body:
             normalized_payload = merge_chat_body_html_cache(
                 normalized_payload,
                 body,
-                explicit_html=html_body,
+                explicit_html=chat_html_body,
             )
 
         return ParsedMessage(

--- a/api/agent/comms/email_forwarding.py
+++ b/api/agent/comms/email_forwarding.py
@@ -1,0 +1,112 @@
+import re
+
+
+# Forward markers may be quoted when a user replies to an already-forwarded email.
+_QUOTE_PREFIX = r"\s*(?:>\s*)*"
+
+FORWARD_ONLY_MARKERS = [
+    r"^" + _QUOTE_PREFIX + r"Begin forwarded message:",
+    r"^" + _QUOTE_PREFIX + r"-{2,}\s*Forwarded message\s*-{2,}$",
+]
+AMBIGUOUS_QUOTE_MARKERS = [
+    r"^" + _QUOTE_PREFIX + r"-----Original Message-----$",
+    r"^" + _QUOTE_PREFIX + r"-{3,}\s*Original Message\s*-{3,}$",
+    r"^" + _QUOTE_PREFIX + r"_{10,}$",
+]
+FORWARD_ONLY_MARKERS_RE = re.compile(
+    "|".join(FORWARD_ONLY_MARKERS),
+    re.IGNORECASE | re.MULTILINE,
+)
+AMBIGUOUS_QUOTE_MARKERS_RE = re.compile(
+    "|".join(AMBIGUOUS_QUOTE_MARKERS),
+    re.IGNORECASE | re.MULTILINE,
+)
+SUBJECT_FWD_RE = re.compile(r"^\s*(fwd?|fw|wg|tr|rv)\s*:", re.IGNORECASE)
+SUBJECT_REPLY_RE = re.compile(r"^\s*re\s*:", re.IGNORECASE)
+FORWARDED_HEADER_LINE_RE = re.compile(
+    r"^" + _QUOTE_PREFIX + r"(From|Date|Sent|Subject|To):\s*.+",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def has_forwarded_header_block(text: str) -> bool:
+    """Return whether text contains a clustered forwarded-email header block."""
+    if not text:
+        return False
+
+    lines = text.split("\n")
+    for index in range(len(lines)):
+        window = "\n".join(lines[index:index + 8])
+        unique_headers = {match.lower() for match in FORWARDED_HEADER_LINE_RE.findall(window)}
+        if "sent" in unique_headers:
+            unique_headers.add("date")
+        if len(unique_headers) >= 3:
+            return True
+    return False
+
+
+def is_forward_like(subject: str, body_text: str, attachments: list[dict]) -> bool:
+    if any(
+        (attachment.get("ContentType", "") or "").lower() == "message/rfc822"
+        for attachment in (attachments or [])
+    ):
+        return True
+    if SUBJECT_FWD_RE.search(subject or ""):
+        return True
+    if FORWARD_ONLY_MARKERS_RE.search(body_text or ""):
+        return True
+
+    # Outlook uses these markers for replies too, so the subject must disambiguate them.
+    if SUBJECT_REPLY_RE.search(subject or ""):
+        return False
+    if AMBIGUOUS_QUOTE_MARKERS_RE.search(body_text or ""):
+        return True
+    return has_forwarded_header_block(body_text)
+
+
+def _find_header_block_start(text: str) -> int | None:
+    if not text:
+        return None
+
+    lines = text.split("\n")
+    line_starts = []
+    position = 0
+    for line in lines:
+        line_starts.append(position)
+        position += len(line) + 1
+
+    for index in range(len(lines)):
+        window_lines = lines[index:index + 8]
+        window = "\n".join(window_lines)
+        unique_headers = {match.lower() for match in FORWARDED_HEADER_LINE_RE.findall(window)}
+        if "sent" in unique_headers:
+            unique_headers.add("date")
+        if len(unique_headers) < 3:
+            continue
+        for offset, line in enumerate(window_lines):
+            if FORWARDED_HEADER_LINE_RE.match(line):
+                return line_starts[index + offset]
+        return line_starts[index]
+    return None
+
+
+def extract_forward_sections(body_text: str) -> tuple[str, str]:
+    """Split a forward into its sender preamble and forwarded message block."""
+    if not body_text:
+        return "", ""
+
+    starts = []
+    forward_marker = FORWARD_ONLY_MARKERS_RE.search(body_text)
+    if forward_marker:
+        starts.append(forward_marker.start())
+    ambiguous_marker = AMBIGUOUS_QUOTE_MARKERS_RE.search(body_text)
+    if ambiguous_marker:
+        starts.append(ambiguous_marker.start())
+    header_start = _find_header_block_start(body_text)
+    if header_start is not None:
+        starts.append(header_start)
+    if not starts:
+        return body_text.strip(), ""
+
+    split_at = min(starts)
+    return body_text[:split_at].strip(), body_text[split_at:].strip()

--- a/api/agent/comms/email_forwarding.py
+++ b/api/agent/comms/email_forwarding.py
@@ -29,20 +29,33 @@ FORWARDED_HEADER_LINE_RE = re.compile(
 )
 
 
+def _find_header_block_line(lines: list[str]) -> int | None:
+    header_matches = []
+    for index, line in enumerate(lines):
+        match = FORWARDED_HEADER_LINE_RE.match(line)
+        if not match:
+            continue
+        header_type = match.group(1).lower()
+        if header_type == "sent":
+            header_type = "date"
+        header_matches.append((index, header_type))
+
+    left = 0
+    for right, (right_line, _) in enumerate(header_matches):
+        while right_line - header_matches[left][0] >= 8:
+            left += 1
+        unique_headers = {
+            header_type
+            for _, header_type in header_matches[left:right + 1]
+        }
+        if len(unique_headers) >= 3:
+            return header_matches[left][0]
+    return None
+
+
 def has_forwarded_header_block(text: str) -> bool:
     """Return whether text contains a clustered forwarded-email header block."""
-    if not text:
-        return False
-
-    lines = text.split("\n")
-    for index in range(len(lines)):
-        window = "\n".join(lines[index:index + 8])
-        unique_headers = {match.lower() for match in FORWARDED_HEADER_LINE_RE.findall(window)}
-        if "sent" in unique_headers:
-            unique_headers.add("date")
-        if len(unique_headers) >= 3:
-            return True
-    return False
+    return bool(text) and _find_header_block_line(text.split("\n")) is not None
 
 
 def is_forward_like(subject: str, body_text: str, attachments: list[dict]) -> bool:
@@ -75,19 +88,8 @@ def _find_header_block_start(text: str) -> int | None:
         line_starts.append(position)
         position += len(line) + 1
 
-    for index in range(len(lines)):
-        window_lines = lines[index:index + 8]
-        window = "\n".join(window_lines)
-        unique_headers = {match.lower() for match in FORWARDED_HEADER_LINE_RE.findall(window)}
-        if "sent" in unique_headers:
-            unique_headers.add("date")
-        if len(unique_headers) < 3:
-            continue
-        for offset, line in enumerate(window_lines):
-            if FORWARDED_HEADER_LINE_RE.match(line):
-                return line_starts[index + offset]
-        return line_starts[index]
-    return None
+    header_block_line = _find_header_block_line(lines)
+    return line_starts[header_block_line] if header_block_line is not None else None
 
 
 def extract_forward_sections(body_text: str) -> tuple[str, str]:

--- a/api/agent/comms/imap_adapter.py
+++ b/api/agent/comms/imap_adapter.py
@@ -16,9 +16,10 @@ from typing import Any, MutableMapping, Optional, Tuple, List
 from django.core.files.base import ContentFile
 
 from api.models import CommsChannel
-from .adapters import EMAIL_BODY_HTML_PAYLOAD_KEY, ParsedMessage, _html_to_text, _is_forward_like, _extract_forward_sections
+from .adapters import EMAIL_BODY_HTML_PAYLOAD_KEY, ParsedMessage, _html_to_text
 from .attachment_filters import is_signature_image_attachment
 from .chat_email_display_cache import merge_chat_body_html_cache
+from .email_forwarding import extract_forward_sections, is_forward_like
 from .rejected_attachments import build_rejected_attachment_metadata
 from config.settings import EMAIL_STRIP_REPLIES
 from api.services.system_settings import get_max_file_size
@@ -240,10 +241,10 @@ class ImapEmailAdapter:
         # Strip forwards/replies if configured
         body_html_preserved = extracted_body.body_html
         if EMAIL_STRIP_REPLIES:
-            is_forward = _is_forward_like(subject or "", body_text or "", [])
+            is_forward = is_forward_like(subject or "", body_text or "", [])
             if is_forward:
                 body_html_preserved = None
-                pre, fwd = _extract_forward_sections(body_text)
+                pre, fwd = extract_forward_sections(body_text)
                 if fwd and pre:
                     body_text = f"{pre}\n\n{fwd}"
                 elif fwd:

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -179,7 +179,10 @@ def _message_body_html(message: PersistentAgentMessage, channel: str | None, att
     payload = message.raw_payload if isinstance(message.raw_payload, dict) else {}
     subject = payload.get("subject")
     subject = subject if isinstance(subject, str) else ""
-    full_mailgun_html = normalize_explicit_email_html(payload.get("body-html"))
+    full_mailgun_html = (
+        normalize_explicit_email_html(payload.get("body-html"))
+        or normalize_explicit_email_html(payload.get("html"))
+    )
     is_mailgun_forward = bool(
         full_mailgun_html
         and is_forward_like(subject, message.body or "", [])

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -25,6 +25,7 @@ from api.agent.core.processing_flags import (
 )
 from api.agent.core.schedule_parser import ScheduleParser
 from api.agent.comms.chat_email_display_cache import get_cached_chat_body_html, normalize_explicit_email_html, render_chat_email_body_html, sanitize_chat_email_html
+from api.agent.comms.email_forwarding import is_forward_like
 from api.agent.comms.human_input_requests import serialize_human_input_tool_result
 from api.agent.comms.adapters import EMAIL_BODY_HTML_PAYLOAD_KEY
 from api.agent.comms.cid_references import CID_SRC_REFERENCE_RE
@@ -176,8 +177,20 @@ def _message_body_html(message: PersistentAgentMessage, channel: str | None, att
     if not channel or channel.lower() != "email":
         return ""
     payload = message.raw_payload if isinstance(message.raw_payload, dict) else {}
-    explicit_html = normalize_explicit_email_html(payload.get(EMAIL_BODY_HTML_PAYLOAD_KEY))
-    cached_html = get_cached_chat_body_html(payload)
+    subject = payload.get("subject")
+    subject = subject if isinstance(subject, str) else ""
+    full_mailgun_html = normalize_explicit_email_html(payload.get("body-html"))
+    is_mailgun_forward = bool(
+        full_mailgun_html
+        and is_forward_like(subject, message.body or "", [])
+    )
+    explicit_html = (
+        full_mailgun_html
+        if is_mailgun_forward
+        else normalize_explicit_email_html(payload.get(EMAIL_BODY_HTML_PAYLOAD_KEY))
+    )
+    # Older Mailgun forwards cached stripped HTML even though the full HTML remains in the payload.
+    cached_html = None if is_mailgun_forward else get_cached_chat_body_html(payload)
     return _render_email_body_html(
         message.body or "",
         attachments,

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -2076,6 +2076,106 @@ class AgentChatAPITests(TestCase):
         self.assertIn("<strong>Cached Ready</strong>", html_event["message"]["bodyHtml"])
 
     @tag("batch_agent_chat")
+    def test_timeline_restores_full_html_for_legacy_mailgun_forward(self):
+        plain_body = (
+            "Please investigate.\n\n"
+            "Begin forwarded message:\n"
+            "From: Customer <customer@example.com>\n"
+            "Subject: Account issue\n\n"
+            "The original request needs attention."
+        )
+        email_sender = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=None,
+            channel=CommsChannel.EMAIL,
+            address="legacy-forward@example.com",
+            is_primary=False,
+        )
+        email_conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address=email_sender.address,
+        )
+        PersistentAgentMessage.objects.create(
+            is_outbound=False,
+            from_endpoint=email_sender,
+            conversation=email_conversation,
+            body=plain_body,
+            owner_agent=self.agent,
+            raw_payload={
+                "subject": "Fwd: Account issue",
+                "body-html": (
+                    "<p>Please investigate.</p>"
+                    "<blockquote><p>The original request needs attention.</p></blockquote>"
+                    "<script>alert('unsafe')</script>"
+                ),
+                "chat_body_html_v1": "<p>Please investigate.</p>",
+            },
+        )
+
+        response = self.client.get(f"/console/api/agents/{self.agent.id}/timeline/")
+
+        self.assertEqual(response.status_code, 200)
+        html_event = next(
+            event
+            for event in response.json().get("events", [])
+            if event.get("kind") == "message" and event["message"].get("bodyText") == plain_body
+        )
+        rendered_html = html_event["message"]["bodyHtml"]
+        self.assertIn("Please investigate.", rendered_html)
+        self.assertIn("The original request needs attention.", rendered_html)
+        self.assertNotIn("<script", rendered_html)
+
+    @tag("batch_agent_chat")
+    def test_timeline_keeps_stripped_cache_for_mailgun_reply(self):
+        plain_body = (
+            "I can help.\n\n"
+            "-----Original Message-----\n"
+            "From: Customer <customer@example.com>\n"
+            "Sent: Monday, July 13, 2026\n"
+            "To: Owner <owner@example.com>\n"
+            "Subject: Account issue\n\n"
+            "Hidden reply history."
+        )
+        email_sender = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=None,
+            channel=CommsChannel.EMAIL,
+            address="legacy-reply@example.com",
+            is_primary=False,
+        )
+        email_conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address=email_sender.address,
+        )
+        PersistentAgentMessage.objects.create(
+            is_outbound=False,
+            from_endpoint=email_sender,
+            conversation=email_conversation,
+            body=plain_body,
+            owner_agent=self.agent,
+            raw_payload={
+                "subject": "Re: Account issue",
+                "body-html": (
+                    "<p>I can help.</p>"
+                    "<blockquote><p>Hidden reply history.</p></blockquote>"
+                ),
+                "chat_body_html_v1": "<p>I can help.</p>",
+            },
+        )
+
+        response = self.client.get(f"/console/api/agents/{self.agent.id}/timeline/")
+
+        self.assertEqual(response.status_code, 200)
+        html_event = next(
+            event
+            for event in response.json().get("events", [])
+            if event.get("kind") == "message" and event["message"].get("bodyText") == plain_body
+        )
+        rendered_html = html_event["message"]["bodyHtml"]
+        self.assertIn("I can help.", rendered_html)
+        self.assertNotIn("Hidden reply history.", rendered_html)
+
+    @tag("batch_agent_chat")
     def test_timeline_serializes_email_subject_only_for_email_messages(self):
         email_address = "subject-line@example.com"
 

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -2077,53 +2077,59 @@ class AgentChatAPITests(TestCase):
 
     @tag("batch_agent_chat")
     def test_timeline_restores_full_html_for_legacy_mailgun_forward(self):
-        plain_body = (
-            "Please investigate.\n\n"
-            "Begin forwarded message:\n"
-            "From: Customer <customer@example.com>\n"
-            "Subject: Account issue\n\n"
-            "The original request needs attention."
-        )
-        email_sender = PersistentAgentCommsEndpoint.objects.create(
-            owner_agent=None,
-            channel=CommsChannel.EMAIL,
-            address="legacy-forward@example.com",
-            is_primary=False,
-        )
-        email_conversation = PersistentAgentConversation.objects.create(
-            owner_agent=self.agent,
-            channel=CommsChannel.EMAIL,
-            address=email_sender.address,
-        )
-        PersistentAgentMessage.objects.create(
-            is_outbound=False,
-            from_endpoint=email_sender,
-            conversation=email_conversation,
-            body=plain_body,
-            owner_agent=self.agent,
-            raw_payload={
-                "subject": "Fwd: Account issue",
-                "body-html": (
-                    "<p>Please investigate.</p>"
-                    "<blockquote><p>The original request needs attention.</p></blockquote>"
-                    "<script>alert('unsafe')</script>"
-                ),
-                "chat_body_html_v1": "<p>Please investigate.</p>",
-            },
-        )
+        for full_html_key in ("body-html", "html"):
+            with self.subTest(full_html_key=full_html_key):
+                plain_body = (
+                    "Please investigate.\n\n"
+                    "Begin forwarded message:\n"
+                    "From: Customer <customer@example.com>\n"
+                    "Subject: Account issue\n\n"
+                    f"The original request from {full_html_key} needs attention."
+                )
+                email_sender = PersistentAgentCommsEndpoint.objects.create(
+                    owner_agent=None,
+                    channel=CommsChannel.EMAIL,
+                    address=f"legacy-forward-{full_html_key}@example.com",
+                    is_primary=False,
+                )
+                email_conversation = PersistentAgentConversation.objects.create(
+                    owner_agent=self.agent,
+                    channel=CommsChannel.EMAIL,
+                    address=email_sender.address,
+                )
+                PersistentAgentMessage.objects.create(
+                    is_outbound=False,
+                    from_endpoint=email_sender,
+                    conversation=email_conversation,
+                    body=plain_body,
+                    owner_agent=self.agent,
+                    raw_payload={
+                        "subject": "Fwd: Account issue",
+                        full_html_key: (
+                            "<p>Please investigate.</p>"
+                            f"<blockquote><p>The original request from {full_html_key} "
+                            "needs attention.</p></blockquote>"
+                            "<script>alert('unsafe')</script>"
+                        ),
+                        "chat_body_html_v1": "<p>Please investigate.</p>",
+                    },
+                )
 
-        response = self.client.get(f"/console/api/agents/{self.agent.id}/timeline/")
+                response = self.client.get(f"/console/api/agents/{self.agent.id}/timeline/")
 
-        self.assertEqual(response.status_code, 200)
-        html_event = next(
-            event
-            for event in response.json().get("events", [])
-            if event.get("kind") == "message" and event["message"].get("bodyText") == plain_body
-        )
-        rendered_html = html_event["message"]["bodyHtml"]
-        self.assertIn("Please investigate.", rendered_html)
-        self.assertIn("The original request needs attention.", rendered_html)
-        self.assertNotIn("<script", rendered_html)
+                self.assertEqual(response.status_code, 200)
+                html_event = next(
+                    event
+                    for event in response.json().get("events", [])
+                    if event.get("kind") == "message" and event["message"].get("bodyText") == plain_body
+                )
+                rendered_html = html_event["message"]["bodyHtml"]
+                self.assertIn("Please investigate.", rendered_html)
+                self.assertIn(
+                    f"The original request from {full_html_key} needs attention.",
+                    rendered_html,
+                )
+                self.assertNotIn("<script", rendered_html)
 
     @tag("batch_agent_chat")
     def test_timeline_keeps_stripped_cache_for_mailgun_reply(self):

--- a/tests/unit/test_api_webhooks.py
+++ b/tests/unit/test_api_webhooks.py
@@ -364,6 +364,72 @@ class MailgunEmailWebhookTest(TestCase):
 
     @tag("batch_email")
     @patch("api.webhooks.ingest_inbound_message")
+    def test_mailgun_forward_caches_full_html(self, mock_ingest):
+        request = self._create_mailgun_request(
+            from_email=self.owner.email,
+            to_email=self.agent_endpoint.address,
+            subject="Fwd: Account issue",
+            body=(
+                "Please investigate.\n\n"
+                "Begin forwarded message:\n"
+                "From: Customer <customer@example.com>\n"
+                "Subject: Account issue\n\n"
+                "The original request needs attention."
+            ),
+        )
+        request.POST = request.POST.copy()
+        request.POST["stripped-text"] = "Please investigate."
+        request.POST["stripped-html"] = "<p>Please investigate.</p>"
+        request.POST["body-html"] = (
+            "<p>Please investigate.</p>"
+            "<blockquote><p>Begin forwarded message:</p>"
+            "<p>The original request needs attention.</p></blockquote>"
+        )
+
+        response: HttpResponse = email_webhook_mailgun(request)
+
+        self.assertEqual(response.status_code, 200)
+        parsed = mock_ingest.call_args[0][1]
+        self.assertIn("The original request needs attention.", parsed.body)
+        cached_html = parsed.raw_payload[CHAT_BODY_HTML_CACHE_KEY]
+        self.assertIn("Begin forwarded message:", cached_html)
+        self.assertIn("The original request needs attention.", cached_html)
+
+    @tag("batch_email")
+    @patch("api.webhooks.ingest_inbound_message")
+    def test_mailgun_reply_caches_stripped_html(self, mock_ingest):
+        request = self._create_mailgun_request(
+            from_email=self.owner.email,
+            to_email=self.agent_endpoint.address,
+            subject="Re: Account issue",
+            body=(
+                "I can help.\n\n"
+                "-----Original Message-----\n"
+                "From: Customer <customer@example.com>\n"
+                "Sent: Monday, July 13, 2026\n"
+                "To: Owner <owner@example.com>\n"
+                "Subject: Account issue\n\n"
+                "Hidden reply history."
+            ),
+        )
+        request.POST = request.POST.copy()
+        request.POST["stripped-text"] = "I can help."
+        request.POST["stripped-html"] = "<p>I can help.</p>"
+        request.POST["body-html"] = (
+            "<p>I can help.</p>"
+            "<blockquote><p>Hidden reply history.</p></blockquote>"
+        )
+
+        response: HttpResponse = email_webhook_mailgun(request)
+
+        self.assertEqual(response.status_code, 200)
+        parsed = mock_ingest.call_args[0][1]
+        cached_html = parsed.raw_payload[CHAT_BODY_HTML_CACHE_KEY]
+        self.assertIn("I can help.", cached_html)
+        self.assertNotIn("Hidden reply history.", cached_html)
+
+    @tag("batch_email")
+    @patch("api.webhooks.ingest_inbound_message")
     @patch("api.webhooks.logger.info")
     def test_mailgun_email_from_non_owner_is_discarded(self, mock_logger, mock_ingest):
         request = self._create_mailgun_request(

--- a/tests/unit/test_forward_detection.py
+++ b/tests/unit/test_forward_detection.py
@@ -300,6 +300,19 @@ class ForwardDetectionTests(unittest.TestCase):
         self.assertEqual(preamble, "")
         self.assertIn("From: sender@example.com", forwarded)
 
+    def test_extract_forward_sections_starts_at_clustered_header(self):
+        body = (
+            "From: unrelated@example.com\n"
+            "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\n"
+            "From: sender@example.com\n"
+            "Date: January 1, 2024\n"
+            "To: recipient@example.com\n"
+            "Original message content.\n"
+        )
+        preamble, forwarded = _extract_forward_sections(body)
+        self.assertIn("From: unrelated@example.com", preamble)
+        self.assertTrue(forwarded.startswith("From: sender@example.com"))
+
     def test_has_forwarded_header_block_true(self):
         """Direct test of _has_forwarded_header_block with valid block."""
         text = (
@@ -315,6 +328,13 @@ class ForwardDetectionTests(unittest.TestCase):
         text = (
             "From: person@example.com\n"
             "Subject: Test\n"
+        )
+        self.assertFalse(_has_forwarded_header_block(text))
+
+    def test_has_forwarded_header_block_treats_sent_as_date(self):
+        text = (
+            "From: person@example.com\n"
+            "Sent: Jan 1, 2024\n"
         )
         self.assertFalse(_has_forwarded_header_block(text))
 

--- a/tests/unit/test_forward_detection.py
+++ b/tests/unit/test_forward_detection.py
@@ -69,10 +69,13 @@ adapters = importlib.util.module_from_spec(spec)
 sys.modules.setdefault("forward_adapters", adapters)
 spec.loader.exec_module(adapters)
 
-_is_forward_like = adapters._is_forward_like
-_extract_forward_sections = adapters._extract_forward_sections
+from api.agent.comms.email_forwarding import (
+    extract_forward_sections as _extract_forward_sections,
+    has_forwarded_header_block as _has_forwarded_header_block,
+    is_forward_like as _is_forward_like,
+)
+
 _html_to_text = adapters._html_to_text
-_has_forwarded_header_block = adapters._has_forwarded_header_block
 
 
 @tag("batch_forward_detection")


### PR DESCRIPTION
## Summary
- Extracted forward-detection and forward-splitting helpers into a shared email forwarding module.
- Updated Mailgun and IMAP inbound parsing to use the shared logic consistently.
- Preserved full HTML for legacy Mailgun forwarded messages while keeping reply caching stripped.
- Adjusted timeline rendering so legacy Mailgun forwards can display the complete forwarded HTML without reintroducing unsafe content.
- Added coverage for forward detection, Mailgun webhook caching, and timeline rendering behavior.

## Testing
- Added/updated unit tests for legacy forward detection, Mailgun forward vs reply handling, and timeline HTML restoration.
- Not run (not requested)