### PR TITLE
Close exhausted agent cycles before queuing follow-up runs

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -884,7 +884,8 @@ def _schedule_agent_follow_up(
     try:
         from ..tasks.process_events import process_agent_events_task  # noqa: WPS433 (runtime import)
 
-        process_agent_events_task.apply_async(args=[str(agent_id)], countdown=delay_seconds, queue=queue)
+        queue_option = {} if queue is None else {"queue": queue}
+        process_agent_events_task.apply_async(args=[str(agent_id)], countdown=delay_seconds, **queue_option)
         if span is not None:
             span.add_event(f"{reason} follow-up scheduled")
     except Exception:
@@ -6492,9 +6493,7 @@ def _run_agent_loop(
                     AgentBudgetManager.close_cycle(agent_id=budget_ctx.agent_id, budget_id=budget_ctx.budget_id)
             except RedisError:
                 budget_exhausted = False
-                logger.warning(
-                    "Budget cycle %s cleanup failed for agent %s", budget_ctx.budget_id, agent.id, exc_info=True
-                )
+                logger.warning("Agent %s budget %s cleanup failed", agent.id, budget_ctx.budget_id, exc_info=True)
             _schedule_agent_follow_up(
                 agent_id=agent.id,
                 delay_seconds=delay_seconds,

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -883,13 +883,9 @@ def _schedule_agent_follow_up(
     try:
         from ..tasks.process_events import process_agent_events_task  # noqa: WPS433 (runtime import)
 
-        apply_async_kwargs = {
-            "args": [str(agent_id)],
-            "countdown": delay_seconds,
-        }
-        if queue is not None:
-            apply_async_kwargs["queue"] = queue
-        process_agent_events_task.apply_async(**apply_async_kwargs)
+        process_agent_events_task.apply_async(
+            args=[str(agent_id)], countdown=delay_seconds, queue=queue
+        )
         if span is not None:
             span.add_event(f"{reason} follow-up scheduled")
     except Exception:
@@ -3299,31 +3295,6 @@ def _attempt_cycle_close_for_sleep(agent: PersistentAgent, budget_ctx: Optional[
         )
     except Exception:
         logger.debug("Failed to close budget cycle on sleep", exc_info=True)
-
-
-def _close_exhausted_cycle_before_follow_up(
-    agent: PersistentAgent,
-    budget_ctx: Optional[BudgetContext],
-) -> bool:
-    """Close a spent cycle before its top-level follow-up is queued."""
-
-    if budget_ctx is None:
-        return False
-
-    steps_used = AgentBudgetManager.get_steps_used(agent_id=budget_ctx.agent_id)
-    if steps_used < budget_ctx.max_steps:
-        return False
-
-    AgentBudgetManager.close_cycle(
-        agent_id=budget_ctx.agent_id,
-        budget_id=budget_ctx.budget_id,
-    )
-    logger.info(
-        "Agent %s exhausted budget cycle %s; closed it before scheduling follow-up.",
-        agent.id,
-        budget_ctx.budget_id,
-    )
-    return True
 
 
 def _runtime_exceeded(started_at: float, max_runtime_seconds: int) -> bool:
@@ -6501,11 +6472,7 @@ def _run_agent_loop(
                 heartbeat.touch("max_iterations")
             try:
                 PersistentAgentStep.objects.create(
-                    agent=agent,
-                    description=(
-                        "Processing paused: max iterations reached. "
-                        "Will resume shortly."
-                    ),
+                    agent=agent, description="Processing paused: max iterations reached. Will resume shortly."
                 )
             except DatabaseError:
                 logger.debug(
@@ -6521,10 +6488,12 @@ def _run_agent_loop(
                 )
             else:
                 delay_seconds = max(0, int(max_iterations_followup_delay_seconds))
-            exhausted_cycle_closed = _close_exhausted_cycle_before_follow_up(
-                agent,
-                budget_ctx,
+            budget_exhausted = budget_ctx is not None and (
+                AgentBudgetManager.get_steps_used(agent_id=budget_ctx.agent_id)
+                >= budget_ctx.max_steps
             )
+            if budget_exhausted:
+                AgentBudgetManager.close_cycle(agent_id=budget_ctx.agent_id, budget_id=budget_ctx.budget_id)
             _schedule_agent_follow_up(
                 agent_id=agent.id,
                 delay_seconds=delay_seconds,
@@ -6532,7 +6501,7 @@ def _run_agent_loop(
                 reason="Max iterations",
                 queue=max_iterations_followup_queue,
             )
-            if not exhausted_cycle_closed:
+            if not budget_exhausted:
                 _attempt_cycle_close_for_sleep(agent, budget_ctx)
 
         return cumulative_token_usage

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -3301,6 +3301,31 @@ def _attempt_cycle_close_for_sleep(agent: PersistentAgent, budget_ctx: Optional[
         logger.debug("Failed to close budget cycle on sleep", exc_info=True)
 
 
+def _close_exhausted_cycle_before_follow_up(
+    agent: PersistentAgent,
+    budget_ctx: Optional[BudgetContext],
+) -> bool:
+    """Close a spent cycle before its top-level follow-up is queued."""
+
+    if budget_ctx is None:
+        return False
+
+    steps_used = AgentBudgetManager.get_steps_used(agent_id=budget_ctx.agent_id)
+    if steps_used < budget_ctx.max_steps:
+        return False
+
+    AgentBudgetManager.close_cycle(
+        agent_id=budget_ctx.agent_id,
+        budget_id=budget_ctx.budget_id,
+    )
+    logger.info(
+        "Agent %s exhausted budget cycle %s; closed it before scheduling follow-up.",
+        agent.id,
+        budget_ctx.budget_id,
+    )
+    return True
+
+
 def _runtime_exceeded(started_at: float, max_runtime_seconds: int) -> bool:
     if max_runtime_seconds <= 0:
         return False
@@ -6496,6 +6521,10 @@ def _run_agent_loop(
                 )
             else:
                 delay_seconds = max(0, int(max_iterations_followup_delay_seconds))
+            exhausted_cycle_closed = _close_exhausted_cycle_before_follow_up(
+                agent,
+                budget_ctx,
+            )
             _schedule_agent_follow_up(
                 agent_id=agent.id,
                 delay_seconds=delay_seconds,
@@ -6503,7 +6532,8 @@ def _run_agent_loop(
                 reason="Max iterations",
                 queue=max_iterations_followup_queue,
             )
-            _attempt_cycle_close_for_sleep(agent, budget_ctx)
+            if not exhausted_cycle_closed:
+                _attempt_cycle_close_for_sleep(agent, budget_ctx)
 
         return cumulative_token_usage
     finally:

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -27,6 +27,7 @@ from kombu.exceptions import OperationalError as KombuOperationalError
 from opentelemetry import baggage, trace
 from pottery import Redlock
 from pottery.exceptions import ExtendUnlockedLock, TooManyExtensions
+from redis.exceptions import RedisError
 from django.apps import apps
 from django.conf import settings as django_settings
 from django.db import DatabaseError, transaction, close_old_connections
@@ -883,9 +884,7 @@ def _schedule_agent_follow_up(
     try:
         from ..tasks.process_events import process_agent_events_task  # noqa: WPS433 (runtime import)
 
-        process_agent_events_task.apply_async(
-            args=[str(agent_id)], countdown=delay_seconds, queue=queue
-        )
+        process_agent_events_task.apply_async(args=[str(agent_id)], countdown=delay_seconds, queue=queue)
         if span is not None:
             span.add_event(f"{reason} follow-up scheduled")
     except Exception:
@@ -6480,20 +6479,22 @@ def _run_agent_loop(
                     agent.id,
                     exc_info=True,
                 )
+            delay_seconds = max(0, int(max_iterations_followup_delay_seconds or 0))
             if max_iterations_followup_delay_seconds is None:
-                pending_settings = get_pending_drain_settings(settings)
-                delay_seconds = max(
-                    int(MAX_ITERATIONS_FOLLOWUP_DELAY_SECONDS),
-                    int(pending_settings.pending_drain_delay_seconds),
+                pending_delay = get_pending_drain_settings(settings).pending_drain_delay_seconds
+                delay_seconds = max(int(MAX_ITERATIONS_FOLLOWUP_DELAY_SECONDS), int(pending_delay))
+            try:
+                budget_exhausted = budget_ctx is not None and (
+                    AgentBudgetManager.get_steps_used(agent_id=budget_ctx.agent_id)
+                    >= budget_ctx.max_steps
                 )
-            else:
-                delay_seconds = max(0, int(max_iterations_followup_delay_seconds))
-            budget_exhausted = budget_ctx is not None and (
-                AgentBudgetManager.get_steps_used(agent_id=budget_ctx.agent_id)
-                >= budget_ctx.max_steps
-            )
-            if budget_exhausted:
-                AgentBudgetManager.close_cycle(agent_id=budget_ctx.agent_id, budget_id=budget_ctx.budget_id)
+                if budget_exhausted:
+                    AgentBudgetManager.close_cycle(agent_id=budget_ctx.agent_id, budget_id=budget_ctx.budget_id)
+            except RedisError:
+                budget_exhausted = False
+                logger.warning(
+                    "Budget cycle %s cleanup failed for agent %s", budget_ctx.budget_id, agent.id, exc_info=True
+                )
             _schedule_agent_follow_up(
                 agent_id=agent.id,
                 delay_seconds=delay_seconds,

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -18,6 +18,7 @@ from unittest.mock import patch, MagicMock, ANY
 
 import zstandard as zstd
 from allauth.account.models import EmailAddress
+from redis.exceptions import RedisError
 
 from api.agent.core.event_processing import (
     OrchestratorPromptStale,
@@ -6183,6 +6184,30 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
         )
         self.assertNotEqual(next_budget_id, budget_ctx.budget_id)
         self.assertEqual(AgentBudgetManager.get_steps_used(agent_id=budget_ctx.agent_id), 0)
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")
+    def test_run_agent_loop_queues_follow_up_when_cycle_close_fails(
+        self,
+        mock_apply_async,
+    ):
+        self._start_budget_cycle(max_steps=1)
+
+        with patch.object(
+            AgentBudgetManager,
+            "close_cycle",
+            side_effect=RedisError("Redis unavailable"),
+        ):
+            self._run_single_iteration_to_cap(
+                followup_delay_seconds=0,
+                followup_queue=AGENT_DEFAULT_PROCESSING_QUEUE,
+            )
+
+        mock_apply_async.assert_called_once_with(
+            args=[str(self.agent.id)],
+            countdown=0,
+            queue=AGENT_DEFAULT_PROCESSING_QUEUE,
+        )
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -6171,7 +6171,6 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
         mock_apply_async.assert_called_once_with(
             args=[str(self.agent.id)],
             countdown=expected_delay_seconds,
-            queue=None,
         )
         next_budget_id, _, _ = AgentBudgetManager.find_or_start_cycle(
             agent_id=budget_ctx.agent_id,

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -6075,7 +6075,12 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
         )
         return budget_ctx
 
-    def _run_single_iteration_to_cap(self) -> None:
+    def _run_single_iteration_to_cap(
+        self,
+        *,
+        followup_delay_seconds: int | None,
+        followup_queue: str | None,
+    ) -> None:
         enable_tools(self.agent, ["sqlite_batch"])
 
         tool_call = MagicMock()
@@ -6120,14 +6125,27 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
                 self.agent,
                 is_first_run=False,
                 max_loop_iterations=1,
-                max_iterations_followup_delay_seconds=0,
-                max_iterations_followup_queue=AGENT_DEFAULT_PROCESSING_QUEUE,
+                max_iterations_followup_delay_seconds=followup_delay_seconds,
+                max_iterations_followup_queue=followup_queue,
             )
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")
-    def test_exhausted_cycle_closes_before_follow_up_enqueue(self, mock_apply_async):
+    @patch("api.agent.core.event_processing.get_pending_drain_settings")
+    def test_run_agent_loop_queues_follow_up_when_max_iterations_reached(
+        self,
+        mock_get_pending_settings,
+        mock_apply_async,
+    ):
+        from api.agent.core import event_processing as ep
+
         budget_ctx = self._start_budget_cycle(max_steps=1)
+        mock_get_pending_settings.return_value = PendingDrainSettings(
+            pending_set_ttl_seconds=123,
+            pending_drain_delay_seconds=10,
+            pending_drain_limit=50,
+            pending_drain_schedule_ttl_seconds=60,
+        )
 
         def assert_cycle_closed_before_enqueue(*_args, **_kwargs):
             self.assertEqual(
@@ -6137,18 +6155,23 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
 
         mock_apply_async.side_effect = assert_cycle_closed_before_enqueue
 
-        self._run_single_iteration_to_cap()
+        self._run_single_iteration_to_cap(
+            followup_delay_seconds=None,
+            followup_queue=None,
+        )
 
+        self.assertTrue(
+            self.agent.steps.filter(description__icontains="max iterations").exists()
+        )
+        expected_delay_seconds = max(
+            int(ep.MAX_ITERATIONS_FOLLOWUP_DELAY_SECONDS),
+            int(mock_get_pending_settings.return_value.pending_drain_delay_seconds),
+        )
         mock_apply_async.assert_called_once_with(
             args=[str(self.agent.id)],
-            countdown=0,
-            queue=AGENT_DEFAULT_PROCESSING_QUEUE,
+            countdown=expected_delay_seconds,
+            queue=None,
         )
-        self.assertEqual(
-            AgentBudgetManager.get_cycle_status(agent_id=budget_ctx.agent_id),
-            "closed",
-        )
-
         next_budget_id, _, _ = AgentBudgetManager.find_or_start_cycle(
             agent_id=budget_ctx.agent_id,
             max_steps=1,
@@ -6163,7 +6186,10 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")
-    def test_explicit_cap_preserves_cycle_with_remaining_budget(self, mock_apply_async):
+    def test_run_agent_loop_queues_immediate_default_follow_up_for_explicit_cap(
+        self,
+        mock_apply_async,
+    ):
         budget_ctx = self._start_budget_cycle(max_steps=2)
 
         def mark_follow_up_queued(*_args, **_kwargs):
@@ -6171,8 +6197,14 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
 
         mock_apply_async.side_effect = mark_follow_up_queued
 
-        self._run_single_iteration_to_cap()
+        self._run_single_iteration_to_cap(
+            followup_delay_seconds=0,
+            followup_queue=AGENT_DEFAULT_PROCESSING_QUEUE,
+        )
 
+        self.assertTrue(
+            self.agent.steps.filter(description__icontains="max iterations").exists()
+        )
         mock_apply_async.assert_called_once_with(
             args=[str(self.agent.id)],
             countdown=0,
@@ -6187,167 +6219,6 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
             agent_id=budget_ctx.agent_id,
         )
         self.assertEqual(active_budget_id, budget_ctx.budget_id)
-
-    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
-    @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")
-    @patch("api.agent.core.event_processing.get_pending_drain_settings")
-    @patch("api.agent.core.event_processing.handle_burn_rate_limit", return_value="none")
-    @patch("api.agent.core.event_processing.get_redis_client")
-    def test_run_agent_loop_queues_follow_up_when_max_iterations_reached(
-        self,
-        mock_get_redis,
-        _mock_burn_control,
-        mock_get_pending_settings,
-        mock_apply_async,
-    ):
-        enable_tools(self.agent, ["sqlite_batch"])
-
-        class _FakeRedis:
-            def get(self, _key):
-                return None
-
-            def exists(self, _key):
-                return 0
-
-        mock_get_redis.return_value = _FakeRedis()
-        mock_get_pending_settings.return_value = PendingDrainSettings(
-            pending_set_ttl_seconds=123,
-            pending_drain_delay_seconds=10,
-            pending_drain_limit=50,
-            pending_drain_schedule_ttl_seconds=60,
-        )
-
-        tool_call = MagicMock()
-        tool_call.function = MagicMock()
-        tool_call.function.name = "sqlite_batch"
-        tool_call.function.arguments = '{"sql": "UPDATE t SET id = 1", "will_continue_work": false}'
-
-        response_message = MagicMock()
-        response_message.tool_calls = [tool_call]
-        response_message.function_call = None
-        response_message.content = None
-        response_message.reasoning_content = None
-
-        response_choice = MagicMock(message=response_message)
-        response = MagicMock()
-        response.choices = [response_choice]
-        response.model_extra = {
-            "usage": MagicMock(
-                prompt_tokens=5,
-                completion_tokens=5,
-                total_tokens=10,
-                prompt_tokens_details=MagicMock(cached_tokens=0),
-            )
-        }
-
-        token_usage = {
-            "prompt_tokens": 5,
-            "completion_tokens": 5,
-            "total_tokens": 10,
-            "model": "mock-model",
-            "provider": "mock-provider",
-            "cached_tokens": 0,
-        }
-
-        with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
-             patch('api.agent.core.prompt_context.ensure_comms_compacted'), \
-             patch('api.agent.core.event_processing.build_prompt_context', return_value=([{"role": "system", "content": "sys"}], 1000, None)), \
-             patch('api.agent.core.event_processing.get_llm_config_with_failover', return_value=[("mock", "mock-model", {})]), \
-             patch('api.agent.core.event_processing._completion_with_failover', return_value=(response, token_usage)), \
-             patch('api.agent.core.event_processing.execute_enabled_tool', return_value={"status": "warning", "message": "0 rows affected"}), \
-             patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None}):
-            from api.agent.core import event_processing as ep
-            with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 1):
-                _run_agent_loop(self.agent, is_first_run=False)
-
-        self.assertTrue(
-            self.agent.steps.filter(description__icontains="max iterations").exists()
-        )
-        expected_delay_seconds = max(
-            int(ep.MAX_ITERATIONS_FOLLOWUP_DELAY_SECONDS),
-            int(mock_get_pending_settings.return_value.pending_drain_delay_seconds),
-        )
-        mock_apply_async.assert_called_once_with(
-            args=[str(self.agent.id)],
-            countdown=expected_delay_seconds,
-        )
-
-    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
-    @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")
-    @patch("api.agent.core.event_processing.handle_burn_rate_limit", return_value="none")
-    @patch("api.agent.core.event_processing.get_redis_client")
-    def test_run_agent_loop_queues_immediate_default_follow_up_for_explicit_cap(
-        self,
-        mock_get_redis,
-        _mock_burn_control,
-        mock_apply_async,
-    ):
-        enable_tools(self.agent, ["sqlite_batch"])
-
-        class _FakeRedis:
-            def get(self, _key):
-                return None
-
-            def exists(self, _key):
-                return 0
-
-        mock_get_redis.return_value = _FakeRedis()
-
-        tool_call = MagicMock()
-        tool_call.function = MagicMock()
-        tool_call.function.name = "sqlite_batch"
-        tool_call.function.arguments = '{"sql": "UPDATE t SET id = 1", "will_continue_work": false}'
-
-        response_message = MagicMock()
-        response_message.tool_calls = [tool_call]
-        response_message.function_call = None
-        response_message.content = None
-        response_message.reasoning_content = None
-
-        response_choice = MagicMock(message=response_message)
-        response = MagicMock()
-        response.choices = [response_choice]
-        response.model_extra = {
-            "usage": MagicMock(
-                prompt_tokens=5,
-                completion_tokens=5,
-                total_tokens=10,
-                prompt_tokens_details=MagicMock(cached_tokens=0),
-            )
-        }
-
-        token_usage = {
-            "prompt_tokens": 5,
-            "completion_tokens": 5,
-            "total_tokens": 10,
-            "model": "mock-model",
-            "provider": "mock-provider",
-            "cached_tokens": 0,
-        }
-
-        with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
-             patch('api.agent.core.prompt_context.ensure_comms_compacted'), \
-             patch('api.agent.core.event_processing.build_prompt_context', return_value=([{"role": "system", "content": "sys"}], 1000, None)), \
-             patch('api.agent.core.event_processing.get_llm_config_with_failover', return_value=[("mock", "mock-model", {})]), \
-             patch('api.agent.core.event_processing._completion_with_failover', return_value=(response, token_usage)), \
-             patch('api.agent.core.event_processing.execute_enabled_tool', return_value={"status": "warning", "message": "0 rows affected"}), \
-             patch('api.agent.core.event_processing._ensure_credit_for_tool', return_value={"cost": None, "credit": None}):
-            _run_agent_loop(
-                self.agent,
-                is_first_run=False,
-                max_loop_iterations=1,
-                max_iterations_followup_delay_seconds=0,
-                max_iterations_followup_queue=AGENT_DEFAULT_PROCESSING_QUEUE,
-            )
-
-        self.assertTrue(
-            self.agent.steps.filter(description__icontains="max iterations").exists()
-        )
-        mock_apply_async.assert_called_once_with(
-            args=[str(self.agent.id)],
-            countdown=0,
-            queue=AGENT_DEFAULT_PROCESSING_QUEUE,
-        )
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -42,10 +42,12 @@ from api.agent.core.event_processing import (
     process_agent_events,
 )
 from api.agent.core.llm_utils import EmptyLiteLLMResponseError
+from api.agent.core.budget import AgentBudgetManager, BudgetContext, set_current_context as set_budget_context
 from api.agent.core.processing_flags import (
     PendingDrainSettings,
     _human_inbound_generation_key,
     bump_human_inbound_generation,
+    clear_processing_queued_flag,
     clear_processing_stop_requested,
     get_consumed_human_inbound_generation,
     get_human_inbound_generation,
@@ -6044,6 +6046,147 @@ class EventProcessingMaxIterationsFollowUpTests(TestCase):
             charter="Test max iterations follow-up",
             browser_use_agent=self.browser_agent,
         )
+        self.addCleanup(set_budget_context, None)
+        self.addCleanup(clear_processing_queued_flag, self.agent.id)
+
+    def _start_budget_cycle(self, *, max_steps: int) -> BudgetContext:
+        budget_id, resolved_max_steps, max_depth = AgentBudgetManager.find_or_start_cycle(
+            agent_id=str(self.agent.id),
+            max_steps=max_steps,
+        )
+        branch_id = AgentBudgetManager.create_branch(
+            agent_id=str(self.agent.id),
+            budget_id=budget_id,
+            depth=0,
+        )
+        budget_ctx = BudgetContext(
+            agent_id=str(self.agent.id),
+            budget_id=budget_id,
+            branch_id=branch_id,
+            depth=0,
+            max_steps=resolved_max_steps,
+            max_depth=max_depth,
+        )
+        set_budget_context(budget_ctx)
+        self.addCleanup(
+            AgentBudgetManager.close_cycle,
+            agent_id=budget_ctx.agent_id,
+            budget_id=budget_ctx.budget_id,
+        )
+        return budget_ctx
+
+    def _run_single_iteration_to_cap(self) -> None:
+        enable_tools(self.agent, ["sqlite_batch"])
+
+        tool_call = MagicMock()
+        tool_call.function = MagicMock()
+        tool_call.function.name = "sqlite_batch"
+        tool_call.function.arguments = '{"sql": "SELECT 1", "will_continue_work": true}'
+
+        response_message = MagicMock()
+        response_message.tool_calls = [tool_call]
+        response_message.function_call = None
+        response_message.content = None
+        response_message.reasoning_content = None
+
+        response = MagicMock()
+        response.choices = [MagicMock(message=response_message)]
+        response.model_extra = {
+            "usage": MagicMock(
+                prompt_tokens=5,
+                completion_tokens=5,
+                total_tokens=10,
+                prompt_tokens_details=MagicMock(cached_tokens=0),
+            )
+        }
+        token_usage = {
+            "prompt_tokens": 5,
+            "completion_tokens": 5,
+            "total_tokens": 10,
+            "model": "mock-model",
+            "provider": "mock-provider",
+            "cached_tokens": 0,
+        }
+
+        with patch("api.agent.core.prompt_context.ensure_steps_compacted"), \
+             patch("api.agent.core.prompt_context.ensure_comms_compacted"), \
+             patch("api.agent.core.event_processing.handle_burn_rate_limit", return_value="none"), \
+             patch("api.agent.core.event_processing.build_prompt_context", return_value=([{"role": "system", "content": "sys"}], 1000, None)), \
+             patch("api.agent.core.event_processing.get_llm_config_with_failover", return_value=[("mock", "mock-model", {})]), \
+             patch("api.agent.core.event_processing._completion_with_failover", return_value=(response, token_usage)), \
+             patch("api.agent.core.event_processing.execute_enabled_tool", return_value={"status": "ok"}), \
+             patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None}):
+            _run_agent_loop(
+                self.agent,
+                is_first_run=False,
+                max_loop_iterations=1,
+                max_iterations_followup_delay_seconds=0,
+                max_iterations_followup_queue=AGENT_DEFAULT_PROCESSING_QUEUE,
+            )
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")
+    def test_exhausted_cycle_closes_before_follow_up_enqueue(self, mock_apply_async):
+        budget_ctx = self._start_budget_cycle(max_steps=1)
+
+        def assert_cycle_closed_before_enqueue(*_args, **_kwargs):
+            self.assertEqual(
+                AgentBudgetManager.get_cycle_status(agent_id=budget_ctx.agent_id),
+                "closed",
+            )
+
+        mock_apply_async.side_effect = assert_cycle_closed_before_enqueue
+
+        self._run_single_iteration_to_cap()
+
+        mock_apply_async.assert_called_once_with(
+            args=[str(self.agent.id)],
+            countdown=0,
+            queue=AGENT_DEFAULT_PROCESSING_QUEUE,
+        )
+        self.assertEqual(
+            AgentBudgetManager.get_cycle_status(agent_id=budget_ctx.agent_id),
+            "closed",
+        )
+
+        next_budget_id, _, _ = AgentBudgetManager.find_or_start_cycle(
+            agent_id=budget_ctx.agent_id,
+            max_steps=1,
+        )
+        self.addCleanup(
+            AgentBudgetManager.close_cycle,
+            agent_id=budget_ctx.agent_id,
+            budget_id=next_budget_id,
+        )
+        self.assertNotEqual(next_budget_id, budget_ctx.budget_id)
+        self.assertEqual(AgentBudgetManager.get_steps_used(agent_id=budget_ctx.agent_id), 0)
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
+    @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")
+    def test_explicit_cap_preserves_cycle_with_remaining_budget(self, mock_apply_async):
+        budget_ctx = self._start_budget_cycle(max_steps=2)
+
+        def mark_follow_up_queued(*_args, **_kwargs):
+            set_processing_queued_flag(self.agent.id)
+
+        mock_apply_async.side_effect = mark_follow_up_queued
+
+        self._run_single_iteration_to_cap()
+
+        mock_apply_async.assert_called_once_with(
+            args=[str(self.agent.id)],
+            countdown=0,
+            queue=AGENT_DEFAULT_PROCESSING_QUEUE,
+        )
+        self.assertEqual(
+            AgentBudgetManager.get_cycle_status(agent_id=budget_ctx.agent_id),
+            "active",
+        )
+        self.assertEqual(AgentBudgetManager.get_steps_used(agent_id=budget_ctx.agent_id), 1)
+        active_budget_id, _, _ = AgentBudgetManager.find_or_start_cycle(
+            agent_id=budget_ctx.agent_id,
+        )
+        self.assertEqual(active_budget_id, budget_ctx.budget_id)
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=False)
     @patch("api.agent.tasks.process_events.process_agent_events_task.apply_async")


### PR DESCRIPTION
## Summary
- Close a budget cycle as soon as it is fully exhausted before scheduling the max-iterations follow-up.
- Preserve the existing sleep-time cycle-close path when the cycle still has remaining budget.
- Add unit coverage for both exhausted and partially used budget cases.

## Testing
- Added focused unit tests for follow-up enqueue behavior and cycle state transitions.
- Not run (not requested).