### PR TITLE
Improve owner reports and reply channel continuity

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3214,9 +3214,8 @@ def _get_web_chat_formatting_guidance() -> str:
 
     return (
         "Web chat and peer DM formatting:\n"
-        "Start with the answer/main finding. General messages use natural prose with personality, not report labels. "
-        "Reports use a human lead-in, titled sections, bullets/tables, status labels, and tasteful visuals. "
-        "Metric, pending-item, or next-run reports: compact operating update with a small table or metric block and done/pending/next. "
+        "Start with the answer/main finding. Keep simple exchanges/outreach natural. "
+        "Reports to owners/creators and multi-part findings, metrics, or recommendations use polished sections, bullets/tables or metric blocks, status labels, and tasteful visual cues, even when not called a report. "
         "Address known recipients naturally once around actions; avoid generic delivery logs and agent-name self-intros unless asked. "
         "Use whitespace, not separators. Charts: paste create_chart result.inline; don't attach/read/rebuild."
     )
@@ -3692,7 +3691,7 @@ def _get_system_instruction(
         f"{stop_explicit_note}"
         "Missing recipient or required content for an email/SMS/outbound send is a blocker: use request_human_input with will_continue_work=false, not chat-only questions. "
         "Ask one compact, option-based tracked request for the missing send details; do not ask the same blocker as ordinary chat. "
-        "Use exactly the requested delivery channel; if asked to email an allowed address and send_email is available, call send_email. "
+        "Use the requested channel; otherwise reply on the latest inbound channel, never an older/preferred one. A skipped web send never permits switching. "
         "Never announce what you're about to do—announcements terminate you before delivery. "
         "Wrong: 'Let me fetch that data...' Right: [just make the tool call with no text]\n\n"
         "Scheduled/background exact feed/API fetches without implied send still need send_chat_message(body=brief sourced report, will_continue_work=false).\n\n"
@@ -3768,10 +3767,10 @@ def _get_system_instruction(
 
         "## Communication Style\n\n"
         "Delivered messages should sound like a specific real person in this relationship: warm, direct, contextual, with natural personality, rhythm, and contractions, never a template. "
-        "Never use Unicode dash punctuation, double hyphens, or dash-line substitutes in recipient prose; rewrite with ordinary punctuation. "
+        "No dash punctuation between phrases in recipient prose, including spaced single hyphens. Hyphenated words, ranges, bullets, and tables are fine. "
         "Plain clarity and honesty beat forced friendliness or corporate polish. "
         "Cut filler, hype, cliches, redundant setup, emoji clutter, and AI-giveaway phrases like \"dive into\", \"unleash\", and \"game-changing\". "
-        "Avoid canned acknowledgements, fake enthusiasm, generic compliments, symmetrical rhetoric, and needless restatement. "
+        "Avoid canned or evaluative acknowledgements, generic praise, formulaic concessions, symmetrical rhetoric, and needless restatement. "
         "Hedge only when unsure. When drafting/editing copy, preserve the user's meaning, voice, key terms, and commitments. "
         "For casual greetings, respond socially; if recent context matters, acknowledge it briefly and bridge to the next useful step. "
         "Do not invent work, results, preferences, or personal experiences. This applies only to delivered messages, not progress narration before tool calls.\n\n"

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -1127,7 +1127,9 @@ class ContinuationModePromptContextTests(TestCase):
 
         self.assertIn("## Communication Style", system_prompt)
         self.assertIn("Delivered messages should sound like a specific real person", system_prompt)
-        self.assertIn("Never use Unicode dash punctuation", system_prompt)
+        self.assertIn("No dash punctuation", system_prompt)
+        self.assertIn("including spaced single hyphens", system_prompt)
+        self.assertIn("bullets, and tables are fine", system_prompt)
         self.assertIn("clarity and honesty beat forced friendliness", system_prompt.lower())
         self.assertIn("preserve the user's meaning, voice, key terms, and commitments", system_prompt)
         self.assertIn("AI-giveaway phrases", system_prompt)

--- a/api/agent/tools/tests/test_attachment_guidance.py
+++ b/api/agent/tools/tests/test_attachment_guidance.py
@@ -81,11 +81,14 @@ class AttachmentGuidanceTests(SimpleTestCase):
         self.assertIn("false when this email is the requested final delivery", email_tool["function"]["parameters"]["properties"]["will_continue_work"]["description"])
         self.assertIn("Do not use this to simulate or confirm an email/SMS delivery", chat_tool["function"]["description"])
         self.assertIn("status labels", chat_guidance)
-        self.assertIn("compact operating update", chat_guidance)
-        self.assertIn("small table or metric block", chat_guidance)
+        self.assertIn("owners/creators", chat_guidance)
+        self.assertIn("even when not called a report", chat_guidance)
+        self.assertIn("tables or metric blocks", chat_guidance)
         self.assertIn("Address known recipients naturally once", chat_guidance)
         self.assertIn("agent-name self-intros", chat_guidance)
-        self.assertIn("emoji labels", chat_tool["function"]["parameters"]["properties"]["body"]["description"])
+        self.assertIn("owners/creators", chat_tool["function"]["parameters"]["properties"]["body"]["description"])
+        self.assertIn("polished Markdown sections", chat_tool["function"]["parameters"]["properties"]["body"]["description"])
+        self.assertIn("tasteful visual cues", chat_tool["function"]["parameters"]["properties"]["body"]["description"])
 
     def test_create_file_tool_schema_requires_content_or_query(self):
         tool = get_create_file_tool()

--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -244,7 +244,7 @@ def get_send_chat_tool() -> Dict[str, Any]:
                     "body": {
                         "type": "string",
                         "description": (
-                            "Natural recipient-facing text with personality; never type an em/en dash or double hyphen. General messages use conversational prose, not template labels. Reports use rich Markdown sections, tables/metric blocks, status labels, tasteful emoji labels, visuals, and clickable item links. "
+                            "Natural recipient text; no dash punctuation between phrases, including spaced hyphens. Keep simple exchanges/outreach light. Reports to owners/creators and multi-part findings use polished Markdown sections, tables/metric blocks, status labels, and tasteful visual cues. "
                             "Do not pass placeholders or tool-call/XML syntax; it is sent literally."
                         ),
                     },
@@ -299,7 +299,10 @@ def execute_send_chat_message(agent: PersistentAgent, params: Dict[str, Any]) ->
     if agent.execution_environment == "eval" and will_continue:
         return {
             "status": "ok",
-            "message": "Skipped eval in-progress chat message.",
+            "message": (
+                "Skipped in-progress chat message. Continue the work, then deliver the substantive reply "
+                "in this web chat; do not switch to email or SMS unless the user requested it."
+            ),
             "auto_sleep_ok": False,
             "skipped": True,
         }
@@ -312,7 +315,10 @@ def execute_send_chat_message(agent: PersistentAgent, params: Dict[str, Any]) ->
     ):
         return {
             "status": "ok",
-            "message": "Skipped routine progress-only chat message.",
+            "message": (
+                "Skipped routine progress-only chat message. Continue the work, then deliver the substantive reply "
+                "in this web chat; do not switch to email or SMS unless the user requested it."
+            ),
             "auto_sleep_ok": False,
             "skipped": True,
         }

--- a/api/evals/scenarios/message_quality.py
+++ b/api/evals/scenarios/message_quality.py
@@ -1,6 +1,7 @@
 import json
 import re
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 from uuid import UUID
 
@@ -10,7 +11,7 @@ from api.agent.comms.message_service import _ensure_participant, _get_or_create_
 from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
 from api.evals.base import EvalScenario, ScenarioTask
 from api.evals.execution import ScenarioExecutionTools
-from api.evals.registry import ScenarioRegistry
+from api.evals.registry import ScenarioRegistry, register_scenario
 from api.models import (
     CommsAllowlistEntry,
     CommsChannel,
@@ -26,6 +27,7 @@ from util.text_sanitizer import has_humanized_message_style_violation
 
 
 MESSAGE_QUALITY_SUITE_SLUG = "message_quality_reports"
+REPLY_CHANNEL_CONTINUITY_SLUG = "message_quality_reply_stays_in_web_chat"
 
 
 @dataclass(frozen=True)
@@ -200,10 +202,53 @@ HUMAN_MESSAGE_QUALITY_CASES = (
         source_example_ids=(),
         quality_target="human_message",
     ),
+    MessageQualityCase(
+        slug="message_quality_chat_evidence_acknowledgement",
+        channel="chat",
+        recipient="web-user",
+        subject="Regression evidence",
+        brief="brief acknowledgement of evidence for an existing issue",
+        source_facts=(
+            "Quick heads-up: the two-hour regression run reproduced malformed source links again. "
+            "I already logged it under existing issue 49 about source verification and fabricated URLs, "
+            "so there is nothing for you to update or create. Just wanted you to know."
+        ),
+        source_example_ids=(),
+        quality_target="human_reply",
+    ),
 )
 
-MESSAGE_QUALITY_CASES = REPORT_MESSAGE_QUALITY_CASES + SIMPLE_EMAIL_QUALITY_CASES + HUMAN_MESSAGE_QUALITY_CASES
-MESSAGE_QUALITY_SCENARIO_SLUGS = tuple(case.slug for case in MESSAGE_QUALITY_CASES)
+OWNER_UPDATE_QUALITY_CASES = (
+    MessageQualityCase(
+        slug="message_quality_chat_owner_pipeline_update",
+        channel="chat",
+        recipient="web-user",
+        subject="Pipeline update",
+        brief="owner-facing recruiting pipeline update",
+        source_facts=(
+            "Audience: the owner of the recruiting agent.\n"
+            "Pipeline: 18 candidates reviewed, 6 qualified, 3 awaiting recruiter review, and 2 interviews booked.\n"
+            "Sources: 11 candidates came from LinkedIn and 7 came from referrals.\n"
+            "Quality: qualified candidates average 8.4 out of 10; the target is 8.0.\n"
+            "Blocker: four profiles are missing compensation expectations.\n"
+            "Spend: $186 used from a $250 weekly sourcing budget.\n"
+            "Next: verify compensation for the four blocked profiles and prepare the six qualified candidates for review."
+        ),
+        source_example_ids=(),
+        quality_target="owner_update",
+    ),
+)
+
+MESSAGE_QUALITY_CASES = (
+    REPORT_MESSAGE_QUALITY_CASES
+    + SIMPLE_EMAIL_QUALITY_CASES
+    + HUMAN_MESSAGE_QUALITY_CASES
+    + OWNER_UPDATE_QUALITY_CASES
+)
+MESSAGE_QUALITY_SCENARIO_SLUGS = (
+    *(case.slug for case in MESSAGE_QUALITY_CASES),
+    REPLY_CHANNEL_CONTINUITY_SLUG,
+)
 
 
 MESSAGE_TOOL_NAMES = {"send_email", "send_chat_message", "send_sms", "send_agent_message"}
@@ -313,6 +358,14 @@ class MessageQualityScenario(EvalScenario, ScenarioExecutionTools):
                 "Send me a quick chat update using only the details below. Do not browse, create files, "
                 f"or ask follow-up questions.\n\n{case.source_facts}\n\nSend the update now."
             )
+        if case.quality_target == "human_reply":
+            return case.source_facts
+        if case.quality_target == "owner_update":
+            return (
+                "How are things looking with the recruiting work right now? Give me the useful update "
+                "using only the details below. Do not browse, create files, or ask follow-up questions.\n\n"
+                f"{case.source_facts}\n\nSend me the update now."
+            )
 
         if case.channel == "email":
             delivery_instruction = (
@@ -354,7 +407,8 @@ class MessageQualityScenario(EvalScenario, ScenarioExecutionTools):
         successful_calls = [
             call
             for call in expected_calls
-            if str(self._tool_result(call).get("status") or "").lower() in {"ok", "queued", "sent", "success"}
+            if self._tool_result(call).get("skipped") is not True
+            and str(self._tool_result(call).get("status") or "").lower() in {"ok", "queued", "sent", "success"}
         ]
         unexpected_calls = self._unexpected_message_calls(case, send_calls)
 
@@ -520,6 +574,10 @@ class MessageQualityScenario(EvalScenario, ScenarioExecutionTools):
             return f"Agent should send a concise outreach email via {case.expected_tool}."
         if case.quality_target == "human_message":
             return f"Agent should send a natural, context-specific update via {case.expected_tool}."
+        if case.quality_target == "human_reply":
+            return f"Agent should acknowledge the user's note naturally via {case.expected_tool}."
+        if case.quality_target == "owner_update":
+            return f"Agent should send a polished, scannable owner update via {case.expected_tool}."
         return f"Agent should send a polished {case.channel} report via {case.expected_tool}."
 
     @staticmethod
@@ -528,6 +586,10 @@ class MessageQualityScenario(EvalScenario, ScenarioExecutionTools):
             return "Judge should pass only restrained, professional outreach email formatting."
         if case.quality_target == "human_message":
             return "Judge should pass only a natural, specific message without assistant-like tells."
+        if case.quality_target == "human_reply":
+            return "Judge should pass only a concise, natural acknowledgement without evaluative padding."
+        if case.quality_target == "owner_update":
+            return "Judge should pass only a human, polished, decision-useful owner update."
         return "Judge should pass only polished, rich, readable report formatting."
 
     @staticmethod
@@ -550,6 +612,21 @@ class MessageQualityScenario(EvalScenario, ScenarioExecutionTools):
                 "specific, conversational, appropriately candid, and allowed to show natural personality or charm. Fail for canned acknowledgements, generic "
                 "enthusiasm, request restatement, polished assistant cadence, symmetrical rhetoric, report formatting, "
                 "template labels, or needless headings. Do not penalize expressive formatting in an explicitly requested report or dashboard."
+            )
+        if case.quality_target == "human_reply":
+            return (
+                "Does this sound like a person responding directly to a short operational note? Pass only if it is a concise, "
+                "context-aware acknowledgement. Fail if it opens by evaluating or praising the result, adds a formulaic concession such as 'even if', "
+                "says this is exactly the kind of evidence needed, restates the user's rationale or decision, or stacks polished "
+                "assistant-style framing around a simple confirmation. Do not require exact wording; a short acknowledgement is enough."
+            )
+        if case.quality_target == "owner_update":
+            return (
+                "Does this feel like a polished update from a thoughtful operator to the owner of the work? "
+                "Pass only if it stays human and direct while making the multi-part operational state easy to scan, "
+                "with clear visual grouping and proportionate use of sections, bullets, a compact table, metric blocks, "
+                "or status labels. Fail if it is a dense plain paragraph, a loose fact dump, needlessly over-formatted, "
+                "or templated/corporate. Do not require any one specific Markdown element."
             )
         if case.channel == "email":
             return (
@@ -737,6 +814,171 @@ class MessageQualityScenario(EvalScenario, ScenarioExecutionTools):
             if re.search(r"^\s*\|.+\|\s*$", body, re.MULTILINE):
                 failures.append("Email body should use HTML tables, not Markdown pipe tables.")
         return failures
+
+
+@register_scenario
+class ReplyChannelContinuityScenario(EvalScenario, ScenarioExecutionTools):
+    slug = REPLY_CHANNEL_CONTINUITY_SLUG
+    version = "1.0"
+    description = "A reply to an active web conversation should not move to an older or preferred email thread."
+    tier = "core"
+    category = "message_quality"
+    expected_runtime = "short"
+    cost_class = "low"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = ("message_quality", "tool_choice", "send_chat_message", "reply_channel")
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_web_chat_delivery", assertion_type="manual"),
+        ScenarioTask(name="verify_no_cross_channel_reply", assertion_type="manual"),
+    ]
+
+    @staticmethod
+    def _seed_email_context(agent: PersistentAgent) -> PersistentAgentCommsEndpoint:
+        owner_email, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
+            channel=CommsChannel.EMAIL,
+            address="owner@example.test",
+            defaults={"owner_agent": None},
+        )
+        agent_email, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
+            owner_agent=agent,
+            channel=CommsChannel.EMAIL,
+            defaults={"address": f"agent-{agent.id}@eval.local", "is_primary": True},
+        )
+        CommsAllowlistEntry.objects.update_or_create(
+            agent=agent,
+            channel=CommsChannel.EMAIL,
+            address=owner_email.address,
+            defaults={
+                "is_active": True,
+                "allow_inbound": True,
+                "allow_outbound": True,
+                "verified": True,
+                "can_configure": True,
+            },
+        )
+        conversation = _get_or_create_conversation(
+            CommsChannel.EMAIL,
+            owner_email.address,
+            owner_agent=agent,
+        )
+        _ensure_participant(
+            conversation,
+            owner_email,
+            PersistentAgentConversationParticipant.ParticipantRole.EXTERNAL,
+        )
+        _ensure_participant(
+            conversation,
+            agent_email,
+            PersistentAgentConversationParticipant.ParticipantRole.AGENT,
+        )
+        prior_email = PersistentAgentMessage.objects.create(
+            owner_agent=agent,
+            from_endpoint=owner_email,
+            to_endpoint=agent_email,
+            conversation=conversation,
+            is_outbound=False,
+            body="Please keep the current outreach batch moving and send a few more when they are ready.",
+            raw_payload={"subject": "Send a few more"},
+        )
+        PersistentAgentMessage.objects.filter(pk=prior_email.pk).update(
+            timestamp=timezone.now() - timedelta(minutes=20),
+        )
+        return owner_email
+
+    @staticmethod
+    def _result(call: PersistentAgentToolCall) -> dict[str, Any]:
+        return MessageQualityScenario._tool_result(call)
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        agent = PersistentAgent.objects.get(id=agent_id)
+        mark_tool_enabled_without_discovery(agent, "send_email")
+        mark_tool_enabled_without_discovery(agent, "send_chat_message")
+        owner_email = self._seed_email_context(agent)
+
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="inject_prompt")
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            inbound = self.inject_message(
+                agent_id,
+                (
+                    "One more thing for this outreach batch only: lead with the self-serve value, mention that it works "
+                    "with the tools people already use, and route unusually large opportunities to the enterprise team. "
+                    "Got it? We can handle the queue separately after this reply."
+                ),
+                trigger_processing=False,
+                eval_run_id=run_id,
+            )
+            PersistentAgent.objects.filter(id=agent_id).update(preferred_contact_endpoint=owner_email)
+            self.trigger_processing(
+                agent_id,
+                eval_run_id=run_id,
+                mock_config={
+                    "send_email": {
+                        "status": "ok",
+                        "message": "Mocked email delivery for reply-channel regression eval.",
+                        "message_id": "eval-reply-channel-email",
+                    },
+                },
+                eval_stop_policy={
+                    "stop_on_tool_names_after_execution": ["send_chat_message", "send_email"],
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": [
+                        "sqlite_batch",
+                        "send_chat_message",
+                        "send_email",
+                        "update_plan",
+                    ],
+                    "ignored_tool_names": ["sqlite_batch", "update_plan"],
+                    "max_relevant_tool_calls": 8,
+                },
+            )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_prompt",
+            observed_summary="Web prompt injected with an older preferred email path available.",
+            artifacts={"message": inbound},
+        )
+
+        calls = MessageQualityScenario._tool_calls_for_run(run_id, after=inbound.timestamp)
+        chat_calls = [call for call in calls if call.tool_name == "send_chat_message"]
+        delivered_chats = [
+            call
+            for call in chat_calls
+            if self._result(call).get("skipped") is not True
+            and str(self._result(call).get("status") or "").lower() in {"ok", "sent", "success"}
+        ]
+        email_calls = [call for call in calls if call.tool_name == "send_email"]
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if len(delivered_chats) == 1 else EvalRunTask.Status.FAILED,
+            task_name="verify_web_chat_delivery",
+            expected_summary="Agent should deliver one non-skipped reply in the active web conversation.",
+            observed_summary=(
+                f"Saw {len(delivered_chats)} delivered web reply/replies after {len(chat_calls)} chat attempt(s)."
+            ),
+            artifacts={"step": (delivered_chats[0].step if delivered_chats else chat_calls[0].step)}
+            if chat_calls
+            else {},
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if not email_calls else EvalRunTask.Status.FAILED,
+            task_name="verify_no_cross_channel_reply",
+            expected_summary="Agent should not move the reply to the older email thread.",
+            observed_summary=(
+                "Agent kept the reply out of email."
+                if not email_calls
+                else f"Agent attempted {len(email_calls)} cross-channel email reply/replies."
+            ),
+            artifacts={"step": email_calls[0].step} if email_calls else {},
+        )
 
 
 def _scenario_class(case: MessageQualityCase):

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -741,7 +741,8 @@ class EffortCalibrationHarnessTests(TestCase):
 
         self.assertEqual(result["status"], "ok")
         self.assertTrue(result["skipped"])
-        self.assertIn("eval in-progress", result["message"])
+        self.assertIn("deliver the substantive reply in this web chat", result["message"])
+        self.assertIn("do not switch to email or SMS", result["message"])
         self.assertFalse(PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=True).exists())
 
     def test_send_chat_skips_progress_only_message_before_any_reply(self):
@@ -1034,7 +1035,8 @@ class FirstRunPromptCalibrationTests(TestCase):
             context, _, _ = build_prompt_context_preview(agent, is_first_run=False)
 
         system_prompt = next(message["content"] for message in context if message["role"] == "system")
-        self.assertIn("Use exactly the requested delivery channel", system_prompt)
+        self.assertIn("Use the requested channel; otherwise reply on the latest inbound channel", system_prompt)
+        self.assertIn("A skipped web send never permits switching", system_prompt)
         self.assertIn("Set false after delivery/config and no active work", system_prompt)
         self.assertIn("Do not set a schedule merely to continue or remember a single research question", system_prompt)
         self.assertIn("explicit SQLite/database request and sqlite_batch is callable", system_prompt)

--- a/api/evals/tests/test_message_quality.py
+++ b/api/evals/tests/test_message_quality.py
@@ -6,6 +6,8 @@ from api.evals.scenarios.message_quality import (
     MESSAGE_QUALITY_CASES,
     MESSAGE_QUALITY_SCENARIO_SLUGS,
     MESSAGE_QUALITY_SUITE_SLUG,
+    OWNER_UPDATE_QUALITY_CASES,
+    REPLY_CHANNEL_CONTINUITY_SLUG,
     REPORT_MESSAGE_QUALITY_CASES,
     SIMPLE_EMAIL_QUALITY_CASES,
     HUMAN_MESSAGE_QUALITY_CASES,
@@ -21,7 +23,8 @@ class MessageQualityScenarioTests(SimpleTestCase):
 
         self.assertIsNotNone(suite)
         self.assertEqual(tuple(suite.scenario_slugs), MESSAGE_QUALITY_SCENARIO_SLUGS)
-        self.assertEqual(len(suite.scenario_slugs), 13)
+        self.assertEqual(len(suite.scenario_slugs), 16)
+        self.assertIn(REPLY_CHANNEL_CONTINUITY_SLUG, suite.scenario_slugs)
 
     def test_generated_cases_cover_email_and_chat_for_each_real_world_domain(self):
         channels_by_brief = {}
@@ -43,13 +46,18 @@ class MessageQualityScenarioTests(SimpleTestCase):
     def test_generated_scenarios_have_message_quality_metadata(self):
         registered = ScenarioRegistry.list_all()
 
-        for slug in MESSAGE_QUALITY_SCENARIO_SLUGS:
+        for slug in (case.slug for case in MESSAGE_QUALITY_CASES):
             scenario = registered[slug]
             metadata = scenario.get_metadata()
             self.assertEqual(metadata.category, "message_quality")
             self.assertEqual(metadata.cost_class, "high")
             self.assertIn("llm_judge", metadata.tags)
             self.assertIn("response_quality", metadata.tags)
+
+        reply_channel_metadata = registered[REPLY_CHANNEL_CONTINUITY_SLUG].get_metadata()
+        self.assertEqual(reply_channel_metadata.category, "message_quality")
+        self.assertEqual(reply_channel_metadata.cost_class, "low")
+        self.assertIn("reply_channel", reply_channel_metadata.tags)
 
     def test_simple_email_prompt_does_not_specify_formatting_style(self):
         case = SIMPLE_EMAIL_QUALITY_CASES[0]
@@ -82,6 +90,30 @@ class MessageQualityScenarioTests(SimpleTestCase):
         self.assertNotIn("dash", prompt)
         self.assertIn("natural message", question)
         self.assertIn("assistant cadence", question)
+
+    def test_human_reply_eval_does_not_name_the_slop_patterns(self):
+        case = next(case for case in HUMAN_MESSAGE_QUALITY_CASES if case.quality_target == "human_reply")
+        prompt = MessageQualityScenario()._prompt(case).lower()
+        question = MessageQualityScenario._judge_question(case)
+
+        self.assertNotIn("exactly the kind", prompt)
+        self.assertNotIn("formulaic", prompt)
+        self.assertNotIn("evaluating", prompt)
+        self.assertIn("evaluating or praising", question)
+        self.assertIn("such as 'even if'", question)
+        self.assertIn("exactly the kind of evidence", question)
+
+    def test_owner_update_eval_does_not_name_the_desired_format(self):
+        case = OWNER_UPDATE_QUALITY_CASES[0]
+        prompt = MessageQualityScenario()._prompt(case).lower()
+        question = MessageQualityScenario._judge_question(case)
+
+        self.assertNotIn("report", prompt)
+        self.assertNotIn("dashboard", prompt)
+        self.assertNotIn("markdown", prompt)
+        self.assertNotIn("table", prompt)
+        self.assertIn("owner of the work", question)
+        self.assertIn("easy to scan", question)
 
     def test_rich_email_judge_rewards_status_encoding_without_mandating_emoji(self):
         case = next(case for case in REPORT_MESSAGE_QUALITY_CASES if case.channel == "email")
@@ -155,15 +187,18 @@ class MessageQualityScenarioTests(SimpleTestCase):
 
     def test_delivery_basics_reject_ai_dash_tells(self):
         case = HUMAN_MESSAGE_QUALITY_CASES[0]
-        body = "The copy finished—Morgan is checking two invoices now."
+        for body in (
+            "The copy finished—Morgan is checking two invoices now.",
+            "The copy finished - Morgan is checking two invoices now.",
+        ):
+            with self.subTest(body=body):
+                failures = MessageQualityScenario()._formatting_failures(
+                    case,
+                    {"body": body, "will_continue_work": False},
+                    body,
+                )
 
-        failures = MessageQualityScenario()._formatting_failures(
-            case,
-            {"body": body, "will_continue_work": False},
-            body,
-        )
-
-        self.assertIn("Recipient-facing prose used prohibited dash punctuation", failures[0])
+                self.assertIn("Recipient-facing prose used prohibited dash punctuation", failures[0])
 
     def test_delivery_basics_accept_terminal_tool_result_when_continue_flag_omitted(self):
         case = next(case for case in MESSAGE_QUALITY_CASES if case.channel == "chat")

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -70,7 +70,7 @@ class ImpliedSendTests(TestCase):
     def test_humanized_message_normalization_covers_built_in_delivery_channels(self):
         for tool_name, params in (
             ("send_chat_message", {"body": "Quick update—this is done."}),
-            ("send_sms", {"body": "Quick update -- this is done."}),
+            ("send_sms", {"body": "Quick update - this is done."}),
             ("send_email", {"subject": "Update—done", "mobile_first_html": "<p>Done.</p>"}),
             ("send_discord_message", {"message": "Quick update—this is done."}),
         ):
@@ -78,6 +78,7 @@ class ImpliedSendTests(TestCase):
                 result = ep._normalize_humanized_message_params(tool_name, params)
                 self.assertNotIn("—", str(result))
                 self.assertNotIn("--", str(result))
+                self.assertNotIn(" - ", str(result))
 
         self.assertEqual(
             ep._normalize_humanized_message_params(
@@ -454,6 +455,8 @@ class ImpliedSendTests(TestCase):
 
         self.assertEqual(result.get("status"), "ok")
         self.assertTrue(result.get("skipped"))
+        self.assertIn("deliver the substantive reply in this web chat", result.get("message", ""))
+        self.assertIn("do not switch to email or SMS", result.get("message", ""))
         self.assertEqual(
             PersistentAgentMessage.objects.filter(owner_agent=self.agent, is_outbound=True).count(),
             0,

--- a/tests/unit/test_text_sanitization.py
+++ b/tests/unit/test_text_sanitization.py
@@ -17,13 +17,15 @@ from util.text_sanitizer import (
 
 @tag("batch_text_sanitization")
 class TextSanitizationTests(TestCase):
-    def test_humanized_message_style_rejects_unicode_and_double_dashes(self):
+    def test_humanized_message_style_rejects_dash_punctuation(self):
         self.assertTrue(has_humanized_message_style_violation("That works—let's do it."))
         self.assertTrue(has_humanized_message_style_violation("That works -- let's do it."))
+        self.assertTrue(has_humanized_message_style_violation("That works - let's do it."))
         self.assertTrue(has_humanized_message_style_violation("<p>That works&mdash;let's do it.</p>"))
 
-    def test_humanized_message_style_allows_normal_hyphens_and_non_prose(self):
+    def test_humanized_message_style_allows_hyphenation_lists_and_non_prose(self):
         self.assertFalse(has_humanized_message_style_violation("A low-pressure, 15-minute chat works."))
+        self.assertFalse(has_humanized_message_style_violation("- Ready\n  - Still in progress\n+ Complete"))
         self.assertFalse(has_humanized_message_style_violation("See https://example.test/a--b and `git --help`."))
 
     def test_humanized_message_style_normalizes_prose_but_preserves_tables(self):
@@ -32,6 +34,15 @@ class TextSanitizationTests(TestCase):
         self.assertEqual(
             normalize_humanized_message_style(text),
             "Update, done.\n\n| Item | Status |\n| --- | --- |\n| Copy | Done |",
+        )
+
+        self.assertEqual(
+            normalize_humanized_message_style("Update - done.\n\n- First item\n- Second item"),
+            "Update, done.\n\n- First item\n- Second item",
+        )
+        self.assertEqual(
+            normalize_humanized_message_style("Rhode Island\n---\nOverview"),
+            "Rhode Island\n\nOverview",
         )
 
     def test_humanized_message_style_preserves_rich_html_exactly(self):

--- a/util/text_sanitizer.py
+++ b/util/text_sanitizer.py
@@ -33,11 +33,11 @@ _CONTROL_CHAR_SUBSTITUTIONS = {
 _CONTROL_HEX_SEQUENCE_RE = re.compile(r"([\u0000-\u0001])([0-9a-fA-F]{2})")
 _TRANSLATION_TABLE = str.maketrans(_CONTROL_CHAR_SUBSTITUTIONS)
 _NON_PROSE_RE = re.compile(
-    r"<(?:code|pre)\b[^>]*>.*?</(?:code|pre)>|```.*?```|`[^`\n]+`|(?:https?://|www\.)[^\s<>]+|<[^>]+>|^[ \t]*\|?[ \t]*:?-{3,}:?[ \t]*(?:\|[ \t]*:?-{3,}:?[ \t]*)+\|?[ \t]*$",
+    r"<(?:code|pre)\b[^>]*>.*?</(?:code|pre)>|```.*?```|`[^`\n]+`|(?:https?://|www\.)[^\s<>]+|<[^>]+>|^[ \t]*[-+*][ \t]+|^[ \t]*\|?[ \t]*:?-{3,}:?[ \t]*(?:\|[ \t]*:?-{3,}:?[ \t]*)+\|?[ \t]*$",
     re.IGNORECASE | re.DOTALL | re.MULTILINE,
 )
 _FORBIDDEN_DASH_RE = re.compile(
-    r"[ \t]*(?:[\u2012\u2013\u2014\u2015\u2e3a\u2e3b]+|--+|&(?:mdash|ndash|#8211|#8212|#x2013|#x2014);)[ \t]*",
+    r"(?:[ \t]*(?:[\u2012\u2013\u2014\u2015\u2e3a\u2e3b]+|--+|&(?:mdash|ndash|#8211|#8212|#x2013|#x2014);)[ \t]*|[ \t]+-[ \t]+)",
     re.IGNORECASE,
 )
 
@@ -47,9 +47,11 @@ def normalize_humanized_message_style(value: str | None) -> str:
 
     def normalize_prose(prose: str) -> str:
         def punctuate(match):
-            before = prose[:match.start()].rstrip()
-            after = prose[match.end():].lstrip()
-            return ", " if before and after and not before.endswith("\n") and not after.startswith("\n") else ""
+            before = prose[:match.start()].rstrip(" \t")
+            after = prose[match.end():].lstrip(" \t")
+            if not before or not after or before.endswith("\n") or after.startswith("\n"):
+                return ""
+            return ", "
 
         return _FORBIDDEN_DASH_RE.sub(punctuate, prose)
 


### PR DESCRIPTION
## Summary

- restore polished, scannable structure for owner-facing reports and dense findings without making casual replies or outreach look like reports
- keep replies on the latest inbound channel, including after a progress-only web-chat send is skipped
- remove dash punctuation, including spaced single hyphens, while preserving hyphenated words, ranges, Markdown lists/tables, code, and URLs
- remove dash-only separator lines cleanly instead of turning them into stray commas
- reduce canned evaluative acknowledgments, formulaic concessions, generic praise, and needless restatement
- add natural real-harness regressions for owner-update structure, active-web-chat continuity, and short operational acknowledgments

## Why

A bounded production trajectory showed the agent repeatedly attempting web chat, receiving skipped progress-only results, then treating email as a workaround. The formatting regression was a separate boundary problem: explicit reports could remain rich, but dense owner updates without the word report were pushed toward plain prose.

During eval validation, a Quonset report exposed a related sanitizer defect: a Markdown dash separator became an isolated comma. The focused cleanup removes line-boundary dashes without inserting punctuation.

## Validation

- rebased over merged PRs #1311 and #1312 with no conflicts
- focused Django regression set on integrated SHA 4c74b0d32: 98/98 passed
- prompt complexity: passed at the existing system-prompt baseline; tool prompt remains 15 bytes below baseline; no baseline update
- DeepSeek V4 Flash message suite on behavior SHA 150063887: 62/63; one plain-prose owner-update judge outlier
- same owner-update scenario immediately repeated: 12/12 across 3 runs
- email price-report follow-up: 12/12 across 3 runs
- earlier targeted DeepSeek runs: owner update 12/12, reply channel 9/9, natural acknowledgment 12/12
- complete DeepSeek suite on the immediate pre-cleanup SHA: 1,416/1,433 assertions passed across all 295 scenarios (98.8%); 10 of 12 failing scenarios cleared on focused retry. The two persistent misses were unrelated existing DeepSeek behaviors: preserving a resume schedule and using an option-based tracked clarification.
- #1312 changed only contact-approval migrations, settings UI, feature flags, and their tests; the integrated SHA reran focused tests and CI, while behavior eval evidence remains from the behavior-identical prompt/tool implementation
- GitHub CI for integrated SHA 4c74b0d32: all shards, frontend, sandbox, tag, and complexity checks passed
- preview deployment for integrated SHA 4c74b0d32: passed; https://pr-1310.ship.gobii.ai returned 200 for `/`, `/app/`, and `/healthz/` (`OK`)

## Safety

Email delivery is mocked in the channel regression. No production messages or mutations were made, and no production identifiers or raw production message bodies are included in this PR.
