### PR TITLE
Add contact auto-approval settings for agent communication

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -2635,17 +2635,30 @@ def _build_contacts_block(
                 allowed_lines.append(f"- email: {collaborator.user.email} (collaborator)")
 
     if owner_email_verified:
-        allowed_lines.append("Only contact people listed here or in recent conversations.")
-        allowed_lines.append(
-            f"For bulk or exact recipient checks, query {CONTACTS_TABLE}; safe outbound recipients "
-            "have status='allowed' AND allow_outbound=1. Use ORDER BY relevance_at DESC for "
-            "recently active or updated contacts. Do not infer approval from local lead status or "
-            "an empty pending contacts queue."
-        )
-        allowed_lines.append("To reach someone new, use request_contact_permission—it returns a link to share with the user.")
-        allowed_lines.append(
-            "If the user asks you to email or text a specific new address or phone number, request contact permission before reading files, searching, drafting, tool search, or asking non-blocking follow-up questions."
-        )
+        if agent.contact_approval_mode == PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL:
+            allowed_lines.append(
+                "You may email a new address directly with send_email; each new To/CC email recipient is automatically added to the contact list up to the account contact limit."
+            )
+            allowed_lines.append(
+                "Do not request contact permission for a new email recipient. SMS contacts still require request_contact_permission and human approval."
+            )
+            allowed_lines.append(
+                f"For existing or bulk recipient checks, query {CONTACTS_TABLE}; currently safe outbound recipients "
+                "have status='allowed' AND allow_outbound=1. Use ORDER BY relevance_at DESC for "
+                "recently active or updated contacts."
+            )
+        else:
+            allowed_lines.append("Only contact people listed here or in recent conversations.")
+            allowed_lines.append(
+                f"For bulk or exact recipient checks, query {CONTACTS_TABLE}; safe outbound recipients "
+                "have status='allowed' AND allow_outbound=1. Use ORDER BY relevance_at DESC for "
+                "recently active or updated contacts. Do not infer approval from local lead status or "
+                "an empty pending contacts queue."
+            )
+            allowed_lines.append("To reach someone new, use request_contact_permission—it returns a link to share with the user.")
+            allowed_lines.append(
+                "If the user asks you to email or text a specific new address or phone number, request contact permission before reading files, searching, drafting, tool search, or asking non-blocking follow-up questions."
+            )
         allowed_lines.append("You do not have to message or reply to everyone; you may choose the best contact or contacts for your needs.")
     else:
         allowed_lines.append("External contacts are unavailable until your owner verifies their email address.")

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -2649,15 +2649,14 @@ def _build_contacts_block(
             allowed_lines.append(
                 "If the user asks you to email or text a specific new address or phone number, request contact permission before reading files, searching, drafting, tool search, or asking non-blocking follow-up questions."
             )
+            allowed_lines.append(
+                "Do not infer approval from local lead status or an empty pending contacts queue."
+            )
         allowed_lines.append(
             f"For existing or bulk recipient checks, query {CONTACTS_TABLE}; safe outbound recipients "
             "have status='allowed' AND allow_outbound=1. Use ORDER BY relevance_at DESC for "
             "recently active or updated contacts."
         )
-        if not auto_approve_email:
-            allowed_lines.append(
-                "Do not infer approval from local lead status or an empty pending contacts queue."
-            )
         allowed_lines.append("You do not have to message or reply to everyone; you may choose the best contact or contacts for your needs.")
     else:
         allowed_lines.append("External contacts are unavailable until your owner verifies their email address.")

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -2635,29 +2635,28 @@ def _build_contacts_block(
                 allowed_lines.append(f"- email: {collaborator.user.email} (collaborator)")
 
     if owner_email_verified:
-        if agent.contact_approval_mode == PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL:
+        auto_approve_email = agent.contact_approval_mode == PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        if auto_approve_email:
             allowed_lines.append(
                 "You may email a new address directly with send_email; each new To/CC email recipient is automatically added to the contact list up to the account contact limit."
             )
             allowed_lines.append(
                 "Do not request contact permission for a new email recipient. SMS contacts still require request_contact_permission and human approval."
             )
-            allowed_lines.append(
-                f"For existing or bulk recipient checks, query {CONTACTS_TABLE}; currently safe outbound recipients "
-                "have status='allowed' AND allow_outbound=1. Use ORDER BY relevance_at DESC for "
-                "recently active or updated contacts."
-            )
         else:
             allowed_lines.append("Only contact people listed here or in recent conversations.")
-            allowed_lines.append(
-                f"For bulk or exact recipient checks, query {CONTACTS_TABLE}; safe outbound recipients "
-                "have status='allowed' AND allow_outbound=1. Use ORDER BY relevance_at DESC for "
-                "recently active or updated contacts. Do not infer approval from local lead status or "
-                "an empty pending contacts queue."
-            )
             allowed_lines.append("To reach someone new, use request_contact_permission—it returns a link to share with the user.")
             allowed_lines.append(
                 "If the user asks you to email or text a specific new address or phone number, request contact permission before reading files, searching, drafting, tool search, or asking non-blocking follow-up questions."
+            )
+        allowed_lines.append(
+            f"For existing or bulk recipient checks, query {CONTACTS_TABLE}; safe outbound recipients "
+            "have status='allowed' AND allow_outbound=1. Use ORDER BY relevance_at DESC for "
+            "recently active or updated contacts."
+        )
+        if not auto_approve_email:
+            allowed_lines.append(
+                "Do not infer approval from local lead status or an empty pending contacts queue."
             )
         allowed_lines.append("You do not have to message or reply to everyone; you may choose the best contact or contacts for your needs.")
     else:

--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -25,6 +25,10 @@ from ..files.attachment_helpers import AttachmentResolutionError, create_message
 from ..files.filespace_service import broadcast_message_attachment_update
 from api.services.email_verification import require_verified_email, EmailVerificationError
 from api.services.signup_preview import can_bypass_email_verification_for_signup_preview_first_email
+from api.services.contact_authorization import (
+    AutomaticContactAuthorizationError,
+    authorize_email_contacts,
+)
 from .attachment_guidance import SEND_EMAIL_ATTACHMENTS_DESCRIPTION
 
 logger = logging.getLogger(__name__)
@@ -255,6 +259,12 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
         from django.db import close_old_connections
         from django.db.utils import OperationalError
         all_recipients = [to_address] + cc_addresses
+        if agent.contact_approval_mode == PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL:
+            try:
+                authorize_email_contacts(agent, all_recipients)
+            except AutomaticContactAuthorizationError as exc:
+                return {"status": "error", "message": str(exc)}
+
         for recipient in all_recipients:
             if not agent.is_recipient_whitelisted(CommsChannel.EMAIL, recipient):
                 return {

--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -12,7 +12,15 @@ from typing import Dict, Any
 from django.conf import settings
 from django.db import transaction
 
-from ...models import PersistentAgent, PersistentAgentCommsEndpoint, PersistentAgentConversationParticipant, PersistentAgentMessage, CommsChannel, DeliveryStatus
+from ...models import (
+    CommsAllowlistEntry,
+    CommsChannel,
+    DeliveryStatus,
+    PersistentAgent,
+    PersistentAgentCommsEndpoint,
+    PersistentAgentConversationParticipant,
+    PersistentAgentMessage,
+)
 from ..comms.email_threading import get_message_channel, get_message_contact_address, normalize_email_address
 from ..comms.outbound_delivery import deliver_agent_email
 from ..comms.email_endpoint_routing import resolve_agent_email_sender_endpoint_for_message
@@ -267,6 +275,19 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
 
         for recipient in all_recipients:
             if not agent.is_recipient_whitelisted(CommsChannel.EMAIL, recipient):
+                if CommsAllowlistEntry.objects.filter(
+                    agent=agent,
+                    channel=CommsChannel.EMAIL,
+                    address=recipient,
+                    is_active=True,
+                ).exists():
+                    return {
+                        "status": "error",
+                        "message": (
+                            f"Outbound email is disabled for contact '{recipient}'. "
+                            "The owner can enable it in Contacts & Access."
+                        ),
+                    }
                 return {
                     "status": "error",
                     "message": (

--- a/api/agent/tools/request_contact_permission.py
+++ b/api/agent/tools/request_contact_permission.py
@@ -2,35 +2,55 @@
 Request contact permission tool for persistent agents.
 
 This tool allows agents to request permission to contact people
-who are not yet in their allowlist. The agent owner must approve
-these requests before the agent can send messages.
+who are not yet in their allowlist. Email contacts may be approved
+automatically when the owner has enabled that mode; SMS never is.
 """
 import logging
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from datetime import timedelta
 
 from ...models import PersistentAgent, CommsAllowlistEntry, CommsAllowlistRequest, CommsChannel, SmsContactPurpose
+from api.services.contact_authorization import (
+    AutomaticContactAuthorizationError,
+    authorize_email_contacts,
+)
 from api.services.sms_contact_purpose import sms_contact_purpose_required
 from util.urls import build_immersive_contact_requests_path, build_immersive_contact_requests_site_url
 
 logger = logging.getLogger(__name__)
 
 
-def get_request_contact_permission_tool() -> dict:
+def get_request_contact_permission_tool(agent: PersistentAgent | None = None) -> dict:
     """Return the tool definition for requesting contact permission."""
+    auto_approve_email = bool(
+        agent
+        and agent.contact_approval_mode == PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+    )
+    if auto_approve_email:
+        description = (
+            "Request approval before texting a specific contact not in your allowlist. "
+            "New email recipients do not need this tool: call send_email directly and they will be added automatically. "
+            "If this tool is called for a new email contact, the contact is approved immediately without a review link. "
+            "SMS contacts still require human approval, and pending SMS requests return a URL you MUST send to the user. "
+            "Use only user-provided or public contact details; do not guess."
+        )
+    else:
+        description = (
+            "Request approval before emailing/texting a specific contact not in your allowlist. "
+            "Use this instead of request_human_input for email/SMS contact approval. "
+            "Returns a URL you MUST send so the user can approve. "
+            "Check allowed contacts first; if the user just gave a specific email/phone not already allowed, request before reading files, searching, drafting, or non-blocking follow-up. "
+            "For setup-only recurring work where the user explicitly says not to send the first email/SMS now, "
+            "do not request contact permission during setup; record the recipient and request only when an actual outbound send is needed. "
+            "Use only user-provided or public contact details; do not guess."
+        )
     return {
         "type": "function",
         "function": {
             "name": "request_contact_permission",
-            "description": (
-                "Request approval before emailing/texting a specific contact not in your allowlist. "
-                "Use this instead of request_human_input for email/SMS contact approval. "
-                "Returns a URL you MUST send so the user can approve. "
-                "Check allowed contacts first; if the user just gave a specific email/phone not already allowed, request before reading files, searching, drafting, or non-blocking follow-up. "
-                "For setup-only recurring work where the user explicitly says not to send the first email/SMS now, "
-                "do not request contact permission during setup; record the recipient and request only when an actual outbound send is needed. "
-                "Use only user-provided or public contact details; do not guess."
-            ),
+            "description": description,
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -84,9 +104,9 @@ def get_request_contact_permission_tool() -> dict:
 def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> dict:
     """Create contact permission requests for the agent.
     
-    This tool allows agents to request permission to contact people
-    who are not yet in their allowlist. The requests are created as
-    CommsAllowlistRequest records that the user must approve.
+    This tool creates CommsAllowlistRequest records for new contacts.
+    Eligible email requests are approved immediately when configured;
+    all other requests remain pending for the user.
     """
     contacts = params.get("contacts")
     if not contacts or not isinstance(contacts, list):
@@ -96,6 +116,7 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
         return {"status": "error", "message": "At least one contact must be specified"}
     
     created_requests = []
+    auto_approved = []
     already_allowed = []
     already_pending = []
     errors = []
@@ -185,6 +206,33 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
                     address, channel, agent.id
                 )
                 continue
+
+            if (
+                channel_enum == CommsChannel.EMAIL
+                and agent.contact_approval_mode == PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+            ):
+                try:
+                    with transaction.atomic():
+                        request_obj = CommsAllowlistRequest.objects.create(
+                            agent=agent,
+                            channel=channel_enum,
+                            address=address,
+                            name=name,
+                            reason=reason,
+                            purpose=purpose,
+                            expires_at=timezone.now() + timedelta(days=7),
+                        )
+                        authorize_email_contacts(agent, [address])
+                        request_obj.approve(invited_by=agent.user, skip_invitation=True)
+                    auto_approved.append({
+                        "address": address,
+                        "channel": channel,
+                        "name": name or "Unknown",
+                        "purpose": purpose,
+                    })
+                except (AutomaticContactAuthorizationError, IntegrityError, ValidationError, ValueError) as exc:
+                    errors.append(f"Failed to automatically allow '{address}': {exc}")
+                continue
             
             # Create the contact request
             # Set expiry to 7 days from now by default
@@ -241,6 +289,12 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
             f"{c['name']} ({c['address']})" for c in created_requests
         ])
         parts.append(f"Created {len(created_requests)} contact request(s): {contacts_list}")
+
+    if auto_approved:
+        contacts_list = ", ".join([
+            f"{c['name']} ({c['address']})" for c in auto_approved
+        ])
+        parts.append(f"Automatically allowed {len(auto_approved)} email contact(s): {contacts_list}")
     
     if already_allowed:
         allowed_list = ", ".join([f"{c['address']}" for c in already_allowed])
@@ -261,9 +315,9 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
         message += f". You must now send a message to the user asking them to approve the contact request(s) at {approval_url}"
     
     # Determine status
-    if created_requests and not errors:
+    if (created_requests or auto_approved) and not errors:
         status = "ok"
-    elif created_requests and errors:
+    elif (created_requests or auto_approved) and errors:
         status = "partial"
     elif already_allowed and not errors:
         status = "ok"
@@ -274,6 +328,7 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
         "status": status,
         "message": message,
         "created_count": len(created_requests),
+        "auto_approved_count": len(auto_approved),
         "already_allowed_count": len(already_allowed),
         "already_pending_count": len(already_pending),
         "approval_url": approval_url if created_requests else None

--- a/api/agent/tools/request_contact_permission.py
+++ b/api/agent/tools/request_contact_permission.py
@@ -213,23 +213,18 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
             ):
                 try:
                     with transaction.atomic():
-                        request_obj = CommsAllowlistRequest.objects.create(
+                        authorize_email_contacts(agent, [address])
+                        CommsAllowlistRequest.objects.create(
                             agent=agent,
                             channel=channel_enum,
                             address=address,
                             name=name,
                             reason=reason,
                             purpose=purpose,
-                            expires_at=timezone.now() + timedelta(days=7),
+                            status=CommsAllowlistRequest.RequestStatus.APPROVED,
+                            responded_at=timezone.now(),
                         )
-                        authorize_email_contacts(agent, [address])
-                        request_obj.approve(invited_by=agent.user, skip_invitation=True)
-                    auto_approved.append({
-                        "address": address,
-                        "channel": channel,
-                        "name": name or "Unknown",
-                        "purpose": purpose,
-                    })
+                    auto_approved.append(f"{name or 'Unknown'} ({address})")
                 except (AutomaticContactAuthorizationError, IntegrityError, ValidationError, ValueError) as exc:
                     errors.append(f"Failed to automatically allow '{address}': {exc}")
                 continue
@@ -267,19 +262,20 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
             errors.append(error_msg)
             logger.exception("Error creating contact request for agent %s", agent.id)
     
-    # Generate the full external URL for the contact requests page
-    try:
-        approval_url = build_immersive_contact_requests_site_url(
-            agent.id,
-            str(agent.organization_id) if agent.organization_id else None,
-        )
-    except Exception:
-        logger.warning(
-            "Failed to generate contact requests URL for agent %s; returning relative fallback",
-            agent.id,
-            exc_info=True,
-        )
-        approval_url = build_immersive_contact_requests_path(agent.id)
+    approval_url = None
+    if created_requests:
+        try:
+            approval_url = build_immersive_contact_requests_site_url(
+                agent.id,
+                str(agent.organization_id) if agent.organization_id else None,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to generate contact requests URL for agent %s; returning relative fallback",
+                agent.id,
+                exc_info=True,
+            )
+            approval_url = build_immersive_contact_requests_path(agent.id)
     
     # Build response message
     parts = []
@@ -291,9 +287,7 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
         parts.append(f"Created {len(created_requests)} contact request(s): {contacts_list}")
 
     if auto_approved:
-        contacts_list = ", ".join([
-            f"{c['name']} ({c['address']})" for c in auto_approved
-        ])
+        contacts_list = ", ".join(auto_approved)
         parts.append(f"Automatically allowed {len(auto_approved)} email contact(s): {contacts_list}")
     
     if already_allowed:
@@ -315,10 +309,8 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
         message += f". You must now send a message to the user asking them to approve the contact request(s) at {approval_url}"
     
     # Determine status
-    if (created_requests or auto_approved) and not errors:
-        status = "ok"
-    elif (created_requests or auto_approved) and errors:
-        status = "partial"
+    if created_requests or auto_approved:
+        status = "partial" if errors else "ok"
     elif already_allowed and not errors:
         status = "ok"
     else:
@@ -331,5 +323,5 @@ def execute_request_contact_permission(agent: PersistentAgent, params: dict) -> 
         "auto_approved_count": len(auto_approved),
         "already_allowed_count": len(already_allowed),
         "already_pending_count": len(already_pending),
-        "approval_url": approval_url if created_requests else None
+        "approval_url": approval_url
     }

--- a/api/agent/tools/static_tools.py
+++ b/api/agent/tools/static_tools.py
@@ -103,7 +103,7 @@ def get_static_tool_definitions(agent: Optional[PersistentAgent]) -> List[dict]:
         get_spawn_web_task_tool(agent),
         get_search_tools_tool(),
         get_request_human_input_tool(),
-        get_request_contact_permission_tool(),
+        get_request_contact_permission_tool(agent),
         get_secure_credentials_request_tool(),
     ])
 

--- a/api/migrations/0425_persistentagent_contact_approval_mode.py
+++ b/api/migrations/0425_persistentagent_contact_approval_mode.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0424_persistentagentmessagefeedback"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="persistentagent",
+            name="contact_approval_mode",
+            field=models.CharField(
+                choices=[
+                    ("require_approval", "Require approval"),
+                    ("auto_approve_email", "Automatically allow email contacts"),
+                ],
+                default="require_approval",
+                help_text=(
+                    "Controls whether new email recipients require per-contact approval or are "
+                    "automatically added to the agent's contact list. SMS always requires approval."
+                ),
+                max_length=32,
+            ),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -6378,6 +6378,20 @@ class PersistentAgent(models.Model):
             "Manual: only addresses/numbers listed on the agent's allowlist (includes owner/org members by default)."
         ),
     )
+
+    class ContactApprovalMode(models.TextChoices):
+        REQUIRE_APPROVAL = "require_approval", "Require approval"
+        AUTO_APPROVE_EMAIL = "auto_approve_email", "Automatically allow email contacts"
+
+    contact_approval_mode = models.CharField(
+        max_length=32,
+        choices=ContactApprovalMode.choices,
+        default=ContactApprovalMode.REQUIRE_APPROVAL,
+        help_text=(
+            "Controls whether new email recipients require per-contact approval or are "
+            "automatically added to the agent's contact list. SMS always requires approval."
+        ),
+    )
     execution_environment = models.CharField(
         max_length=64,
         default=get_default_execution_environment,

--- a/api/services/contact_authorization.py
+++ b/api/services/contact_authorization.py
@@ -41,24 +41,25 @@ def authorize_email_contacts(agent: PersistentAgent, addresses) -> None:
                 "This agent requires approval before adding new email contacts."
             )
 
+        active_contact_addresses = set(
+            CommsAllowlistEntry.objects.select_for_update().filter(
+                agent=locked_agent,
+                channel=CommsChannel.EMAIL,
+                address__in=normalized_addresses,
+                is_active=True,
+            ).values_list("address", flat=True)
+        )
         addresses_to_authorize = [
             address
             for address in normalized_addresses
-            if not locked_agent.is_recipient_whitelisted(CommsChannel.EMAIL, address)
+            if address not in active_contact_addresses
+            and not locked_agent.is_recipient_whitelisted(CommsChannel.EMAIL, address)
         ]
         agent.whitelist_policy = locked_agent.whitelist_policy
         if not addresses_to_authorize:
             return
 
-        active_addresses = set(
-            CommsAllowlistEntry.objects.select_for_update().filter(
-                agent=locked_agent,
-                channel=CommsChannel.EMAIL,
-                address__in=addresses_to_authorize,
-                is_active=True,
-            ).values_list("address", flat=True)
-        )
-        slots_needed = len(addresses_to_authorize) - len(active_addresses)
+        slots_needed = len(addresses_to_authorize)
 
         contact_cap = get_user_max_contacts_per_agent(
             locked_agent.user,

--- a/api/services/contact_authorization.py
+++ b/api/services/contact_authorization.py
@@ -1,10 +1,12 @@
-from dataclasses import dataclass
-
-from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
 from django.db import transaction
 
-from api.models import CommsAllowlistEntry, CommsChannel, PersistentAgent, get_agent_contact_counts
+from api.models import (
+    CommsAllowlistEntry,
+    CommsChannel,
+    PersistentAgent,
+    PersistentAgentCommsEndpoint,
+    get_agent_contact_counts,
+)
 from util.subscription_helper import get_user_max_contacts_per_agent
 
 
@@ -12,43 +14,24 @@ class AutomaticContactAuthorizationError(Exception):
     pass
 
 
-@dataclass(frozen=True)
-class EmailContactAuthorizationResult:
-    addresses: tuple[str, ...]
-    created_addresses: tuple[str, ...]
-    reactivated_addresses: tuple[str, ...]
-
-
 def _normalize_email_addresses(addresses) -> list[str]:
-    normalized_addresses: list[str] = []
-    seen: set[str] = set()
-    for raw_address in addresses:
-        address = (raw_address or "").strip().lower()
-        try:
-            validate_email(address)
-        except ValidationError as exc:
-            raise AutomaticContactAuthorizationError(
-                f"Recipient address '{address or raw_address}' is not a valid email address."
-            ) from exc
-        if address not in seen:
-            seen.add(address)
-            normalized_addresses.append(address)
-    return normalized_addresses
+    return list(dict.fromkeys(
+        normalized
+        for address in addresses
+        if (
+            normalized := PersistentAgentCommsEndpoint.normalize_address(
+                CommsChannel.EMAIL,
+                address,
+            )
+        )
+    ))
 
 
-def authorize_email_contacts(agent: PersistentAgent, addresses) -> EmailContactAuthorizationResult:
+def authorize_email_contacts(agent: PersistentAgent, addresses) -> None:
     """Add otherwise-unauthorized email recipients when the agent owner opted in."""
     normalized_addresses = _normalize_email_addresses(addresses)
     if not normalized_addresses:
-        return EmailContactAuthorizationResult((), (), ())
-
-    if agent.contact_approval_mode != PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL:
-        raise AutomaticContactAuthorizationError(
-            "This agent requires approval before adding new email contacts."
-        )
-
-    created_addresses: list[str] = []
-    reactivated_addresses: list[str] = []
+        return
 
     with transaction.atomic():
         locked_agent = (
@@ -66,22 +49,19 @@ def authorize_email_contacts(agent: PersistentAgent, addresses) -> EmailContactA
             for address in normalized_addresses
             if not locked_agent.is_recipient_whitelisted(CommsChannel.EMAIL, address)
         ]
+        agent.whitelist_policy = locked_agent.whitelist_policy
         if not addresses_to_authorize:
-            return EmailContactAuthorizationResult(tuple(normalized_addresses), (), ())
+            return
 
-        existing_entries = {
-            entry.address: entry
-            for entry in CommsAllowlistEntry.objects.select_for_update().filter(
+        active_addresses = set(
+            CommsAllowlistEntry.objects.select_for_update().filter(
                 agent=locked_agent,
                 channel=CommsChannel.EMAIL,
                 address__in=addresses_to_authorize,
-            )
-        }
-        slots_needed = sum(
-            1
-            for address in addresses_to_authorize
-            if address not in existing_entries or not existing_entries[address].is_active
+                is_active=True,
+            ).values_list("address", flat=True)
         )
+        slots_needed = len(addresses_to_authorize) - len(active_addresses)
 
         contact_cap = get_user_max_contacts_per_agent(
             locked_agent.user,
@@ -97,37 +77,21 @@ def authorize_email_contacts(agent: PersistentAgent, addresses) -> EmailContactA
                 )
 
         for address in addresses_to_authorize:
-            entry = existing_entries.get(address)
-            if entry is None:
-                CommsAllowlistEntry.objects.create(
-                    agent=locked_agent,
-                    channel=CommsChannel.EMAIL,
-                    address=address,
-                    is_active=True,
-                    allow_inbound=True,
-                    allow_outbound=True,
-                    can_configure=False,
-                )
-                created_addresses.append(address)
-                continue
+            CommsAllowlistEntry.objects.update_or_create(
+                agent=locked_agent,
+                channel=CommsChannel.EMAIL,
+                address=address,
+                defaults={
+                    "is_active": True,
+                    "allow_inbound": True,
+                    "allow_outbound": True,
+                    "can_configure": False,
+                },
+            )
 
-            was_inactive = not entry.is_active
-            entry.is_active = True
-            entry.allow_inbound = True
-            entry.allow_outbound = True
-            entry.can_configure = False
-            entry.save(update_fields=[
-                "is_active",
-                "allow_inbound",
-                "allow_outbound",
-                "can_configure",
-                "updated_at",
-            ])
-            if was_inactive:
-                reactivated_addresses.append(address)
+        if locked_agent.whitelist_policy != PersistentAgent.WhitelistPolicy.MANUAL:
+            locked_agent.whitelist_policy = PersistentAgent.WhitelistPolicy.MANUAL
+            locked_agent.save(update_fields=["whitelist_policy"])
 
-    return EmailContactAuthorizationResult(
-        tuple(normalized_addresses),
-        tuple(created_addresses),
-        tuple(reactivated_addresses),
-    )
+    # send_email reuses this instance for its post-authorization allowlist check.
+    agent.whitelist_policy = locked_agent.whitelist_policy

--- a/api/services/contact_authorization.py
+++ b/api/services/contact_authorization.py
@@ -41,18 +41,33 @@ def authorize_email_contacts(agent: PersistentAgent, addresses) -> None:
                 "This agent requires approval before adding new email contacts."
             )
 
-        active_contact_addresses = set(
+        active_contacts = dict(
             CommsAllowlistEntry.objects.select_for_update().filter(
                 agent=locked_agent,
                 channel=CommsChannel.EMAIL,
                 address__in=normalized_addresses,
                 is_active=True,
-            ).values_list("address", flat=True)
+            ).values_list("address", "allow_outbound")
         )
+        blocked_address = next(
+            (
+                address
+                for address in normalized_addresses
+                if active_contacts.get(address) is False
+                and not locked_agent.is_internal_responder_identity(CommsChannel.EMAIL, address)
+            ),
+            None,
+        )
+        if blocked_address:
+            raise AutomaticContactAuthorizationError(
+                f"Outbound email is disabled for contact '{blocked_address}'. "
+                "The owner can enable it in Contacts & Access."
+            )
+
         addresses_to_authorize = [
             address
             for address in normalized_addresses
-            if address not in active_contact_addresses
+            if address not in active_contacts
             and not locked_agent.is_recipient_whitelisted(CommsChannel.EMAIL, address)
         ]
         agent.whitelist_policy = locked_agent.whitelist_policy

--- a/api/services/contact_authorization.py
+++ b/api/services/contact_authorization.py
@@ -1,0 +1,133 @@
+from dataclasses import dataclass
+
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from django.db import transaction
+
+from api.models import CommsAllowlistEntry, CommsChannel, PersistentAgent, get_agent_contact_counts
+from util.subscription_helper import get_user_max_contacts_per_agent
+
+
+class AutomaticContactAuthorizationError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class EmailContactAuthorizationResult:
+    addresses: tuple[str, ...]
+    created_addresses: tuple[str, ...]
+    reactivated_addresses: tuple[str, ...]
+
+
+def _normalize_email_addresses(addresses) -> list[str]:
+    normalized_addresses: list[str] = []
+    seen: set[str] = set()
+    for raw_address in addresses:
+        address = (raw_address or "").strip().lower()
+        try:
+            validate_email(address)
+        except ValidationError as exc:
+            raise AutomaticContactAuthorizationError(
+                f"Recipient address '{address or raw_address}' is not a valid email address."
+            ) from exc
+        if address not in seen:
+            seen.add(address)
+            normalized_addresses.append(address)
+    return normalized_addresses
+
+
+def authorize_email_contacts(agent: PersistentAgent, addresses) -> EmailContactAuthorizationResult:
+    """Add otherwise-unauthorized email recipients when the agent owner opted in."""
+    normalized_addresses = _normalize_email_addresses(addresses)
+    if not normalized_addresses:
+        return EmailContactAuthorizationResult((), (), ())
+
+    if agent.contact_approval_mode != PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL:
+        raise AutomaticContactAuthorizationError(
+            "This agent requires approval before adding new email contacts."
+        )
+
+    created_addresses: list[str] = []
+    reactivated_addresses: list[str] = []
+
+    with transaction.atomic():
+        locked_agent = (
+            PersistentAgent.objects.select_for_update()
+            .select_related("user", "organization")
+            .get(pk=agent.pk)
+        )
+        if locked_agent.contact_approval_mode != PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL:
+            raise AutomaticContactAuthorizationError(
+                "This agent requires approval before adding new email contacts."
+            )
+
+        addresses_to_authorize = [
+            address
+            for address in normalized_addresses
+            if not locked_agent.is_recipient_whitelisted(CommsChannel.EMAIL, address)
+        ]
+        if not addresses_to_authorize:
+            return EmailContactAuthorizationResult(tuple(normalized_addresses), (), ())
+
+        existing_entries = {
+            entry.address: entry
+            for entry in CommsAllowlistEntry.objects.select_for_update().filter(
+                agent=locked_agent,
+                channel=CommsChannel.EMAIL,
+                address__in=addresses_to_authorize,
+            )
+        }
+        slots_needed = sum(
+            1
+            for address in addresses_to_authorize
+            if address not in existing_entries or not existing_entries[address].is_active
+        )
+
+        contact_cap = get_user_max_contacts_per_agent(
+            locked_agent.user,
+            organization=locked_agent.organization,
+        )
+        contact_counts = get_agent_contact_counts(locked_agent)
+        if contact_cap > 0 and contact_counts is not None:
+            available_slots = max(contact_cap - contact_counts["total"], 0)
+            if slots_needed > available_slots:
+                raise AutomaticContactAuthorizationError(
+                    f"Cannot add {slots_needed} new email contact(s). "
+                    f"This agent has {available_slots} of {contact_cap} contact slots available."
+                )
+
+        for address in addresses_to_authorize:
+            entry = existing_entries.get(address)
+            if entry is None:
+                CommsAllowlistEntry.objects.create(
+                    agent=locked_agent,
+                    channel=CommsChannel.EMAIL,
+                    address=address,
+                    is_active=True,
+                    allow_inbound=True,
+                    allow_outbound=True,
+                    can_configure=False,
+                )
+                created_addresses.append(address)
+                continue
+
+            was_inactive = not entry.is_active
+            entry.is_active = True
+            entry.allow_inbound = True
+            entry.allow_outbound = True
+            entry.can_configure = False
+            entry.save(update_fields=[
+                "is_active",
+                "allow_inbound",
+                "allow_outbound",
+                "can_configure",
+                "updated_at",
+            ])
+            if was_inactive:
+                reactivated_addresses.append(address)
+
+    return EmailContactAuthorizationResult(
+        tuple(normalized_addresses),
+        tuple(created_addresses),
+        tuple(reactivated_addresses),
+    )

--- a/api/services/contact_authorization.py
+++ b/api/services/contact_authorization.py
@@ -34,11 +34,8 @@ def authorize_email_contacts(agent: PersistentAgent, addresses) -> None:
         return
 
     with transaction.atomic():
-        locked_agent = (
-            PersistentAgent.objects.select_for_update()
-            .select_related("user", "organization")
-            .get(pk=agent.pk)
-        )
+        # PostgreSQL cannot lock the nullable side of the organization outer join.
+        locked_agent = PersistentAgent.objects.select_for_update().get(pk=agent.pk)
         if locked_agent.contact_approval_mode != PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL:
             raise AutomaticContactAuthorizationError(
                 "This agent requires approval before adding new email contacts."

--- a/console/agent_settings/service.py
+++ b/console/agent_settings/service.py
@@ -485,13 +485,6 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
         except (AttributeError, DatabaseError):
             owner_phone = None
 
-        html = render_to_string('console/partials/_allowlist_entries_inline.html', {
-            'allowlist_entries': entries,
-            'pending_invites': pending_invites,
-            'owner_email': owner_email,
-            'owner_phone': owner_phone,
-        })
-
         active_count = CommsAllowlistEntry.objects.filter(
             agent=agent,
             is_active=True
@@ -507,7 +500,6 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
 
         return {
             'success': True,
-            'html': html,
             'active_count': total_count,
             'allowlist': self._serialize_allowlist_state(
                 agent,

--- a/console/agent_settings/service.py
+++ b/console/agent_settings/service.py
@@ -677,6 +677,41 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
         except Exception as exc:
             return JsonResponse({'success': False, 'error': str(exc)})
 
+    def _handle_update_allowlist_ajax(
+        self,
+        request,
+        agent: PersistentAgent,
+        *,
+        max_contacts_per_agent: int | None,
+    ) -> JsonResponse:
+        entry_id = request.POST.get('entry_id')
+        allow_inbound = request.POST.get('allow_inbound')
+        allow_outbound = request.POST.get('allow_outbound')
+        if allow_inbound not in {'true', 'false'} or allow_outbound not in {'true', 'false'}:
+            return JsonResponse({'success': False, 'error': 'Select valid inbound and outbound permissions.'})
+
+        entry = CommsAllowlistEntry.objects.filter(
+            agent=agent,
+            id=entry_id,
+            is_active=True,
+        ).first()
+        if entry is None:
+            return JsonResponse({'success': False, 'error': 'Contact not found.'}, status=404)
+
+        entry.allow_inbound = allow_inbound == 'true'
+        entry.allow_outbound = allow_outbound == 'true'
+        try:
+            entry.save(update_fields=['allow_inbound', 'allow_outbound', 'updated_at'])
+        except ValidationError as exc:
+            return JsonResponse({'success': False, 'error': _format_validation_error(exc)})
+
+        process_agent_events_task.delay(str(agent.id))
+        return self._allowlist_ajax_success_response(
+            request,
+            agent,
+            max_contacts_per_agent=max_contacts_per_agent,
+        )
+
     def _handle_cancel_invite_ajax(
         self,
         request,
@@ -705,6 +740,7 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
     ) -> JsonResponse | None:
         handlers = {
             'add_allowlist': self._handle_add_allowlist_ajax,
+            'update_allowlist': self._handle_update_allowlist_ajax,
             'remove_allowlist': self._handle_remove_allowlist_ajax,
             'cancel_invite': self._handle_cancel_invite_ajax,
         }
@@ -1179,6 +1215,7 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
         action = request.POST.get('action')
         ajax_actions = {
             'add_allowlist',
+            'update_allowlist',
             'remove_allowlist',
             'cancel_invite',
             'add_collaborator',

--- a/console/agent_settings/service.py
+++ b/console/agent_settings/service.py
@@ -1104,6 +1104,7 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
                 'createdAtDisplay': _datetime_display(agent.created_at, "F j, Y \a\t g:i A"),
                 'pendingTransfer': pending_transfer_payload,
                 'whitelistPolicy': agent.whitelist_policy,
+                'contactApprovalMode': agent.contact_approval_mode,
                 'preferredLlmTier': getattr(getattr(agent, 'preferred_llm_tier', None), 'key', AgentLLMTier.STANDARD.value),
                 'organization': (
                     {
@@ -1597,6 +1598,12 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
 
         # Handle whitelist policy update (flag removed)
         new_whitelist_policy = request.POST.get('whitelist_policy', '').strip()
+        new_contact_approval_mode = (
+            request.POST.get('contact_approval_mode')
+            or agent.contact_approval_mode
+        ).strip()
+        if new_contact_approval_mode not in PersistentAgent.ContactApprovalMode.values:
+            return _general_error("Select a valid contact approval option.")
 
         avatar_file = request.FILES.get('avatar')
         clear_avatar_flag = (request.POST.get('clear_avatar') or '').strip().lower() in {'1', 'true', 'yes', 'on'}
@@ -1649,6 +1656,7 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
         prev_hard_limit = agent.get_daily_credit_hard_limit()
         prev_preferred_tier = getattr(getattr(agent, "preferred_llm_tier", None), "key", AgentLLMTier.STANDARD.value)
         prev_whitelist_policy = agent.whitelist_policy
+        prev_contact_approval_mode = agent.contact_approval_mode
 
         plan = None
         if owner is not None:
@@ -1830,6 +1838,10 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
                         agent.whitelist_policy = new_whitelist_policy
                         agent_fields_to_update.append('whitelist_policy')
 
+                if agent.contact_approval_mode != new_contact_approval_mode:
+                    agent.contact_approval_mode = new_contact_approval_mode
+                    agent_fields_to_update.append('contact_approval_mode')
+
                 # Update daily credit limit if changed
                 if agent.daily_credit_limit != new_daily_limit:
                     agent.daily_credit_limit = new_daily_limit
@@ -1978,6 +1990,8 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
                     update_props['previous_preferred_llm_tier'] = prev_preferred_tier
                 if 'whitelist_policy' in changed_fields_for_analytics:
                     update_props['previous_whitelist_policy'] = prev_whitelist_policy
+                if 'contact_approval_mode' in changed_fields_for_analytics:
+                    update_props['previous_contact_approval_mode'] = prev_contact_approval_mode
                 Analytics.track_event(
                     user_id=request.user.id,
                     event=AnalyticsEvent.PERSISTENT_AGENT_UPDATED,
@@ -2011,6 +2025,7 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
                 'miniDescription': agent.mini_description,
                 'miniDescriptionMode': agent.mini_description_mode,
                 'preferredLlmTier': getattr(getattr(agent, "preferred_llm_tier", None), "key", None),
+                'contactApprovalMode': agent.contact_approval_mode,
                 'warning': preferred_tier_warning,
             })
 

--- a/frontend/src/components/agentSettings/AddContactModal.tsx
+++ b/frontend/src/components/agentSettings/AddContactModal.tsx
@@ -1,21 +1,31 @@
 import type { FormEvent } from 'react'
 import { useState } from 'react'
-import { Check, Mail } from 'lucide-react'
+import { Check, Mail, Phone } from 'lucide-react'
 import { Checkbox as AriaCheckbox } from 'react-aria-components'
 
 import { FormField, TextInput } from '../common/FormControls'
 import { ModalForm } from '../common/ModalForm'
-import type { AllowlistInput } from './contactTypes'
+import type { AllowlistInput, AllowlistTableRow } from './contactTypes'
 
 type AddContactModalProps = {
   onSubmit: (input: AllowlistInput) => Promise<void> | void
   onClose: () => void
 }
 
-export function AddContactModal({ onSubmit, onClose }: AddContactModalProps) {
-  const [address, setAddress] = useState('')
-  const [allowInbound, setAllowInbound] = useState(true)
-  const [allowOutbound, setAllowOutbound] = useState(true)
+type EditContactModalProps = AddContactModalProps & {
+  contact: AllowlistTableRow
+}
+
+type ContactModalProps = AddContactModalProps & {
+  contact?: AllowlistTableRow
+}
+
+function ContactModal({ contact, onSubmit, onClose }: ContactModalProps) {
+  const editing = Boolean(contact)
+  const channel = contact?.channel ?? 'email'
+  const [address, setAddress] = useState(contact?.address ?? '')
+  const [allowInbound, setAllowInbound] = useState(contact?.allowInbound ?? true)
+  const [allowOutbound, setAllowOutbound] = useState(contact?.allowOutbound ?? true)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -29,14 +39,14 @@ export function AddContactModal({ onSubmit, onClose }: AddContactModalProps) {
     setError(null)
     try {
       await onSubmit({
-        channel: 'email',
+        channel,
         address: address.trim(),
         allowInbound,
         allowOutbound,
       })
       onClose()
     } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : 'Unable to add contact.')
+      setError(submitError instanceof Error ? submitError.message : `Unable to ${editing ? 'update' : 'add'} contact.`)
     } finally {
       setSubmitting(false)
     }
@@ -45,80 +55,94 @@ export function AddContactModal({ onSubmit, onClose }: AddContactModalProps) {
   return (
     <ModalForm
       id="allowlist-contact-form"
-      title="Add Contact"
-      subtitle="Add an email contact to this agent's allowlist."
+      title={editing ? 'Edit Contact' : 'Add Contact'}
+      subtitle={editing
+        ? 'Choose how this contact can communicate with the agent.'
+        : "Add an email contact to this agent's allowlist."}
       onClose={onClose}
       onSubmit={handleSubmit}
       widthClass="sm:max-w-lg"
-      icon={Mail}
-      submitLabel="Add Contact"
+      icon={channel.toLowerCase() === 'sms' ? Phone : Mail}
+      submitLabel={editing ? 'Apply Changes' : 'Add Contact'}
       submitting={submitting}
-      submitDisabled={!address.trim()}
+      submitDisabled={!address.trim() || Boolean(
+        contact
+          && contact.allowInbound === allowInbound
+          && contact.allowOutbound === allowOutbound,
+      )}
       errorMessages={error ? [error] : null}
       formClassName="space-y-5"
     >
-        <FormField id="allowlist-contact-address" label="Email address">
-          <TextInput
-            id="allowlist-contact-address"
-            type="email"
-            autoFocus
-            required
-            value={address}
-            onChange={(event) => setAddress(event.currentTarget.value)}
-            placeholder="email@example.com"
-            disabled={submitting}
-          />
-        </FormField>
+      <FormField id="allowlist-contact-address" label={channel.toLowerCase() === 'sms' ? 'Phone number' : 'Email address'}>
+        <TextInput
+          id="allowlist-contact-address"
+          type={channel.toLowerCase() === 'sms' ? 'tel' : 'email'}
+          autoFocus={!editing}
+          required
+          value={address}
+          onChange={(event) => setAddress(event.currentTarget.value)}
+          placeholder={channel.toLowerCase() === 'sms' ? '+1 555 123 4567' : 'email@example.com'}
+          disabled={submitting || editing}
+        />
+      </FormField>
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          <AriaCheckbox
-            isSelected={allowInbound}
-            onChange={setAllowInbound}
-            isDisabled={submitting}
-            className="group inline-flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50/60 px-4 py-3 text-sm text-slate-700"
-          >
-            {({ isSelected }) => (
-              <>
-                <span
-                  aria-hidden="true"
-                  className={`mt-0.5 flex h-4 w-4 items-center justify-center rounded border transition ${
-                    isSelected ? 'border-emerald-600 bg-emerald-600 text-white' : 'border-emerald-300 bg-white text-transparent'
-                  }`}
-                >
-                  <Check className="h-3 w-3" aria-hidden="true" />
-                </span>
-                <span className="flex flex-col leading-tight">
-                  <span className="font-medium text-slate-800">Allow inbound</span>
-                  <span className="text-xs text-slate-600">This contact can send messages to the agent.</span>
-                </span>
-              </>
-            )}
-          </AriaCheckbox>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <AriaCheckbox
+          isSelected={allowInbound}
+          onChange={setAllowInbound}
+          isDisabled={submitting}
+          className="group inline-flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50/60 px-4 py-3 text-sm text-slate-700"
+        >
+          {({ isSelected }) => (
+            <>
+              <span
+                aria-hidden="true"
+                className={`mt-0.5 flex h-4 w-4 items-center justify-center rounded border transition ${
+                  isSelected ? 'border-emerald-600 bg-emerald-600 text-white' : 'border-emerald-300 bg-white text-transparent'
+                }`}
+              >
+                <Check className="h-3 w-3" aria-hidden="true" />
+              </span>
+              <span className="flex flex-col leading-tight">
+                <span className="font-medium text-slate-800">Allow inbound</span>
+                <span className="text-xs text-slate-600">This contact can send messages to the agent.</span>
+              </span>
+            </>
+          )}
+        </AriaCheckbox>
 
-          <AriaCheckbox
-            isSelected={allowOutbound}
-            onChange={setAllowOutbound}
-            isDisabled={submitting}
-            className="group inline-flex items-start gap-3 rounded-xl border border-sky-200 bg-sky-50/60 px-4 py-3 text-sm text-slate-700"
-          >
-            {({ isSelected }) => (
-              <>
-                <span
-                  aria-hidden="true"
-                  className={`mt-0.5 flex h-4 w-4 items-center justify-center rounded border transition ${
-                    isSelected ? 'border-sky-600 bg-sky-600 text-white' : 'border-sky-300 bg-white text-transparent'
-                  }`}
-                >
-                  <Check className="h-3 w-3" aria-hidden="true" />
-                </span>
-                <span className="flex flex-col leading-tight">
-                  <span className="font-medium text-slate-800">Allow outbound</span>
-                  <span className="text-xs text-slate-600">The agent can send messages to this contact.</span>
-                </span>
-              </>
-            )}
-          </AriaCheckbox>
-        </div>
+        <AriaCheckbox
+          isSelected={allowOutbound}
+          onChange={setAllowOutbound}
+          isDisabled={submitting}
+          className="group inline-flex items-start gap-3 rounded-xl border border-sky-200 bg-sky-50/60 px-4 py-3 text-sm text-slate-700"
+        >
+          {({ isSelected }) => (
+            <>
+              <span
+                aria-hidden="true"
+                className={`mt-0.5 flex h-4 w-4 items-center justify-center rounded border transition ${
+                  isSelected ? 'border-sky-600 bg-sky-600 text-white' : 'border-sky-300 bg-white text-transparent'
+                }`}
+              >
+                <Check className="h-3 w-3" aria-hidden="true" />
+              </span>
+              <span className="flex flex-col leading-tight">
+                <span className="font-medium text-slate-800">Allow outbound</span>
+                <span className="text-xs text-slate-600">The agent can send messages to this contact.</span>
+              </span>
+            </>
+          )}
+        </AriaCheckbox>
+      </div>
     </ModalForm>
   )
+}
+
+export function AddContactModal(props: AddContactModalProps) {
+  return <ContactModal {...props} />
+}
+
+export function EditContactModal({ contact, ...props }: EditContactModalProps) {
+  return <ContactModal {...props} contact={contact} />
 }

--- a/frontend/src/components/agentSettings/AllowlistContactsTable.tsx
+++ b/frontend/src/components/agentSettings/AllowlistContactsTable.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { ColumnDef, RowSelectionState } from '@tanstack/react-table'
 import { getCoreRowModel, useReactTable } from '@tanstack/react-table'
-import { ArrowDownToLine, ArrowUpFromLine, Mail, Phone, Trash2 } from 'lucide-react'
+import { ArrowDownToLine, ArrowUpFromLine, Mail, Pencil, Phone, Trash2 } from 'lucide-react'
 
 import type { AllowlistTableRow } from './contactTypes'
 import { TanStackTableShell } from '../common/TanStackTableShell'
 import {
   EmbeddedRemoveButton,
   EmbeddedStatusBadge,
+  EmbeddedTableActionButton,
   EmbeddedTableFrame,
   EmbeddedTableHeader,
   embeddedBulkBannerClassName,
@@ -17,6 +18,7 @@ import {
 type AllowlistContactsTableProps = {
   rows: AllowlistTableRow[]
   disabled?: boolean
+  onEditRow: (row: AllowlistTableRow) => void
   onRemoveRow: (row: AllowlistTableRow) => void
   onRemoveRows: (rows: AllowlistTableRow[]) => void
 }
@@ -32,6 +34,9 @@ function renderStatus(row: AllowlistTableRow) {
   if (row.pendingType === 'remove') {
     return <EmbeddedStatusBadge tone="danger">Pending removal</EmbeddedStatusBadge>
   }
+  if (row.pendingType === 'update') {
+    return <EmbeddedStatusBadge tone="pending">Pending changes</EmbeddedStatusBadge>
+  }
   if (row.pendingType === 'cancel_invite') {
     return <EmbeddedStatusBadge tone="danger">Pending cancel</EmbeddedStatusBadge>
   }
@@ -41,7 +46,7 @@ function renderStatus(row: AllowlistTableRow) {
   return <EmbeddedStatusBadge tone="active">Allowed</EmbeddedStatusBadge>
 }
 
-export function AllowlistContactsTable({ rows, disabled = false, onRemoveRow, onRemoveRows }: AllowlistContactsTableProps) {
+export function AllowlistContactsTable({ rows, disabled = false, onEditRow, onRemoveRow, onRemoveRows }: AllowlistContactsTableProps) {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
 
   useEffect(() => {
@@ -149,14 +154,25 @@ export function AllowlistContactsTable({ rows, disabled = false, onRemoveRow, on
           }
 
           return (
-            <EmbeddedRemoveButton onClick={() => onRemoveRow(row.original)} disabled={disabled}>
-              {row.original.kind === 'invite' ? 'Cancel invite' : 'Remove'}
-            </EmbeddedRemoveButton>
+            <div className="flex items-center gap-2">
+              {row.original.kind === 'entry' && (
+                <EmbeddedTableActionButton
+                  icon={Pencil}
+                  onClick={() => onEditRow(row.original)}
+                  disabled={disabled}
+                >
+                  Edit
+                </EmbeddedTableActionButton>
+              )}
+              <EmbeddedRemoveButton onClick={() => onRemoveRow(row.original)} disabled={disabled}>
+                {row.original.kind === 'invite' ? 'Cancel invite' : 'Remove'}
+              </EmbeddedRemoveButton>
+            </div>
           )
         },
       },
     ]
-  }, [disabled, onRemoveRow])
+  }, [disabled, onEditRow, onRemoveRow])
 
   const table = useReactTable({
     data: rows,

--- a/frontend/src/components/agentSettings/contactTypes.ts
+++ b/frontend/src/components/agentSettings/contactTypes.ts
@@ -22,6 +22,7 @@ export type PendingAllowlistAction =
       smsContactPermissionAttested?: boolean | null
       smsContactPermissionAttestedAt?: string | null
     }
+  | { type: 'update'; id: string; allowInbound: boolean; allowOutbound: boolean }
   | { type: 'remove'; id: string }
   | { type: 'cancel_invite'; id: string }
 

--- a/frontend/src/components/common/SaveBar.tsx
+++ b/frontend/src/components/common/SaveBar.tsx
@@ -47,7 +47,9 @@ export function SaveBar({
   const isEmbedded = variant === 'embedded'
   const isFixed = placement === 'fixed'
   const rootClassName = isFixed ? 'fixed inset-x-0 bottom-0 z-40 pointer-events-none' : 'sticky bottom-4 z-20'
-  const frameClassName = isFixed ? 'pointer-events-auto mx-auto w-full max-w-5xl px-4 pb-4' : 'w-full'
+  const frameClassName = isFixed
+    ? `pointer-events-auto mx-auto w-full px-4 pb-4 ${isEmbedded ? '' : 'max-w-5xl'}`
+    : 'w-full'
   const surfaceClassName = isEmbedded
     ? getSettingsSurfaceClassName({ variant: 'embedded', className: 'px-4 py-3' })
     : getSettingsSurfaceClassName({

--- a/frontend/src/components/common/SaveBar.tsx
+++ b/frontend/src/components/common/SaveBar.tsx
@@ -47,9 +47,7 @@ export function SaveBar({
   const isEmbedded = variant === 'embedded'
   const isFixed = placement === 'fixed'
   const rootClassName = isFixed ? 'fixed inset-x-0 bottom-0 z-40 pointer-events-none' : 'sticky bottom-4 z-20'
-  const frameClassName = isFixed
-    ? `pointer-events-auto mx-auto w-full px-4 pb-4 ${isEmbedded ? '' : 'max-w-5xl'}`
-    : 'w-full'
+  const frameClassName = isFixed ? 'pointer-events-auto mx-auto w-full max-w-5xl px-4 pb-4' : 'w-full'
   const surfaceClassName = isEmbedded
     ? getSettingsSurfaceClassName({ variant: 'embedded', className: 'px-4 py-3' })
     : getSettingsSurfaceClassName({

--- a/frontend/src/screens/AgentDetailScreen.tsx
+++ b/frontend/src/screens/AgentDetailScreen.tsx
@@ -45,6 +45,7 @@ import type {
   AgentInboundWebhook,
   AgentOrganization,
   AgentSettingsData,
+  ContactApprovalMode,
   MiniDescriptionMode,
   AgentSettingsReassignmentInfo as ReassignmentInfo,
   AgentSummary,
@@ -133,6 +134,7 @@ type FormState = {
   sliderValue: number
   dedicatedProxyId: string
   preferredTier: IntelligenceTierKey
+  contactApprovalMode: ContactApprovalMode
 }
 
 const generateTempId = () =>
@@ -433,6 +435,7 @@ export function AgentSettingsWorkspace({
       sliderValue: initialData.dailyCredits.sliderValue ?? fallbackSliderEmptyValue,
       dedicatedProxyId: initialData.dedicatedIps.selectedId ?? '',
       preferredTier: (initialData.agent.preferredLlmTier || 'standard') as IntelligenceTierKey,
+      contactApprovalMode: initialData.agent.contactApprovalMode,
     }),
     [
       initialData.agent.name,
@@ -441,6 +444,7 @@ export function AgentSettingsWorkspace({
       initialData.agent.miniDescriptionMode,
       initialData.agent.isActive,
       initialData.agent.preferredLlmTier,
+      initialData.agent.contactApprovalMode,
       initialData.dailyCredits.limit,
       initialData.dailyCredits.sliderValue,
       initialData.dedicatedIps.selectedId,
@@ -554,6 +558,7 @@ export function AgentSettingsWorkspace({
       formState.sliderValue !== savedFormState.sliderValue ||
       formState.dedicatedProxyId !== savedFormState.dedicatedProxyId ||
       formState.preferredTier !== savedFormState.preferredTier ||
+      formState.contactApprovalMode !== savedFormState.contactApprovalMode ||
       avatarFile !== null ||
       (removeAvatar && Boolean(savedAvatarUrl))
     )
@@ -1187,6 +1192,9 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
         }
         if (data?.miniDescriptionMode === 'auto' || data?.miniDescriptionMode === 'manual') {
           nextFormState.miniDescriptionMode = data.miniDescriptionMode
+        }
+        if (data?.contactApprovalMode === 'require_approval' || data?.contactApprovalMode === 'auto_approve_email') {
+          nextFormState.contactApprovalMode = data.contactApprovalMode
         }
         if (serverTierRaw && (initialData.llmIntelligence?.options ?? []).some((option) => option.key === serverTierRaw)) {
           const serverTier = serverTierRaw as IntelligenceTierKey
@@ -1898,6 +1906,7 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
       {initialData.allowlist.show && (
         <input type="hidden" name="whitelist_policy" value={initialData.agent.whitelistPolicy} />
       )}
+      <input type="hidden" name="contact_approval_mode" value={formState.contactApprovalMode} />
         <details className={sectionClassName} id="agent-identity">
           <summary className={sectionSummaryClassName}>
             <div>
@@ -2202,9 +2211,14 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
               state={savedAllowlistState}
               rows={allowlistRows}
               projectedSlotsUsed={projectedContactSlots}
+              contactApprovalMode={formState.contactApprovalMode}
               saving={saving}
               onAddContact={openAddContactModal}
               onRemoveRows={confirmAllowlistRemoval}
+              onContactApprovalModeChange={(contactApprovalMode) => setFormState((prev) => ({
+                ...prev,
+                contactApprovalMode,
+              }))}
               contactRequestsUrl={initialData.urls.contactRequests}
               onOpenContactRequests={onOpenContactRequests}
             />
@@ -2465,14 +2479,27 @@ type AllowlistManagerProps = {
   state: AllowlistState
   rows: AllowlistTableRow[]
   projectedSlotsUsed: number
+  contactApprovalMode: ContactApprovalMode
   saving: boolean
   onAddContact: () => void
   onRemoveRows: (rows: AllowlistTableRow[]) => void
+  onContactApprovalModeChange: (mode: ContactApprovalMode) => void
   contactRequestsUrl: string
   onOpenContactRequests?: () => void
 }
 
-function AllowlistManager({ state, rows, projectedSlotsUsed, saving, onAddContact, onRemoveRows, contactRequestsUrl, onOpenContactRequests }: AllowlistManagerProps) {
+function AllowlistManager({
+  state,
+  rows,
+  projectedSlotsUsed,
+  contactApprovalMode,
+  saving,
+  onAddContact,
+  onRemoveRows,
+  onContactApprovalModeChange,
+  contactRequestsUrl,
+  onOpenContactRequests,
+}: AllowlistManagerProps) {
   const contactCapReached = typeof state.maxContacts === 'number' && state.maxContacts > 0 && projectedSlotsUsed >= state.maxContacts
   const embeddedInfoBannerClassName = 'flex items-start gap-2 rounded-lg border border-amber-300/20 bg-amber-950/30 px-4 py-3'
   const embeddedInfoCardClassName = 'rounded-xl border border-slate-200/20 bg-slate-950/35 px-4 py-4'
@@ -2481,12 +2508,60 @@ function AllowlistManager({ state, rows, projectedSlotsUsed, saving, onAddContac
 
   return (
     <div className="space-y-5">
-      <div className="space-y-1">
-        <p className="text-xs text-gray-500">
-          By default, the agent owner and team members can communicate with this agent. You can add additional contacts below.
-          Note: Multi-recipient messaging is limited to email only.
-        </p>
-        <p className="text-xs text-slate-600">Contact slots include allowlist entries and collaborators.</p>
+      <div className="space-y-3">
+        <div>
+          <h4 className="text-sm font-semibold text-slate-700">New contact approval</h4>
+          <p className="mt-1 text-xs text-slate-500">Choose how this agent handles email addresses that are not already listed.</p>
+        </div>
+        <div className="grid gap-3 lg:grid-cols-2" role="radiogroup" aria-label="New contact approval">
+          <button
+            type="button"
+            role="radio"
+            aria-checked={contactApprovalMode === 'require_approval'}
+            onClick={() => onContactApprovalModeChange('require_approval')}
+            className={`flex items-start gap-3 rounded-xl border px-4 py-4 text-left transition-colors ${
+              contactApprovalMode === 'require_approval'
+                ? 'border-blue-400/60 bg-blue-950/30'
+                : 'border-slate-200/20 bg-transparent hover:border-slate-300/40'
+            }`}
+          >
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-slate-200/20 bg-slate-900/45 text-slate-300">
+              <ShieldAlert className="size-4" aria-hidden="true" />
+            </span>
+            <span>
+              <span className="block text-sm font-semibold text-slate-100">Ask before adding</span>
+              <span className="mt-1 block text-xs leading-5 text-slate-400">Review each new email or SMS contact before the agent can reach them.</span>
+            </span>
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={contactApprovalMode === 'auto_approve_email'}
+            onClick={() => onContactApprovalModeChange('auto_approve_email')}
+            className={`flex items-start gap-3 rounded-xl border px-4 py-4 text-left transition-colors ${
+              contactApprovalMode === 'auto_approve_email'
+                ? 'border-blue-400/60 bg-blue-950/30'
+                : 'border-slate-200/20 bg-transparent hover:border-slate-300/40'
+            }`}
+          >
+            <span className="relative flex size-9 shrink-0 items-center justify-center rounded-lg border border-slate-200/20 bg-slate-900/45 text-slate-300">
+              <Mail className="size-4" aria-hidden="true" />
+              <Zap className="absolute -right-1 -top-1 size-3 text-amber-300" aria-hidden="true" />
+            </span>
+            <span>
+              <span className="block text-sm font-semibold text-slate-100">Automatically allow email contacts</span>
+              <span className="mt-1 block text-xs leading-5 text-slate-400">Anyone your agent emails is added to its contacts.</span>
+            </span>
+          </button>
+        </div>
+        {contactApprovalMode === 'auto_approve_email' && (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-300/20 bg-amber-950/30 px-4 py-3 text-xs leading-5 text-amber-100">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-400" aria-hidden="true" />
+            <p>
+              This agent can add email contacts without asking you first. New contacts remain visible and removable below. SMS contacts always require approval.
+            </p>
+          </div>
+        )}
       </div>
 
       {!state.emailVerified && (
@@ -2523,13 +2598,18 @@ function AllowlistManager({ state, rows, projectedSlotsUsed, saving, onAddContac
               </a>
             )}
           </div>
+          {contactApprovalMode === 'auto_approve_email' && (
+            <p className="mt-2 pl-7 text-xs text-amber-200/80">
+              Email requests shown here predate automatic approval; SMS requests always need your review.
+            </p>
+          )}
         </div>
       )}
 
       {(state.ownerEmail || state.ownerPhone) && (
         <div className={embeddedInfoCardClassName}>
           <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">Owner Endpoints</div>
-          <p className="mt-1 text-xs text-slate-600">Owner endpoints are always allowed in default mode.</p>
+          <p className="mt-1 text-xs text-slate-600">Owner endpoints can always be contacted by the agent.</p>
           {state.ownerEmail && (
             <div className="mt-3 flex items-center gap-2 text-sm text-slate-700">
               <span className={embeddedInfoIconClassName}>

--- a/frontend/src/screens/AgentDetailScreen.tsx
+++ b/frontend/src/screens/AgentDetailScreen.tsx
@@ -31,7 +31,7 @@ import { SettingsBanner } from '../components/agentSettings/SettingsBanner'
 import { getSettingsSurfaceClassName } from '../components/common/SettingsSurface'
 import { AgentIntelligenceSlider } from '../components/common/AgentIntelligenceSlider'
 import { SaveBar } from '../components/common/SaveBar'
-import { AddContactModal } from '../components/agentSettings/AddContactModal'
+import { AddContactModal, EditContactModal } from '../components/agentSettings/AddContactModal'
 import { AllowlistContactsTable } from '../components/agentSettings/AllowlistContactsTable'
 import { CollaboratorsTable } from '../components/agentSettings/CollaboratorsTable'
 import type { AllowlistInput, AllowlistTableRow, CollaboratorTableRow, PendingAllowlistAction, PendingCollaboratorAction } from '../components/agentSettings/contactTypes'
@@ -248,7 +248,7 @@ function stagePersistedRowActions<
     .filter((row) => !row.temp)
     .map(getPersistedAction)
     .filter((action): action is Extract<TPendingAction, PendingIdAction> => action !== null)
-  const persistedKeys = new Set(persistedActions.map((action) => `${action.type}:${action.id}`))
+  const persistedIds = new Set(persistedActions.map((action) => action.id))
 
   const next = pendingActions.filter((action) => {
     if (isCreatePendingAction(action)) {
@@ -259,7 +259,7 @@ function stagePersistedRowActions<
       return true
     }
 
-    return !persistedKeys.has(`${action.type}:${action.id}`)
+    return !persistedIds.has(action.id)
   })
 
   return [...next, ...persistedActions] as TPendingAction[]
@@ -298,7 +298,7 @@ async function runPendingActionGroup<TAction>({
 }
 
 function buildAllowlistRows(state: AllowlistState, pendingActions: PendingAllowlistAction[]): AllowlistTableRow[] {
-  return buildStagedRows({
+  const rows = buildStagedRows({
     baseRows: [
       ...state.entries.map<AllowlistTableRow>((entry) => ({
         id: entry.id,
@@ -326,7 +326,7 @@ function buildAllowlistRows(state: AllowlistState, pendingActions: PendingAllowl
       })),
     ],
     pendingActions,
-    createRow: (action) => ({
+    createRow: (action): AllowlistTableRow => ({
       id: action.tempId,
       kind: 'entry',
       channel: action.channel,
@@ -350,6 +350,17 @@ function buildAllowlistRows(state: AllowlistState, pendingActions: PendingAllowl
       }
       return left.id.localeCompare(right.id)
     },
+  })
+  const updates = new Map(
+    pendingActions
+      .filter((action): action is Extract<PendingAllowlistAction, { type: 'update' }> => action.type === 'update')
+      .map((action) => [action.id, action] as const),
+  )
+  return rows.map((row) => {
+    const update = updates.get(row.id)
+    return update
+      ? { ...row, allowInbound: update.allowInbound, allowOutbound: update.allowOutbound }
+      : row
   })
 }
 
@@ -996,7 +1007,16 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
   const submitAllowlistAction = useCallback(
     async (action: PendingAllowlistAction) => {
       const formData = new FormData()
-      formData.append('action', action.type === 'cancel_invite' ? 'cancel_invite' : action.type === 'remove' ? 'remove_allowlist' : 'add_allowlist')
+      formData.append(
+        'action',
+        action.type === 'cancel_invite'
+          ? 'cancel_invite'
+          : action.type === 'remove'
+            ? 'remove_allowlist'
+            : action.type === 'update'
+              ? 'update_allowlist'
+              : 'add_allowlist',
+      )
       if (action.type === 'create') {
         formData.append('channel', action.channel)
         formData.append('address', action.address)
@@ -1011,6 +1031,10 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
         if (action.smsContactPermissionAttested != null) {
           formData.append('sms_contact_permission_attested', String(action.smsContactPermissionAttested))
         }
+      } else if (action.type === 'update') {
+        formData.append('entry_id', action.id)
+        formData.append('allow_inbound', String(action.allowInbound))
+        formData.append('allow_outbound', String(action.allowOutbound))
       } else if (action.type === 'remove') {
         formData.append('entry_id', action.id)
       } else {
@@ -1549,6 +1573,54 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
       />
     ))
   }, [showModal, stageAllowlistAdd])
+
+  const stageAllowlistUpdate = useCallback(
+    async (row: AllowlistTableRow, input: AllowlistInput) => {
+      if (row.temp) {
+        setPendingAllowlistActions((prev) => prev.map((action) => (
+          action.type === 'create' && action.tempId === row.id
+            ? { ...action, allowInbound: input.allowInbound, allowOutbound: input.allowOutbound }
+            : action
+        )))
+        return
+      }
+
+      const savedEntry = savedAllowlistState.entries.find((entry) => entry.id === row.id)
+      setPendingAllowlistActions((prev) => {
+        const withoutCurrentUpdate = prev.filter((action) => !(action.type === 'update' && action.id === row.id))
+        if (
+          savedEntry
+          && savedEntry.allowInbound === input.allowInbound
+          && savedEntry.allowOutbound === input.allowOutbound
+        ) {
+          return withoutCurrentUpdate
+        }
+        return [
+          ...withoutCurrentUpdate,
+          {
+            type: 'update',
+            id: row.id,
+            allowInbound: input.allowInbound,
+            allowOutbound: input.allowOutbound,
+          },
+        ]
+      })
+    },
+    [savedAllowlistState.entries],
+  )
+
+  const openEditContactModal = useCallback(
+    (row: AllowlistTableRow) => {
+      showModal((onClose) => (
+        <EditContactModal
+          contact={row}
+          onSubmit={(input) => stageAllowlistUpdate(row, input)}
+          onClose={onClose}
+        />
+      ))
+    },
+    [showModal, stageAllowlistUpdate],
+  )
 
   const confirmAllowlistRemoval = useCallback(
     (rows: AllowlistTableRow[]) => {
@@ -2231,6 +2303,7 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
               contactApprovalMode={formState.contactApprovalMode}
               saving={saving}
               onAddContact={openAddContactModal}
+              onEditContact={openEditContactModal}
               onRemoveRows={confirmAllowlistRemoval}
               onContactApprovalModeChange={(contactApprovalMode) => setFormState((prev) => ({
                 ...prev,
@@ -2303,7 +2376,7 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
         error={saveError}
         helperText="Save now to update the chat shell and gallery immediately."
         variant="embedded"
-        placement="fixed"
+        placement="sticky"
       />
 
       {modal}
@@ -2499,6 +2572,7 @@ type AllowlistManagerProps = {
   contactApprovalMode: ContactApprovalMode
   saving: boolean
   onAddContact: () => void
+  onEditContact: (row: AllowlistTableRow) => void
   onRemoveRows: (rows: AllowlistTableRow[]) => void
   onContactApprovalModeChange: (mode: ContactApprovalMode) => void
   contactRequestsUrl: string
@@ -2512,6 +2586,7 @@ function AllowlistManager({
   contactApprovalMode,
   saving,
   onAddContact,
+  onEditContact,
   onRemoveRows,
   onContactApprovalModeChange,
   contactRequestsUrl,
@@ -2668,6 +2743,7 @@ function AllowlistManager({
         <AllowlistContactsTable
           rows={rows}
           disabled={saving}
+          onEditRow={onEditContact}
           onRemoveRow={(row) => onRemoveRows([row])}
           onRemoveRows={onRemoveRows}
         />

--- a/frontend/src/screens/AgentDetailScreen.tsx
+++ b/frontend/src/screens/AgentDetailScreen.tsx
@@ -137,6 +137,19 @@ type FormState = {
   contactApprovalMode: ContactApprovalMode
 }
 
+const CONTACT_APPROVAL_OPTIONS = [
+  {
+    value: 'require_approval',
+    title: 'Ask before adding',
+    description: 'Review each new email or SMS contact before the agent can reach them.',
+  },
+  {
+    value: 'auto_approve_email',
+    title: 'Automatically allow email contacts',
+    description: 'Anyone your agent emails is added to its contacts.',
+  },
+] as const
+
 const generateTempId = () =>
   typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`
 
@@ -2508,51 +2521,37 @@ function AllowlistManager({
 
   return (
     <div className="space-y-5">
-      <div className="space-y-3">
-        <div>
-          <h4 className="text-sm font-semibold text-slate-700">New contact approval</h4>
-          <p className="mt-1 text-xs text-slate-500">Choose how this agent handles email addresses that are not already listed.</p>
-        </div>
-        <div className="grid gap-3 lg:grid-cols-2" role="radiogroup" aria-label="New contact approval">
-          <button
-            type="button"
-            role="radio"
-            aria-checked={contactApprovalMode === 'require_approval'}
-            onClick={() => onContactApprovalModeChange('require_approval')}
-            className={`flex items-start gap-3 rounded-xl border px-4 py-4 text-left transition-colors ${
-              contactApprovalMode === 'require_approval'
-                ? 'border-blue-400/60 bg-blue-950/30'
-                : 'border-slate-200/20 bg-transparent hover:border-slate-300/40'
-            }`}
-          >
-            <span className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-slate-200/20 bg-slate-900/45 text-slate-300">
-              <ShieldAlert className="size-4" aria-hidden="true" />
-            </span>
-            <span>
-              <span className="block text-sm font-semibold text-slate-100">Ask before adding</span>
-              <span className="mt-1 block text-xs leading-5 text-slate-400">Review each new email or SMS contact before the agent can reach them.</span>
-            </span>
-          </button>
-          <button
-            type="button"
-            role="radio"
-            aria-checked={contactApprovalMode === 'auto_approve_email'}
-            onClick={() => onContactApprovalModeChange('auto_approve_email')}
-            className={`flex items-start gap-3 rounded-xl border px-4 py-4 text-left transition-colors ${
-              contactApprovalMode === 'auto_approve_email'
-                ? 'border-blue-400/60 bg-blue-950/30'
-                : 'border-slate-200/20 bg-transparent hover:border-slate-300/40'
-            }`}
-          >
-            <span className="relative flex size-9 shrink-0 items-center justify-center rounded-lg border border-slate-200/20 bg-slate-900/45 text-slate-300">
-              <Mail className="size-4" aria-hidden="true" />
-              <Zap className="absolute -right-1 -top-1 size-3 text-amber-300" aria-hidden="true" />
-            </span>
-            <span>
-              <span className="block text-sm font-semibold text-slate-100">Automatically allow email contacts</span>
-              <span className="mt-1 block text-xs leading-5 text-slate-400">Anyone your agent emails is added to its contacts.</span>
-            </span>
-          </button>
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-semibold text-slate-700">New contact approval</legend>
+        <p className="text-xs text-slate-500">Choose how this agent handles email addresses that are not already listed.</p>
+        <div className="grid gap-3 lg:grid-cols-2">
+          {CONTACT_APPROVAL_OPTIONS.map((option) => {
+            const selected = contactApprovalMode === option.value
+            return (
+              <label
+                key={option.value}
+                className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-4 text-left transition-colors ${
+                  selected
+                    ? 'border-blue-400/60 bg-blue-950/30'
+                    : 'border-slate-200/20 bg-transparent hover:border-slate-300/40'
+                } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
+              >
+                <input
+                  type="radio"
+                  name="contact-approval-mode-choice"
+                  value={option.value}
+                  checked={selected}
+                  disabled={saving}
+                  onChange={() => onContactApprovalModeChange(option.value)}
+                  className="mt-1 size-4 shrink-0 accent-blue-500"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-slate-100">{option.title}</span>
+                  <span className="mt-1 block text-xs leading-5 text-slate-400">{option.description}</span>
+                </span>
+              </label>
+            )
+          })}
         </div>
         {contactApprovalMode === 'auto_approve_email' && (
           <div className="flex items-start gap-2 rounded-lg border border-amber-300/20 bg-amber-950/30 px-4 py-3 text-xs leading-5 text-amber-100">
@@ -2562,7 +2561,7 @@ function AllowlistManager({
             </p>
           </div>
         )}
-      </div>
+      </fieldset>
 
       {!state.emailVerified && (
         <div className={embeddedInfoBannerClassName}>

--- a/frontend/src/screens/AgentDetailScreen.tsx
+++ b/frontend/src/screens/AgentDetailScreen.tsx
@@ -142,11 +142,15 @@ const CONTACT_APPROVAL_OPTIONS = [
     value: 'require_approval',
     title: 'Ask before adding',
     description: 'Review each new email or SMS contact before the agent can reach them.',
+    icon: ShieldAlert,
+    badge: null,
   },
   {
     value: 'auto_approve_email',
     title: 'Automatically allow email contacts',
     description: 'Anyone your agent emails is added to its contacts.',
+    icon: Mail,
+    badge: Zap,
   },
 ] as const
 
@@ -2299,7 +2303,7 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
         error={saveError}
         helperText="Save now to update the chat shell and gallery immediately."
         variant="embedded"
-        placement="sticky"
+        placement="fixed"
       />
 
       {modal}
@@ -2526,6 +2530,8 @@ function AllowlistManager({
         <p className="text-xs text-slate-500">Choose how this agent handles email addresses that are not already listed.</p>
         <div className="grid gap-3 lg:grid-cols-2">
           {CONTACT_APPROVAL_OPTIONS.map((option) => {
+            const Icon = option.icon
+            const Badge = option.badge
             const selected = contactApprovalMode === option.value
             return (
               <label
@@ -2536,6 +2542,14 @@ function AllowlistManager({
                     : 'border-slate-200/20 bg-transparent hover:border-slate-300/40'
                 } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
               >
+                <span className="relative flex size-9 shrink-0 items-center justify-center rounded-lg border border-slate-200/20 bg-slate-900/45 text-slate-300">
+                  <Icon className="size-4" aria-hidden="true" />
+                  {Badge && <Badge className="absolute -right-1 -top-1 size-3 text-amber-300" aria-hidden="true" />}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-slate-100">{option.title}</span>
+                  <span className="mt-1 block text-xs leading-5 text-slate-400">{option.description}</span>
+                </span>
                 <input
                   type="radio"
                   name="contact-approval-mode-choice"
@@ -2543,12 +2557,8 @@ function AllowlistManager({
                   checked={selected}
                   disabled={saving}
                   onChange={() => onContactApprovalModeChange(option.value)}
-                  className="mt-1 size-4 shrink-0 accent-blue-500"
+                  className="mt-2 size-4 shrink-0 accent-blue-500"
                 />
-                <span className="min-w-0 flex-1">
-                  <span className="block text-sm font-semibold text-slate-100">{option.title}</span>
-                  <span className="mt-1 block text-xs leading-5 text-slate-400">{option.description}</span>
-                </span>
               </label>
             )
           })}

--- a/frontend/src/types/agentSettings.ts
+++ b/frontend/src/types/agentSettings.ts
@@ -15,6 +15,7 @@ export type AgentOrganization = {
 } | null
 
 export type MiniDescriptionMode = 'auto' | 'manual'
+export type ContactApprovalMode = 'require_approval' | 'auto_approve_email'
 
 export type AgentSummary = {
   id: string
@@ -27,6 +28,7 @@ export type AgentSummary = {
   createdAtDisplay: string
   pendingTransfer: PendingTransfer | null
   whitelistPolicy: string
+  contactApprovalMode: ContactApprovalMode
   organization: AgentOrganization
   preferredLlmTier: string
 }

--- a/tests/unit/test_agent_settings_contact_approval.py
+++ b/tests/unit/test_agent_settings_contact_approval.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 from django.urls import reverse
@@ -106,3 +108,23 @@ class AgentSettingsContactApprovalTests(TestCase):
             self.agent.contact_approval_mode,
             PersistentAgent.ContactApprovalMode.REQUIRE_APPROVAL,
         )
+
+    @patch("console.agent_settings.service.process_agent_events_task.delay")
+    def test_allowlist_ajax_returns_structured_payload_without_legacy_html(self, _mock_process_events):
+        self.client.force_login(self.owner)
+
+        response = self.client.post(
+            self.url,
+            {
+                "action": "add_allowlist",
+                "channel": CommsChannel.EMAIL,
+                "address": "structured@example.com",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        payload = response.json()
+        self.assertTrue(payload["success"])
+        self.assertIn("allowlist", payload)
+        self.assertNotIn("html", payload)

--- a/tests/unit/test_agent_settings_contact_approval.py
+++ b/tests/unit/test_agent_settings_contact_approval.py
@@ -4,7 +4,13 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 from django.urls import reverse
 
-from api.models import BrowserUseAgent, CommsAllowlistRequest, CommsChannel, PersistentAgent
+from api.models import (
+    BrowserUseAgent,
+    CommsAllowlistEntry,
+    CommsAllowlistRequest,
+    CommsChannel,
+    PersistentAgent,
+)
 
 
 @tag("batch_console_allowlist")
@@ -128,3 +134,36 @@ class AgentSettingsContactApprovalTests(TestCase):
         self.assertTrue(payload["success"])
         self.assertIn("allowlist", payload)
         self.assertNotIn("html", payload)
+
+    @patch("console.agent_settings.service.process_agent_events_task.delay")
+    def test_allowlist_ajax_updates_contact_directions(self, _mock_process_events):
+        entry = CommsAllowlistEntry.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="permissions@example.com",
+            allow_inbound=True,
+            allow_outbound=True,
+        )
+        self.client.force_login(self.owner)
+
+        response = self.client.post(
+            self.url,
+            {
+                "action": "update_allowlist",
+                "entry_id": str(entry.id),
+                "allow_inbound": "false",
+                "allow_outbound": "true",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        entry.refresh_from_db()
+        self.assertFalse(entry.allow_inbound)
+        self.assertTrue(entry.allow_outbound)
+        serialized = next(
+            item for item in response.json()["allowlist"]["entries"]
+            if item["id"] == str(entry.id)
+        )
+        self.assertFalse(serialized["allowInbound"])
+        self.assertTrue(serialized["allowOutbound"])

--- a/tests/unit/test_agent_settings_contact_approval.py
+++ b/tests/unit/test_agent_settings_contact_approval.py
@@ -1,0 +1,108 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase, tag
+from django.urls import reverse
+
+from api.models import BrowserUseAgent, CommsAllowlistRequest, CommsChannel, PersistentAgent
+
+
+@tag("batch_console_allowlist")
+class AgentSettingsContactApprovalTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.owner = User.objects.create_user(
+            username="contact-settings-owner",
+            email="contact-settings-owner@example.com",
+            password="pw",
+            is_staff=True,
+        )
+        self.other = User.objects.create_user(
+            username="contact-settings-other",
+            email="contact-settings-other@example.com",
+            password="pw",
+        )
+        browser_agent = BrowserUseAgent.objects.create(user=self.owner, name="Contact Settings Browser")
+        self.agent = PersistentAgent.objects.create(
+            user=self.owner,
+            name="Contact Settings Agent",
+            charter="Manage contact approval settings.",
+            browser_use_agent=browser_agent,
+        )
+        self.url = reverse("console_agent_settings", kwargs={"agent_id": self.agent.id})
+
+    def _settings_form(self, **overrides):
+        data = {
+            "name": self.agent.name,
+            "charter": self.agent.charter,
+            "mini_description_mode": self.agent.mini_description_mode,
+            "mini_description": self.agent.mini_description,
+            "is_active": "on",
+            "whitelist_policy": self.agent.whitelist_policy,
+            "contact_approval_mode": self.agent.contact_approval_mode,
+            "preferred_llm_tier": self.agent.preferred_llm_tier.key,
+        }
+        data.update(overrides)
+        return data
+
+    def test_settings_payload_defaults_to_required_approval(self):
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        self.assertEqual(response.json()["agent"]["contactApprovalMode"], "require_approval")
+
+    def test_settings_update_changes_mode_without_resolving_pending_requests(self):
+        pending = CommsAllowlistRequest.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="pending@example.com",
+            reason="Pending before settings change.",
+            purpose="Existing request",
+        )
+        self.client.force_login(self.owner)
+
+        response = self.client.post(
+            self.url,
+            self._settings_form(contact_approval_mode="auto_approve_email"),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        self.agent.refresh_from_db()
+        pending.refresh_from_db()
+        self.assertEqual(self.agent.contact_approval_mode, "auto_approve_email")
+        self.assertEqual(pending.status, CommsAllowlistRequest.RequestStatus.PENDING)
+        self.assertEqual(response.json()["contactApprovalMode"], "auto_approve_email")
+
+    def test_settings_update_rejects_invalid_mode(self):
+        self.client.force_login(self.owner)
+
+        response = self.client.post(
+            self.url,
+            self._settings_form(contact_approval_mode="allow_everything"),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 400, response.content.decode())
+        self.assertIn("valid contact approval", response.json()["error"])
+        self.agent.refresh_from_db()
+        self.assertEqual(
+            self.agent.contact_approval_mode,
+            PersistentAgent.ContactApprovalMode.REQUIRE_APPROVAL,
+        )
+
+    def test_non_owner_cannot_manage_contact_approval_mode(self):
+        self.client.force_login(self.other)
+
+        response = self.client.post(
+            self.url,
+            self._settings_form(contact_approval_mode="auto_approve_email"),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertIn(response.status_code, {403, 404})
+        self.agent.refresh_from_db()
+        self.assertEqual(
+            self.agent.contact_approval_mode,
+            PersistentAgent.ContactApprovalMode.REQUIRE_APPROVAL,
+        )

--- a/tests/unit/test_allowlist_direction.py
+++ b/tests/unit/test_allowlist_direction.py
@@ -15,7 +15,10 @@ from api.models import (
     Organization,
     SmsContactPurpose,
 )
-from api.agent.tools.request_contact_permission import execute_request_contact_permission
+from api.agent.tools.request_contact_permission import (
+    execute_request_contact_permission,
+    get_request_contact_permission_tool,
+)
 from constants.feature_flags import SMS_CONTACT_PURPOSE_REQUIRED
 
 User = get_user_model()
@@ -351,6 +354,102 @@ class AllowlistDirectionTests(TestCase):
             request.sms_contact_purpose_details,
             "Internal team action item alerts only.",
         )
+
+    def test_request_contact_permission_auto_approves_new_email(self):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+
+        result = execute_request_contact_permission(self.agent, {
+            "contacts": [
+                {
+                    "channel": "email",
+                    "address": "Auto.Approved@Example.com",
+                    "name": "Auto Approved",
+                    "reason": "Send an update.",
+                    "purpose": "Status update",
+                }
+            ]
+        })
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["auto_approved_count"], 1)
+        self.assertEqual(result["created_count"], 0)
+        self.assertIsNone(result["approval_url"])
+        request = CommsAllowlistRequest.objects.get(address="auto.approved@example.com")
+        self.assertEqual(request.status, CommsAllowlistRequest.RequestStatus.APPROVED)
+        entry = CommsAllowlistEntry.objects.get(address="auto.approved@example.com")
+        self.assertTrue(entry.allow_inbound)
+        self.assertTrue(entry.allow_outbound)
+        self.assertFalse(entry.can_configure)
+
+    def test_request_contact_permission_auto_approves_email_but_keeps_sms_pending(self):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+
+        result = execute_request_contact_permission(self.agent, {
+            "contacts": [
+                {
+                    "channel": "email",
+                    "address": "email@example.com",
+                    "reason": "Send an update.",
+                    "purpose": "Status update",
+                },
+                {
+                    "channel": "sms",
+                    "address": "+15551234567",
+                    "reason": "Send an alert.",
+                    "purpose": "Operational alert",
+                },
+            ]
+        })
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["auto_approved_count"], 1)
+        self.assertEqual(result["created_count"], 1)
+        self.assertIsNotNone(result["approval_url"])
+        self.assertEqual(
+            CommsAllowlistRequest.objects.get(channel=CommsChannel.EMAIL).status,
+            CommsAllowlistRequest.RequestStatus.APPROVED,
+        )
+        self.assertEqual(
+            CommsAllowlistRequest.objects.get(channel=CommsChannel.SMS).status,
+            CommsAllowlistRequest.RequestStatus.PENDING,
+        )
+
+    def test_request_contact_permission_leaves_existing_pending_email_for_review(self):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+        pending = CommsAllowlistRequest.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="pending@example.com",
+            reason="Existing request.",
+            purpose="Existing purpose",
+        )
+
+        result = execute_request_contact_permission(self.agent, {
+            "contacts": [
+                {
+                    "channel": "email",
+                    "address": "pending@example.com",
+                    "reason": "Try again.",
+                    "purpose": "Follow up",
+                }
+            ]
+        })
+
+        self.assertEqual(result["already_pending_count"], 1)
+        pending.refresh_from_db()
+        self.assertEqual(pending.status, CommsAllowlistRequest.RequestStatus.PENDING)
+        self.assertFalse(CommsAllowlistEntry.objects.filter(address="pending@example.com").exists())
+
+    def test_auto_approval_tool_description_keeps_sms_review_explicit(self):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        tool = get_request_contact_permission_tool(self.agent)
+        description = tool["function"]["description"]
+
+        self.assertIn("call send_email directly", description)
+        self.assertIn("SMS contacts still require human approval", description)
     
     def test_case_insensitive_email_with_directions(self):
         """Test that email addresses are case-insensitive with direction settings."""

--- a/tests/unit/test_outbound_whitelist_gating.py
+++ b/tests/unit/test_outbound_whitelist_gating.py
@@ -148,7 +148,11 @@ class OutboundWhitelistGatingTests(TransactionTestCase):
 
     @patch("api.agent.tools.email_sender.deliver_agent_email")
     @tag("batch_outbound_email")
-    def test_email_auto_approval_honors_mode_change_before_lock(self, mock_deliver_email, mock_close_old_connections):
+    def test_email_auto_approval_uses_persisted_mode_and_ignores_instance_changes(
+        self,
+        mock_deliver_email,
+        mock_close_old_connections,
+    ):
         self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
 
         result = execute_send_email(self.agent, {
@@ -193,7 +197,11 @@ class OutboundWhitelistGatingTests(TransactionTestCase):
 
     @patch("api.agent.tools.email_sender.deliver_agent_email")
     @tag("batch_outbound_email")
-    def test_email_auto_approval_preserves_disabled_outbound(self, mock_deliver_email, mock_close_old_connections):
+    def test_email_auto_approval_preflights_blocked_recipient_before_adding_contacts(
+        self,
+        mock_deliver_email,
+        mock_close_old_connections,
+    ):
         self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
         self.agent.save(update_fields=["contact_approval_mode"])
         entry = CommsAllowlistEntry.objects.create(
@@ -206,6 +214,7 @@ class OutboundWhitelistGatingTests(TransactionTestCase):
 
         result = execute_send_email(self.agent, {
             "to_address": entry.address,
+            "cc_addresses": ["new-contact@example.com"],
             "subject": "Should remain blocked",
             "mobile_first_html": "<p>Hello</p>",
         })
@@ -214,6 +223,12 @@ class OutboundWhitelistGatingTests(TransactionTestCase):
         self.assertIn("Outbound email is disabled", result.get("message", ""))
         entry.refresh_from_db()
         self.assertFalse(entry.allow_outbound)
+        self.assertFalse(
+            CommsAllowlistEntry.objects.filter(
+                agent=self.agent,
+                address="new-contact@example.com",
+            ).exists()
+        )
         mock_deliver_email.assert_not_called()
 
     @patch("api.services.contact_authorization.get_user_max_contacts_per_agent", return_value=1)

--- a/tests/unit/test_outbound_whitelist_gating.py
+++ b/tests/unit/test_outbound_whitelist_gating.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from api.models import (
     PersistentAgent,
     BrowserUseAgent,
+    CommsAllowlistEntry,
     CommsChannel,
     UserPhoneNumber,
 )
@@ -103,6 +104,111 @@ class OutboundWhitelistGatingTests(TransactionTestCase):
             "mobile_first_html": "<p>hi</p>",
         })
         self.assertEqual(blocked.get("status"), "error")
+
+    @patch("api.agent.tools.email_sender.deliver_agent_email")
+    @tag("batch_outbound_email")
+    def test_email_auto_approval_adds_to_and_cc_contacts(self, mock_deliver_email, mock_close_old_connections):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+
+        result = execute_send_email(self.agent, {
+            "to_address": "New.Person@Example.com",
+            "cc_addresses": ["copy@example.com", "COPY@example.com"],
+            "subject": "Automatic contacts",
+            "mobile_first_html": "<p>Hello</p>",
+        })
+
+        self.assertEqual(result.get("status"), "ok")
+        entries = CommsAllowlistEntry.objects.filter(agent=self.agent).order_by("address")
+        self.assertEqual(list(entries.values_list("address", flat=True)), [
+            "copy@example.com",
+            "new.person@example.com",
+        ])
+        self.assertTrue(all(entry.allow_inbound and entry.allow_outbound for entry in entries))
+        self.assertTrue(all(not entry.can_configure for entry in entries))
+        mock_deliver_email.assert_called_once()
+
+    @patch("api.agent.tools.email_sender.deliver_agent_email")
+    @tag("batch_outbound_email")
+    def test_email_auto_approval_reactivates_inactive_contact(self, mock_deliver_email, mock_close_old_connections):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+        entry = CommsAllowlistEntry.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="returning@example.com",
+            is_active=False,
+            allow_inbound=False,
+            allow_outbound=False,
+            can_configure=True,
+        )
+
+        result = execute_send_email(self.agent, {
+            "to_address": "returning@example.com",
+            "subject": "Welcome back",
+            "mobile_first_html": "<p>Hello</p>",
+        })
+
+        self.assertEqual(result.get("status"), "ok")
+        entry.refresh_from_db()
+        self.assertTrue(entry.is_active)
+        self.assertTrue(entry.allow_inbound)
+        self.assertTrue(entry.allow_outbound)
+        self.assertFalse(entry.can_configure)
+        mock_deliver_email.assert_called_once()
+
+    @patch("api.services.contact_authorization.get_user_max_contacts_per_agent", return_value=1)
+    @patch("api.agent.tools.email_sender.deliver_agent_email")
+    @tag("batch_outbound_email")
+    def test_email_auto_approval_contact_cap_is_atomic(
+        self,
+        mock_deliver_email,
+        _mock_contact_cap,
+        mock_close_old_connections,
+    ):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+
+        result = execute_send_email(self.agent, {
+            "to_address": "first@example.com",
+            "cc_addresses": ["second@example.com"],
+            "subject": "Too many contacts",
+            "mobile_first_html": "<p>Hello</p>",
+        })
+
+        self.assertEqual(result.get("status"), "error")
+        self.assertIn("1 of 1 contact slots available", result.get("message", ""))
+        self.assertFalse(CommsAllowlistEntry.objects.filter(agent=self.agent).exists())
+        mock_deliver_email.assert_not_called()
+
+    @patch(
+        "api.agent.tools.email_sender.deliver_agent_email",
+        side_effect=RuntimeError("Delivery provider unavailable"),
+    )
+    @tag("batch_outbound_email")
+    def test_email_auto_approved_contact_remains_when_delivery_fails(
+        self,
+        _mock_deliver_email,
+        mock_close_old_connections,
+    ):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+
+        result = execute_send_email(self.agent, {
+            "to_address": "retry-later@example.com",
+            "subject": "Delivery retry",
+            "mobile_first_html": "<p>Hello</p>",
+        })
+
+        self.assertEqual(result.get("status"), "error")
+        self.assertTrue(
+            CommsAllowlistEntry.objects.filter(
+                agent=self.agent,
+                address="retry-later@example.com",
+                is_active=True,
+                allow_outbound=True,
+            ).exists()
+        )
 
     @patch("api.agent.tools.email_sender.deliver_agent_email")
     @tag("batch_outbound_email")

--- a/tests/unit/test_outbound_whitelist_gating.py
+++ b/tests/unit/test_outbound_whitelist_gating.py
@@ -130,6 +130,40 @@ class OutboundWhitelistGatingTests(TransactionTestCase):
 
     @patch("api.agent.tools.email_sender.deliver_agent_email")
     @tag("batch_outbound_email")
+    def test_email_auto_approval_activates_manual_policy(self, mock_deliver_email, mock_close_old_connections):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.whitelist_policy = PersistentAgent.WhitelistPolicy.DEFAULT
+        self.agent.save(update_fields=["contact_approval_mode", "whitelist_policy"])
+
+        result = execute_send_email(self.agent, {
+            "to_address": "new-policy-contact@example.com",
+            "subject": "Automatic contacts",
+            "mobile_first_html": "<p>Hello</p>",
+        })
+
+        self.assertEqual(result.get("status"), "ok")
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.whitelist_policy, PersistentAgent.WhitelistPolicy.MANUAL)
+        mock_deliver_email.assert_called_once()
+
+    @patch("api.agent.tools.email_sender.deliver_agent_email")
+    @tag("batch_outbound_email")
+    def test_email_auto_approval_honors_mode_change_before_lock(self, mock_deliver_email, mock_close_old_connections):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+
+        result = execute_send_email(self.agent, {
+            "to_address": "needs-review@example.com",
+            "subject": "Automatic contacts",
+            "mobile_first_html": "<p>Hello</p>",
+        })
+
+        self.assertEqual(result.get("status"), "error")
+        self.assertIn("requires approval", result.get("message", ""))
+        self.assertFalse(CommsAllowlistEntry.objects.filter(agent=self.agent).exists())
+        mock_deliver_email.assert_not_called()
+
+    @patch("api.agent.tools.email_sender.deliver_agent_email")
+    @tag("batch_outbound_email")
     def test_email_auto_approval_reactivates_inactive_contact(self, mock_deliver_email, mock_close_old_connections):
         self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
         self.agent.save(update_fields=["contact_approval_mode"])

--- a/tests/unit/test_outbound_whitelist_gating.py
+++ b/tests/unit/test_outbound_whitelist_gating.py
@@ -191,6 +191,31 @@ class OutboundWhitelistGatingTests(TransactionTestCase):
         self.assertFalse(entry.can_configure)
         mock_deliver_email.assert_called_once()
 
+    @patch("api.agent.tools.email_sender.deliver_agent_email")
+    @tag("batch_outbound_email")
+    def test_email_auto_approval_preserves_disabled_outbound(self, mock_deliver_email, mock_close_old_connections):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+        entry = CommsAllowlistEntry.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="inbound-only@example.com",
+            allow_inbound=True,
+            allow_outbound=False,
+        )
+
+        result = execute_send_email(self.agent, {
+            "to_address": entry.address,
+            "subject": "Should remain blocked",
+            "mobile_first_html": "<p>Hello</p>",
+        })
+
+        self.assertEqual(result.get("status"), "error")
+        self.assertIn("Outbound email is disabled", result.get("message", ""))
+        entry.refresh_from_db()
+        self.assertFalse(entry.allow_outbound)
+        mock_deliver_email.assert_not_called()
+
     @patch("api.services.contact_authorization.get_user_max_contacts_per_agent", return_value=1)
     @patch("api.agent.tools.email_sender.deliver_agent_email")
     @tag("batch_outbound_email")

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -128,6 +128,30 @@ class PromptContextContactsGuidanceTests(TestCase):
         self.assertNotIn("person-00@example.com", allowed_contacts)
         self.assertIn("status='allowed' AND allow_outbound=1", allowed_contacts)
 
+    def test_auto_approval_prompt_sends_email_directly_but_keeps_sms_approval(self):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+        collector = _PromptSectionCollector()
+        config_authority = prompt_context._ConfigAuthorityResolver(self.agent)
+        contact_records = prompt_context.build_contacts_snapshot_records(
+            self.agent,
+            display_name_for_user=prompt_context._build_user_display_name,
+            user_can_configure=config_authority.user_can_configure,
+        )
+
+        prompt_context._build_contacts_block(
+            self.agent,
+            collector,
+            _NoopSpan(),
+            config_authority,
+            contact_records,
+        )
+
+        allowed_contacts = collector.sections["allowed_contacts"]
+        self.assertIn("email a new address directly with send_email", allowed_contacts)
+        self.assertIn("SMS contacts still require request_contact_permission", allowed_contacts)
+        self.assertNotIn("To reach someone new, use request_contact_permission", allowed_contacts)
+
     def test_allowed_contact_channels_do_not_imply_sending_channels(self):
         PersistentAgentCommsEndpoint.objects.create(
             owner_agent=self.agent,


### PR DESCRIPTION
## Summary
- Adds a persistent contact approval mode for agents, including migration and model support.
- Updates contact authorization, outbound email tooling, and prompt context guidance to respect the new setting.
- Expands agent settings UI so allowlisted contacts and approval behavior can be managed from the console.
- Covers the new flow with unit tests for approval gating, allowlist direction, and prompt context behavior.

## Testing
- Added and updated unit tests for contact approval modes, outbound whitelist gating, allowlist direction, and SQLite prompt guidance.
- Not run (not requested).