### PR TITLE
Replace integrations apps section with shared native integration surfaces

### DIFF
--- a/frontend/src/components/common/SettingsSurface.tsx
+++ b/frontend/src/components/common/SettingsSurface.tsx
@@ -1,8 +1,28 @@
-import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react'
+import { createContext, useContext, type ComponentPropsWithoutRef, type ElementType, type ReactNode } from 'react'
 
 export type SettingsSurfaceVariant = 'embedded' | 'standalone'
 export type SettingsSurfacePadding = 'none' | 'sm' | 'md' | 'lg'
 export type SettingsSurfaceOverflow = 'visible' | 'hidden'
+
+const SettingsSurfaceVariantContext = createContext<SettingsSurfaceVariant>('standalone')
+
+export function SettingsSurfaceProvider({
+  variant,
+  children,
+}: {
+  variant: SettingsSurfaceVariant
+  children: ReactNode
+}) {
+  return (
+    <SettingsSurfaceVariantContext.Provider value={variant}>
+      {children}
+    </SettingsSurfaceVariantContext.Provider>
+  )
+}
+
+export function useSettingsSurfaceVariant(): SettingsSurfaceVariant {
+  return useContext(SettingsSurfaceVariantContext)
+}
 
 export const sharedSettingsGlassFrameClassName = 'settings-card-surface overflow-hidden rounded-2xl border'
 export const embeddedSettingsSurfaceClassName = 'settings-card-surface--embedded border-slate-200/20 text-slate-100'

--- a/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
+++ b/frontend/src/components/homepage/HomepageIntegrationsModal.tsx
@@ -573,7 +573,7 @@ function HomepageNativeProviderRow({
           <NativeIntegrationSummaryCell
             provider={provider}
             descriptionClassName="mt-1 text-sm text-slate-600"
-            showConnectedBadge
+            badge="native-connected"
           />
         </div>
         <div className="ml-auto flex shrink-0 flex-wrap justify-end gap-2">

--- a/frontend/src/components/mcp/AgentPipedreamAppsModal.tsx
+++ b/frontend/src/components/mcp/AgentPipedreamAppsModal.tsx
@@ -7,7 +7,6 @@ import { disconnectAgentPipedreamApp, fetchAgentPipedreamApps, removeAgentPipedr
 import { fetchNativeIntegrations, type NativeIntegrationProvider } from '../../api/nativeIntegrations'
 import {
   PipedreamAppSummaryCell,
-  PipedreamConnectionButton,
   PipedreamEmptyState,
   PipedreamErrorState,
   PipedreamListFrame,
@@ -22,6 +21,7 @@ import {
   useWindowFocusRefetch,
   type PipedreamStatusMessage,
 } from './PipedreamAppsShared'
+import { IntegrationConnectionButton } from './IntegrationActionButtons'
 import {
   confirmNativeIntegrationDisconnect,
   NativeIntegrationGridRow,
@@ -459,7 +459,7 @@ function AgentPipedreamAppRowItem({
         )}
       </div>
       <div className="flex justify-start md:justify-end">
-        <PipedreamConnectionButton
+        <IntegrationConnectionButton
           connected={app.connected}
           pendingKind={pendingKind === 'connect' || pendingKind === 'disconnect' ? pendingKind : null}
           disabled={disabled}

--- a/frontend/src/components/mcp/DiscordNativeAppModal.tsx
+++ b/frontend/src/components/mcp/DiscordNativeAppModal.tsx
@@ -16,7 +16,8 @@ import {
 } from '../../api/discordNative'
 import { safeErrorMessage } from '../../api/safeErrorMessage'
 import type { AgentRosterEntry } from '../../types/agentRoster'
-import { PipedreamEmptyState, PipedreamErrorState, PipedreamLoadingState, PipedreamStatusBanner, type PipedreamStatusMessage } from './PipedreamAppsShared'
+import type { SettingsSurfaceVariant } from '../common/SettingsSurface'
+import { PipedreamEmptyState, PipedreamErrorState, PipedreamListFrame, PipedreamLoadingState, PipedreamStatusBanner, type PipedreamStatusMessage } from './PipedreamAppsShared'
 
 export type PendingDiscordAction = 'connect' | 'save' | null
 
@@ -136,6 +137,7 @@ export function DiscordConfigurationScreen({
   statusMessage,
   onBack,
   onSave,
+  surface = 'standalone',
 }: {
   agentId: string
   app: AgentDiscordApp
@@ -144,6 +146,7 @@ export function DiscordConfigurationScreen({
   statusMessage: PipedreamStatusMessage
   onBack: () => void
   onSave: (subscriptions: DiscordSubscriptionSelection[]) => void
+  surface?: SettingsSurfaceVariant
 }) {
   const initialSelections = useMemo(() => activeDiscordSelections(app), [app.subscriptions])
   const [selectedSubscriptions, setSelectedSubscriptions] = useState<Record<string, DiscordSubscriptionSelection>>(initialSelections)
@@ -158,6 +161,9 @@ export function DiscordConfigurationScreen({
   const selectedKeys = useMemo(() => Object.keys(selectedSubscriptions).sort(), [selectedSubscriptions])
   const hasChanges = selectedKeys.join('|') !== savedKeys
   const isPendingSave = pendingDiscordAction === 'save'
+  const saveButtonClassName = surface === 'embedded'
+    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
+    : 'bg-blue-600 text-white hover:bg-blue-700'
 
   const toggleChannel = (channel: DiscordChannel) => {
     const key = discordSubscriptionKey(channel.guildId, channel.channelId)
@@ -181,10 +187,10 @@ export function DiscordConfigurationScreen({
   return (
     <div className="space-y-4 p-1">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <BackButton disabled={disabled} onClick={onBack} />
+        <BackButton disabled={disabled} onClick={onBack} surface={surface} />
         <button
           type="button"
-          className="inline-flex min-w-28 items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+          className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${saveButtonClassName}`}
           onClick={() => onSave(Object.values(selectedSubscriptions))}
           disabled={disabled || isPendingSave || !hasChanges}
         >
@@ -193,8 +199,8 @@ export function DiscordConfigurationScreen({
         </button>
       </div>
 
-      <DiscordSummaryCell app={app} />
-      <PipedreamStatusBanner statusMessage={statusMessage} />
+      <DiscordSummaryCell app={app} surface={surface} />
+      <PipedreamStatusBanner statusMessage={statusMessage} surface={surface} />
 
       {app.guilds.length > 0 ? (
         <div className="space-y-3">
@@ -207,11 +213,12 @@ export function DiscordConfigurationScreen({
               selectedSubscriptions={selectedSubscriptions}
               disabled={disabled}
               onToggleChannel={toggleChannel}
+              surface={surface}
             />
           ))}
         </div>
       ) : (
-        <PipedreamEmptyState label="No Discord servers are connected yet." />
+        <PipedreamEmptyState label="No Discord servers are connected yet." surface={surface} />
       )}
     </div>
   )
@@ -229,6 +236,7 @@ export function DiscordAgentConnectionsScreen({
   onBack,
   onConnect,
   onConfigure,
+  surface = 'standalone',
 }: {
   agents: AgentRosterEntry[]
   isLoading: boolean
@@ -241,6 +249,7 @@ export function DiscordAgentConnectionsScreen({
   onBack: () => void
   onConnect: (agent: AgentRosterEntry) => void
   onConfigure: (agent: AgentRosterEntry) => void
+  surface?: SettingsSurfaceVariant
 }) {
   const sortedAgents = useMemo(() => (
     [...agents].sort((a, b) => Number(!agentHasDiscordNative(a)) - Number(!agentHasDiscordNative(b)) || a.name.localeCompare(b.name))
@@ -248,69 +257,90 @@ export function DiscordAgentConnectionsScreen({
 
   return (
     <div className="space-y-4 p-1">
-      <BackButton disabled={isBusy} onClick={onBack} />
+      <BackButton disabled={isBusy} onClick={onBack} surface={surface} />
 
       <div className="flex items-center gap-3">
         <DiscordIconTile />
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-slate-900">Discord</p>
-          <p className="text-sm text-slate-600">{isFetching ? 'Refreshing connections…' : 'Configure Discord channels per agent.'}</p>
+          <p className={`truncate text-sm font-semibold ${surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'}`}>Discord</p>
+          <p className={`text-sm ${surface === 'embedded' ? 'text-slate-400' : 'text-slate-600'}`}>{isFetching ? 'Refreshing connections…' : 'Configure Discord channels per agent.'}</p>
         </div>
       </div>
 
-      <PipedreamStatusBanner statusMessage={statusMessage} />
+      <PipedreamStatusBanner statusMessage={statusMessage} surface={surface} />
 
       {isError ? (
-        <PipedreamErrorState error={error} fallback="Unable to load agents." />
+        <PipedreamErrorState error={error} fallback="Unable to load agents." surface={surface} />
       ) : isLoading ? (
-        <PipedreamLoadingState label="Loading agents…" />
+        <PipedreamLoadingState label="Loading agents…" surface={surface} />
       ) : sortedAgents.length === 0 ? (
-        <PipedreamEmptyState label="No agents found." />
+        <PipedreamEmptyState label="No agents found." surface={surface} />
       ) : (
-        <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
-          <div className="divide-y divide-slate-200">
-            {sortedAgents.map((agent) => (
-              <DiscordAgentConnectionRow
-                key={agent.id}
-                agent={agent}
-                pendingDiscordAgentAction={pendingDiscordAgentAction}
-                disabled={isBusy}
-                onConnect={() => onConnect(agent)}
-                onConfigure={() => onConfigure(agent)}
-              />
-            ))}
-          </div>
-        </div>
+        <PipedreamListFrame isMobile={false} constrainHeight={false} surface={surface}>
+          {sortedAgents.map((agent) => (
+            <DiscordAgentConnectionRow
+              key={agent.id}
+              agent={agent}
+              pendingDiscordAgentAction={pendingDiscordAgentAction}
+              disabled={isBusy}
+              onConnect={() => onConnect(agent)}
+              onConfigure={() => onConfigure(agent)}
+              surface={surface}
+            />
+          ))}
+        </PipedreamListFrame>
       )}
     </div>
   )
 }
 
-export function DiscordSummaryCell({ app }: { app: AgentDiscordApp }) {
+export function DiscordSummaryCell({
+  app,
+  surface = 'standalone',
+}: {
+  app: AgentDiscordApp
+  surface?: SettingsSurfaceVariant
+}) {
   const detail = app.connected
     ? `${app.guildCount} ${app.guildCount === 1 ? 'server' : 'servers'} connected; ${app.activeSubscriptionCount} ${app.activeSubscriptionCount === 1 ? 'channel' : 'channels'} subscribed.`
     : app.description
+  const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
+  const descriptionClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-600'
+  const badgeClassName = surface === 'embedded'
+    ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-200'
+    : 'border-emerald-200 bg-emerald-50 text-emerald-700'
   return (
     <div className="flex min-w-0 items-center gap-3">
       <DiscordIconTile />
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
-          <p className="truncate text-sm font-semibold text-slate-900">{app.displayName}</p>
-          <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-700">
+          <p className={`truncate text-sm font-semibold ${titleClassName}`}>{app.displayName}</p>
+          <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${badgeClassName}`}>
             Native
           </span>
         </div>
-        <p className="mt-1 line-clamp-2 text-sm text-slate-600">{detail}</p>
+        <p className={`mt-1 line-clamp-2 text-sm ${descriptionClassName}`}>{detail}</p>
       </div>
     </div>
   )
 }
 
-export function BackButton({ disabled, onClick }: { disabled: boolean; onClick: () => void }) {
+export function BackButton({
+  disabled,
+  onClick,
+  surface = 'standalone',
+}: {
+  disabled: boolean
+  onClick: () => void
+  surface?: SettingsSurfaceVariant
+}) {
+  const className = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/20 text-slate-300 hover:border-slate-100/35 hover:bg-slate-900/40'
+    : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
   return (
     <button
       type="button"
-      className="inline-flex w-fit items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+      className={`inline-flex w-fit items-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${className}`}
       onClick={onClick}
       disabled={disabled}
     >
@@ -326,15 +356,34 @@ function DiscordAgentConnectionRow({
   disabled,
   onConnect,
   onConfigure,
+  surface = 'standalone',
 }: {
   agent: AgentRosterEntry
   pendingDiscordAgentAction: PendingDiscordAgentAction
   disabled: boolean
   onConnect: () => void
   onConfigure: () => void
+  surface?: SettingsSurfaceVariant
 }) {
   const enabled = agentHasDiscordNative(agent)
   const pendingKind = pendingDiscordAgentAction?.agentId === agent.id ? pendingDiscordAgentAction.kind : null
+  const fallbackAvatarClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-900 text-slate-200'
+    : 'border-slate-200 bg-white text-slate-700'
+  const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
+  const descriptionClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-600'
+  const enabledBadgeClassName = surface === 'embedded'
+    ? 'border-sky-300/25 bg-sky-950/45 text-sky-200'
+    : 'border-blue-200 bg-blue-50 text-blue-700'
+  const disabledBadgeClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/20 text-slate-400'
+    : 'border-slate-200 text-slate-500'
+  const configureClassName = surface === 'embedded'
+    ? 'border-sky-300/25 bg-sky-950/20 text-sky-100 hover:border-sky-200/40 hover:bg-sky-900/40'
+    : 'border-blue-200 bg-white text-blue-700 hover:bg-blue-50'
+  const connectClassName = surface === 'embedded'
+    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
+    : 'bg-blue-600 text-white hover:bg-blue-700'
 
   return (
     <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_8rem_9rem] md:items-center">
@@ -347,25 +396,25 @@ function DiscordAgentConnectionRow({
             loading="lazy"
           />
         ) : (
-          <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-xs font-semibold uppercase text-slate-700">
+          <span className={`inline-flex h-9 w-9 items-center justify-center rounded-full border text-xs font-semibold uppercase ${fallbackAvatarClassName}`}>
             {agent.name.slice(0, 2)}
           </span>
         )}
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-slate-900">{agent.name}</p>
-          <p className="truncate text-sm text-slate-600">
+          <p className={`truncate text-sm font-semibold ${titleClassName}`}>{agent.name}</p>
+          <p className={`truncate text-sm ${descriptionClassName}`}>
             {enabled ? 'Discord is enabled for this agent.' : 'Connect Discord before selecting channels.'}
           </p>
         </div>
       </div>
       <div>
         {enabled ? (
-          <span className="inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">
+          <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold ${enabledBadgeClassName}`}>
             <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
             Enabled
           </span>
         ) : (
-          <span className="inline-flex rounded-full border border-slate-200 px-2.5 py-1 text-xs font-semibold text-slate-500">
+          <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${disabledBadgeClassName}`}>
             Not enabled
           </span>
         )}
@@ -374,7 +423,7 @@ function DiscordAgentConnectionRow({
         {enabled ? (
           <button
             type="button"
-            className="inline-flex min-w-28 items-center justify-center gap-2 rounded-md border border-blue-200 bg-white px-3 py-2 text-sm font-semibold text-blue-700 transition hover:bg-blue-50 disabled:opacity-60"
+            className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${configureClassName}`}
             onClick={onConfigure}
             disabled={disabled}
           >
@@ -384,7 +433,7 @@ function DiscordAgentConnectionRow({
         ) : (
           <button
             type="button"
-            className="inline-flex min-w-28 items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+            className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${connectClassName}`}
             onClick={onConnect}
             disabled={disabled}
           >
@@ -404,6 +453,7 @@ function DiscordGuildChannelSection({
   selectedSubscriptions,
   disabled,
   onToggleChannel,
+  surface = 'standalone',
 }: {
   agentId: string
   guild: DiscordGuild
@@ -411,6 +461,7 @@ function DiscordGuildChannelSection({
   selectedSubscriptions: Record<string, DiscordSubscriptionSelection>
   disabled: boolean
   onToggleChannel: (channel: DiscordChannel) => void
+  surface?: SettingsSurfaceVariant
 }) {
   const channelsQuery = useQuery({
     queryKey: ['agent-discord-channels', agentId, guild.guildId],
@@ -432,27 +483,43 @@ function DiscordGuildChannelSection({
     channelsByKey.set(discordSubscriptionKey(channel.guildId, channel.channelId), channel)
   }
   const channels = Array.from(channelsByKey.values()).sort((a, b) => a.channelName.localeCompare(b.channelName))
+  const sectionClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/30'
+    : 'border-indigo-100 bg-white'
+  const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
+  const descriptionClassName = 'text-slate-500'
+  const actionRequiredClassName = surface === 'embedded'
+    ? 'border-amber-300/25 bg-amber-950/35 text-amber-200'
+    : 'border-amber-200 bg-amber-50 text-amber-800'
+  const actionLinkClassName = surface === 'embedded' ? 'text-amber-100' : 'text-amber-900'
+  const errorClassName = surface === 'embedded'
+    ? 'border-rose-300/25 bg-rose-950/35 text-rose-200'
+    : 'border-red-200 bg-red-50 text-red-700'
+  const channelClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/25 text-slate-300 hover:border-sky-300/35 hover:text-slate-100'
+    : 'border-slate-200 bg-white text-slate-700 hover:border-indigo-200 hover:text-slate-950'
+  const emptyClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-600'
 
   return (
-    <section className="rounded-lg border border-indigo-100 bg-white px-3 py-3" aria-label={`${guild.name} Discord channels`}>
+    <section className={`rounded-lg border px-3 py-3 ${sectionClassName}`} aria-label={`${guild.name} Discord channels`}>
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-slate-900">{guild.name}</p>
-          <p className="text-xs text-slate-500">Choose channels that should wake this agent.</p>
+          <p className={`truncate text-sm font-semibold ${titleClassName}`}>{guild.name}</p>
+          <p className={`text-xs ${descriptionClassName}`}>Choose channels that should wake this agent.</p>
         </div>
         {channelsQuery.isLoading ? <Loader2 className="h-4 w-4 animate-spin text-indigo-600" aria-hidden="true" /> : null}
       </div>
       {channelsQuery.data?.status === 'action_required' ? (
-        <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        <div className={`mt-3 rounded-md border px-3 py-2 text-sm ${actionRequiredClassName}`}>
           <p>{channelsQuery.data.message || 'The Gobii Discord bot needs access to list channels in this server.'}</p>
           {channelsQuery.data.botInviteUrl ? (
-            <a href={channelsQuery.data.botInviteUrl} target="_blank" rel="noreferrer" className="mt-2 inline-flex font-semibold text-amber-900 underline">
+            <a href={channelsQuery.data.botInviteUrl} target="_blank" rel="noreferrer" className={`mt-2 inline-flex font-semibold underline ${actionLinkClassName}`}>
               Invite bot
             </a>
           ) : null}
         </div>
       ) : channelsQuery.isError ? (
-        <div className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+        <div className={`mt-3 rounded-md border px-3 py-2 text-sm ${errorClassName}`}>
           {safeErrorMessage(channelsQuery.error)}
         </div>
       ) : channels.length > 0 ? (
@@ -462,7 +529,7 @@ function DiscordGuildChannelSection({
             return (
               <label
                 key={key}
-                className="flex min-w-0 items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 transition hover:border-indigo-200 hover:text-slate-950"
+                className={`flex min-w-0 items-center gap-2 rounded-md border px-3 py-2 text-sm transition ${channelClassName}`}
               >
                 <input
                   type="checkbox"
@@ -478,7 +545,7 @@ function DiscordGuildChannelSection({
           })}
         </div>
       ) : channelsQuery.isLoading ? null : (
-        <p className="mt-3 text-sm text-slate-600">No text channels were found for this server.</p>
+        <p className={`mt-3 text-sm ${emptyClassName}`}>No text channels were found for this server.</p>
       )}
     </section>
   )

--- a/frontend/src/components/mcp/DiscordNativeAppModal.tsx
+++ b/frontend/src/components/mcp/DiscordNativeAppModal.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../api/discordNative'
 import { safeErrorMessage } from '../../api/safeErrorMessage'
 import type { AgentRosterEntry } from '../../types/agentRoster'
-import type { SettingsSurfaceVariant } from '../common/SettingsSurface'
+import { useSettingsSurfaceVariant } from '../common/SettingsSurface'
 import { PipedreamEmptyState, PipedreamErrorState, PipedreamListFrame, PipedreamLoadingState, PipedreamStatusBanner, type PipedreamStatusMessage } from './PipedreamAppsShared'
 
 export type PendingDiscordAction = 'connect' | 'save' | null
@@ -137,7 +137,6 @@ export function DiscordConfigurationScreen({
   statusMessage,
   onBack,
   onSave,
-  surface = 'standalone',
 }: {
   agentId: string
   app: AgentDiscordApp
@@ -146,8 +145,8 @@ export function DiscordConfigurationScreen({
   statusMessage: PipedreamStatusMessage
   onBack: () => void
   onSave: (subscriptions: DiscordSubscriptionSelection[]) => void
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const initialSelections = useMemo(() => activeDiscordSelections(app), [app.subscriptions])
   const [selectedSubscriptions, setSelectedSubscriptions] = useState<Record<string, DiscordSubscriptionSelection>>(initialSelections)
   const savedKeys = useMemo(() => Object.keys(initialSelections).sort().join('|'), [initialSelections])
@@ -187,7 +186,7 @@ export function DiscordConfigurationScreen({
   return (
     <div className="space-y-4 p-1">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <BackButton disabled={disabled} onClick={onBack} surface={surface} />
+        <BackButton disabled={disabled} onClick={onBack} />
         <button
           type="button"
           className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${saveButtonClassName}`}
@@ -199,8 +198,8 @@ export function DiscordConfigurationScreen({
         </button>
       </div>
 
-      <DiscordSummaryCell app={app} surface={surface} />
-      <PipedreamStatusBanner statusMessage={statusMessage} surface={surface} />
+      <DiscordSummaryCell app={app} />
+      <PipedreamStatusBanner statusMessage={statusMessage} />
 
       {app.guilds.length > 0 ? (
         <div className="space-y-3">
@@ -213,12 +212,11 @@ export function DiscordConfigurationScreen({
               selectedSubscriptions={selectedSubscriptions}
               disabled={disabled}
               onToggleChannel={toggleChannel}
-              surface={surface}
             />
           ))}
         </div>
       ) : (
-        <PipedreamEmptyState label="No Discord servers are connected yet." surface={surface} />
+        <PipedreamEmptyState label="No Discord servers are connected yet." />
       )}
     </div>
   )
@@ -236,7 +234,6 @@ export function DiscordAgentConnectionsScreen({
   onBack,
   onConnect,
   onConfigure,
-  surface = 'standalone',
 }: {
   agents: AgentRosterEntry[]
   isLoading: boolean
@@ -249,15 +246,15 @@ export function DiscordAgentConnectionsScreen({
   onBack: () => void
   onConnect: (agent: AgentRosterEntry) => void
   onConfigure: (agent: AgentRosterEntry) => void
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const sortedAgents = useMemo(() => (
     [...agents].sort((a, b) => Number(!agentHasDiscordNative(a)) - Number(!agentHasDiscordNative(b)) || a.name.localeCompare(b.name))
   ), [agents])
 
   return (
     <div className="space-y-4 p-1">
-      <BackButton disabled={isBusy} onClick={onBack} surface={surface} />
+      <BackButton disabled={isBusy} onClick={onBack} />
 
       <div className="flex items-center gap-3">
         <DiscordIconTile />
@@ -267,16 +264,16 @@ export function DiscordAgentConnectionsScreen({
         </div>
       </div>
 
-      <PipedreamStatusBanner statusMessage={statusMessage} surface={surface} />
+      <PipedreamStatusBanner statusMessage={statusMessage} />
 
       {isError ? (
-        <PipedreamErrorState error={error} fallback="Unable to load agents." surface={surface} />
+        <PipedreamErrorState error={error} fallback="Unable to load agents." />
       ) : isLoading ? (
-        <PipedreamLoadingState label="Loading agents…" surface={surface} />
+        <PipedreamLoadingState label="Loading agents…" />
       ) : sortedAgents.length === 0 ? (
-        <PipedreamEmptyState label="No agents found." surface={surface} />
+        <PipedreamEmptyState label="No agents found." />
       ) : (
-        <PipedreamListFrame isMobile={false} constrainHeight={false} surface={surface}>
+        <PipedreamListFrame isMobile={false} constrainHeight={false}>
           {sortedAgents.map((agent) => (
             <DiscordAgentConnectionRow
               key={agent.id}
@@ -285,7 +282,6 @@ export function DiscordAgentConnectionsScreen({
               disabled={isBusy}
               onConnect={() => onConnect(agent)}
               onConfigure={() => onConfigure(agent)}
-              surface={surface}
             />
           ))}
         </PipedreamListFrame>
@@ -296,11 +292,10 @@ export function DiscordAgentConnectionsScreen({
 
 export function DiscordSummaryCell({
   app,
-  surface = 'standalone',
 }: {
   app: AgentDiscordApp
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const detail = app.connected
     ? `${app.guildCount} ${app.guildCount === 1 ? 'server' : 'servers'} connected; ${app.activeSubscriptionCount} ${app.activeSubscriptionCount === 1 ? 'channel' : 'channels'} subscribed.`
     : app.description
@@ -328,12 +323,11 @@ export function DiscordSummaryCell({
 export function BackButton({
   disabled,
   onClick,
-  surface = 'standalone',
 }: {
   disabled: boolean
   onClick: () => void
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const className = surface === 'embedded'
     ? 'border-slate-200/20 bg-slate-950/20 text-slate-300 hover:border-slate-100/35 hover:bg-slate-900/40'
     : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
@@ -356,15 +350,14 @@ function DiscordAgentConnectionRow({
   disabled,
   onConnect,
   onConfigure,
-  surface = 'standalone',
 }: {
   agent: AgentRosterEntry
   pendingDiscordAgentAction: PendingDiscordAgentAction
   disabled: boolean
   onConnect: () => void
   onConfigure: () => void
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const enabled = agentHasDiscordNative(agent)
   const pendingKind = pendingDiscordAgentAction?.agentId === agent.id ? pendingDiscordAgentAction.kind : null
   const fallbackAvatarClassName = surface === 'embedded'
@@ -453,7 +446,6 @@ function DiscordGuildChannelSection({
   selectedSubscriptions,
   disabled,
   onToggleChannel,
-  surface = 'standalone',
 }: {
   agentId: string
   guild: DiscordGuild
@@ -461,8 +453,8 @@ function DiscordGuildChannelSection({
   selectedSubscriptions: Record<string, DiscordSubscriptionSelection>
   disabled: boolean
   onToggleChannel: (channel: DiscordChannel) => void
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const channelsQuery = useQuery({
     queryKey: ['agent-discord-channels', agentId, guild.guildId],
     queryFn: () => fetchAgentDiscordGuildChannels(agentId, guild.guildId),

--- a/frontend/src/components/mcp/IntegrationActionButtons.tsx
+++ b/frontend/src/components/mcp/IntegrationActionButtons.tsx
@@ -1,0 +1,73 @@
+import { Loader2, Plug, Unplug, Users } from 'lucide-react'
+
+import { useSettingsSurfaceVariant } from '../common/SettingsSurface'
+
+type ConnectionKind = 'connect' | 'disconnect' | 'picker' | null
+
+export function IntegrationConnectionButton({
+  connected,
+  pendingKind,
+  disabled,
+  onConnect,
+  onDisconnect,
+  disconnectTone = 'danger',
+  minWidth = true,
+}: {
+  connected: boolean
+  pendingKind: ConnectionKind
+  disabled: boolean
+  onConnect?: () => void
+  onDisconnect?: () => void
+  disconnectTone?: 'danger' | 'neutral'
+  minWidth?: boolean
+}) {
+  const surface = useSettingsSurfaceVariant()
+  const action = connected ? 'disconnect' : 'connect'
+  const className = action === 'connect'
+    ? surface === 'embedded'
+      ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
+      : 'bg-blue-600 text-white hover:bg-blue-700'
+    : surface === 'embedded'
+      ? disconnectTone === 'danger'
+        ? 'border-rose-300/25 bg-rose-950/20 text-rose-200 hover:border-rose-200/40 hover:bg-rose-900/35'
+        : 'border-slate-200/20 bg-slate-950/20 text-slate-300 hover:border-slate-100/35 hover:bg-slate-900/40'
+      : disconnectTone === 'danger'
+        ? 'border-red-200 bg-white text-red-700 hover:bg-red-50'
+        : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
+  const isPending = pendingKind === action
+  const Icon = connected ? Unplug : Plug
+  const onClick = connected ? onDisconnect : onConnect
+
+  return (
+    <button
+      type="button"
+      className={[
+        `inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${connected ? 'border' : ''} ${className}`,
+        minWidth ? 'min-w-28' : '',
+      ].filter(Boolean).join(' ')}
+      onClick={onClick}
+      disabled={disabled || !onClick}
+    >
+      {isPending ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Icon className="h-4 w-4" aria-hidden="true" />}
+      {connected ? 'Disconnect' : 'Connect'}
+    </button>
+  )
+}
+
+export function IntegrationManageButton({ disabled, onClick }: { disabled: boolean; onClick: () => void }) {
+  const surface = useSettingsSurfaceVariant()
+  const className = surface === 'embedded'
+    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
+    : 'bg-blue-600 text-white hover:bg-blue-700'
+  return (
+    <button
+      type="button"
+      className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${className}`}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <Users className="h-4 w-4" aria-hidden="true" />
+      Manage
+    </button>
+  )
+}

--- a/frontend/src/components/mcp/NativeIntegrationShared.tsx
+++ b/frontend/src/components/mcp/NativeIntegrationShared.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { CheckCircle2, ChevronDown, ChevronRight, FileText, FolderOpen, Loader2, Plug, Table2, Unplug } from 'lucide-react'
+import { CheckCircle2, ChevronDown, ChevronRight, FileText, FolderOpen, Loader2, Plug, Table2 } from 'lucide-react'
 
 import type {
   NativeIntegrationAccessibleFile,
@@ -16,7 +16,8 @@ import {
 } from '../../api/nativeIntegrations'
 import { safeErrorMessage } from '../../api/safeErrorMessage'
 import { readStoredConsoleContext } from '../../util/consoleContextStorage'
-import type { SettingsSurfaceVariant } from '../common/SettingsSurface'
+import { useSettingsSurfaceVariant } from '../common/SettingsSurface'
+import { IntegrationConnectionButton } from './IntegrationActionButtons'
 
 type GoogleDocsView = {
   setMimeTypes: (mimeTypes: string) => GoogleDocsView
@@ -440,24 +441,18 @@ export function useNativeIntegrationPickerMutation({
 export function NativeIntegrationSummaryCell({
   provider,
   descriptionClassName,
-  showNativeBadge = true,
-  showConnectedBadge = false,
-  surface = 'standalone',
+  badge = 'native',
 }: {
   provider: NativeIntegrationProvider
   descriptionClassName?: string
-  showNativeBadge?: boolean
-  showConnectedBadge?: boolean
-  surface?: SettingsSurfaceVariant
+  badge?: 'native' | 'connected' | 'native-connected' | 'none'
 }) {
+  const surface = useSettingsSurfaceVariant()
   const resolvedDescriptionClassName = descriptionClassName ?? (
     surface === 'embedded' ? 'mt-1 line-clamp-2 text-sm text-slate-400' : 'mt-1 line-clamp-2 text-sm text-slate-600'
   )
   const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
-  const nativeBadgeClassName = surface === 'embedded'
-    ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-200'
-    : 'border-emerald-200 bg-emerald-50 text-emerald-700'
-  const connectedBadgeClassName = surface === 'embedded'
+  const badgeClassName = surface === 'embedded'
     ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-200'
     : 'border-emerald-200 bg-emerald-50 text-emerald-700'
   return (
@@ -466,13 +461,13 @@ export function NativeIntegrationSummaryCell({
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
           <p className={`truncate text-sm font-semibold ${titleClassName}`}>{provider.displayName}</p>
-          {showNativeBadge ? (
-            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${nativeBadgeClassName}`}>
+          {badge === 'native' || badge === 'native-connected' ? (
+            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${badgeClassName}`}>
               Native
             </span>
           ) : null}
-          {showConnectedBadge && provider.connected ? (
-            <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold ${connectedBadgeClassName}`}>
+          {(badge === 'connected' || badge === 'native-connected') && provider.connected ? (
+            <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold ${badgeClassName}`}>
               <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
               Connected
             </span>
@@ -486,11 +481,10 @@ export function NativeIntegrationSummaryCell({
 
 export function NativeIntegrationStatusBadge({
   connected,
-  surface = 'standalone',
 }: {
   connected: boolean
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   if (connected) {
     const connectedClassName = surface === 'embedded'
       ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-200'
@@ -517,14 +511,13 @@ export function NativeIntegrationPickerButton({
   disabled,
   onClick,
   minWidth = true,
-  surface = 'standalone',
 }: {
   pendingKind: NativePendingKind
   disabled: boolean
   onClick: () => void
   minWidth?: boolean
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const className = surface === 'embedded'
     ? 'border-sky-300/25 bg-sky-950/20 text-sky-100 hover:border-sky-200/40 hover:bg-sky-900/40'
     : 'border-blue-200 bg-white text-blue-700 hover:bg-blue-50'
@@ -548,76 +541,6 @@ export function NativeIntegrationPickerButton({
   )
 }
 
-export function NativeIntegrationConnectionButton({
-  connected,
-  pendingKind,
-  disabled,
-  onConnect,
-  onDisconnect,
-  disconnectTone = 'danger',
-  minWidth = true,
-  surface = 'standalone',
-}: {
-  connected: boolean
-  pendingKind: NativePendingKind
-  disabled: boolean
-  onConnect: () => void
-  onDisconnect: () => void
-  disconnectTone?: 'danger' | 'neutral'
-  minWidth?: boolean
-  surface?: SettingsSurfaceVariant
-}) {
-  if (connected) {
-    const connectedClassName = surface === 'embedded'
-      ? disconnectTone === 'danger'
-        ? 'border-rose-300/25 bg-rose-950/20 text-rose-200 hover:border-rose-200/40 hover:bg-rose-900/35'
-        : 'border-slate-200/20 bg-slate-950/20 text-slate-300 hover:border-slate-100/35 hover:bg-slate-900/40'
-      : disconnectTone === 'danger'
-        ? 'border-red-200 bg-white text-red-700 hover:bg-red-50'
-        : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
-    return (
-      <button
-        type="button"
-        className={[
-          `inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${connectedClassName}`,
-          minWidth ? 'min-w-28' : '',
-        ].filter(Boolean).join(' ')}
-        onClick={onDisconnect}
-        disabled={disabled}
-      >
-        {pendingKind === 'disconnect' ? (
-          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-        ) : (
-          <Unplug className="h-4 w-4" aria-hidden="true" />
-        )}
-        Disconnect
-      </button>
-    )
-  }
-
-  const connectClassName = surface === 'embedded'
-    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
-    : 'bg-blue-600 text-white hover:bg-blue-700'
-  return (
-    <button
-      type="button"
-      className={[
-        `inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${connectClassName}`,
-        minWidth ? 'min-w-28' : '',
-      ].filter(Boolean).join(' ')}
-      onClick={onConnect}
-      disabled={disabled}
-    >
-      {pendingKind === 'connect' ? (
-        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-      ) : (
-        <Plug className="h-4 w-4" aria-hidden="true" />
-      )}
-      Connect
-    </button>
-  )
-}
-
 export function NativeIntegrationActionButtons({
   provider,
   pendingKind,
@@ -627,7 +550,6 @@ export function NativeIntegrationActionButtons({
   onPicker,
   disconnectTone,
   minWidth = true,
-  surface = 'standalone',
 }: {
   provider: NativeIntegrationProvider
   pendingKind: NativePendingKind
@@ -637,7 +559,6 @@ export function NativeIntegrationActionButtons({
   onPicker: () => void
   disconnectTone?: 'danger' | 'neutral'
   minWidth?: boolean
-  surface?: SettingsSurfaceVariant
 }) {
   const pickerEnabled = provider.connected && supportsNativeIntegrationPicker(provider)
   return (
@@ -648,10 +569,9 @@ export function NativeIntegrationActionButtons({
           disabled={disabled}
           onClick={onPicker}
           minWidth={minWidth}
-          surface={surface}
         />
       ) : null}
-      <NativeIntegrationConnectionButton
+      <IntegrationConnectionButton
         connected={provider.connected}
         pendingKind={pendingKind}
         disabled={disabled}
@@ -659,7 +579,6 @@ export function NativeIntegrationActionButtons({
         onDisconnect={onDisconnect}
         disconnectTone={disconnectTone}
         minWidth={minWidth}
-        surface={surface}
       />
     </>
   )
@@ -672,11 +591,7 @@ export function NativeIntegrationGridRow({
   onConnect,
   onDisconnect,
   onPicker,
-  gridClassName = 'grid gap-3 sm:grid-cols-[minmax(0,1fr)_7rem_8rem_8rem] sm:items-start',
-  showStatusColumn = true,
-  showNativeBadge = true,
-  showConnectedBadge = false,
-  surface = 'standalone',
+  variant = 'agent',
 }: {
   provider: NativeIntegrationProvider
   pendingKind: NativePendingKind
@@ -684,55 +599,48 @@ export function NativeIntegrationGridRow({
   onConnect: () => void
   onDisconnect: () => void
   onPicker: () => void
-  gridClassName?: string
-  showStatusColumn?: boolean
-  showNativeBadge?: boolean
-  showConnectedBadge?: boolean
-  surface?: SettingsSurfaceVariant
+  variant?: 'agent' | 'workspace'
 }) {
   const pickerEnabled = provider.connected && supportsNativeIntegrationPicker(provider)
+  const workspace = variant === 'workspace'
   return (
     <div className="px-4 py-3">
-      <div className={gridClassName}>
+      <div className={`grid gap-3 sm:items-start ${workspace ? 'sm:grid-cols-[minmax(0,1fr)_8rem_8rem]' : 'sm:grid-cols-[minmax(0,1fr)_7rem_8rem_8rem]'}`}>
         <NativeIntegrationSummaryCell
           provider={provider}
-          showNativeBadge={showNativeBadge}
-          showConnectedBadge={showConnectedBadge}
-          surface={surface}
+          badge={workspace ? 'connected' : 'native'}
         />
-        {showStatusColumn ? (
+        {!workspace ? (
           <div>
-            <NativeIntegrationStatusBadge connected={provider.connected} surface={surface} />
+            <NativeIntegrationStatusBadge connected={provider.connected} />
           </div>
         ) : null}
         <div className="flex justify-start md:justify-end">
           {pickerEnabled ? (
-            <NativeIntegrationPickerButton pendingKind={pendingKind} disabled={disabled} onClick={onPicker} surface={surface} />
+            <NativeIntegrationPickerButton pendingKind={pendingKind} disabled={disabled} onClick={onPicker} />
           ) : null}
         </div>
         <div className="flex justify-start md:justify-end">
-          <NativeIntegrationConnectionButton
+          <IntegrationConnectionButton
             connected={provider.connected}
             pendingKind={pendingKind}
             disabled={disabled}
             onConnect={onConnect}
             onDisconnect={onDisconnect}
-            surface={surface}
           />
         </div>
       </div>
-      <NativeIntegrationFilesDisclosure provider={provider} surface={surface} />
+      <NativeIntegrationFilesDisclosure provider={provider} />
     </div>
   )
 }
 
 export function NativeIntegrationFilesDisclosure({
   provider,
-  surface = 'standalone',
 }: {
   provider: NativeIntegrationProvider
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const [expanded, setExpanded] = useState(false)
   const fileListEnabled = supportsNativeIntegrationFileList(provider)
   const filesQuery = useQuery({
@@ -786,7 +694,7 @@ export function NativeIntegrationFilesDisclosure({
           ) : files.length > 0 ? (
             <ul className="space-y-1">
               {files.map((file) => (
-                <NativeIntegrationFileItem key={file.externalId} file={file} surface={surface} />
+                <NativeIntegrationFileItem key={file.externalId} file={file} />
               ))}
             </ul>
           ) : (
@@ -802,11 +710,10 @@ export function NativeIntegrationFilesDisclosure({
 
 function NativeIntegrationFileItem({
   file,
-  surface = 'standalone',
 }: {
   file: NativeIntegrationAccessibleFile
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const textClassName = surface === 'embedded' ? 'text-slate-300 hover:text-slate-100' : 'text-slate-700 hover:text-slate-950'
   const icon = file.mimeType === GOOGLE_SHEETS_MIME_TYPE
     ? <Table2 className="h-4 w-4 text-emerald-700" aria-hidden="true" />

--- a/frontend/src/components/mcp/NativeIntegrationShared.tsx
+++ b/frontend/src/components/mcp/NativeIntegrationShared.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../api/nativeIntegrations'
 import { safeErrorMessage } from '../../api/safeErrorMessage'
 import { readStoredConsoleContext } from '../../util/consoleContextStorage'
+import type { SettingsSurfaceVariant } from '../common/SettingsSurface'
 
 type GoogleDocsView = {
   setMimeTypes: (mimeTypes: string) => GoogleDocsView
@@ -438,46 +439,70 @@ export function useNativeIntegrationPickerMutation({
 
 export function NativeIntegrationSummaryCell({
   provider,
-  descriptionClassName = 'mt-1 line-clamp-2 text-sm text-slate-600',
+  descriptionClassName,
   showConnectedBadge = false,
+  surface = 'standalone',
 }: {
   provider: NativeIntegrationProvider
   descriptionClassName?: string
   showConnectedBadge?: boolean
+  surface?: SettingsSurfaceVariant
 }) {
+  const resolvedDescriptionClassName = descriptionClassName ?? (
+    surface === 'embedded' ? 'mt-1 line-clamp-2 text-sm text-slate-400' : 'mt-1 line-clamp-2 text-sm text-slate-600'
+  )
+  const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
+  const nativeBadgeClassName = surface === 'embedded'
+    ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-200'
+    : 'border-emerald-200 bg-emerald-50 text-emerald-700'
+  const connectedBadgeClassName = surface === 'embedded'
+    ? 'border-sky-300/25 bg-sky-950/45 text-sky-200'
+    : 'border-blue-200 bg-blue-50 text-blue-700'
   return (
     <div className="flex min-w-0 items-center gap-3">
       <NativeProviderIconTile provider={provider} />
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
-          <p className="truncate text-sm font-semibold text-slate-900">{provider.displayName}</p>
-          <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-700">
+          <p className={`truncate text-sm font-semibold ${titleClassName}`}>{provider.displayName}</p>
+          <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${nativeBadgeClassName}`}>
             Native
           </span>
           {showConnectedBadge && provider.connected ? (
-            <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-700">
+            <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${connectedBadgeClassName}`}>
               <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
               Connected
             </span>
           ) : null}
         </div>
-        {provider.description ? <p className={descriptionClassName}>{provider.description}</p> : null}
+        {provider.description ? <p className={resolvedDescriptionClassName}>{provider.description}</p> : null}
       </div>
     </div>
   )
 }
 
-export function NativeIntegrationStatusBadge({ connected }: { connected: boolean }) {
+export function NativeIntegrationStatusBadge({
+  connected,
+  surface = 'standalone',
+}: {
+  connected: boolean
+  surface?: SettingsSurfaceVariant
+}) {
   if (connected) {
+    const connectedClassName = surface === 'embedded'
+      ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-200'
+      : 'border-emerald-200 bg-emerald-50 text-emerald-700'
     return (
-      <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-xs font-semibold text-emerald-700">
+      <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold ${connectedClassName}`}>
         <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
         Connected
       </span>
     )
   }
+  const workspaceClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/20 text-slate-400'
+    : 'border-slate-200 text-slate-500'
   return (
-    <span className="inline-flex rounded-full border border-slate-200 px-2.5 py-1 text-xs font-semibold text-slate-500">
+    <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${workspaceClassName}`}>
       Workspace
     </span>
   )
@@ -488,17 +513,22 @@ export function NativeIntegrationPickerButton({
   disabled,
   onClick,
   minWidth = true,
+  surface = 'standalone',
 }: {
   pendingKind: NativePendingKind
   disabled: boolean
   onClick: () => void
   minWidth?: boolean
+  surface?: SettingsSurfaceVariant
 }) {
+  const className = surface === 'embedded'
+    ? 'border-sky-300/25 bg-sky-950/20 text-sky-100 hover:border-sky-200/40 hover:bg-sky-900/40'
+    : 'border-blue-200 bg-white text-blue-700 hover:bg-blue-50'
   return (
     <button
       type="button"
       className={[
-        'inline-flex items-center justify-center gap-2 rounded-md border border-blue-200 bg-white px-3 py-2 text-sm font-semibold text-blue-700 transition hover:bg-blue-50 disabled:opacity-60',
+        `inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${className}`,
         minWidth ? 'min-w-28' : '',
       ].filter(Boolean).join(' ')}
       onClick={onClick}
@@ -522,6 +552,7 @@ export function NativeIntegrationConnectionButton({
   onDisconnect,
   disconnectTone = 'danger',
   minWidth = true,
+  surface = 'standalone',
 }: {
   connected: boolean
   pendingKind: NativePendingKind
@@ -530,17 +561,22 @@ export function NativeIntegrationConnectionButton({
   onDisconnect: () => void
   disconnectTone?: 'danger' | 'neutral'
   minWidth?: boolean
+  surface?: SettingsSurfaceVariant
 }) {
   if (connected) {
+    const connectedClassName = surface === 'embedded'
+      ? disconnectTone === 'danger'
+        ? 'border-rose-300/25 bg-rose-950/20 text-rose-200 hover:border-rose-200/40 hover:bg-rose-900/35'
+        : 'border-slate-200/20 bg-slate-950/20 text-slate-300 hover:border-slate-100/35 hover:bg-slate-900/40'
+      : disconnectTone === 'danger'
+        ? 'border-red-200 bg-white text-red-700 hover:bg-red-50'
+        : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
     return (
       <button
         type="button"
         className={[
-          'inline-flex items-center justify-center gap-2 rounded-md border bg-white px-3 py-2 text-sm font-semibold transition disabled:opacity-60',
+          `inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${connectedClassName}`,
           minWidth ? 'min-w-28' : '',
-          disconnectTone === 'danger'
-            ? 'border-red-200 text-red-700 hover:bg-red-50'
-            : 'border-slate-200 text-slate-700 hover:bg-slate-50',
         ].filter(Boolean).join(' ')}
         onClick={onDisconnect}
         disabled={disabled}
@@ -555,11 +591,14 @@ export function NativeIntegrationConnectionButton({
     )
   }
 
+  const connectClassName = surface === 'embedded'
+    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
+    : 'bg-blue-600 text-white hover:bg-blue-700'
   return (
     <button
       type="button"
       className={[
-        'inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60',
+        `inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${connectClassName}`,
         minWidth ? 'min-w-28' : '',
       ].filter(Boolean).join(' ')}
       onClick={onConnect}
@@ -584,6 +623,7 @@ export function NativeIntegrationActionButtons({
   onPicker,
   disconnectTone,
   minWidth = true,
+  surface = 'standalone',
 }: {
   provider: NativeIntegrationProvider
   pendingKind: NativePendingKind
@@ -593,6 +633,7 @@ export function NativeIntegrationActionButtons({
   onPicker: () => void
   disconnectTone?: 'danger' | 'neutral'
   minWidth?: boolean
+  surface?: SettingsSurfaceVariant
 }) {
   const pickerEnabled = provider.connected && supportsNativeIntegrationPicker(provider)
   return (
@@ -603,6 +644,7 @@ export function NativeIntegrationActionButtons({
           disabled={disabled}
           onClick={onPicker}
           minWidth={minWidth}
+          surface={surface}
         />
       ) : null}
       <NativeIntegrationConnectionButton
@@ -613,6 +655,7 @@ export function NativeIntegrationActionButtons({
         onDisconnect={onDisconnect}
         disconnectTone={disconnectTone}
         minWidth={minWidth}
+        surface={surface}
       />
     </>
   )
@@ -626,6 +669,7 @@ export function NativeIntegrationGridRow({
   onDisconnect,
   onPicker,
   gridClassName = 'grid gap-3 sm:grid-cols-[minmax(0,1fr)_7rem_8rem_8rem] sm:items-start',
+  surface = 'standalone',
 }: {
   provider: NativeIntegrationProvider
   pendingKind: NativePendingKind
@@ -634,18 +678,19 @@ export function NativeIntegrationGridRow({
   onDisconnect: () => void
   onPicker: () => void
   gridClassName?: string
+  surface?: SettingsSurfaceVariant
 }) {
   const pickerEnabled = provider.connected && supportsNativeIntegrationPicker(provider)
   return (
     <div className="px-4 py-3">
       <div className={gridClassName}>
-        <NativeIntegrationSummaryCell provider={provider} />
+        <NativeIntegrationSummaryCell provider={provider} surface={surface} />
         <div>
-          <NativeIntegrationStatusBadge connected={provider.connected} />
+          <NativeIntegrationStatusBadge connected={provider.connected} surface={surface} />
         </div>
         <div className="flex justify-start md:justify-end">
           {pickerEnabled ? (
-            <NativeIntegrationPickerButton pendingKind={pendingKind} disabled={disabled} onClick={onPicker} />
+            <NativeIntegrationPickerButton pendingKind={pendingKind} disabled={disabled} onClick={onPicker} surface={surface} />
           ) : null}
         </div>
         <div className="flex justify-start md:justify-end">
@@ -655,15 +700,22 @@ export function NativeIntegrationGridRow({
             disabled={disabled}
             onConnect={onConnect}
             onDisconnect={onDisconnect}
+            surface={surface}
           />
         </div>
       </div>
-      <NativeIntegrationFilesDisclosure provider={provider} />
+      <NativeIntegrationFilesDisclosure provider={provider} surface={surface} />
     </div>
   )
 }
 
-export function NativeIntegrationFilesDisclosure({ provider }: { provider: NativeIntegrationProvider }) {
+export function NativeIntegrationFilesDisclosure({
+  provider,
+  surface = 'standalone',
+}: {
+  provider: NativeIntegrationProvider
+  surface?: SettingsSurfaceVariant
+}) {
   const [expanded, setExpanded] = useState(false)
   const fileListEnabled = supportsNativeIntegrationFileList(provider)
   const filesQuery = useQuery({
@@ -677,12 +729,22 @@ export function NativeIntegrationFilesDisclosure({ provider }: { provider: Nativ
   }
 
   const files = filesQuery.data?.files ?? []
+  const disclosureClassName = surface === 'embedded'
+    ? 'text-slate-300 hover:text-slate-100'
+    : 'text-slate-700 hover:text-slate-950'
+  const loadingClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-500'
+  const errorClassName = surface === 'embedded'
+    ? 'border-rose-300/25 bg-rose-950/35 text-rose-200'
+    : 'border-red-200 bg-red-50 text-red-700'
+  const emptyClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/30 text-slate-400'
+    : 'border-slate-200 bg-white text-slate-600'
 
   return (
     <div className="mt-3 pl-12">
       <button
         type="button"
-        className="inline-flex items-center gap-2 text-sm font-semibold text-slate-700 transition hover:text-slate-950"
+        className={`inline-flex items-center gap-2 text-sm font-semibold transition ${disclosureClassName}`}
         onClick={() => setExpanded((current) => !current)}
         aria-expanded={expanded}
       >
@@ -696,22 +758,22 @@ export function NativeIntegrationFilesDisclosure({ provider }: { provider: Nativ
       {expanded ? (
         <div className="mt-3">
           {filesQuery.isLoading ? (
-            <div className="inline-flex items-center gap-2 text-sm text-slate-500">
+            <div className={`inline-flex items-center gap-2 text-sm ${loadingClassName}`}>
               <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
               Loading files...
             </div>
           ) : filesQuery.isError ? (
-            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            <div className={`rounded-lg border px-3 py-2 text-sm ${errorClassName}`}>
               {safeErrorMessage(filesQuery.error)}
             </div>
           ) : files.length > 0 ? (
             <ul className="space-y-1">
               {files.map((file) => (
-                <NativeIntegrationFileItem key={file.externalId} file={file} />
+                <NativeIntegrationFileItem key={file.externalId} file={file} surface={surface} />
               ))}
             </ul>
           ) : (
-            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600">
+            <div className={`rounded-lg border px-3 py-2 text-sm ${emptyClassName}`}>
               No selected Google Docs or Sheets files found.
             </div>
           )}
@@ -721,7 +783,14 @@ export function NativeIntegrationFilesDisclosure({ provider }: { provider: Nativ
   )
 }
 
-function NativeIntegrationFileItem({ file }: { file: NativeIntegrationAccessibleFile }) {
+function NativeIntegrationFileItem({
+  file,
+  surface = 'standalone',
+}: {
+  file: NativeIntegrationAccessibleFile
+  surface?: SettingsSurfaceVariant
+}) {
+  const textClassName = surface === 'embedded' ? 'text-slate-300 hover:text-slate-100' : 'text-slate-700 hover:text-slate-950'
   const icon = file.mimeType === GOOGLE_SHEETS_MIME_TYPE
     ? <Table2 className="h-4 w-4 text-emerald-700" aria-hidden="true" />
     : <FileText className="h-4 w-4 text-blue-700" aria-hidden="true" />
@@ -739,7 +808,7 @@ function NativeIntegrationFileItem({ file }: { file: NativeIntegrationAccessible
           href={file.webUrl}
           target="_blank"
           rel="noreferrer"
-          className="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm text-slate-700 transition hover:text-slate-950"
+          className={`flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm transition ${textClassName}`}
         >
           {content}
         </a>
@@ -748,7 +817,7 @@ function NativeIntegrationFileItem({ file }: { file: NativeIntegrationAccessible
   }
 
   return (
-    <li className="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm text-slate-700">
+    <li className={`flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-sm ${textClassName}`}>
       {content}
     </li>
   )

--- a/frontend/src/components/mcp/NativeIntegrationShared.tsx
+++ b/frontend/src/components/mcp/NativeIntegrationShared.tsx
@@ -440,11 +440,13 @@ export function useNativeIntegrationPickerMutation({
 export function NativeIntegrationSummaryCell({
   provider,
   descriptionClassName,
+  showNativeBadge = true,
   showConnectedBadge = false,
   surface = 'standalone',
 }: {
   provider: NativeIntegrationProvider
   descriptionClassName?: string
+  showNativeBadge?: boolean
   showConnectedBadge?: boolean
   surface?: SettingsSurfaceVariant
 }) {
@@ -456,20 +458,22 @@ export function NativeIntegrationSummaryCell({
     ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-200'
     : 'border-emerald-200 bg-emerald-50 text-emerald-700'
   const connectedBadgeClassName = surface === 'embedded'
-    ? 'border-sky-300/25 bg-sky-950/45 text-sky-200'
-    : 'border-blue-200 bg-blue-50 text-blue-700'
+    ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-200'
+    : 'border-emerald-200 bg-emerald-50 text-emerald-700'
   return (
     <div className="flex min-w-0 items-center gap-3">
       <NativeProviderIconTile provider={provider} />
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
           <p className={`truncate text-sm font-semibold ${titleClassName}`}>{provider.displayName}</p>
-          <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${nativeBadgeClassName}`}>
-            Native
-          </span>
+          {showNativeBadge ? (
+            <span className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${nativeBadgeClassName}`}>
+              Native
+            </span>
+          ) : null}
           {showConnectedBadge && provider.connected ? (
-            <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${connectedBadgeClassName}`}>
-              <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+            <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold ${connectedBadgeClassName}`}>
+              <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
               Connected
             </span>
           ) : null}
@@ -669,6 +673,9 @@ export function NativeIntegrationGridRow({
   onDisconnect,
   onPicker,
   gridClassName = 'grid gap-3 sm:grid-cols-[minmax(0,1fr)_7rem_8rem_8rem] sm:items-start',
+  showStatusColumn = true,
+  showNativeBadge = true,
+  showConnectedBadge = false,
   surface = 'standalone',
 }: {
   provider: NativeIntegrationProvider
@@ -678,16 +685,26 @@ export function NativeIntegrationGridRow({
   onDisconnect: () => void
   onPicker: () => void
   gridClassName?: string
+  showStatusColumn?: boolean
+  showNativeBadge?: boolean
+  showConnectedBadge?: boolean
   surface?: SettingsSurfaceVariant
 }) {
   const pickerEnabled = provider.connected && supportsNativeIntegrationPicker(provider)
   return (
     <div className="px-4 py-3">
       <div className={gridClassName}>
-        <NativeIntegrationSummaryCell provider={provider} surface={surface} />
-        <div>
-          <NativeIntegrationStatusBadge connected={provider.connected} surface={surface} />
-        </div>
+        <NativeIntegrationSummaryCell
+          provider={provider}
+          showNativeBadge={showNativeBadge}
+          showConnectedBadge={showConnectedBadge}
+          surface={surface}
+        />
+        {showStatusColumn ? (
+          <div>
+            <NativeIntegrationStatusBadge connected={provider.connected} surface={surface} />
+          </div>
+        ) : null}
         <div className="flex justify-start md:justify-end">
           {pickerEnabled ? (
             <NativeIntegrationPickerButton pendingKind={pendingKind} disabled={disabled} onClick={onPicker} surface={surface} />

--- a/frontend/src/components/mcp/PipedreamAppsPanel.tsx
+++ b/frontend/src/components/mcp/PipedreamAppsPanel.tsx
@@ -1,12 +1,6 @@
 import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
 
-import { fetchPipedreamAppSettings } from '../../api/mcp'
-import { SurfaceHeader, getSettingsSurfaceClassName } from '../common/SettingsSurface'
-import {
-  PipedreamErrorState,
-  PipedreamLoadingState,
-} from './PipedreamAppsShared'
+import { SettingsSurfaceProvider, SurfaceHeader, getSettingsSurfaceClassName } from '../common/SettingsSurface'
 import { WorkspaceAppsManager } from './WorkspaceAppsManager'
 
 type PipedreamAppsPanelProps = {
@@ -24,20 +18,6 @@ export function PipedreamAppsPanel({
   onError,
   embedded = false,
 }: PipedreamAppsPanelProps) {
-  const queryKey = useMemo(() => ['pipedream-app-settings', settingsUrl] as const, [settingsUrl])
-  const settingsQuery = useQuery({
-    queryKey,
-    queryFn: () => fetchPipedreamAppSettings(settingsUrl as string),
-    enabled: Boolean(settingsUrl && searchUrl),
-  })
-  const emptySettings = useMemo(() => ({
-    ownerScope: '',
-    ownerLabel: '',
-    platformApps: [],
-    selectedApps: [],
-    effectiveApps: [],
-  }), [])
-  const hasPipedreamApps = Boolean(settingsUrl && searchUrl)
   const deepLinkRequest = useMemo(() => {
     if (typeof window === 'undefined') {
       return null
@@ -52,38 +32,29 @@ export function PipedreamAppsPanel({
     ? getSettingsSurfaceClassName({ variant: 'embedded', roundedClassName: 'rounded-xl' })
     : 'gobii-card-base overflow-hidden'
   const contentClassName = embedded ? 'px-6 pb-6' : 'px-6 py-5'
+  const surface = embedded ? 'embedded' : 'standalone'
 
   return (
-    <section className={sectionClassName}>
-      <SurfaceHeader
-        variant={embedded ? 'embedded' : 'standalone'}
-        title="Apps"
-        subtitle="Search apps and manage agent connections."
-        titleClassName={embedded ? 'text-2xl font-semibold text-slate-50' : undefined}
-      />
+    <SettingsSurfaceProvider variant={surface}>
+      <section className={sectionClassName}>
+        <SurfaceHeader
+          variant={surface}
+          title="Apps"
+          subtitle="Search apps and manage agent connections."
+          titleClassName={embedded ? 'text-2xl font-semibold text-slate-50' : undefined}
+        />
 
-      <div className={contentClassName}>
-        {hasPipedreamApps && settingsQuery.isLoading ? (
-          <PipedreamLoadingState label="Loading apps…" surface={embedded ? 'embedded' : 'standalone'} />
-        ) : hasPipedreamApps && settingsQuery.isError ? (
-          <PipedreamErrorState
-            error={settingsQuery.error}
-            fallback="Unable to load apps right now."
-            surface={embedded ? 'embedded' : 'standalone'}
-          />
-        ) : (
+        <div className={contentClassName}>
           <WorkspaceAppsManager
             settingsUrl={settingsUrl ?? null}
             searchUrl={searchUrl ?? null}
             nativeIntegrationsUrl={nativeIntegrationsUrl}
             initialNativeProviderKey={deepLinkRequest?.providerKey ?? null}
             initialNativeConnect={Boolean(deepLinkRequest?.connect)}
-            initialSettings={settingsQuery.data ?? emptySettings}
             onError={onError}
-            surface={embedded ? 'embedded' : 'standalone'}
           />
-        )}
-      </div>
-    </section>
+        </div>
+      </section>
+    </SettingsSurfaceProvider>
   )
 }

--- a/frontend/src/components/mcp/PipedreamAppsPanel.tsx
+++ b/frontend/src/components/mcp/PipedreamAppsPanel.tsx
@@ -1,18 +1,13 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { CheckCircle2, Loader2, Plus, Sparkles } from 'lucide-react'
 
-import { fetchAgentRoster } from '../../api/agents'
-import { fetchPipedreamAppSettings, type PipedreamAppSummary } from '../../api/mcp'
-import { fetchNativeIntegrations, type NativeIntegrationProvider } from '../../api/nativeIntegrations'
-import { InlineStatusBanner } from '../common/InlineStatusBanner'
-import { getSettingsSurfaceClassName } from '../common/SettingsSurface'
-import { useModal } from '../../hooks/useModal'
-import { agentHasDiscordNative } from './DiscordNativeAppModal'
-import { withDiscordNativeProviderConnection } from './DiscordNativeShared'
-import { NativeProviderIcon } from './NativeIntegrationShared'
-import { PipedreamAppsModal } from './PipedreamAppsModal'
-import { PipedreamAppIcon, resolvePipedreamAppsErrorMessage } from './PipedreamAppsShared'
+import { fetchPipedreamAppSettings } from '../../api/mcp'
+import { SurfaceHeader, getSettingsSurfaceClassName } from '../common/SettingsSurface'
+import {
+  PipedreamErrorState,
+  PipedreamLoadingState,
+} from './PipedreamAppsShared'
+import { WorkspaceAppsManager } from './WorkspaceAppsManager'
 
 type PipedreamAppsPanelProps = {
   settingsUrl?: string | null
@@ -29,29 +24,12 @@ export function PipedreamAppsPanel({
   onError,
   embedded = false,
 }: PipedreamAppsPanelProps) {
-  const [modal, showModal] = useModal()
-  const [deepLinkHandled, setDeepLinkHandled] = useState(false)
   const queryKey = useMemo(() => ['pipedream-app-settings', settingsUrl] as const, [settingsUrl])
   const settingsQuery = useQuery({
     queryKey,
     queryFn: () => fetchPipedreamAppSettings(settingsUrl as string),
     enabled: Boolean(settingsUrl && searchUrl),
   })
-  const nativeQueryKey = useMemo(
-    () => ['native-integrations', nativeIntegrationsUrl] as const,
-    [nativeIntegrationsUrl],
-  )
-  const nativeIntegrationsQuery = useQuery({
-    queryKey: nativeQueryKey,
-    queryFn: () => fetchNativeIntegrations(nativeIntegrationsUrl as string),
-    enabled: Boolean(nativeIntegrationsUrl),
-  })
-  const agentRosterQuery = useQuery({
-    queryKey: ['agent-roster'],
-    queryFn: () => fetchAgentRoster(),
-    enabled: Boolean(nativeIntegrationsUrl),
-  })
-
   const emptySettings = useMemo(() => ({
     ownerScope: '',
     ownerLabel: '',
@@ -59,276 +37,53 @@ export function PipedreamAppsPanel({
     selectedApps: [],
     effectiveApps: [],
   }), [])
-  const effectiveSettings = settingsQuery.data ?? emptySettings
-  const discordConnected = useMemo(
-    () => (agentRosterQuery.data?.agents ?? []).some(agentHasDiscordNative),
-    [agentRosterQuery.data?.agents],
-  )
-  const nativeProviders = useMemo(() => {
-    return withDiscordNativeProviderConnection(nativeIntegrationsQuery.data?.providers ?? [], discordConnected)
-  }, [discordConnected, nativeIntegrationsQuery.data?.providers])
   const hasPipedreamApps = Boolean(settingsUrl && searchUrl)
-  const canOpenModal = hasPipedreamApps ? Boolean(settingsQuery.data) : Boolean(nativeIntegrationsUrl)
-
   const deepLinkRequest = useMemo(() => {
     if (typeof window === 'undefined') {
       return null
     }
     const params = new URLSearchParams(window.location.search)
-    const providerKey = params.get('provider')?.trim() || null
     return {
-      providerKey,
+      providerKey: params.get('provider')?.trim() || null,
       connect: params.get('connect') === '1',
     }
   }, [])
-
-  const openModal = useCallback((options: { providerKey?: string | null; connect?: boolean } = {}) => {
-    if (!hasPipedreamApps && !nativeIntegrationsUrl) {
-      return
-    }
-    if (hasPipedreamApps && !settingsQuery.data) {
-      return
-    }
-    showModal((onClose) => (
-      <PipedreamAppsModal
-        settingsUrl={settingsUrl ?? null}
-        searchUrl={searchUrl ?? null}
-        nativeIntegrationsUrl={nativeIntegrationsUrl}
-        initialNativeProviderKey={options.providerKey ?? null}
-        initialNativeConnect={Boolean(options.connect)}
-        initialSettings={effectiveSettings}
-        onClose={onClose}
-        onError={onError}
-      />
-    ))
-  }, [
-    effectiveSettings,
-    hasPipedreamApps,
-    nativeIntegrationsUrl,
-    onError,
-    searchUrl,
-    settingsQuery.data,
-    settingsUrl,
-    showModal,
-  ])
-
-  useEffect(() => {
-    if (deepLinkHandled || !deepLinkRequest?.providerKey || !deepLinkRequest.connect || !canOpenModal) {
-      return
-    }
-    if (settingsQuery.isLoading || nativeIntegrationsQuery.isLoading || agentRosterQuery.isLoading) {
-      return
-    }
-    setDeepLinkHandled(true)
-    openModal({ providerKey: deepLinkRequest.providerKey, connect: true })
-  }, [
-    agentRosterQuery.isLoading,
-    canOpenModal,
-    deepLinkHandled,
-    deepLinkRequest,
-    nativeIntegrationsQuery.isLoading,
-    openModal,
-    settingsQuery.isLoading,
-  ])
-
   const sectionClassName = embedded
     ? getSettingsSurfaceClassName({ variant: 'embedded', roundedClassName: 'rounded-xl' })
     : 'gobii-card-base overflow-hidden'
-  const headerClassName = embedded
-    ? 'flex flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between'
-    : 'flex flex-col gap-4 border-b border-gray-200/70 px-6 py-4 sm:flex-row sm:items-center sm:justify-between'
-  const badgeClassName = embedded
-    ? 'inline-flex items-center gap-2 rounded-full border border-sky-300/25 bg-sky-950/45 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-100'
-    : 'inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700'
-  const titleClassName = embedded ? 'text-lg font-semibold text-slate-50' : 'text-lg font-semibold text-gray-800'
-  const buttonClassName = embedded
-    ? 'inline-flex items-center justify-center gap-2 rounded-lg border border-sky-300/25 bg-sky-900/55 px-4 py-2 text-sm font-semibold text-sky-50 transition hover:border-sky-200/40 hover:bg-sky-900/75 disabled:opacity-60'
-    : 'inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-blue-700 disabled:opacity-60'
-  const loadingClassName = embedded
-    ? 'flex items-center gap-2 px-6 py-8 text-sm text-slate-400'
-    : 'flex items-center gap-2 px-6 py-8 text-sm text-slate-500'
+  const contentClassName = embedded ? 'px-6 pb-6' : 'px-6 py-5'
 
   return (
-    <>
-      <section className={sectionClassName}>
-        <div className={headerClassName}>
-          <div className="space-y-1">
-            <div className={badgeClassName}>
-              <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
-              Apps
-            </div>
-            <div>
-              <h2 className={titleClassName}>Additional apps</h2>
-            </div>
-          </div>
-          <button
-            type="button"
-            className={buttonClassName}
-            onClick={() => openModal()}
-            disabled={!canOpenModal || settingsQuery.isLoading || nativeIntegrationsQuery.isLoading || agentRosterQuery.isLoading}
-          >
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            Add Apps
-          </button>
-        </div>
+    <section className={sectionClassName}>
+      <SurfaceHeader
+        variant={embedded ? 'embedded' : 'standalone'}
+        title="Apps"
+        subtitle="Search apps and manage agent connections."
+        titleClassName={embedded ? 'text-2xl font-semibold text-slate-50' : undefined}
+      />
 
-        {(hasPipedreamApps && settingsQuery.isLoading) || nativeIntegrationsQuery.isLoading || agentRosterQuery.isLoading ? (
-          <div className={loadingClassName}>
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Loading apps…
-          </div>
-        ) : (hasPipedreamApps && settingsQuery.isError) || nativeIntegrationsQuery.isError || agentRosterQuery.isError ? (
-          <div className="px-6 py-5">
-            <InlineStatusBanner variant="error" surface={embedded ? 'embedded' : 'standalone'}>
-              {resolvePipedreamAppsErrorMessage(settingsQuery.error ?? nativeIntegrationsQuery.error ?? agentRosterQuery.error, 'Unable to load apps right now.')}
-            </InlineStatusBanner>
-          </div>
+      <div className={contentClassName}>
+        {hasPipedreamApps && settingsQuery.isLoading ? (
+          <PipedreamLoadingState label="Loading apps…" surface={embedded ? 'embedded' : 'standalone'} />
+        ) : hasPipedreamApps && settingsQuery.isError ? (
+          <PipedreamErrorState
+            error={settingsQuery.error}
+            fallback="Unable to load apps right now."
+            surface={embedded ? 'embedded' : 'standalone'}
+          />
         ) : (
-          <div className={`grid gap-6 px-6 py-5 ${nativeIntegrationsUrl && hasPipedreamApps ? 'lg:grid-cols-3' : 'lg:grid-cols-2'}`}>
-            {nativeIntegrationsUrl ? (
-              <NativeAppColumn
-                title="Native apps"
-                caption="Connected at the workspace level."
-                providers={nativeProviders}
-                embedded={embedded}
-              />
-            ) : null}
-            {hasPipedreamApps ? (
-              <>
-            <AppColumn
-              title="Included apps"
-              caption="Available automatically for this workspace."
-              apps={effectiveSettings.platformApps}
-              emptyText="No included apps configured."
-              tone="platform"
-              embedded={embedded}
-            />
-            <AppColumn
-              title="Your apps"
-              caption="Additional apps enabled for your Agents"
-              apps={effectiveSettings.selectedApps}
-              emptyText="No additional apps enabled yet."
-              tone="selected"
-              embedded={embedded}
-            />
-              </>
-            ) : null}
-          </div>
+          <WorkspaceAppsManager
+            settingsUrl={settingsUrl ?? null}
+            searchUrl={searchUrl ?? null}
+            nativeIntegrationsUrl={nativeIntegrationsUrl}
+            initialNativeProviderKey={deepLinkRequest?.providerKey ?? null}
+            initialNativeConnect={Boolean(deepLinkRequest?.connect)}
+            initialSettings={settingsQuery.data ?? emptySettings}
+            onError={onError}
+            surface={embedded ? 'embedded' : 'standalone'}
+          />
         )}
-      </section>
-      {modal}
-    </>
-  )
-}
-
-function NativeAppColumn({
-  title,
-  caption,
-  providers,
-  embedded = false,
-}: {
-  title: string
-  caption: string
-  providers: NativeIntegrationProvider[]
-  embedded?: boolean
-}) {
-  const titleClassName = embedded ? 'text-sm font-semibold text-slate-100' : 'text-sm font-semibold text-slate-900'
-  const captionClassName = embedded ? 'text-sm text-slate-400' : 'text-sm text-slate-600'
-  const connectedClassName = embedded
-    ? 'border-emerald-300/25 bg-emerald-950/45 text-emerald-100'
-    : 'border-emerald-200 bg-emerald-50 text-emerald-700'
-  const disconnectedClassName = embedded
-    ? 'border-slate-200/20 bg-slate-900/45 text-slate-200'
-    : 'border-slate-200 bg-white text-slate-700'
-  const emptyClassName = embedded
-    ? 'rounded-lg border border-dashed border-slate-200/20 bg-slate-950/25 px-4 py-4 text-sm text-slate-400'
-    : 'rounded-lg border border-dashed border-slate-200 bg-white px-4 py-4 text-sm text-slate-600'
-
-  return (
-    <div className="space-y-3">
-      <div>
-        <h3 className={titleClassName}>{title}</h3>
-        <p className={captionClassName}>{caption}</p>
       </div>
-      {providers.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
-          {providers.map((provider) => (
-            <span
-              key={provider.providerKey}
-              className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium ${
-                provider.connected ? connectedClassName : disconnectedClassName
-              }`}
-            >
-              <NativeProviderIcon provider={provider} />
-              <span>{provider.displayName}</span>
-              {provider.connected ? <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" /> : null}
-            </span>
-          ))}
-        </div>
-      ) : (
-        <div className={emptyClassName}>
-          No native apps configured.
-        </div>
-      )}
-    </div>
-  )
-}
-
-function AppColumn({
-  title,
-  caption,
-  apps,
-  emptyText,
-  tone,
-  embedded = false,
-}: {
-  title: string
-  caption: string
-  apps: PipedreamAppSummary[]
-  emptyText: string
-  tone: 'platform' | 'selected'
-  embedded?: boolean
-}) {
-  const accentClass =
-    embedded
-      ? tone === 'platform'
-        ? 'border-slate-200/20 bg-slate-900/45 text-slate-200'
-        : 'border-sky-300/25 bg-sky-950/45 text-sky-100'
-      : tone === 'platform'
-        ? 'border-slate-200 bg-slate-50 text-slate-700'
-        : 'border-blue-200 bg-blue-50 text-blue-700'
-  const titleClassName = embedded ? 'text-sm font-semibold text-slate-100' : 'text-sm font-semibold text-slate-900'
-  const captionClassName = embedded ? 'text-sm text-slate-400' : 'text-sm text-slate-600'
-  const appNameClassName = embedded
-    ? tone === 'platform' ? 'text-slate-100' : 'text-sky-50'
-    : tone === 'platform' ? 'text-slate-800' : 'text-blue-900'
-  const emptyClassName = embedded
-    ? 'rounded-lg border border-dashed border-slate-200/20 bg-slate-950/25 px-4 py-4 text-sm text-slate-400'
-    : 'rounded-lg border border-dashed border-slate-200 bg-slate-50/60 px-4 py-4 text-sm text-slate-600'
-
-  return (
-    <div className="space-y-3">
-      <div>
-        <h3 className={titleClassName}>{title}</h3>
-        <p className={captionClassName}>{caption}</p>
-      </div>
-      {apps.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
-          {apps.map((app) => (
-            <span
-              key={app.slug}
-              className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium ${accentClass}`}
-            >
-              <PipedreamAppIcon app={app} size="sm" />
-              <span className={appNameClassName}>{app.name}</span>
-            </span>
-          ))}
-        </div>
-      ) : (
-        <div className={emptyClassName}>
-          {emptyText}
-        </div>
-      )}
-    </div>
+    </section>
   )
 }

--- a/frontend/src/components/mcp/PipedreamAppsShared.tsx
+++ b/frontend/src/components/mcp/PipedreamAppsShared.tsx
@@ -4,6 +4,7 @@ import { Loader2, Plug, Search, Sparkles, Trash2, Unplug } from 'lucide-react'
 import { HttpError } from '../../api/http'
 import type { PipedreamAppAgentConnection, PipedreamAppSummary } from '../../api/mcp'
 import { ImmersiveDialog } from '../common/ImmersiveDialog'
+import type { SettingsSurfaceVariant } from '../common/SettingsSurface'
 export { useIsMobile } from '../../hooks/useIsMobile'
 
 export type PipedreamStatusMessage = {
@@ -14,9 +15,10 @@ export type PipedreamStatusMessage = {
 type PipedreamAppIconProps = {
   app: PipedreamAppSummary
   size?: 'sm' | 'md'
+  surface?: SettingsSurfaceVariant
 }
 
-export function PipedreamAppIcon({ app, size = 'md' }: PipedreamAppIconProps) {
+export function PipedreamAppIcon({ app, size = 'md', surface = 'standalone' }: PipedreamAppIconProps) {
   const sizeClass = size === 'sm' ? 'h-6 w-6 rounded-lg text-[10px]' : 'h-9 w-9 rounded-lg text-xs'
 
   if (app.iconUrl) {
@@ -30,8 +32,12 @@ export function PipedreamAppIcon({ app, size = 'md' }: PipedreamAppIconProps) {
     )
   }
 
+  const fallbackClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-900 text-slate-200'
+    : 'border-slate-200 bg-white text-slate-700'
+
   return (
-    <span className={`inline-flex items-center justify-center border border-slate-200 bg-slate-50 font-semibold uppercase text-slate-700 ${sizeClass}`}>
+    <span className={`inline-flex items-center justify-center border font-semibold uppercase ${fallbackClassName} ${sizeClass}`}>
       {app.name.slice(0, 2)}
     </span>
   )
@@ -95,12 +101,26 @@ export function PipedreamModalShell({
   )
 }
 
-export function PipedreamStatusBanner({ statusMessage }: { statusMessage: PipedreamStatusMessage }) {
+export function PipedreamStatusBanner({
+  statusMessage,
+  surface = 'standalone',
+}: {
+  statusMessage: PipedreamStatusMessage
+  surface?: SettingsSurfaceVariant
+}) {
   if (!statusMessage) {
     return null
   }
+  const isError = statusMessage.tone === 'error'
+  const className = surface === 'embedded'
+    ? isError
+      ? 'border-rose-300/25 bg-rose-950/35 text-rose-200'
+      : 'border-emerald-300/25 bg-emerald-950/35 text-emerald-200'
+    : isError
+      ? 'border-red-200 bg-red-50 text-red-700'
+      : 'border-emerald-200 bg-emerald-50 text-emerald-700'
   return (
-    <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+    <div className={`rounded-lg border px-4 py-3 text-sm ${className}`}>
       {statusMessage.text}
     </div>
   )
@@ -111,20 +131,26 @@ export function PipedreamSearchInput({
   onChange,
   isFetching,
   disabled,
+  surface = 'standalone',
 }: {
   value: string
   onChange: (value: string) => void
   isFetching: boolean
   disabled: boolean
+  surface?: SettingsSurfaceVariant
 }) {
+  const inputClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/45 text-slate-100 placeholder:text-slate-500 focus:border-sky-300/50 focus:ring-sky-300/30'
+    : 'border-slate-300 bg-white text-slate-800 shadow-sm focus:border-blue-500 focus:ring-blue-500'
+  const labelClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-500'
   return (
-    <label className="relative block text-sm text-slate-500">
+    <label className={`relative block text-sm ${labelClassName}`}>
       <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
         {isFetching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" aria-hidden="true" />}
       </span>
       <input
         type="search"
-        className="w-full rounded-lg border border-slate-300 bg-white py-3 pl-10 pr-3 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500"
+        className={`w-full rounded-lg border py-3 pl-10 pr-3 text-sm focus:outline-none focus:ring-1 ${inputClassName}`}
         placeholder="Search apps"
         value={value}
         onChange={(event) => onChange(event.target.value)}
@@ -136,32 +162,46 @@ export function PipedreamSearchInput({
 
 export function PipedreamListFrame({
   isMobile,
+  constrainHeight = true,
+  surface = 'standalone',
   children,
 }: {
   isMobile: boolean
+  constrainHeight?: boolean
+  surface?: SettingsSurfaceVariant
   children: ReactNode
 }) {
+  const frameClassName = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-900'
+    : 'border-slate-200 bg-white'
+  const dividerClassName = surface === 'embedded' ? 'divide-slate-200/10' : 'divide-slate-200'
   return (
-    <div className={`overflow-hidden rounded-lg border border-slate-200 bg-white ${isMobile ? '' : 'max-h-[28rem] overflow-y-auto'}`}>
-      <div className="divide-y divide-slate-200">
+    <div className={`overflow-hidden rounded-lg border ${frameClassName} ${!isMobile && constrainHeight ? 'max-h-[28rem] overflow-y-auto' : ''}`}>
+      <div className={`divide-y ${dividerClassName}`}>
         {children}
       </div>
     </div>
   )
 }
 
-export function PipedreamLoadingState({ label }: { label: string }) {
+export function PipedreamLoadingState({ label, surface = 'standalone' }: { label: string; surface?: SettingsSurfaceVariant }) {
+  const className = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/30 text-slate-400'
+    : 'border-slate-200 bg-white text-slate-600'
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-5 text-sm text-slate-600">
+    <div className={`flex items-center gap-2 rounded-lg border px-4 py-5 text-sm ${className}`}>
       <Loader2 className="h-4 w-4 animate-spin" />
       {label}
     </div>
   )
 }
 
-export function PipedreamEmptyState({ label }: { label: string }) {
+export function PipedreamEmptyState({ label, surface = 'standalone' }: { label: string; surface?: SettingsSurfaceVariant }) {
+  const className = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/30 text-slate-400'
+    : 'border-slate-200 bg-white text-slate-600'
   return (
-    <div className="rounded-lg border border-slate-200 bg-white px-4 py-5 text-sm text-slate-600">
+    <div className={`rounded-lg border px-4 py-5 text-sm ${className}`}>
       {label}
     </div>
   )
@@ -170,12 +210,17 @@ export function PipedreamEmptyState({ label }: { label: string }) {
 export function PipedreamErrorState({
   error,
   fallback,
+  surface = 'standalone',
 }: {
   error: unknown
   fallback: string
+  surface?: SettingsSurfaceVariant
 }) {
+  const className = surface === 'embedded'
+    ? 'border-rose-300/25 bg-rose-950/35 text-rose-200'
+    : 'border-red-200 bg-red-50 text-red-700'
   return (
-    <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+    <div className={`rounded-lg border px-4 py-3 text-sm ${className}`}>
       {resolvePipedreamAppsErrorMessage(error, fallback)}
     </div>
   )
@@ -183,15 +228,19 @@ export function PipedreamErrorState({
 
 export function PipedreamAppSummaryCell({
   app,
+  surface = 'standalone',
 }: {
   app: PipedreamAppSummary
+  surface?: SettingsSurfaceVariant
 }) {
+  const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
+  const descriptionClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-600'
   return (
     <div className="flex min-w-0 items-center gap-3">
-      <PipedreamAppIcon app={app} />
+      <PipedreamAppIcon app={app} surface={surface} />
       <div className="min-w-0">
-        <p className="truncate text-sm font-semibold text-slate-900">{app.name}</p>
-        {app.description ? <p className="mt-1 line-clamp-2 text-sm text-slate-600">{app.description}</p> : null}
+        <p className={`truncate text-sm font-semibold ${titleClassName}`}>{app.name}</p>
+        {app.description ? <p className={`mt-1 line-clamp-2 text-sm ${descriptionClassName}`}>{app.description}</p> : null}
       </div>
     </div>
   )
@@ -203,18 +252,23 @@ export function PipedreamConnectionButton({
   disabled,
   onConnect,
   onDisconnect,
+  surface = 'standalone',
 }: {
   connected: boolean
   pendingKind: 'connect' | 'disconnect' | null
   disabled: boolean
   onConnect: () => void
   onDisconnect: () => void
+  surface?: SettingsSurfaceVariant
 }) {
   if (connected) {
+    const disconnectClassName = surface === 'embedded'
+      ? 'border-rose-300/25 bg-rose-950/20 text-rose-200 hover:border-rose-200/40 hover:bg-rose-900/35'
+      : 'border-red-200 bg-white text-red-700 hover:bg-red-50'
     return (
       <button
         type="button"
-        className="inline-flex min-w-28 items-center justify-center gap-2 rounded-md border border-red-200 bg-white px-3 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-50 disabled:opacity-60"
+        className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${disconnectClassName}`}
         onClick={onDisconnect}
         disabled={disabled}
       >
@@ -228,10 +282,13 @@ export function PipedreamConnectionButton({
     )
   }
 
+  const connectClassName = surface === 'embedded'
+    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
+    : 'bg-blue-600 text-white hover:bg-blue-700'
   return (
     <button
       type="button"
-      className="inline-flex min-w-28 items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+      className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${connectClassName}`}
       onClick={onConnect}
       disabled={disabled}
     >
@@ -250,16 +307,21 @@ export function PipedreamRemoveButton({
   disabled,
   title,
   onClick,
+  surface = 'standalone',
 }: {
   isPending: boolean
   disabled: boolean
   title: string
   onClick: () => void
+  surface?: SettingsSurfaceVariant
 }) {
+  const className = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-950/20 text-slate-300 hover:border-slate-100/35 hover:bg-slate-900/40'
+    : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
   return (
     <button
       type="button"
-      className="inline-flex min-w-24 items-center justify-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-45"
+      className={`inline-flex min-w-24 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-45 ${className}`}
       onClick={onClick}
       disabled={disabled}
       title={title}
@@ -274,7 +336,13 @@ export function PipedreamRemoveButton({
   )
 }
 
-export function AgentConnectionAvatar({ agent }: { agent: PipedreamAppAgentConnection }) {
+export function AgentConnectionAvatar({
+  agent,
+  surface = 'standalone',
+}: {
+  agent: PipedreamAppAgentConnection
+  surface?: SettingsSurfaceVariant
+}) {
   if (agent.avatarUrl) {
     return (
       <img
@@ -286,8 +354,11 @@ export function AgentConnectionAvatar({ agent }: { agent: PipedreamAppAgentConne
     )
   }
 
+  const className = surface === 'embedded'
+    ? 'border-slate-200/20 bg-slate-900 text-slate-200'
+    : 'border-slate-200 bg-white text-slate-700'
   return (
-    <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-xs font-semibold uppercase text-slate-700">
+    <span className={`inline-flex h-9 w-9 items-center justify-center rounded-full border text-xs font-semibold uppercase ${className}`}>
       {agent.name.slice(0, 2)}
     </span>
   )

--- a/frontend/src/components/mcp/PipedreamAppsShared.tsx
+++ b/frontend/src/components/mcp/PipedreamAppsShared.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, type ReactNode } from 'react'
-import { Loader2, Plug, Search, Sparkles, Trash2, Unplug } from 'lucide-react'
+import { Loader2, Search, Sparkles, Trash2 } from 'lucide-react'
 
 import { HttpError } from '../../api/http'
 import type { PipedreamAppAgentConnection, PipedreamAppSummary } from '../../api/mcp'
 import { ImmersiveDialog } from '../common/ImmersiveDialog'
-import type { SettingsSurfaceVariant } from '../common/SettingsSurface'
+import { useSettingsSurfaceVariant } from '../common/SettingsSurface'
 export { useIsMobile } from '../../hooks/useIsMobile'
 
 export type PipedreamStatusMessage = {
@@ -15,10 +15,10 @@ export type PipedreamStatusMessage = {
 type PipedreamAppIconProps = {
   app: PipedreamAppSummary
   size?: 'sm' | 'md'
-  surface?: SettingsSurfaceVariant
 }
 
-export function PipedreamAppIcon({ app, size = 'md', surface = 'standalone' }: PipedreamAppIconProps) {
+export function PipedreamAppIcon({ app, size = 'md' }: PipedreamAppIconProps) {
+  const surface = useSettingsSurfaceVariant()
   const sizeClass = size === 'sm' ? 'h-6 w-6 rounded-lg text-[10px]' : 'h-9 w-9 rounded-lg text-xs'
 
   if (app.iconUrl) {
@@ -103,11 +103,10 @@ export function PipedreamModalShell({
 
 export function PipedreamStatusBanner({
   statusMessage,
-  surface = 'standalone',
 }: {
   statusMessage: PipedreamStatusMessage
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   if (!statusMessage) {
     return null
   }
@@ -131,14 +130,13 @@ export function PipedreamSearchInput({
   onChange,
   isFetching,
   disabled,
-  surface = 'standalone',
 }: {
   value: string
   onChange: (value: string) => void
   isFetching: boolean
   disabled: boolean
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const inputClassName = surface === 'embedded'
     ? 'border-slate-200/20 bg-slate-950/45 text-slate-100 placeholder:text-slate-500 focus:border-sky-300/50 focus:ring-sky-300/30'
     : 'border-slate-300 bg-white text-slate-800 shadow-sm focus:border-blue-500 focus:ring-blue-500'
@@ -163,14 +161,13 @@ export function PipedreamSearchInput({
 export function PipedreamListFrame({
   isMobile,
   constrainHeight = true,
-  surface = 'standalone',
   children,
 }: {
   isMobile: boolean
   constrainHeight?: boolean
-  surface?: SettingsSurfaceVariant
   children: ReactNode
 }) {
+  const surface = useSettingsSurfaceVariant()
   const frameClassName = surface === 'embedded'
     ? 'border-slate-200/20 bg-slate-900'
     : 'border-slate-200 bg-white'
@@ -184,7 +181,8 @@ export function PipedreamListFrame({
   )
 }
 
-export function PipedreamLoadingState({ label, surface = 'standalone' }: { label: string; surface?: SettingsSurfaceVariant }) {
+export function PipedreamLoadingState({ label }: { label: string }) {
+  const surface = useSettingsSurfaceVariant()
   const className = surface === 'embedded'
     ? 'border-slate-200/20 bg-slate-950/30 text-slate-400'
     : 'border-slate-200 bg-white text-slate-600'
@@ -196,7 +194,8 @@ export function PipedreamLoadingState({ label, surface = 'standalone' }: { label
   )
 }
 
-export function PipedreamEmptyState({ label, surface = 'standalone' }: { label: string; surface?: SettingsSurfaceVariant }) {
+export function PipedreamEmptyState({ label }: { label: string }) {
+  const surface = useSettingsSurfaceVariant()
   const className = surface === 'embedded'
     ? 'border-slate-200/20 bg-slate-950/30 text-slate-400'
     : 'border-slate-200 bg-white text-slate-600'
@@ -210,12 +209,11 @@ export function PipedreamEmptyState({ label, surface = 'standalone' }: { label: 
 export function PipedreamErrorState({
   error,
   fallback,
-  surface = 'standalone',
 }: {
   error: unknown
   fallback: string
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const className = surface === 'embedded'
     ? 'border-rose-300/25 bg-rose-950/35 text-rose-200'
     : 'border-red-200 bg-red-50 text-red-700'
@@ -228,16 +226,15 @@ export function PipedreamErrorState({
 
 export function PipedreamAppSummaryCell({
   app,
-  surface = 'standalone',
 }: {
   app: PipedreamAppSummary
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
   const descriptionClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-600'
   return (
     <div className="flex min-w-0 items-center gap-3">
-      <PipedreamAppIcon app={app} surface={surface} />
+      <PipedreamAppIcon app={app} />
       <div className="min-w-0">
         <p className={`truncate text-sm font-semibold ${titleClassName}`}>{app.name}</p>
         {app.description ? <p className={`mt-1 line-clamp-2 text-sm ${descriptionClassName}`}>{app.description}</p> : null}
@@ -246,75 +243,18 @@ export function PipedreamAppSummaryCell({
   )
 }
 
-export function PipedreamConnectionButton({
-  connected,
-  pendingKind,
-  disabled,
-  onConnect,
-  onDisconnect,
-  surface = 'standalone',
-}: {
-  connected: boolean
-  pendingKind: 'connect' | 'disconnect' | null
-  disabled: boolean
-  onConnect: () => void
-  onDisconnect: () => void
-  surface?: SettingsSurfaceVariant
-}) {
-  if (connected) {
-    const disconnectClassName = surface === 'embedded'
-      ? 'border-rose-300/25 bg-rose-950/20 text-rose-200 hover:border-rose-200/40 hover:bg-rose-900/35'
-      : 'border-red-200 bg-white text-red-700 hover:bg-red-50'
-    return (
-      <button
-        type="button"
-        className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${disconnectClassName}`}
-        onClick={onDisconnect}
-        disabled={disabled}
-      >
-        {pendingKind === 'disconnect' ? (
-          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-        ) : (
-          <Unplug className="h-4 w-4" aria-hidden="true" />
-        )}
-        Disconnect
-      </button>
-    )
-  }
-
-  const connectClassName = surface === 'embedded'
-    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
-    : 'bg-blue-600 text-white hover:bg-blue-700'
-  return (
-    <button
-      type="button"
-      className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${connectClassName}`}
-      onClick={onConnect}
-      disabled={disabled}
-    >
-      {pendingKind === 'connect' ? (
-        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-      ) : (
-        <Plug className="h-4 w-4" aria-hidden="true" />
-      )}
-      Connect
-    </button>
-  )
-}
-
 export function PipedreamRemoveButton({
   isPending,
   disabled,
   title,
   onClick,
-  surface = 'standalone',
 }: {
   isPending: boolean
   disabled: boolean
   title: string
   onClick: () => void
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const className = surface === 'embedded'
     ? 'border-slate-200/20 bg-slate-950/20 text-slate-300 hover:border-slate-100/35 hover:bg-slate-900/40'
     : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50'
@@ -338,11 +278,10 @@ export function PipedreamRemoveButton({
 
 export function AgentConnectionAvatar({
   agent,
-  surface = 'standalone',
 }: {
   agent: PipedreamAppAgentConnection
-  surface?: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   if (agent.avatarUrl) {
     return (
       <img

--- a/frontend/src/components/mcp/WorkspaceAppsManager.tsx
+++ b/frontend/src/components/mcp/WorkspaceAppsManager.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Loader2, Unplug, Users } from 'lucide-react'
+import { Loader2, Unplug, Users } from 'lucide-react'
 
 import { agentDiscordAppQueryKey, fetchAgentDiscordApp } from '../../api/discordNative'
 import { fetchAgentRoster } from '../../api/agents'
@@ -16,6 +16,7 @@ import {
   type PipedreamAppSummary,
 } from '../../api/mcp'
 import { fetchNativeIntegrations, type NativeIntegrationProvider } from '../../api/nativeIntegrations'
+import type { SettingsSurfaceVariant } from '../common/SettingsSurface'
 import { DISCORD_NATIVE_PROVIDER_KEY, withDiscordNativeProvider } from './DiscordNativeShared'
 import {
   AgentConnectionAvatar,
@@ -26,7 +27,6 @@ import {
   PipedreamErrorState,
   PipedreamListFrame,
   PipedreamLoadingState,
-  PipedreamModalShell,
   PipedreamRemoveButton,
   PipedreamSearchInput,
   PipedreamStatusBanner,
@@ -50,6 +50,7 @@ import {
 import { useManualNativeIntegrationConnect } from './useManualNativeIntegrationConnect'
 import {
   agentHasDiscordNative,
+  BackButton,
   DiscordAgentConnectionsScreen,
   DiscordConfigurationScreen,
   useDiscordNativeAgentActions,
@@ -57,15 +58,15 @@ import {
   useDiscordOAuthCompleteRefetch,
 } from './DiscordNativeAppModal'
 
-type PipedreamAppsModalProps = {
+type WorkspaceAppsManagerProps = {
   settingsUrl: string | null
   searchUrl: string | null
   nativeIntegrationsUrl?: string | null
   initialNativeProviderKey?: string | null
   initialNativeConnect?: boolean
   initialSettings: PipedreamAppSettings
-  onClose: () => void
   onError: (message: string) => void
+  surface?: SettingsSurfaceVariant
 }
 
 type WorkspacePipedreamAppRow = PipedreamAppSummary & {
@@ -92,16 +93,16 @@ type PendingAgentAction = {
   kind: 'connect' | 'disconnect'
 } | null
 
-export function PipedreamAppsModal({
+export function WorkspaceAppsManager({
   settingsUrl,
   searchUrl,
   nativeIntegrationsUrl = null,
   initialNativeProviderKey = null,
   initialNativeConnect = false,
   initialSettings,
-  onClose,
   onError,
-}: PipedreamAppsModalProps) {
+  surface = 'standalone',
+}: WorkspaceAppsManagerProps) {
   const queryClient = useQueryClient()
   const settingsQueryKey = useMemo(() => ['pipedream-app-settings', settingsUrl] as const, [settingsUrl])
   const isMobile = useIsMobile()
@@ -388,41 +389,30 @@ export function PipedreamAppsModal({
     || nativePickerMutation.isPending
     || discordDisconnectMutation.isPending
     || isDiscordAgentActionPending
-  const activeDiscordAgent = activeDiscordAgentId
-    ? (agentRosterQuery.data?.agents ?? []).find((agent) => agent.id === activeDiscordAgentId) ?? null
-    : null
   const body = activeDiscordAgentId ? (
     activeDiscordAppQuery.isError ? (
       <div className="space-y-4 p-1">
-        <button
-          type="button"
-          className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+        <BackButton
+          surface={surface}
           onClick={() => {
             setActiveDiscordAgentId(null)
             setStatusMessage(null)
           }}
           disabled={isBusy}
-        >
-          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-          Back
-        </button>
-        <PipedreamErrorState error={activeDiscordAppQuery.error} fallback="Unable to load Discord configuration." />
+        />
+        <PipedreamErrorState error={activeDiscordAppQuery.error} fallback="Unable to load Discord configuration." surface={surface} />
       </div>
     ) : activeDiscordAppQuery.isLoading || !activeDiscordAppQuery.data ? (
       <div className="space-y-4 p-1">
-        <button
-          type="button"
-          className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
+        <BackButton
+          surface={surface}
           onClick={() => {
             setActiveDiscordAgentId(null)
             setStatusMessage(null)
           }}
           disabled={isBusy}
-        >
-          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-          Back
-        </button>
-        <PipedreamLoadingState label="Loading Discord configuration…" />
+        />
+        <PipedreamLoadingState label="Loading Discord configuration…" surface={surface} />
       </div>
     ) : (
       <DiscordConfigurationScreen
@@ -436,6 +426,7 @@ export function PipedreamAppsModal({
           setStatusMessage(null)
         }}
         onSave={(subscriptions) => saveDiscordAgentSubscriptions(activeDiscordAgentId, subscriptions)}
+        surface={surface}
       />
     )
   ) : discordConnectionsOpen ? (
@@ -457,6 +448,7 @@ export function PipedreamAppsModal({
         setActiveDiscordAgentId(agent.id)
         setStatusMessage(null)
       }}
+      surface={surface}
     />
   ) : activeApp ? (
     <AppConnectionsScreen
@@ -475,6 +467,7 @@ export function PipedreamAppsModal({
       }}
       onConnect={(agent) => connectMutation.mutate({ agent, app: activeApp })}
       onDisconnect={(agent) => disconnectMutation.mutate({ agent, app: activeApp })}
+      surface={surface}
     />
   ) : (
     <AppListScreen
@@ -517,6 +510,7 @@ export function PipedreamAppsModal({
         }
       }}
       onNativePicker={(provider) => nativePickerMutation.mutate(provider)}
+      surface={surface}
     />
   )
 
@@ -559,21 +553,7 @@ export function PipedreamAppsModal({
 
   return (
     <>
-      <PipedreamModalShell
-        title={activeDiscordAgentId ? 'Configure Discord' : discordConnectionsOpen || activeApp ? 'Manage connections' : 'Manage integrations'}
-        subtitle={
-          activeDiscordAgentId
-            ? `Choose Discord channels for ${activeDiscordAgent?.name ?? 'this agent'}.`
-            : discordConnectionsOpen
-              ? 'Configure Discord for each agent.'
-              : activeApp
-                ? `${activeApp.name} connections across agents.`
-                : 'Search apps and manage agent connections.'
-        }
-        onClose={onClose}
-      >
-        {body}
-      </PipedreamModalShell>
+      {body}
       {credentialModal}
     </>
   )
@@ -599,6 +579,7 @@ function AppListScreen({
   onNativeDisconnect,
   onDiscordDisconnect,
   onNativePicker,
+  surface,
 }: {
   apps: WorkspaceAppRow[]
   searchTerm: string
@@ -619,25 +600,27 @@ function AppListScreen({
   onNativeDisconnect: (provider: NativeIntegrationProvider) => void
   onDiscordDisconnect: (provider: NativeIntegrationProvider) => void
   onNativePicker: (provider: NativeIntegrationProvider) => void
+  surface: SettingsSurfaceVariant
 }) {
   return (
     <div className="space-y-4 p-1">
-      <PipedreamStatusBanner statusMessage={statusMessage} />
+      <PipedreamStatusBanner statusMessage={statusMessage} surface={surface} />
       <PipedreamSearchInput
         value={searchTerm}
         onChange={onSearchTermChange}
         isFetching={isFetching}
         disabled={isBusy}
+        surface={surface}
       />
 
       {isError ? (
-        <PipedreamErrorState error={error} fallback="Unable to load apps." />
+        <PipedreamErrorState error={error} fallback="Unable to load apps." surface={surface} />
       ) : isLoading ? (
-        <PipedreamLoadingState label="Loading apps…" />
+        <PipedreamLoadingState label="Loading apps…" surface={surface} />
       ) : apps.length === 0 ? (
-        <PipedreamEmptyState label="No apps matched your search." />
+        <PipedreamEmptyState label="No apps matched your search." surface={surface} />
       ) : (
-        <PipedreamListFrame isMobile={isMobile}>
+        <PipedreamListFrame isMobile={isMobile} constrainHeight={false} surface={surface}>
           {apps.map((app) => app.kind === 'native' ? (
             <NativeAppRowItem
               key={`native-${app.providerKey}`}
@@ -647,6 +630,7 @@ function AppListScreen({
               onConnect={() => onNativeConnect(app)}
               onDisconnect={() => onNativeDisconnect(app)}
               onPicker={() => onNativePicker(app)}
+              surface={surface}
             />
           ) : app.kind === 'discord' ? (
             <WorkspaceDiscordAppRowItem
@@ -656,6 +640,7 @@ function AppListScreen({
               disabled={isBusy}
               onManageConnections={onManageDiscordConnections}
               onDisconnect={() => onDiscordDisconnect(app)}
+              surface={surface}
             />
           ) : (
             <PipedreamAppRowItem
@@ -665,6 +650,7 @@ function AppListScreen({
               disabled={isBusy}
               onManageConnections={() => onManageConnections(app)}
               onRemove={() => onRemove(app)}
+              surface={surface}
             />
           ))}
         </PipedreamListFrame>
@@ -679,34 +665,42 @@ function WorkspaceDiscordAppRowItem({
   disabled,
   onManageConnections,
   onDisconnect,
+  surface,
 }: {
   provider: NativeIntegrationProvider
   pendingNativeAction: PendingNativeAction
   disabled: boolean
   onManageConnections: () => void
   onDisconnect: () => void
+  surface: SettingsSurfaceVariant
 }) {
   const isPendingDisconnect = pendingNativeAction?.providerKey === provider.providerKey && pendingNativeAction.kind === 'disconnect'
+  const manageClassName = surface === 'embedded'
+    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
+    : 'bg-blue-600 text-white hover:bg-blue-700'
+  const disconnectClassName = surface === 'embedded'
+    ? 'border-rose-300/25 bg-rose-950/20 text-rose-200 hover:border-rose-200/40 hover:bg-rose-900/35'
+    : 'border-red-200 bg-white text-red-700 hover:bg-red-50'
 
   return (
     <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_12rem_8rem] md:items-center">
-      <NativeIntegrationSummaryCell provider={provider} />
+      <NativeIntegrationSummaryCell provider={provider} surface={surface} />
       <div className="flex justify-start md:justify-end">
         <button
           type="button"
-          className="inline-flex min-w-44 items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+          className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${manageClassName}`}
           onClick={onManageConnections}
           disabled={disabled}
         >
           <Users className="h-4 w-4" aria-hidden="true" />
-          Manage Connections
+          Manage
         </button>
       </div>
       <div className="flex justify-start md:justify-end">
         {provider.connected ? (
           <button
             type="button"
-            className="inline-flex min-w-28 items-center justify-center gap-2 rounded-md border border-red-200 bg-white px-3 py-2 text-sm font-semibold text-red-700 transition hover:bg-red-50 disabled:opacity-60"
+            className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${disconnectClassName}`}
             onClick={onDisconnect}
             disabled={disabled}
           >
@@ -730,6 +724,7 @@ function NativeAppRowItem({
   onConnect,
   onDisconnect,
   onPicker,
+  surface,
 }: {
   provider: NativeIntegrationProvider
   pendingNativeAction: PendingNativeAction
@@ -737,6 +732,7 @@ function NativeAppRowItem({
   onConnect: () => void
   onDisconnect: () => void
   onPicker: () => void
+  surface: SettingsSurfaceVariant
 }) {
   const isPending = pendingNativeAction?.providerKey === provider.providerKey
   const pendingKind = isPending ? pendingNativeAction?.kind : null
@@ -750,6 +746,7 @@ function NativeAppRowItem({
       onDisconnect={onDisconnect}
       onPicker={onPicker}
       gridClassName="grid gap-3 sm:grid-cols-[minmax(0,1fr)_8rem_8rem_8rem] sm:items-start"
+      surface={surface}
     />
   )
 }
@@ -760,12 +757,14 @@ function PipedreamAppRowItem({
   disabled,
   onManageConnections,
   onRemove,
+  surface,
 }: {
   app: WorkspacePipedreamAppRow
   pendingAppAction: PendingAppAction
   disabled: boolean
   onManageConnections: () => void
   onRemove: () => void
+  surface: SettingsSurfaceVariant
 }) {
   const isPendingRemove = pendingAppAction?.slug === app.slug && pendingAppAction.kind === 'remove'
   const removeDisabled = disabled || app.source !== 'added'
@@ -774,19 +773,22 @@ function PipedreamAppRowItem({
     : app.source === 'available'
       ? 'Add this app before removing it'
       : 'Remove app'
+  const manageClassName = surface === 'embedded'
+    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
+    : 'bg-blue-600 text-white hover:bg-blue-700'
 
   return (
-    <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_12rem_7rem] md:items-center">
-      <PipedreamAppSummaryCell app={app} />
+    <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_12rem_8rem] md:items-center">
+      <PipedreamAppSummaryCell app={app} surface={surface} />
       <div className="flex justify-start md:justify-end">
         <button
           type="button"
-          className="inline-flex min-w-44 items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+          className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${manageClassName}`}
           onClick={onManageConnections}
           disabled={disabled}
         >
           <Users className="h-4 w-4" aria-hidden="true" />
-          Manage Connections
+          Manage
         </button>
       </div>
       <div className="flex justify-start md:justify-end">
@@ -795,6 +797,7 @@ function PipedreamAppRowItem({
           disabled={removeDisabled}
           title={removeTitle}
           onClick={onRemove}
+          surface={surface}
         />
       </div>
     </div>
@@ -814,6 +817,7 @@ function AppConnectionsScreen({
   onBack,
   onConnect,
   onDisconnect,
+  surface,
 }: {
   app: WorkspacePipedreamAppRow
   agents: PipedreamAppAgentConnection[]
@@ -827,50 +831,44 @@ function AppConnectionsScreen({
   onBack: () => void
   onConnect: (agent: PipedreamAppAgentConnection) => void
   onDisconnect: (agent: PipedreamAppAgentConnection) => void
+  surface: SettingsSurfaceVariant
 }) {
+  const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
+  const descriptionClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-600'
   return (
     <div className="space-y-4 p-1">
-      <button
-        type="button"
-        className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:opacity-60"
-        onClick={onBack}
-        disabled={isBusy}
-      >
-        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-        Back
-      </button>
+      <BackButton onClick={onBack} disabled={isBusy} surface={surface} />
 
       <div className="flex items-center gap-3">
-        <PipedreamAppIcon app={app} />
+        <PipedreamAppIcon app={app} surface={surface} />
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-slate-900">{app.name}</p>
-          <p className="text-sm text-slate-600">{isFetching ? 'Refreshing connections…' : 'Connected agents are shown first.'}</p>
+          <p className={`truncate text-sm font-semibold ${titleClassName}`}>{app.name}</p>
+          <p className={`text-sm ${descriptionClassName}`}>{isFetching ? 'Refreshing connections…' : 'Connected agents are shown first.'}</p>
         </div>
       </div>
 
-      <PipedreamStatusBanner statusMessage={statusMessage} />
+      <PipedreamStatusBanner statusMessage={statusMessage} surface={surface} />
 
       {isError ? (
-        <PipedreamErrorState error={error} fallback="Unable to load agent connections." />
+        <PipedreamErrorState error={error} fallback="Unable to load agent connections." surface={surface} />
       ) : isLoading ? (
-        <PipedreamLoadingState label="Loading agents…" />
+        <PipedreamLoadingState label="Loading agents…" surface={surface} />
       ) : agents.length === 0 ? (
-        <PipedreamEmptyState label="No agents found." />
+        <PipedreamEmptyState label="No agents found." surface={surface} />
       ) : (
-        <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
-          <div className="divide-y divide-slate-200">
-            {agents.map((agent) => (
-              <AgentConnectionRow
-                key={agent.agentId}
-                agent={agent}
-                pendingAgentAction={pendingAgentAction}
-                disabled={isBusy}
-                onConnect={() => onConnect(agent)}
-                onDisconnect={() => onDisconnect(agent)}
-              />
-            ))}
-          </div>
-        </div>
+        <PipedreamListFrame isMobile={false} constrainHeight={false} surface={surface}>
+          {agents.map((agent) => (
+            <AgentConnectionRow
+              key={agent.agentId}
+              agent={agent}
+              pendingAgentAction={pendingAgentAction}
+              disabled={isBusy}
+              onConnect={() => onConnect(agent)}
+              onDisconnect={() => onDisconnect(agent)}
+              surface={surface}
+            />
+          ))}
+        </PipedreamListFrame>
       )}
     </div>
   )
@@ -882,12 +880,14 @@ function AgentConnectionRow({
   disabled,
   onConnect,
   onDisconnect,
+  surface,
 }: {
   agent: PipedreamAppAgentConnection
   pendingAgentAction: PendingAgentAction
   disabled: boolean
   onConnect: () => void
   onDisconnect: () => void
+  surface: SettingsSurfaceVariant
 }) {
   const isPending = pendingAgentAction?.agentId === agent.agentId
   const pendingKind = isPending ? pendingAgentAction?.kind : null
@@ -895,9 +895,9 @@ function AgentConnectionRow({
   return (
     <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_8rem] md:items-center">
       <div className="flex min-w-0 items-center gap-3">
-        <AgentConnectionAvatar agent={agent} />
+        <AgentConnectionAvatar agent={agent} surface={surface} />
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-slate-900">{agent.name}</p>
+          <p className={`truncate text-sm font-semibold ${surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'}`}>{agent.name}</p>
         </div>
       </div>
       <div className="flex justify-start md:justify-end">
@@ -907,6 +907,7 @@ function AgentConnectionRow({
           disabled={disabled}
           onConnect={onConnect}
           onDisconnect={onDisconnect}
+          surface={surface}
         />
       </div>
     </div>

--- a/frontend/src/components/mcp/WorkspaceAppsManager.tsx
+++ b/frontend/src/components/mcp/WorkspaceAppsManager.tsx
@@ -684,7 +684,12 @@ function WorkspaceDiscordAppRowItem({
 
   return (
     <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_12rem_8rem] md:items-center">
-      <NativeIntegrationSummaryCell provider={provider} surface={surface} />
+      <NativeIntegrationSummaryCell
+        provider={provider}
+        showNativeBadge={false}
+        showConnectedBadge
+        surface={surface}
+      />
       <div className="flex justify-start md:justify-end">
         <button
           type="button"
@@ -745,7 +750,10 @@ function NativeAppRowItem({
       onConnect={onConnect}
       onDisconnect={onDisconnect}
       onPicker={onPicker}
-      gridClassName="grid gap-3 sm:grid-cols-[minmax(0,1fr)_8rem_8rem_8rem] sm:items-start"
+      gridClassName="grid gap-3 sm:grid-cols-[minmax(0,1fr)_8rem_8rem] sm:items-start"
+      showStatusColumn={false}
+      showNativeBadge={false}
+      showConnectedBadge
       surface={surface}
     />
   )

--- a/frontend/src/components/mcp/WorkspaceAppsManager.tsx
+++ b/frontend/src/components/mcp/WorkspaceAppsManager.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Loader2, Unplug, Users } from 'lucide-react'
 
 import { agentDiscordAppQueryKey, fetchAgentDiscordApp } from '../../api/discordNative'
 import { fetchAgentRoster } from '../../api/agents'
 import {
   disconnectAgentPipedreamApp,
   fetchPipedreamAppAgentConnections,
+  fetchPipedreamAppSettings,
   searchPipedreamApps,
   startAgentPipedreamAppConnect,
   updatePipedreamAppSettings,
@@ -16,13 +16,13 @@ import {
   type PipedreamAppSummary,
 } from '../../api/mcp'
 import { fetchNativeIntegrations, type NativeIntegrationProvider } from '../../api/nativeIntegrations'
-import type { SettingsSurfaceVariant } from '../common/SettingsSurface'
+import { useSettingsSurfaceVariant } from '../common/SettingsSurface'
 import { DISCORD_NATIVE_PROVIDER_KEY, withDiscordNativeProvider } from './DiscordNativeShared'
+import { IntegrationConnectionButton, IntegrationManageButton } from './IntegrationActionButtons'
 import {
   AgentConnectionAvatar,
   PipedreamAppIcon,
   PipedreamAppSummaryCell,
-  PipedreamConnectionButton,
   PipedreamEmptyState,
   PipedreamErrorState,
   PipedreamListFrame,
@@ -64,9 +64,7 @@ type WorkspaceAppsManagerProps = {
   nativeIntegrationsUrl?: string | null
   initialNativeProviderKey?: string | null
   initialNativeConnect?: boolean
-  initialSettings: PipedreamAppSettings
   onError: (message: string) => void
-  surface?: SettingsSurfaceVariant
 }
 
 type WorkspacePipedreamAppRow = PipedreamAppSummary & {
@@ -93,22 +91,33 @@ type PendingAgentAction = {
   kind: 'connect' | 'disconnect'
 } | null
 
+const EMPTY_SETTINGS: PipedreamAppSettings = {
+  ownerScope: '',
+  ownerLabel: '',
+  platformApps: [],
+  selectedApps: [],
+  effectiveApps: [],
+}
+
 export function WorkspaceAppsManager({
   settingsUrl,
   searchUrl,
   nativeIntegrationsUrl = null,
   initialNativeProviderKey = null,
   initialNativeConnect = false,
-  initialSettings,
   onError,
-  surface = 'standalone',
 }: WorkspaceAppsManagerProps) {
   const queryClient = useQueryClient()
   const settingsQueryKey = useMemo(() => ['pipedream-app-settings', settingsUrl] as const, [settingsUrl])
+  const settingsQuery = useQuery({
+    queryKey: settingsQueryKey,
+    queryFn: () => fetchPipedreamAppSettings(settingsUrl as string),
+    enabled: Boolean(settingsUrl && searchUrl),
+  })
+  const settings = settingsQuery.data ?? EMPTY_SETTINGS
   const isMobile = useIsMobile()
   const [searchTerm, setSearchTerm] = useState('')
   const debouncedSearchTerm = useDebouncedValue(searchTerm)
-  const [settings, setSettings] = useState(initialSettings)
   const [activeApp, setActiveApp] = useState<WorkspacePipedreamAppRow | null>(null)
   const [discordConnectionsOpen, setDiscordConnectionsOpen] = useState(false)
   const [activeDiscordAgentId, setActiveDiscordAgentId] = useState<string | null>(null)
@@ -139,10 +148,6 @@ export function WorkspaceAppsManager({
     onStart: () => setStatusMessage(null),
     onError: handleDiscordError,
   })
-
-  useEffect(() => {
-    setSettings(initialSettings)
-  }, [initialSettings])
 
   useEffect(() => {
     setActiveApp(null)
@@ -260,7 +265,6 @@ export function WorkspaceAppsManager({
       setStatusMessage(null)
     },
     onSuccess: (updatedSettings) => {
-      setSettings(updatedSettings)
       queryClient.setQueryData(settingsQueryKey, updatedSettings)
     },
     onError: (error) => {
@@ -280,7 +284,7 @@ export function WorkspaceAppsManager({
     },
     onSuccess: (result, { app }) => {
       window.open(result.connectUrl, '_blank', 'noopener,noreferrer')
-      setSettings((current) => {
+      queryClient.setQueryData<PipedreamAppSettings>(settingsQueryKey, (current = EMPTY_SETTINGS) => {
         if (current.selectedApps.some((selectedApp) => selectedApp.slug === result.app.slug)) {
           return current
         }
@@ -393,26 +397,24 @@ export function WorkspaceAppsManager({
     activeDiscordAppQuery.isError ? (
       <div className="space-y-4 p-1">
         <BackButton
-          surface={surface}
           onClick={() => {
             setActiveDiscordAgentId(null)
             setStatusMessage(null)
           }}
           disabled={isBusy}
         />
-        <PipedreamErrorState error={activeDiscordAppQuery.error} fallback="Unable to load Discord configuration." surface={surface} />
+        <PipedreamErrorState error={activeDiscordAppQuery.error} fallback="Unable to load Discord configuration." />
       </div>
     ) : activeDiscordAppQuery.isLoading || !activeDiscordAppQuery.data ? (
       <div className="space-y-4 p-1">
         <BackButton
-          surface={surface}
           onClick={() => {
             setActiveDiscordAgentId(null)
             setStatusMessage(null)
           }}
           disabled={isBusy}
         />
-        <PipedreamLoadingState label="Loading Discord configuration…" surface={surface} />
+        <PipedreamLoadingState label="Loading Discord configuration…" />
       </div>
     ) : (
       <DiscordConfigurationScreen
@@ -426,7 +428,6 @@ export function WorkspaceAppsManager({
           setStatusMessage(null)
         }}
         onSave={(subscriptions) => saveDiscordAgentSubscriptions(activeDiscordAgentId, subscriptions)}
-        surface={surface}
       />
     )
   ) : discordConnectionsOpen ? (
@@ -448,7 +449,6 @@ export function WorkspaceAppsManager({
         setActiveDiscordAgentId(agent.id)
         setStatusMessage(null)
       }}
-      surface={surface}
     />
   ) : activeApp ? (
     <AppConnectionsScreen
@@ -467,16 +467,15 @@ export function WorkspaceAppsManager({
       }}
       onConnect={(agent) => connectMutation.mutate({ agent, app: activeApp })}
       onDisconnect={(agent) => disconnectMutation.mutate({ agent, app: activeApp })}
-      surface={surface}
     />
   ) : (
     <AppListScreen
       apps={rows}
       searchTerm={searchTerm}
-      isLoading={searchQuery.isLoading || nativeIntegrationsQuery.isLoading || agentRosterQuery.isLoading}
+      isLoading={settingsQuery.isLoading || searchQuery.isLoading || nativeIntegrationsQuery.isLoading || agentRosterQuery.isLoading}
       isFetching={searchQuery.isFetching || nativeIntegrationsQuery.isFetching || agentRosterQuery.isFetching}
-      isError={searchQuery.isError || nativeIntegrationsQuery.isError || agentRosterQuery.isError}
-      error={searchQuery.error ?? nativeIntegrationsQuery.error ?? agentRosterQuery.error}
+      isError={settingsQuery.isError || searchQuery.isError || nativeIntegrationsQuery.isError || agentRosterQuery.isError}
+      error={settingsQuery.error ?? searchQuery.error ?? nativeIntegrationsQuery.error ?? agentRosterQuery.error}
       isBusy={isBusy}
       isMobile={isMobile}
       pendingAppAction={pendingAppAction}
@@ -510,7 +509,6 @@ export function WorkspaceAppsManager({
         }
       }}
       onNativePicker={(provider) => nativePickerMutation.mutate(provider)}
-      surface={surface}
     />
   )
 
@@ -579,7 +577,6 @@ function AppListScreen({
   onNativeDisconnect,
   onDiscordDisconnect,
   onNativePicker,
-  surface,
 }: {
   apps: WorkspaceAppRow[]
   searchTerm: string
@@ -600,27 +597,25 @@ function AppListScreen({
   onNativeDisconnect: (provider: NativeIntegrationProvider) => void
   onDiscordDisconnect: (provider: NativeIntegrationProvider) => void
   onNativePicker: (provider: NativeIntegrationProvider) => void
-  surface: SettingsSurfaceVariant
 }) {
   return (
     <div className="space-y-4 p-1">
-      <PipedreamStatusBanner statusMessage={statusMessage} surface={surface} />
+      <PipedreamStatusBanner statusMessage={statusMessage} />
       <PipedreamSearchInput
         value={searchTerm}
         onChange={onSearchTermChange}
         isFetching={isFetching}
         disabled={isBusy}
-        surface={surface}
       />
 
       {isError ? (
-        <PipedreamErrorState error={error} fallback="Unable to load apps." surface={surface} />
+        <PipedreamErrorState error={error} fallback="Unable to load apps." />
       ) : isLoading ? (
-        <PipedreamLoadingState label="Loading apps…" surface={surface} />
+        <PipedreamLoadingState label="Loading apps…" />
       ) : apps.length === 0 ? (
-        <PipedreamEmptyState label="No apps matched your search." surface={surface} />
+        <PipedreamEmptyState label="No apps matched your search." />
       ) : (
-        <PipedreamListFrame isMobile={isMobile} constrainHeight={false} surface={surface}>
+        <PipedreamListFrame isMobile={isMobile} constrainHeight={false}>
           {apps.map((app) => app.kind === 'native' ? (
             <NativeAppRowItem
               key={`native-${app.providerKey}`}
@@ -630,7 +625,6 @@ function AppListScreen({
               onConnect={() => onNativeConnect(app)}
               onDisconnect={() => onNativeDisconnect(app)}
               onPicker={() => onNativePicker(app)}
-              surface={surface}
             />
           ) : app.kind === 'discord' ? (
             <WorkspaceDiscordAppRowItem
@@ -640,7 +634,6 @@ function AppListScreen({
               disabled={isBusy}
               onManageConnections={onManageDiscordConnections}
               onDisconnect={() => onDiscordDisconnect(app)}
-              surface={surface}
             />
           ) : (
             <PipedreamAppRowItem
@@ -650,7 +643,6 @@ function AppListScreen({
               disabled={isBusy}
               onManageConnections={() => onManageConnections(app)}
               onRemove={() => onRemove(app)}
-              surface={surface}
             />
           ))}
         </PipedreamListFrame>
@@ -665,57 +657,32 @@ function WorkspaceDiscordAppRowItem({
   disabled,
   onManageConnections,
   onDisconnect,
-  surface,
 }: {
   provider: NativeIntegrationProvider
   pendingNativeAction: PendingNativeAction
   disabled: boolean
   onManageConnections: () => void
   onDisconnect: () => void
-  surface: SettingsSurfaceVariant
 }) {
   const isPendingDisconnect = pendingNativeAction?.providerKey === provider.providerKey && pendingNativeAction.kind === 'disconnect'
-  const manageClassName = surface === 'embedded'
-    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
-    : 'bg-blue-600 text-white hover:bg-blue-700'
-  const disconnectClassName = surface === 'embedded'
-    ? 'border-rose-300/25 bg-rose-950/20 text-rose-200 hover:border-rose-200/40 hover:bg-rose-900/35'
-    : 'border-red-200 bg-white text-red-700 hover:bg-red-50'
 
   return (
     <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_12rem_8rem] md:items-center">
       <NativeIntegrationSummaryCell
         provider={provider}
-        showNativeBadge={false}
-        showConnectedBadge
-        surface={surface}
+        badge="connected"
       />
       <div className="flex justify-start md:justify-end">
-        <button
-          type="button"
-          className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${manageClassName}`}
-          onClick={onManageConnections}
-          disabled={disabled}
-        >
-          <Users className="h-4 w-4" aria-hidden="true" />
-          Manage
-        </button>
+        <IntegrationManageButton onClick={onManageConnections} disabled={disabled} />
       </div>
       <div className="flex justify-start md:justify-end">
         {provider.connected ? (
-          <button
-            type="button"
-            className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${disconnectClassName}`}
-            onClick={onDisconnect}
+          <IntegrationConnectionButton
+            connected
+            pendingKind={isPendingDisconnect ? 'disconnect' : null}
             disabled={disabled}
-          >
-            {isPendingDisconnect ? (
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-            ) : (
-              <Unplug className="h-4 w-4" aria-hidden="true" />
-            )}
-            Disconnect
-          </button>
+            onDisconnect={onDisconnect}
+          />
         ) : null}
       </div>
     </div>
@@ -729,7 +696,6 @@ function NativeAppRowItem({
   onConnect,
   onDisconnect,
   onPicker,
-  surface,
 }: {
   provider: NativeIntegrationProvider
   pendingNativeAction: PendingNativeAction
@@ -737,7 +703,6 @@ function NativeAppRowItem({
   onConnect: () => void
   onDisconnect: () => void
   onPicker: () => void
-  surface: SettingsSurfaceVariant
 }) {
   const isPending = pendingNativeAction?.providerKey === provider.providerKey
   const pendingKind = isPending ? pendingNativeAction?.kind : null
@@ -750,11 +715,7 @@ function NativeAppRowItem({
       onConnect={onConnect}
       onDisconnect={onDisconnect}
       onPicker={onPicker}
-      gridClassName="grid gap-3 sm:grid-cols-[minmax(0,1fr)_8rem_8rem] sm:items-start"
-      showStatusColumn={false}
-      showNativeBadge={false}
-      showConnectedBadge
-      surface={surface}
+      variant="workspace"
     />
   )
 }
@@ -765,14 +726,12 @@ function PipedreamAppRowItem({
   disabled,
   onManageConnections,
   onRemove,
-  surface,
 }: {
   app: WorkspacePipedreamAppRow
   pendingAppAction: PendingAppAction
   disabled: boolean
   onManageConnections: () => void
   onRemove: () => void
-  surface: SettingsSurfaceVariant
 }) {
   const isPendingRemove = pendingAppAction?.slug === app.slug && pendingAppAction.kind === 'remove'
   const removeDisabled = disabled || app.source !== 'added'
@@ -781,23 +740,11 @@ function PipedreamAppRowItem({
     : app.source === 'available'
       ? 'Add this app before removing it'
       : 'Remove app'
-  const manageClassName = surface === 'embedded'
-    ? 'border border-sky-300/25 bg-sky-900/55 text-sky-50 hover:border-sky-200/40 hover:bg-sky-900/75'
-    : 'bg-blue-600 text-white hover:bg-blue-700'
-
   return (
     <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_12rem_8rem] md:items-center">
-      <PipedreamAppSummaryCell app={app} surface={surface} />
+      <PipedreamAppSummaryCell app={app} />
       <div className="flex justify-start md:justify-end">
-        <button
-          type="button"
-          className={`inline-flex min-w-28 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${manageClassName}`}
-          onClick={onManageConnections}
-          disabled={disabled}
-        >
-          <Users className="h-4 w-4" aria-hidden="true" />
-          Manage
-        </button>
+        <IntegrationManageButton onClick={onManageConnections} disabled={disabled} />
       </div>
       <div className="flex justify-start md:justify-end">
         <PipedreamRemoveButton
@@ -805,7 +752,6 @@ function PipedreamAppRowItem({
           disabled={removeDisabled}
           title={removeTitle}
           onClick={onRemove}
-          surface={surface}
         />
       </div>
     </div>
@@ -825,7 +771,6 @@ function AppConnectionsScreen({
   onBack,
   onConnect,
   onDisconnect,
-  surface,
 }: {
   app: WorkspacePipedreamAppRow
   agents: PipedreamAppAgentConnection[]
@@ -839,32 +784,32 @@ function AppConnectionsScreen({
   onBack: () => void
   onConnect: (agent: PipedreamAppAgentConnection) => void
   onDisconnect: (agent: PipedreamAppAgentConnection) => void
-  surface: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const titleClassName = surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'
   const descriptionClassName = surface === 'embedded' ? 'text-slate-400' : 'text-slate-600'
   return (
     <div className="space-y-4 p-1">
-      <BackButton onClick={onBack} disabled={isBusy} surface={surface} />
+      <BackButton onClick={onBack} disabled={isBusy} />
 
       <div className="flex items-center gap-3">
-        <PipedreamAppIcon app={app} surface={surface} />
+        <PipedreamAppIcon app={app} />
         <div className="min-w-0">
           <p className={`truncate text-sm font-semibold ${titleClassName}`}>{app.name}</p>
           <p className={`text-sm ${descriptionClassName}`}>{isFetching ? 'Refreshing connections…' : 'Connected agents are shown first.'}</p>
         </div>
       </div>
 
-      <PipedreamStatusBanner statusMessage={statusMessage} surface={surface} />
+      <PipedreamStatusBanner statusMessage={statusMessage} />
 
       {isError ? (
-        <PipedreamErrorState error={error} fallback="Unable to load agent connections." surface={surface} />
+        <PipedreamErrorState error={error} fallback="Unable to load agent connections." />
       ) : isLoading ? (
-        <PipedreamLoadingState label="Loading agents…" surface={surface} />
+        <PipedreamLoadingState label="Loading agents…" />
       ) : agents.length === 0 ? (
-        <PipedreamEmptyState label="No agents found." surface={surface} />
+        <PipedreamEmptyState label="No agents found." />
       ) : (
-        <PipedreamListFrame isMobile={false} constrainHeight={false} surface={surface}>
+        <PipedreamListFrame isMobile={false} constrainHeight={false}>
           {agents.map((agent) => (
             <AgentConnectionRow
               key={agent.agentId}
@@ -873,7 +818,6 @@ function AppConnectionsScreen({
               disabled={isBusy}
               onConnect={() => onConnect(agent)}
               onDisconnect={() => onDisconnect(agent)}
-              surface={surface}
             />
           ))}
         </PipedreamListFrame>
@@ -888,34 +832,32 @@ function AgentConnectionRow({
   disabled,
   onConnect,
   onDisconnect,
-  surface,
 }: {
   agent: PipedreamAppAgentConnection
   pendingAgentAction: PendingAgentAction
   disabled: boolean
   onConnect: () => void
   onDisconnect: () => void
-  surface: SettingsSurfaceVariant
 }) {
+  const surface = useSettingsSurfaceVariant()
   const isPending = pendingAgentAction?.agentId === agent.agentId
   const pendingKind = isPending ? pendingAgentAction?.kind : null
 
   return (
     <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_8rem] md:items-center">
       <div className="flex min-w-0 items-center gap-3">
-        <AgentConnectionAvatar agent={agent} surface={surface} />
+        <AgentConnectionAvatar agent={agent} />
         <div className="min-w-0">
           <p className={`truncate text-sm font-semibold ${surface === 'embedded' ? 'text-slate-100' : 'text-slate-900'}`}>{agent.name}</p>
         </div>
       </div>
       <div className="flex justify-start md:justify-end">
-        <PipedreamConnectionButton
+        <IntegrationConnectionButton
           connected={agent.connected}
           pendingKind={pendingKind}
           disabled={disabled}
           onConnect={onConnect}
           onDisconnect={onDisconnect}
-          surface={surface}
         />
       </div>
     </div>

--- a/frontend/src/components/mcp/WorkspaceAppsManager.tsx
+++ b/frontend/src/components/mcp/WorkspaceAppsManager.tsx
@@ -211,22 +211,24 @@ export function WorkspaceAppsManager({
   const rows = useMemo<WorkspaceAppRow[]>(() => {
     const visibleApps = debouncedSearchTerm ? (searchQuery.data ?? []) : settings.effectiveApps
     const normalizedSearch = debouncedSearchTerm.toLowerCase()
-    const nativeRows = withDiscordNativeProvider(nativeIntegrationsQuery.data?.providers ?? [])
-      .filter((provider) => {
-        if (!normalizedSearch) {
-          return true
-        }
-        return [
-          provider.providerKey,
-          provider.displayName,
-          provider.description,
-        ].some((value) => value.toLowerCase().includes(normalizedSearch))
-      })
-      .map((provider) => ({
-        ...provider,
-        connected: provider.providerKey === DISCORD_NATIVE_PROVIDER_KEY ? discordConnected : provider.connected,
-        kind: provider.providerKey === DISCORD_NATIVE_PROVIDER_KEY ? 'discord' as const : 'native' as const,
-      }))
+    const nativeRows = nativeIntegrationsUrl
+      ? withDiscordNativeProvider(nativeIntegrationsQuery.data?.providers ?? [])
+        .filter((provider) => {
+          if (!normalizedSearch) {
+            return true
+          }
+          return [
+            provider.providerKey,
+            provider.displayName,
+            provider.description,
+          ].some((value) => value.toLowerCase().includes(normalizedSearch))
+        })
+        .map((provider) => ({
+          ...provider,
+          connected: provider.providerKey === DISCORD_NATIVE_PROVIDER_KEY ? discordConnected : provider.connected,
+          kind: provider.providerKey === DISCORD_NATIVE_PROVIDER_KEY ? 'discord' as const : 'native' as const,
+        }))
+      : []
     const pipedreamRows = visibleApps.map((app) => {
       const source: AgentPipedreamAppSource = platformSlugSet.has(app.slug)
         ? 'built_in'
@@ -243,6 +245,7 @@ export function WorkspaceAppsManager({
   }, [
     debouncedSearchTerm,
     discordConnected,
+    nativeIntegrationsUrl,
     nativeIntegrationsQuery.data?.providers,
     platformSlugSet,
     searchQuery.data,


### PR DESCRIPTION
## Summary
- Reworks the integrations apps section around shared native integration components.
- Updates homepage and MCP modals to use the new shared surface and action button structure.
- Consolidates integration UI logic across workspace apps, Pipedream apps, and native app modals.

## Testing
- Not run (not requested)