### PR TITLE
Add thumbs feedback for agent messages

### DIFF
--- a/api/migrations/0424_persistentagentmessagefeedback.py
+++ b/api/migrations/0424_persistentagentmessagefeedback.py
@@ -1,0 +1,54 @@
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0423_persistentagentcompletion_prompt_archive"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PersistentAgentMessageFeedback",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                (
+                    "rating",
+                    models.CharField(
+                        choices=[("up", "Thumbs up"), ("down", "Thumbs down")],
+                        max_length=8,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "message",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="feedback",
+                        to="api.persistentagentmessage",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="persistent_agent_message_feedback",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="persistentagentmessagefeedback",
+            constraint=models.UniqueConstraint(
+                fields=("message", "user"),
+                name="uniq_pa_msg_feedback_message_user",
+            ),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -11082,6 +11082,36 @@ class PersistentAgentMessage(models.Model):
         super().save(*args, **kwargs)
 
 
+class PersistentAgentMessageFeedback(models.Model):
+
+    class Rating(models.TextChoices):
+        UP = "up", "Thumbs up"
+        DOWN = "down", "Thumbs down"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    message = models.ForeignKey(
+        PersistentAgentMessage,
+        on_delete=models.CASCADE,
+        related_name="feedback",
+    )
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="persistent_agent_message_feedback",
+    )
+    rating = models.CharField(max_length=8, choices=Rating.choices)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["message", "user"], name="uniq_pa_msg_feedback_message_user"),
+        ]
+
+    def __str__(self):
+        return f"MSG_FEEDBACK<{self.message_id}:{self.user_id}:{self.rating}>"
+
+
 class PersistentAgentMessageRead(models.Model):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/config/urls.py
+++ b/config/urls.py
@@ -24,6 +24,7 @@ from console.api_views import (
     AgentFsNodeUploadAPIView,
     AgentMessageCopyAPIView,
     AgentMessageCreateAPIView,
+    AgentMessageFeedbackAPIView,
     AgentMessageReportIssueAPIView,
     AgentLatestMessageReadAPIView,
     AgentHumanInputRequestBatchResponseAPIView,
@@ -359,6 +360,11 @@ urlpatterns = [
         "console/api/agents/<uuid:agent_id>/messages/<uuid:message_id>/copy/",
         AgentMessageCopyAPIView.as_view(),
         name="console_agent_message_copy",
+    ),
+    path(
+        "console/api/agents/<uuid:agent_id>/messages/<uuid:message_id>/feedback/",
+        AgentMessageFeedbackAPIView.as_view(),
+        name="console_agent_message_feedback",
     ),
     path(
         "console/api/agents/<uuid:agent_id>/messages/<uuid:message_id>/report-issue/",

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -39,6 +39,7 @@ from api.models import (
     PersistentAgentCompletion,
     PersistentAgentMessage,
     PersistentAgentMessageAttachment,
+    PersistentAgentMessageFeedback,
     PersistentAgentStep,
     PersistentAgentToolCall,
     PersistentAgentUserActionEvent,
@@ -338,6 +339,23 @@ def _build_web_user_lookup(messages: Iterable[PersistentAgentMessage]) -> dict[i
     return {user.id: _build_user_display_name(user) for user in users}
 
 
+def _build_viewer_message_feedback_lookup(
+    messages: Iterable[PersistentAgentMessage],
+    viewer_user,
+) -> dict[uuid.UUID, str]:
+    if viewer_user is None or not getattr(viewer_user, "is_authenticated", False):
+        return {}
+    message_ids = {message.id for message in messages}
+    if not message_ids:
+        return {}
+    return dict(
+        PersistentAgentMessageFeedback.objects.filter(
+            message_id__in=message_ids,
+            user=viewer_user,
+        ).values_list("message_id", "rating")
+    )
+
+
 def _discord_outbound_channel_label(message: PersistentAgentMessage, conversation) -> str:
     if not message.is_outbound:
         return ""
@@ -468,7 +486,11 @@ def serialize_plan_snapshot(agent: PersistentAgent, snapshot: PlanSnapshot | Non
     }
 
 
-def _serialize_message(env: MessageEnvelope, user_lookup: Mapping[int, str | None] | None = None) -> dict:
+def _serialize_message(
+    env: MessageEnvelope,
+    user_lookup: Mapping[int, str | None] | None = None,
+    feedback_lookup: Mapping[uuid.UUID, str] | None = None,
+) -> dict:
     message = env.message
     timestamp = message.timestamp
     channel = "web"
@@ -555,6 +577,7 @@ def _serialize_message(env: MessageEnvelope, user_lookup: Mapping[int, str | Non
             "sourceKind": source_kind,
             "sourceLabel": source_label,
             "webhookMeta": webhook_meta,
+            "viewerFeedback": feedback_lookup.get(message.id) if feedback_lookup else None,
         },
     }
 
@@ -1483,6 +1506,10 @@ def fetch_timeline_window(
     if " " in agent_name:
         agent_name = agent_name.split()[0]
     user_lookup = _build_web_user_lookup(env.message for env in message_envelopes)
+    feedback_lookup = _build_viewer_message_feedback_lookup(
+        (env.message for env in truncated if isinstance(env, MessageEnvelope)),
+        viewer_user,
+    )
     for env in truncated:
         if isinstance(env, StepEnvelope):
             cluster_buffer.append(env)
@@ -1497,7 +1524,7 @@ def fetch_timeline_window(
         elif isinstance(env, UserActionEnvelope):
             timeline_events.append(_serialize_user_action(env, viewer_user=viewer_user))
         else:
-            timeline_events.append(_serialize_message(env, user_lookup))
+            timeline_events.append(_serialize_message(env, user_lookup, feedback_lookup))
     if cluster_buffer:
         timeline_events.append(_build_cluster(cluster_buffer, tool_label_map))
 

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -96,6 +96,7 @@ from api.models import (
     PersistentAgentHumanInputRequest,
     PersistentAgentJudgeSuggestion,
     PersistentAgentMessage,
+    PersistentAgentMessageFeedback,
     PersistentAgentSecret,
     PersistentAgentSystemSkillState,
     PersistentAgentSystemMessage,
@@ -4937,6 +4938,70 @@ class AgentMessageCopyAPIView(LoginRequiredMixin, View):
             properties=_agent_message_action_properties(agent, message),
         )
         return JsonResponse({"ok": True})
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class AgentMessageFeedbackAPIView(LoginRequiredMixin, View):
+    http_method_names = ["post"]
+
+    def post(self, request: HttpRequest, agent_id: str, message_id: str, *args: Any, **kwargs: Any):
+        agent = resolve_agent_for_request(
+            request,
+            agent_id,
+            allow_shared=True,
+            allow_delinquent_personal_chat=True,
+        )
+        message = _resolve_reportable_agent_message(agent, message_id)
+        try:
+            payload = _parse_json_body(request)
+            if not isinstance(payload, dict):
+                return HttpResponseBadRequest("Invalid request payload.")
+        except ValueError as exc:
+            return HttpResponseBadRequest(str(exc))
+
+        if "feedback" not in payload:
+            return HttpResponseBadRequest("feedback is required")
+        feedback = payload["feedback"]
+        valid_feedback = {choice.value for choice in PersistentAgentMessageFeedback.Rating}
+        if feedback is not None and (not isinstance(feedback, str) or feedback not in valid_feedback):
+            return HttpResponseBadRequest("feedback must be 'up', 'down', or null")
+
+        with transaction.atomic():
+            existing = (
+                PersistentAgentMessageFeedback.objects.select_for_update()
+                .filter(message=message, user=request.user)
+                .first()
+            )
+            previous_feedback = existing.rating if existing else None
+            changed = previous_feedback != feedback
+            if changed and feedback is None:
+                PersistentAgentMessageFeedback.objects.filter(
+                    message=message,
+                    user=request.user,
+                ).delete()
+            elif changed:
+                PersistentAgentMessageFeedback.objects.update_or_create(
+                    message=message,
+                    user=request.user,
+                    defaults={"rating": feedback},
+                )
+
+        if changed:
+            Analytics.track_event(
+                user_id=str(request.user.id),
+                event=AnalyticsEvent.AGENT_MESSAGE_FEEDBACK_UPDATED,
+                source=AnalyticsSource.WEB,
+                properties=_agent_message_action_properties(
+                    agent,
+                    message,
+                    {
+                        "previous_feedback": previous_feedback or "none",
+                        "feedback": feedback or "none",
+                    },
+                ),
+            )
+
+        return JsonResponse({"ok": True, "feedback": feedback})
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -4948,7 +4948,6 @@ class AgentMessageCopyAPIView(LoginRequiredMixin, View):
         return JsonResponse({"ok": True})
 
 
-@method_decorator(csrf_exempt, name="dispatch")
 class AgentMessageFeedbackAPIView(LoginRequiredMixin, View):
     http_method_names = ["post"]
 

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -4884,7 +4884,7 @@ class AgentMessageCreateAPIView(LoginRequiredMixin, View):
 AGENT_MESSAGE_REPORT_COMMENT_MAX_LENGTH = 2000
 
 
-def _resolve_reportable_agent_message(agent: PersistentAgent, message_id: str) -> PersistentAgentMessage:
+def _resolve_actionable_agent_message(agent: PersistentAgent, message_id: str) -> PersistentAgentMessage:
     message = (
         PersistentAgentMessage.objects.filter(
             id=message_id,
@@ -4898,6 +4898,20 @@ def _resolve_reportable_agent_message(agent: PersistentAgent, message_id: str) -
     if message is None:
         raise Http404("Message not found.")
     return message
+
+
+def _resolve_agent_message_action(
+    request: HttpRequest,
+    agent_id: str,
+    message_id: str,
+) -> tuple[PersistentAgent, PersistentAgentMessage]:
+    agent = resolve_agent_for_request(
+        request,
+        agent_id,
+        allow_shared=True,
+        allow_delinquent_personal_chat=True,
+    )
+    return agent, _resolve_actionable_agent_message(agent, message_id)
 
 
 def _agent_message_action_properties(
@@ -4924,13 +4938,7 @@ class AgentMessageCopyAPIView(LoginRequiredMixin, View):
     http_method_names = ["post"]
 
     def post(self, request: HttpRequest, agent_id: str, message_id: str, *args: Any, **kwargs: Any):
-        agent = resolve_agent_for_request(
-            request,
-            agent_id,
-            allow_shared=True,
-            allow_delinquent_personal_chat=True,
-        )
-        message = _resolve_reportable_agent_message(agent, message_id)
+        agent, message = _resolve_agent_message_action(request, agent_id, message_id)
         Analytics.track_event(
             user_id=str(request.user.id),
             event=AnalyticsEvent.AGENT_MESSAGE_COPIED,
@@ -4945,25 +4953,16 @@ class AgentMessageFeedbackAPIView(LoginRequiredMixin, View):
     http_method_names = ["post"]
 
     def post(self, request: HttpRequest, agent_id: str, message_id: str, *args: Any, **kwargs: Any):
-        agent = resolve_agent_for_request(
-            request,
-            agent_id,
-            allow_shared=True,
-            allow_delinquent_personal_chat=True,
-        )
-        message = _resolve_reportable_agent_message(agent, message_id)
+        agent, message = _resolve_agent_message_action(request, agent_id, message_id)
         try:
             payload = _parse_json_body(request)
-            if not isinstance(payload, dict):
-                return HttpResponseBadRequest("Invalid request payload.")
         except ValueError as exc:
             return HttpResponseBadRequest(str(exc))
 
         if "feedback" not in payload:
             return HttpResponseBadRequest("feedback is required")
         feedback = payload["feedback"]
-        valid_feedback = {choice.value for choice in PersistentAgentMessageFeedback.Rating}
-        if feedback is not None and (not isinstance(feedback, str) or feedback not in valid_feedback):
+        if feedback is not None and feedback not in PersistentAgentMessageFeedback.Rating.values:
             return HttpResponseBadRequest("feedback must be 'up', 'down', or null")
 
         with transaction.atomic():
@@ -4975,10 +4974,10 @@ class AgentMessageFeedbackAPIView(LoginRequiredMixin, View):
             previous_feedback = existing.rating if existing else None
             changed = previous_feedback != feedback
             if changed and feedback is None:
-                PersistentAgentMessageFeedback.objects.filter(
-                    message=message,
-                    user=request.user,
-                ).delete()
+                existing.delete()
+            elif changed and existing is not None:
+                existing.rating = feedback
+                existing.save(update_fields=["rating", "updated_at"])
             elif changed:
                 PersistentAgentMessageFeedback.objects.update_or_create(
                     message=message,
@@ -5009,17 +5008,9 @@ class AgentMessageReportIssueAPIView(LoginRequiredMixin, View):
     http_method_names = ["post"]
 
     def post(self, request: HttpRequest, agent_id: str, message_id: str, *args: Any, **kwargs: Any):
-        agent = resolve_agent_for_request(
-            request,
-            agent_id,
-            allow_shared=True,
-            allow_delinquent_personal_chat=True,
-        )
-        message = _resolve_reportable_agent_message(agent, message_id)
+        agent, message = _resolve_agent_message_action(request, agent_id, message_id)
         try:
             payload = _parse_json_body(request)
-            if not isinstance(payload, dict):
-                return HttpResponseBadRequest("Invalid request payload.")
         except ValueError as exc:
             return HttpResponseBadRequest(str(exc))
 

--- a/frontend/src/api/agentChat.ts
+++ b/frontend/src/api/agentChat.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentMessageFeedback,
   PendingActionRequest,
   PendingContactRequest,
   PendingHumanInputRequest,
@@ -460,6 +461,23 @@ export async function trackAgentMessageCopy(agentId: string, messageId: string):
   return jsonRequest<{ ok: boolean }>(`/console/api/agents/${agentId}/messages/${messageId}/copy/`, {
     method: 'POST',
     includeCsrf: true,
+  })
+}
+
+export type AgentMessageFeedbackResponse = {
+  ok: boolean
+  feedback: AgentMessageFeedback | null
+}
+
+export async function updateAgentMessageFeedback(
+  agentId: string,
+  messageId: string,
+  feedback: AgentMessageFeedback | null,
+): Promise<AgentMessageFeedbackResponse> {
+  return jsonRequest<AgentMessageFeedbackResponse>(`/console/api/agents/${agentId}/messages/${messageId}/feedback/`, {
+    method: 'POST',
+    includeCsrf: true,
+    json: { feedback },
   })
 }
 

--- a/frontend/src/api/agentChat.ts
+++ b/frontend/src/api/agentChat.ts
@@ -464,17 +464,12 @@ export async function trackAgentMessageCopy(agentId: string, messageId: string):
   })
 }
 
-export type AgentMessageFeedbackResponse = {
-  ok: boolean
-  feedback: AgentMessageFeedback | null
-}
-
 export async function updateAgentMessageFeedback(
   agentId: string,
   messageId: string,
   feedback: AgentMessageFeedback | null,
-): Promise<AgentMessageFeedbackResponse> {
-  return jsonRequest<AgentMessageFeedbackResponse>(`/console/api/agents/${agentId}/messages/${messageId}/feedback/`, {
+): Promise<{ ok: boolean; feedback: AgentMessageFeedback | null }> {
+  return jsonRequest<{ ok: boolean; feedback: AgentMessageFeedback | null }>(`/console/api/agents/${agentId}/messages/${messageId}/feedback/`, {
     method: 'POST',
     includeCsrf: true,
     json: { feedback },

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -13,7 +13,7 @@ import { AgentChatSettingsPanel } from './AgentChatSettingsPanel'
 import { AgentChatAddonsPanel } from './AgentChatAddonsPanel'
 import { PlanPanel } from './PlanPanel'
 import { HighPriorityBanner, type HighPriorityBannerConfig } from './HighPriorityBanner'
-import { reportAgentMessageIssue, trackAgentMessageCopy, type PendingActionMutationResult } from '../../api/agentChat'
+import { reportAgentMessageIssue, trackAgentMessageCopy, updateAgentMessageFeedback, type PendingActionMutationResult } from '../../api/agentChat'
 import { AgentSignupPreviewPanel } from './AgentSignupPreviewPanel'
 import { AgentUpgradePlansPanel } from './AgentUpgradePlansPanel'
 import type { AgentChatSidebarMode } from './sidebarMode'
@@ -26,7 +26,7 @@ import { useIsMobile } from '../../hooks/useIsMobile'
 import type { SelectionShellPage } from './SelectionShellPageSwitcher'
 import type { SidebarSettingsInfo } from './SidebarSettingsMenu'
 import type { AgentTimelineProps } from './types'
-import type { PendingActionRequest, AgentMessage, PlanSnapshot } from '../../types/agentChat'
+import type { PendingActionRequest, AgentMessage, AgentMessageFeedback, PlanSnapshot } from '../../types/agentChat'
 import type { SignupPreviewState } from '../../types/agentRoster'
 import type { TemplateRecommendation } from '../../api/agentSpawnIntent'
 import { isContinuationUpgradeModalSource, selectSubscriptionState, subscriptionActions, type PlanTier } from '../../store/subscriptionSlice'
@@ -668,6 +668,17 @@ export function AgentChatLayout({
     void trackAgentMessageCopy(agentId, message.id).catch(() => {
       // Copying is already complete; tracking should not interrupt the UI.
     })
+  }, [agentId])
+
+  const handleMessageFeedback = useCallback(async (
+    message: AgentMessage,
+    feedback: AgentMessageFeedback | null,
+  ): Promise<AgentMessageFeedback | null> => {
+    if (!agentId) {
+      throw new Error('Agent is unavailable.')
+    }
+    const response = await updateAgentMessageFeedback(agentId, message.id, feedback)
+    return response.feedback
   }, [agentId])
 
   const handleReportMessage = useCallback((message: AgentMessage) => {
@@ -1534,6 +1545,7 @@ export function AgentChatLayout({
             onHardLimitQuickIncrease={quickIncreaseTarget !== null ? handleQuickIncreaseLimit : undefined}
             onJumpToLatest={onJumpToLatest}
             onMessageCopied={handleMessageCopied}
+            onMessageFeedback={handleMessageFeedback}
             onMessageLinkClick={handleMessageLinkClick}
             onPurchaseSeats={handlePurchaseSeats}
             onReportMessage={handleReportMessage}

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -13,7 +13,7 @@ import { AgentChatSettingsPanel } from './AgentChatSettingsPanel'
 import { AgentChatAddonsPanel } from './AgentChatAddonsPanel'
 import { PlanPanel } from './PlanPanel'
 import { HighPriorityBanner, type HighPriorityBannerConfig } from './HighPriorityBanner'
-import { reportAgentMessageIssue, trackAgentMessageCopy, updateAgentMessageFeedback, type PendingActionMutationResult } from '../../api/agentChat'
+import { reportAgentMessageIssue, type PendingActionMutationResult } from '../../api/agentChat'
 import { AgentSignupPreviewPanel } from './AgentSignupPreviewPanel'
 import { AgentUpgradePlansPanel } from './AgentUpgradePlansPanel'
 import type { AgentChatSidebarMode } from './sidebarMode'
@@ -26,7 +26,7 @@ import { useIsMobile } from '../../hooks/useIsMobile'
 import type { SelectionShellPage } from './SelectionShellPageSwitcher'
 import type { SidebarSettingsInfo } from './SidebarSettingsMenu'
 import type { AgentTimelineProps } from './types'
-import type { PendingActionRequest, AgentMessage, AgentMessageFeedback, PlanSnapshot } from '../../types/agentChat'
+import type { PendingActionRequest, AgentMessage, PlanSnapshot } from '../../types/agentChat'
 import type { SignupPreviewState } from '../../types/agentRoster'
 import type { TemplateRecommendation } from '../../api/agentSpawnIntent'
 import { isContinuationUpgradeModalSource, selectSubscriptionState, subscriptionActions, type PlanTier } from '../../store/subscriptionSlice'
@@ -660,26 +660,6 @@ export function AgentChatLayout({
   const handleAddonsClose = useCallback(() => {
     setAddonsMode(null)
   }, [])
-
-  const handleMessageCopied = useCallback((message: AgentMessage) => {
-    if (!agentId) {
-      return
-    }
-    void trackAgentMessageCopy(agentId, message.id).catch(() => {
-      // Copying is already complete; tracking should not interrupt the UI.
-    })
-  }, [agentId])
-
-  const handleMessageFeedback = useCallback(async (
-    message: AgentMessage,
-    feedback: AgentMessageFeedback | null,
-  ): Promise<AgentMessageFeedback | null> => {
-    if (!agentId) {
-      throw new Error('Agent is unavailable.')
-    }
-    const response = await updateAgentMessageFeedback(agentId, message.id, feedback)
-    return response.feedback
-  }, [agentId])
 
   const handleReportMessage = useCallback((message: AgentMessage) => {
     setReportMessage(message)
@@ -1544,8 +1524,6 @@ export function AgentChatLayout({
             onHardLimitOpenSettings={handleSettingsOpen}
             onHardLimitQuickIncrease={quickIncreaseTarget !== null ? handleQuickIncreaseLimit : undefined}
             onJumpToLatest={onJumpToLatest}
-            onMessageCopied={handleMessageCopied}
-            onMessageFeedback={handleMessageFeedback}
             onMessageLinkClick={handleMessageLinkClick}
             onPurchaseSeats={handlePurchaseSeats}
             onReportMessage={handleReportMessage}

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -11,7 +11,7 @@ import { StarterPromptSuggestions, type StarterPrompt } from './StarterPromptSug
 import { TemplateRecommendationCards } from './TemplateRecommendationCards'
 import type { SimplifiedTimelineItem } from '../../hooks/useSimplifiedTimeline'
 import type { TemplateRecommendation } from '../../api/agentSpawnIntent'
-import type { AgentMessage, AgentMessageFeedback } from '../../types/agentChat'
+import type { AgentMessage } from '../../types/agentChat'
 import type { StatusExpansionTargets } from './statusExpansion'
 import { chatActions, selectActiveChatSession } from '../../store/chatSlice'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
@@ -49,8 +49,6 @@ type AgentTimelinePaneProps = {
   onHardLimitOpenSettings: () => void
   onHardLimitQuickIncrease?: () => void
   onJumpToLatest?: () => void
-  onMessageCopied?: (message: AgentMessage) => void | Promise<void>
-  onMessageFeedback?: (message: AgentMessage, feedback: AgentMessageFeedback | null) => Promise<AgentMessageFeedback | null>
   onMessageLinkClick?: (href: string) => boolean | void
   onPurchaseSeats?: () => void
   onReportMessage?: (message: AgentMessage) => void
@@ -107,8 +105,6 @@ export function AgentTimelinePane({
   onHardLimitOpenSettings,
   onHardLimitQuickIncrease,
   onJumpToLatest,
-  onMessageCopied,
-  onMessageFeedback,
   onMessageLinkClick,
   onPurchaseSeats,
   onReportMessage,
@@ -217,8 +213,6 @@ export function AgentTimelinePane({
                       animateIncoming={animateCursors?.has(event.cursor) ?? false}
                       onIncomingAnimationConsumed={onIncomingAnimationConsumed}
                       onMessageLinkClick={onMessageLinkClick}
-                      onMessageCopied={onMessageCopied}
-                      onMessageFeedback={onMessageFeedback}
                       onReportMessage={onReportMessage}
                       onRetryMessage={onRetryMessage}
                     />

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -11,7 +11,7 @@ import { StarterPromptSuggestions, type StarterPrompt } from './StarterPromptSug
 import { TemplateRecommendationCards } from './TemplateRecommendationCards'
 import type { SimplifiedTimelineItem } from '../../hooks/useSimplifiedTimeline'
 import type { TemplateRecommendation } from '../../api/agentSpawnIntent'
-import type { AgentMessage } from '../../types/agentChat'
+import type { AgentMessage, AgentMessageFeedback } from '../../types/agentChat'
 import type { StatusExpansionTargets } from './statusExpansion'
 import { chatActions, selectActiveChatSession } from '../../store/chatSlice'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
@@ -50,6 +50,7 @@ type AgentTimelinePaneProps = {
   onHardLimitQuickIncrease?: () => void
   onJumpToLatest?: () => void
   onMessageCopied?: (message: AgentMessage) => void | Promise<void>
+  onMessageFeedback?: (message: AgentMessage, feedback: AgentMessageFeedback | null) => Promise<AgentMessageFeedback | null>
   onMessageLinkClick?: (href: string) => boolean | void
   onPurchaseSeats?: () => void
   onReportMessage?: (message: AgentMessage) => void
@@ -107,6 +108,7 @@ export function AgentTimelinePane({
   onHardLimitQuickIncrease,
   onJumpToLatest,
   onMessageCopied,
+  onMessageFeedback,
   onMessageLinkClick,
   onPurchaseSeats,
   onReportMessage,
@@ -216,6 +218,7 @@ export function AgentTimelinePane({
                       onIncomingAnimationConsumed={onIncomingAnimationConsumed}
                       onMessageLinkClick={onMessageLinkClick}
                       onMessageCopied={onMessageCopied}
+                      onMessageFeedback={onMessageFeedback}
                       onReportMessage={onReportMessage}
                       onRetryMessage={onRetryMessage}
                     />

--- a/frontend/src/components/agentChat/MessageEventCard.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.tsx
@@ -1,8 +1,9 @@
 import ReactJsonView from '@microlink/react-json-view'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { Check, Copy, Flag, RotateCcw } from 'lucide-react'
-import type { AgentMessage } from './types'
+import type { AgentMessage, AgentMessageFeedback } from './types'
 import { MessageContent } from './MessageContent'
+import { MessageFeedbackActions } from './MessageFeedbackActions'
 import { AgentAvatarBadge } from '../common/AgentAvatarBadge'
 import { useRelativeTimestamp } from '../../hooks/useRelativeTimestamp'
 import { sanitizeHtml } from '../../util/sanitize'
@@ -31,6 +32,7 @@ type MessageEventCardProps = {
   viewerEmail?: string | null
   onMessageLinkClick?: (href: string) => boolean | void
   onMessageCopied?: (message: AgentMessage) => void | Promise<void>
+  onMessageFeedback?: (message: AgentMessage, feedback: AgentMessageFeedback | null) => Promise<AgentMessageFeedback | null>
   onReportMessage?: (message: AgentMessage) => void
   onRetryMessage?: (message: AgentMessage) => void | Promise<void>
 }
@@ -79,6 +81,7 @@ export const MessageEventCard = memo(function MessageEventCard({
   viewerEmail,
   onMessageLinkClick,
   onMessageCopied,
+  onMessageFeedback,
   onReportMessage,
   onRetryMessage,
 }: MessageEventCardProps) {
@@ -258,6 +261,7 @@ export const MessageEventCard = memo(function MessageEventCard({
                 >
                   {copied ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : <Copy className="h-3.5 w-3.5" aria-hidden="true" />}
                 </button>
+                <MessageFeedbackActions message={message} onMessageFeedback={onMessageFeedback} />
                 <button
                   type="button"
                   className="chat-message-action-button"

--- a/frontend/src/components/agentChat/MessageEventCard.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.tsx
@@ -264,7 +264,7 @@ export const MessageEventCard = memo(function MessageEventCard({
                 >
                   {copied ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : <Copy className="h-3.5 w-3.5" aria-hidden="true" />}
                 </button>
-                <MessageFeedbackActions agentId={agentId} message={message} />
+                <MessageFeedbackActions key={`${message.id}:${message.viewerFeedback ?? ''}`} agentId={agentId} message={message} />
                 <button
                   type="button"
                   className="chat-message-action-button"

--- a/frontend/src/components/agentChat/MessageEventCard.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.tsx
@@ -1,7 +1,8 @@
 import ReactJsonView from '@microlink/react-json-view'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { Check, Copy, Flag, RotateCcw } from 'lucide-react'
-import type { AgentMessage, AgentMessageFeedback } from './types'
+import type { AgentMessage } from './types'
+import { trackAgentMessageCopy } from '../../api/agentChat'
 import { MessageContent } from './MessageContent'
 import { MessageFeedbackActions } from './MessageFeedbackActions'
 import { AgentAvatarBadge } from '../common/AgentAvatarBadge'
@@ -25,14 +26,13 @@ function getChannelLabel(raw?: string) {
 
 type MessageEventCardProps = {
   eventCursor: string
+  agentId?: string | null
   message: AgentMessage
   agentFirstName: string
   agentAvatarUrl?: string | null
   viewerUserId?: number | null
   viewerEmail?: string | null
   onMessageLinkClick?: (href: string) => boolean | void
-  onMessageCopied?: (message: AgentMessage) => void | Promise<void>
-  onMessageFeedback?: (message: AgentMessage, feedback: AgentMessageFeedback | null) => Promise<AgentMessageFeedback | null>
   onReportMessage?: (message: AgentMessage) => void
   onRetryMessage?: (message: AgentMessage) => void | Promise<void>
 }
@@ -74,14 +74,13 @@ async function writeMessageToClipboard(plainText: string, htmlText: string): Pro
 
 export const MessageEventCard = memo(function MessageEventCard({
   eventCursor,
+  agentId,
   message,
   agentFirstName,
   agentAvatarUrl,
   viewerUserId,
   viewerEmail,
   onMessageLinkClick,
-  onMessageCopied,
-  onMessageFeedback,
   onReportMessage,
   onRetryMessage,
 }: MessageEventCardProps) {
@@ -204,11 +203,15 @@ export const MessageEventCard = memo(function MessageEventCard({
       await writeMessageToClipboard(clipboardPlainText, clipboardHtml)
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1600)
-      void onMessageCopied?.(message)
+      if (agentId) {
+        void trackAgentMessageCopy(agentId, message.id).catch(() => {
+          // Copying is already complete; tracking should not interrupt the UI.
+        })
+      }
     } catch {
       setCopied(false)
     }
-  }, [clipboardHtml, clipboardPlainText, copyDisabled, message, onMessageCopied])
+  }, [agentId, clipboardHtml, clipboardPlainText, copyDisabled, message.id])
 
   const handleReportMessage = useCallback(() => {
     onReportMessage?.(message)
@@ -261,7 +264,7 @@ export const MessageEventCard = memo(function MessageEventCard({
                 >
                   {copied ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : <Copy className="h-3.5 w-3.5" aria-hidden="true" />}
                 </button>
-                <MessageFeedbackActions message={message} onMessageFeedback={onMessageFeedback} />
+                <MessageFeedbackActions agentId={agentId} message={message} />
                 <button
                   type="button"
                   className="chat-message-action-button"

--- a/frontend/src/components/agentChat/MessageFeedbackActions.tsx
+++ b/frontend/src/components/agentChat/MessageFeedbackActions.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useState } from 'react'
+import { ThumbsDown, ThumbsUp } from 'lucide-react'
+import type { AgentMessage, AgentMessageFeedback } from './types'
+
+type MessageFeedbackActionsProps = {
+  message: AgentMessage
+  onMessageFeedback?: (message: AgentMessage, feedback: AgentMessageFeedback | null) => Promise<AgentMessageFeedback | null>
+}
+
+export function MessageFeedbackActions({ message, onMessageFeedback }: MessageFeedbackActionsProps) {
+  const [feedback, setFeedback] = useState<AgentMessageFeedback | null>(message.viewerFeedback ?? null)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleFeedback = useCallback(async (requestedFeedback: AgentMessageFeedback) => {
+    if (!onMessageFeedback || submitting) {
+      return
+    }
+    const previousFeedback = feedback
+    const nextFeedback = feedback === requestedFeedback ? null : requestedFeedback
+    setFeedback(nextFeedback)
+    setError(null)
+    setSubmitting(true)
+    try {
+      const savedFeedback = await onMessageFeedback(message, nextFeedback)
+      setFeedback(savedFeedback)
+    } catch {
+      setFeedback(previousFeedback)
+      setError('Unable to save feedback. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }, [feedback, message, onMessageFeedback, submitting])
+
+  return (
+    <>
+      <button
+        type="button"
+        className="chat-message-action-button"
+        data-active={feedback === 'up' ? 'true' : 'false'}
+        data-feedback="up"
+        onClick={() => void handleFeedback('up')}
+        disabled={submitting || !onMessageFeedback}
+        title={error || (feedback === 'up' ? 'Remove thumbs up' : 'Thumbs up')}
+        aria-label={feedback === 'up' ? 'Remove thumbs up feedback' : 'Give thumbs up feedback'}
+        aria-pressed={feedback === 'up'}
+      >
+        <ThumbsUp className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        className="chat-message-action-button"
+        data-active={feedback === 'down' ? 'true' : 'false'}
+        data-feedback="down"
+        onClick={() => void handleFeedback('down')}
+        disabled={submitting || !onMessageFeedback}
+        title={error || (feedback === 'down' ? 'Remove thumbs down' : 'Thumbs down')}
+        aria-label={feedback === 'down' ? 'Remove thumbs down feedback' : 'Give thumbs down feedback'}
+        aria-pressed={feedback === 'down'}
+      >
+        <ThumbsDown className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+      <span className="sr-only" role="status" aria-live="polite">
+        {error || (submitting ? 'Saving message feedback' : '')}
+      </span>
+    </>
+  )
+}

--- a/frontend/src/components/agentChat/MessageFeedbackActions.tsx
+++ b/frontend/src/components/agentChat/MessageFeedbackActions.tsx
@@ -59,8 +59,9 @@ export function MessageFeedbackActions({ agentId, message }: MessageFeedbackActi
           </button>
         )
       })}
+      {error ? <span className="chat-message-feedback-error absolute right-0 top-[calc(100%+0.3rem)] z-[1] w-max max-w-[min(16rem,80vw)] rounded-md border border-rose-600/35 bg-white px-2 py-1 text-[0.6875rem] font-medium leading-tight text-rose-700" role="alert">{error}</span> : null}
       <span className="sr-only" role="status" aria-live="polite">
-        {error || (submitting ? 'Saving message feedback' : '')}
+        {submitting ? 'Saving message feedback' : ''}
       </span>
     </>
   )

--- a/frontend/src/components/agentChat/MessageFeedbackActions.tsx
+++ b/frontend/src/components/agentChat/MessageFeedbackActions.tsx
@@ -1,19 +1,25 @@
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 import { ThumbsDown, ThumbsUp } from 'lucide-react'
 import type { AgentMessage, AgentMessageFeedback } from './types'
+import { updateAgentMessageFeedback } from '../../api/agentChat'
+
+const FEEDBACK_OPTIONS = [
+  { value: 'up', label: 'Thumbs up', Icon: ThumbsUp },
+  { value: 'down', label: 'Thumbs down', Icon: ThumbsDown },
+] as const
 
 type MessageFeedbackActionsProps = {
+  agentId?: string | null
   message: AgentMessage
-  onMessageFeedback?: (message: AgentMessage, feedback: AgentMessageFeedback | null) => Promise<AgentMessageFeedback | null>
 }
 
-export function MessageFeedbackActions({ message, onMessageFeedback }: MessageFeedbackActionsProps) {
+export function MessageFeedbackActions({ agentId, message }: MessageFeedbackActionsProps) {
   const [feedback, setFeedback] = useState<AgentMessageFeedback | null>(message.viewerFeedback ?? null)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const handleFeedback = useCallback(async (requestedFeedback: AgentMessageFeedback) => {
-    if (!onMessageFeedback || submitting) {
+  async function handleFeedback(requestedFeedback: AgentMessageFeedback) {
+    if (!agentId || submitting) {
       return
     }
     const previousFeedback = feedback
@@ -22,44 +28,37 @@ export function MessageFeedbackActions({ message, onMessageFeedback }: MessageFe
     setError(null)
     setSubmitting(true)
     try {
-      const savedFeedback = await onMessageFeedback(message, nextFeedback)
-      setFeedback(savedFeedback)
+      const response = await updateAgentMessageFeedback(agentId, message.id, nextFeedback)
+      setFeedback(response.feedback)
     } catch {
       setFeedback(previousFeedback)
       setError('Unable to save feedback. Please try again.')
     } finally {
       setSubmitting(false)
     }
-  }, [feedback, message, onMessageFeedback, submitting])
+  }
 
   return (
     <>
-      <button
-        type="button"
-        className="chat-message-action-button"
-        data-active={feedback === 'up' ? 'true' : 'false'}
-        data-feedback="up"
-        onClick={() => void handleFeedback('up')}
-        disabled={submitting || !onMessageFeedback}
-        title={error || (feedback === 'up' ? 'Remove thumbs up' : 'Thumbs up')}
-        aria-label={feedback === 'up' ? 'Remove thumbs up feedback' : 'Give thumbs up feedback'}
-        aria-pressed={feedback === 'up'}
-      >
-        <ThumbsUp className="h-3.5 w-3.5" aria-hidden="true" />
-      </button>
-      <button
-        type="button"
-        className="chat-message-action-button"
-        data-active={feedback === 'down' ? 'true' : 'false'}
-        data-feedback="down"
-        onClick={() => void handleFeedback('down')}
-        disabled={submitting || !onMessageFeedback}
-        title={error || (feedback === 'down' ? 'Remove thumbs down' : 'Thumbs down')}
-        aria-label={feedback === 'down' ? 'Remove thumbs down feedback' : 'Give thumbs down feedback'}
-        aria-pressed={feedback === 'down'}
-      >
-        <ThumbsDown className="h-3.5 w-3.5" aria-hidden="true" />
-      </button>
+      {FEEDBACK_OPTIONS.map(({ value, label, Icon }) => {
+        const active = feedback === value
+        return (
+          <button
+            key={value}
+            type="button"
+            className="chat-message-action-button"
+            data-active={active ? 'true' : 'false'}
+            data-feedback={value}
+            onClick={() => void handleFeedback(value)}
+            disabled={submitting || !agentId}
+            title={error || (active ? `Remove ${label.toLowerCase()}` : label)}
+            aria-label={active ? `Remove ${label.toLowerCase()} feedback` : `Give ${label.toLowerCase()} feedback`}
+            aria-pressed={active}
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        )
+      })}
       <span className="sr-only" role="status" aria-live="polite">
         {error || (submitting ? 'Saving message feedback' : '')}
       </span>

--- a/frontend/src/components/agentChat/TimelineEventItem.tsx
+++ b/frontend/src/components/agentChat/TimelineEventItem.tsx
@@ -5,7 +5,7 @@ import { ToolClusterCard } from './ToolClusterCard'
 import { CollapsedActivityCard } from './CollapsedActivityCard'
 import { InlineScheduleCard } from './InlineStatusCard'
 import type { SimplifiedTimelineItem } from '../../hooks/useSimplifiedTimeline'
-import type { AgentMessage, AgentMessageFeedback, DeveloperTimelineEvent } from '../../types/agentChat'
+import type { AgentMessage, DeveloperTimelineEvent } from '../../types/agentChat'
 import type { ToolClusterEvent } from '../../types/agentChat'
 import { buildThinkingCluster, flattenTimelineEventsToEntries } from './activityEntryUtils'
 import type { StatusExpansionTargets } from './statusExpansion'
@@ -26,8 +26,6 @@ type TimelineEventItemProps = {
   animateIncoming?: boolean
   onIncomingAnimationConsumed?: (cursor: string) => void
   onMessageLinkClick?: (href: string) => boolean | void
-  onMessageCopied?: (message: AgentMessage) => void | Promise<void>
-  onMessageFeedback?: (message: AgentMessage, feedback: AgentMessageFeedback | null) => Promise<AgentMessageFeedback | null>
   onReportMessage?: (message: AgentMessage) => void
   onRetryMessage?: (message: AgentMessage) => void | Promise<void>
 }
@@ -44,8 +42,6 @@ export const TimelineEventItem = memo(function TimelineEventItem({
   animateIncoming = false,
   onIncomingAnimationConsumed,
   onMessageLinkClick,
-  onMessageCopied,
-  onMessageFeedback,
   onReportMessage,
   onRetryMessage,
 }: TimelineEventItemProps) {
@@ -77,14 +73,13 @@ export const TimelineEventItem = memo(function TimelineEventItem({
     return (
       <MessageEventCard
         eventCursor={event.cursor}
+        agentId={activeAgentId}
         message={event.message}
         agentFirstName={agentFirstName}
         agentAvatarUrl={agentAvatarUrl}
         viewerUserId={viewerUserId ?? null}
         viewerEmail={viewerEmail ?? null}
         onMessageLinkClick={onMessageLinkClick}
-        onMessageCopied={onMessageCopied}
-        onMessageFeedback={onMessageFeedback}
         onReportMessage={onReportMessage}
         onRetryMessage={onRetryMessage}
       />

--- a/frontend/src/components/agentChat/TimelineEventItem.tsx
+++ b/frontend/src/components/agentChat/TimelineEventItem.tsx
@@ -5,7 +5,7 @@ import { ToolClusterCard } from './ToolClusterCard'
 import { CollapsedActivityCard } from './CollapsedActivityCard'
 import { InlineScheduleCard } from './InlineStatusCard'
 import type { SimplifiedTimelineItem } from '../../hooks/useSimplifiedTimeline'
-import type { AgentMessage, DeveloperTimelineEvent } from '../../types/agentChat'
+import type { AgentMessage, AgentMessageFeedback, DeveloperTimelineEvent } from '../../types/agentChat'
 import type { ToolClusterEvent } from '../../types/agentChat'
 import { buildThinkingCluster, flattenTimelineEventsToEntries } from './activityEntryUtils'
 import type { StatusExpansionTargets } from './statusExpansion'
@@ -27,6 +27,7 @@ type TimelineEventItemProps = {
   onIncomingAnimationConsumed?: (cursor: string) => void
   onMessageLinkClick?: (href: string) => boolean | void
   onMessageCopied?: (message: AgentMessage) => void | Promise<void>
+  onMessageFeedback?: (message: AgentMessage, feedback: AgentMessageFeedback | null) => Promise<AgentMessageFeedback | null>
   onReportMessage?: (message: AgentMessage) => void
   onRetryMessage?: (message: AgentMessage) => void | Promise<void>
 }
@@ -44,6 +45,7 @@ export const TimelineEventItem = memo(function TimelineEventItem({
   onIncomingAnimationConsumed,
   onMessageLinkClick,
   onMessageCopied,
+  onMessageFeedback,
   onReportMessage,
   onRetryMessage,
 }: TimelineEventItemProps) {
@@ -82,6 +84,7 @@ export const TimelineEventItem = memo(function TimelineEventItem({
         viewerEmail={viewerEmail ?? null}
         onMessageLinkClick={onMessageLinkClick}
         onMessageCopied={onMessageCopied}
+        onMessageFeedback={onMessageFeedback}
         onReportMessage={onReportMessage}
         onRetryMessage={onRetryMessage}
       />

--- a/frontend/src/components/agentChat/types.ts
+++ b/frontend/src/components/agentChat/types.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage, AgentTimelineSnapshot, TimelineEvent, MessageEvent, ToolClusterEvent, ToolCallEntry, ThinkingEvent, PlanEvent, PlanStepChange, PlanSnapshot } from '../../types/agentChat'
+import type { AgentMessage, AgentMessageFeedback, AgentTimelineSnapshot, TimelineEvent, MessageEvent, ToolClusterEvent, ToolCallEntry, ThinkingEvent, PlanEvent, PlanStepChange, PlanSnapshot } from '../../types/agentChat'
 
 export type AgentTimelineProps = AgentTimelineSnapshot
 
@@ -12,4 +12,5 @@ export type {
   PlanStepChange,
   PlanSnapshot,
   AgentMessage,
+  AgentMessageFeedback,
 }

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3609,6 +3609,10 @@
     transform: translateY(-50%);
     transition: opacity 0.15s ease;
 }
+.chat-message-actions:has(.chat-message-feedback-error) {
+    opacity: 1;
+    pointer-events: auto;
+}
 .chat-message-action-button {
     width: 1.45rem;
     height: 1.45rem;

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3632,6 +3632,19 @@
     cursor: not-allowed;
     opacity: 0.45;
 }
+.chat-message-action-button[data-feedback="up"][data-active="true"] {
+    border-color: rgba(5, 150, 105, 0.4);
+    background: rgba(236, 253, 245, 0.96);
+    color: #047857;
+}
+.chat-message-action-button[data-feedback="down"][data-active="true"] {
+    border-color: rgba(225, 29, 72, 0.38);
+    background: rgba(255, 241, 242, 0.96);
+    color: #be123c;
+}
+.chat-message-action-button[data-feedback][data-active="true"] svg {
+    fill: currentColor;
+}
 .chat-bubble:hover .chat-timestamp {
     opacity: 1;
 }

--- a/frontend/src/types/agentChat.ts
+++ b/frontend/src/types/agentChat.ts
@@ -31,6 +31,8 @@ export type WebhookMeta = {
   payload?: unknown
 }
 
+export type AgentMessageFeedback = 'up' | 'down'
+
 export type AgentMessage = {
   id: string
   cursor?: string
@@ -55,6 +57,7 @@ export type AgentMessage = {
   sourceKind?: string | null
   sourceLabel?: string | null
   webhookMeta?: WebhookMeta | null
+  viewerFeedback?: AgentMessageFeedback | null
 }
 
 export type ToolMeta = {

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -51,6 +51,7 @@ from api.models import (
     PersistentAgentInboundWebhook,
     PersistentAgentMessage,
     PersistentAgentMessageAttachment,
+    PersistentAgentMessageFeedback,
     PersistentAgentSecret,
     PersistentAgentStep,
     PersistentAgentToolCall,
@@ -2903,6 +2904,191 @@ class AgentChatAPITests(TestCase):
         self.assertEqual(props.get("message_id"), str(message.id))
         self.assertNotIn("body", props)
         self.assertNotIn("comment", props)
+
+    @tag("batch_agent_chat")
+    @patch("console.api_views.Analytics.track_event")
+    def test_agent_message_feedback_creates_switches_and_clears(self, mock_track_event):
+        message = PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            from_endpoint=self.agent_endpoint,
+            to_endpoint=self.user_endpoint,
+            is_outbound=True,
+            body="Rate this agent reply",
+        )
+        url = f"/console/api/agents/{self.agent.id}/messages/{message.id}/feedback/"
+
+        up_response = self.client.post(
+            url,
+            data=json.dumps({"feedback": "up"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(up_response.status_code, 200, up_response.content)
+        self.assertEqual(up_response.json(), {"ok": True, "feedback": "up"})
+        feedback = PersistentAgentMessageFeedback.objects.get(message=message, user=self.user)
+        self.assertEqual(feedback.rating, PersistentAgentMessageFeedback.Rating.UP)
+        self.assertEqual(mock_track_event.call_args.kwargs["event"], AnalyticsEvent.AGENT_MESSAGE_FEEDBACK_UPDATED)
+        props = mock_track_event.call_args.kwargs["properties"]
+        self.assertEqual(props["previous_feedback"], "none")
+        self.assertEqual(props["feedback"], "up")
+        self.assertNotIn("body", props)
+
+        mock_track_event.reset_mock()
+        repeated_response = self.client.post(
+            url,
+            data=json.dumps({"feedback": "up"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(repeated_response.status_code, 200, repeated_response.content)
+        self.assertEqual(PersistentAgentMessageFeedback.objects.filter(message=message, user=self.user).count(), 1)
+        mock_track_event.assert_not_called()
+
+        down_response = self.client.post(
+            url,
+            data=json.dumps({"feedback": "down"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(down_response.status_code, 200, down_response.content)
+        feedback.refresh_from_db()
+        self.assertEqual(feedback.rating, PersistentAgentMessageFeedback.Rating.DOWN)
+        props = mock_track_event.call_args.kwargs["properties"]
+        self.assertEqual(props["previous_feedback"], "up")
+        self.assertEqual(props["feedback"], "down")
+
+        mock_track_event.reset_mock()
+        clear_response = self.client.post(
+            url,
+            data=json.dumps({"feedback": None}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(clear_response.status_code, 200, clear_response.content)
+        self.assertEqual(clear_response.json(), {"ok": True, "feedback": None})
+        self.assertFalse(PersistentAgentMessageFeedback.objects.filter(message=message, user=self.user).exists())
+        props = mock_track_event.call_args.kwargs["properties"]
+        self.assertEqual(props["previous_feedback"], "down")
+        self.assertEqual(props["feedback"], "none")
+
+    @tag("batch_agent_chat")
+    def test_timeline_serializes_feedback_for_current_viewer(self):
+        message = PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            from_endpoint=self.agent_endpoint,
+            to_endpoint=self.user_endpoint,
+            is_outbound=True,
+            body="Viewer-specific feedback",
+        )
+        other_user = get_user_model().objects.create_user(
+            username="feedback-viewer",
+            email="feedback-viewer@example.com",
+            password="password123",
+        )
+        PersistentAgentMessageFeedback.objects.create(
+            message=message,
+            user=self.user,
+            rating=PersistentAgentMessageFeedback.Rating.UP,
+        )
+        PersistentAgentMessageFeedback.objects.create(
+            message=message,
+            user=other_user,
+            rating=PersistentAgentMessageFeedback.Rating.DOWN,
+        )
+
+        owner_window = fetch_timeline_window(self.agent, viewer_user=self.user)
+        other_window = fetch_timeline_window(self.agent, viewer_user=other_user)
+        anonymous_window = fetch_timeline_window(self.agent)
+
+        def serialized_feedback(window):
+            return next(
+                event["message"]["viewerFeedback"]
+                for event in window.events
+                if event.get("kind") == "message" and event["message"]["id"] == str(message.id)
+            )
+
+        self.assertEqual(serialized_feedback(owner_window), "up")
+        self.assertEqual(serialized_feedback(other_window), "down")
+        self.assertIsNone(serialized_feedback(anonymous_window))
+
+    @tag("batch_agent_chat")
+    @patch("console.api_views.Analytics.track_event")
+    def test_agent_message_feedback_rejects_invalid_or_unreportable_messages(self, mock_track_event):
+        outbound = PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            from_endpoint=self.agent_endpoint,
+            to_endpoint=self.user_endpoint,
+            is_outbound=True,
+            body="Valid outbound message",
+        )
+        inbound = PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            from_endpoint=self.user_endpoint,
+            to_endpoint=self.agent_endpoint,
+            is_outbound=False,
+            body="Inbound user message",
+        )
+        peer = PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            peer_agent=self.agent,
+            from_endpoint=self.agent_endpoint,
+            to_endpoint=self.user_endpoint,
+            is_outbound=True,
+            body="Peer message",
+        )
+        other_user = get_user_model().objects.create_user(
+            username="foreign-feedback-owner",
+            email="foreign-feedback-owner@example.com",
+            password="password123",
+        )
+        other_browser_agent = BrowserUseAgent.objects.create(user=other_user, name="Foreign Feedback Browser Agent")
+        other_agent = PersistentAgent.objects.create(
+            user=other_user,
+            name="Foreign Feedback Agent",
+            charter="Other work",
+            browser_use_agent=other_browser_agent,
+        )
+        other_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=other_agent,
+            channel=CommsChannel.WEB,
+            address=build_web_agent_address(other_agent.id),
+            is_primary=True,
+        )
+        foreign_message = PersistentAgentMessage.objects.create(
+            owner_agent=other_agent,
+            from_endpoint=other_endpoint,
+            to_endpoint=self.user_endpoint,
+            is_outbound=True,
+            body="Foreign agent reply",
+        )
+
+        invalid_response = self.client.post(
+            f"/console/api/agents/{self.agent.id}/messages/{outbound.id}/feedback/",
+            data=json.dumps({"feedback": ["up"]}),
+            content_type="application/json",
+        )
+        inbound_response = self.client.post(
+            f"/console/api/agents/{self.agent.id}/messages/{inbound.id}/feedback/",
+            data=json.dumps({"feedback": "down"}),
+            content_type="application/json",
+        )
+        peer_response = self.client.post(
+            f"/console/api/agents/{self.agent.id}/messages/{peer.id}/feedback/",
+            data=json.dumps({"feedback": "up"}),
+            content_type="application/json",
+        )
+        foreign_response = self.client.post(
+            f"/console/api/agents/{self.agent.id}/messages/{foreign_message.id}/feedback/",
+            data=json.dumps({"feedback": "up"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(invalid_response.status_code, 400)
+        self.assertEqual(inbound_response.status_code, 404)
+        self.assertEqual(peer_response.status_code, 404)
+        self.assertEqual(foreign_response.status_code, 404)
+        self.assertFalse(PersistentAgentMessageFeedback.objects.exists())
+        mock_track_event.assert_not_called()
 
     @tag("batch_agent_chat")
     @override_settings(SUPPORT_EMAIL="support@example.com")

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -3067,6 +3067,11 @@ class AgentChatAPITests(TestCase):
             data=json.dumps({"feedback": ["up"]}),
             content_type="application/json",
         )
+        non_object_response = self.client.post(
+            f"/console/api/agents/{self.agent.id}/messages/{outbound.id}/feedback/",
+            data=json.dumps(["up"]),
+            content_type="application/json",
+        )
         inbound_response = self.client.post(
             f"/console/api/agents/{self.agent.id}/messages/{inbound.id}/feedback/",
             data=json.dumps({"feedback": "down"}),
@@ -3084,11 +3089,34 @@ class AgentChatAPITests(TestCase):
         )
 
         self.assertEqual(invalid_response.status_code, 400)
+        self.assertEqual(non_object_response.status_code, 400)
+        self.assertEqual(non_object_response.content, b"JSON object expected")
         self.assertEqual(inbound_response.status_code, 404)
         self.assertEqual(peer_response.status_code, 404)
         self.assertEqual(foreign_response.status_code, 404)
         self.assertFalse(PersistentAgentMessageFeedback.objects.exists())
         mock_track_event.assert_not_called()
+
+    @tag("batch_agent_chat")
+    def test_agent_message_feedback_requires_csrf_token(self):
+        message = PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            from_endpoint=self.agent_endpoint,
+            to_endpoint=self.user_endpoint,
+            is_outbound=True,
+            body="CSRF-protected feedback",
+        )
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_client.force_login(self.user)
+
+        response = csrf_client.post(
+            f"/console/api/agents/{self.agent.id}/messages/{message.id}/feedback/",
+            data=json.dumps({"feedback": "up"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(PersistentAgentMessageFeedback.objects.filter(message=message, user=self.user).exists())
 
     @tag("batch_agent_chat")
     @override_settings(SUPPORT_EMAIL="support@example.com")

--- a/util/analytics.py
+++ b/util/analytics.py
@@ -109,6 +109,7 @@ class AnalyticsEvent(StrEnum):
     WEB_CHAT_SESSION_ENDED = 'Web Chat Session Ended'
     WEB_CHAT_MESSAGE_SENT = 'Web Chat Message Sent'
     AGENT_MESSAGE_COPIED = 'Agent Message Copied'
+    AGENT_MESSAGE_FEEDBACK_UPDATED = 'Agent Message Feedback Updated'
     AGENT_MESSAGE_ISSUE_REPORTED = 'Agent Message Issue Reported'
     SIGNUP_PREVIEW_ENTERED = 'Signup Preview Entered'
     SIGNUP_PREVIEW_AGENT_CREATED = 'Signup Preview Agent Created'


### PR DESCRIPTION
## Summary
- Add persisted thumbs up/down feedback for agent messages with per-user uniqueness.
- Expose a new API endpoint to create, update, or clear message feedback and emit analytics on changes.
- Surface the viewer's existing feedback in the agent timeline and add inline thumbs controls in the chat UI.
- Preserve copy tracking in the message card while removing the old callback plumbing.

## Testing
- Added unit coverage for creating, switching, and clearing feedback, including validation and analytics behavior.
- Added frontend state handling for optimistic feedback updates and existing feedback rendering.
- Not run (not requested).