### PR TITLE
Allow organization managers to delete other members' agents

### DIFF
--- a/console/views.py
+++ b/console/views.py
@@ -109,7 +109,13 @@ from util.urls import (
     build_immersive_contact_requests_url,
     load_daily_limit_action_payload,
 )
-from console.agent_chat.access import resolve_agent_for_request, resolve_manageable_agent_for_request, user_can_manage_agent, user_is_collaborator
+from console.agent_chat.access import (
+    resolve_agent_for_request,
+    resolve_manageable_agent_for_request,
+    user_can_manage_agent,
+    user_can_manage_agent_settings,
+    user_is_collaborator,
+)
 from config import settings
 from config.stripe_config import get_stripe_settings
 from config.plans import PLAN_CONFIG
@@ -1668,9 +1674,10 @@ class AgentDeleteView(LoginRequiredMixin, View):
         try:
             agent = PersistentAgent.objects.non_eval().alive().get(
                 pk=self.kwargs['pk'],
-                user=request.user,
             )
             _enforce_personal_agent_access_or_raise(request.user, agent)
+            if not user_can_manage_agent_settings(request.user, agent):
+                raise PermissionDenied("You do not have permission to delete this agent.")
 
             agent_name = agent.name
             agent_id = str(agent.pk)
@@ -1712,7 +1719,7 @@ class AgentDeleteView(LoginRequiredMixin, View):
             return response
             
         except PersistentAgent.DoesNotExist:
-            return HttpResponse("Agent not found or you don't have permission.", status=404)
+            return HttpResponse("Agent not found.", status=404)
         except PermissionDenied:
             raise
 

--- a/console/views.py
+++ b/console/views.py
@@ -1677,6 +1677,11 @@ class AgentDeleteView(LoginRequiredMixin, View):
             )
             _enforce_personal_agent_access_or_raise(request.user, agent)
             if not user_can_manage_agent_settings(request.user, agent):
+                if not (
+                    user_can_manage_agent(request.user, agent)
+                    or user_is_collaborator(request.user, agent)
+                ):
+                    return HttpResponse("Agent not found.", status=404)
                 raise PermissionDenied("You do not have permission to delete this agent.")
 
             agent_name = agent.name

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+import uuid
 from decimal import Decimal
 from datetime import timedelta
 import shutil
@@ -2233,6 +2234,189 @@ class ConsoleViewsTest(TestCase):
         self.assertIsNone(persistent_agent.schedule)
         self.assertTrue(persistent_agent.is_deleted)
         self.assertIsNotNone(persistent_agent.deleted_at)
+
+    @tag("batch_console_agents")
+    def test_org_managers_can_delete_agents_created_by_another_member(self):
+        from api.models import (
+            BrowserUseAgent,
+            Organization,
+            OrganizationMembership,
+            PersistentAgent,
+        )
+
+        User = get_user_model()
+        creator = User.objects.create_user(
+            username="org-agent-creator@example.com",
+            email="org-agent-creator@example.com",
+            password="testpass123",
+        )
+        allowed_roles = (
+            OrganizationMembership.OrgRole.OWNER,
+            OrganizationMembership.OrgRole.ADMIN,
+            OrganizationMembership.OrgRole.SOLUTIONS_PARTNER,
+        )
+
+        for role in allowed_roles:
+            with self.subTest(role=role):
+                organization = Organization.objects.create(
+                    name=f"Delete Agent {role}",
+                    slug=f"delete-agent-{role}",
+                    created_by=creator,
+                )
+                organization.billing.purchased_seats = 2
+                organization.billing.save(update_fields=["purchased_seats"])
+                OrganizationMembership.objects.create(
+                    org=organization,
+                    user=creator,
+                    role=OrganizationMembership.OrgRole.MEMBER,
+                    status=OrganizationMembership.OrgStatus.ACTIVE,
+                )
+                OrganizationMembership.objects.create(
+                    org=organization,
+                    user=self.user,
+                    role=role,
+                    status=OrganizationMembership.OrgStatus.ACTIVE,
+                )
+                browser_agent = BrowserUseAgent.objects.create(
+                    user=creator,
+                    name=f"Delete Agent {role} Browser",
+                )
+                agent = PersistentAgent.objects.create(
+                    user=creator,
+                    organization=organization,
+                    name=f"Delete Agent {role}",
+                    charter="Test organization manager deletion",
+                    browser_use_agent=browser_agent,
+                )
+
+                response = self.client.delete(
+                    reverse("agent_delete", kwargs={"pk": agent.id}),
+                    HTTP_X_GOBII_CONTEXT_TYPE="organization",
+                    HTTP_X_GOBII_CONTEXT_ID=str(organization.id),
+                )
+
+                self.assertEqual(response.status_code, 200)
+                agent.refresh_from_db()
+                self.assertTrue(agent.is_deleted)
+                self.assertEqual(agent.life_state, PersistentAgent.LifeState.EXPIRED)
+
+    @tag("batch_console_agents")
+    def test_org_non_managers_cannot_delete_agent_created_by_another_member(self):
+        from api.models import (
+            BrowserUseAgent,
+            Organization,
+            OrganizationMembership,
+            PersistentAgent,
+        )
+
+        User = get_user_model()
+        creator = User.objects.create_user(
+            username="protected-org-agent-creator@example.com",
+            email="protected-org-agent-creator@example.com",
+            password="testpass123",
+        )
+        denied_roles = (
+            OrganizationMembership.OrgRole.BILLING,
+            OrganizationMembership.OrgRole.MEMBER,
+            OrganizationMembership.OrgRole.VIEWER,
+        )
+
+        for role in denied_roles:
+            with self.subTest(role=role):
+                organization = Organization.objects.create(
+                    name=f"Protected Delete Agent {role}",
+                    slug=f"protected-delete-agent-{role}",
+                    created_by=creator,
+                )
+                organization.billing.purchased_seats = 2
+                organization.billing.save(update_fields=["purchased_seats"])
+                OrganizationMembership.objects.create(
+                    org=organization,
+                    user=creator,
+                    role=OrganizationMembership.OrgRole.OWNER,
+                    status=OrganizationMembership.OrgStatus.ACTIVE,
+                )
+                OrganizationMembership.objects.create(
+                    org=organization,
+                    user=self.user,
+                    role=role,
+                    status=OrganizationMembership.OrgStatus.ACTIVE,
+                )
+                browser_agent = BrowserUseAgent.objects.create(
+                    user=creator,
+                    name=f"Protected Delete Agent {role} Browser",
+                )
+                agent = PersistentAgent.objects.create(
+                    user=creator,
+                    organization=organization,
+                    name=f"Protected Delete Agent {role}",
+                    charter="Test organization member deletion denial",
+                    browser_use_agent=browser_agent,
+                )
+
+                response = self.client.delete(
+                    reverse("agent_delete", kwargs={"pk": agent.id}),
+                    HTTP_X_GOBII_CONTEXT_TYPE="organization",
+                    HTTP_X_GOBII_CONTEXT_ID=str(organization.id),
+                )
+
+                self.assertEqual(response.status_code, 403)
+                agent.refresh_from_db()
+                self.assertFalse(agent.is_deleted)
+                self.assertEqual(agent.life_state, PersistentAgent.LifeState.ACTIVE)
+
+    @tag("batch_console_agents")
+    def test_org_agent_creator_can_delete_without_manager_role(self):
+        from api.models import (
+            BrowserUseAgent,
+            Organization,
+            OrganizationMembership,
+            PersistentAgent,
+        )
+
+        organization = Organization.objects.create(
+            name="Creator Delete Agent Org",
+            slug="creator-delete-agent-org",
+            created_by=self.user,
+        )
+        organization.billing.purchased_seats = 1
+        organization.billing.save(update_fields=["purchased_seats"])
+        OrganizationMembership.objects.create(
+            org=organization,
+            user=self.user,
+            role=OrganizationMembership.OrgRole.MEMBER,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+        browser_agent = BrowserUseAgent.objects.create(
+            user=self.user,
+            name="Creator Delete Agent Browser",
+        )
+        agent = PersistentAgent.objects.create(
+            user=self.user,
+            organization=organization,
+            name="Creator Delete Agent",
+            charter="Test creator deletion",
+            browser_use_agent=browser_agent,
+        )
+
+        response = self.client.delete(
+            reverse("agent_delete", kwargs={"pk": agent.id}),
+            HTTP_X_GOBII_CONTEXT_TYPE="organization",
+            HTTP_X_GOBII_CONTEXT_ID=str(organization.id),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        agent.refresh_from_db()
+        self.assertTrue(agent.is_deleted)
+
+    @tag("batch_console_agents")
+    def test_delete_missing_agent_returns_not_found(self):
+        response = self.client.delete(
+            reverse("agent_delete", kwargs={"pk": uuid.uuid4()}),
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.content, b"Agent not found.")
 
     @tag("batch_console_agents")
     def test_delete_persistent_agent_handles_missing_browser_agent(self):

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -2419,6 +2419,68 @@ class ConsoleViewsTest(TestCase):
         self.assertEqual(response.content, b"Agent not found.")
 
     @tag("batch_console_agents")
+    def test_delete_agent_outside_user_visibility_returns_not_found(self):
+        from api.models import (
+            BrowserUseAgent,
+            Organization,
+            OrganizationMembership,
+            PersistentAgent,
+        )
+
+        User = get_user_model()
+        other_user = User.objects.create_user(
+            username="other-user-private@example.com",
+            email="other-user-private@example.com",
+            password="testpass123",
+        )
+        personal_browser_agent = BrowserUseAgent.objects.create(
+            user=other_user,
+            name="Other User Private Browser",
+        )
+        personal_agent = PersistentAgent.objects.create(
+            user=other_user,
+            name="Other User Private Agent",
+            charter="Private agent",
+            browser_use_agent=personal_browser_agent,
+        )
+
+        organization = Organization.objects.create(
+            name="Other User Private Org",
+            slug="other-user-private-org",
+            created_by=other_user,
+        )
+        organization.billing.purchased_seats = 1
+        organization.billing.save(update_fields=["purchased_seats"])
+        OrganizationMembership.objects.create(
+            org=organization,
+            user=other_user,
+            role=OrganizationMembership.OrgRole.OWNER,
+            status=OrganizationMembership.OrgStatus.ACTIVE,
+        )
+        org_browser_agent = BrowserUseAgent.objects.create(
+            user=other_user,
+            name="Other Org Private Browser",
+        )
+        org_agent = PersistentAgent.objects.create(
+            user=other_user,
+            organization=organization,
+            name="Other Org Private Agent",
+            charter="Private organization agent",
+            browser_use_agent=org_browser_agent,
+        )
+
+        for agent in (personal_agent, org_agent):
+            with self.subTest(agent=agent.name):
+                response = self.client.delete(
+                    reverse("agent_delete", kwargs={"pk": agent.id}),
+                )
+
+                self.assertEqual(response.status_code, 404)
+                self.assertEqual(response.content, b"Agent not found.")
+                agent.refresh_from_db()
+                self.assertFalse(agent.is_deleted)
+
+    @tag("batch_console_agents")
     def test_delete_persistent_agent_handles_missing_browser_agent(self):
         """Deletion should succeed even if BrowserUseAgent queries fail."""
         from api.models import PersistentAgent, BrowserUseAgent


### PR DESCRIPTION
## Summary
- Allow org managers with agent settings access to delete agents created by other members
- Keep creator deletion allowed even without a manager role
- Return a plain 404 for missing agents instead of exposing permission details
- Add unit coverage for allowed, denied, creator-owned, and missing-agent delete cases

## Testing
- Added targeted unit tests for organization deletion permissions and not-found behavior
- Not run (not requested)