### PR TITLE
Fix assignment panel timeline rendering and tool metadata

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -97,7 +97,7 @@ from ..tools.email_sender import execute_send_email
 from ..tools.sms_sender import execute_send_sms
 from ..tools.spawn_web_task import execute_spawn_web_task
 from ..tools.schedule_updater import execute_update_schedule
-from ..tools.sqlite_agent_config import apply_sqlite_agent_config_updates, seed_sqlite_agent_config
+from ..tools.sqlite_agent_config import apply_sqlite_agent_config_updates, read_sqlite_agent_config_snapshot, seed_sqlite_agent_config
 from ..tools.sqlite_skills import apply_sqlite_skill_updates, refresh_skills_for_tool, seed_sqlite_skills
 from ..tools.custom_tools import execute_create_custom_tool
 from ..tools.custom_tool_names import CREATE_CUSTOM_TOOL_NAME
@@ -188,6 +188,7 @@ MESSAGE_TOOL_BODY_KEYS = {
 HUMANIZED_MESSAGE_BODY_KEYS = {**MESSAGE_TOOL_BODY_KEYS, "send_discord_message": "message"}
 SQLITE_MUTATION_RE = re.compile(r"\b(?:insert|update|delete|replace|alter|drop|create)\b", re.IGNORECASE)
 AGENT_CONFIG_TABLE_RE = re.compile(r"\b__agent_config\b", re.IGNORECASE)
+AGENT_CONFIG_CHARTER_ASSIGNMENT_RE = re.compile(r"\bcharter\b\s*=", re.IGNORECASE)
 DURABLE_CONFIG_INTENT_RE = re.compile(
     r"\b(?:going forward|from now on|in the future|next time|always|never|remember|prefer|preference|"
     r"(?:my |this )?feedback:|each time|every time|make (?:that|this|it) a rule|should(?:n'?t| not) have to|"
@@ -1312,6 +1313,7 @@ def _persist_tool_call_step(
     attach_completion: Any,
     attach_prompt_archive: Any,
     parent_tool_call: Any = None,
+    display_metadata: Dict[str, Any] | None = None,
 ) -> Optional["PersistentAgentStep"]:
     """Persist a tool call step with robust error handling.
 
@@ -1349,6 +1351,7 @@ def _persist_tool_call_step(
             tool_name=safe_tool_name,
             tool_params=tool_params,
             result=normalized_result,
+            display_metadata=display_metadata or None,
             execution_duration_ms=execution_duration_ms,
             status=tool_call_status,
         )
@@ -1496,6 +1499,7 @@ def _finalize_pending_tool_call_step(
     execution_duration_ms: Optional[int],
     status: str,
     parent_tool_call: Any = None,
+    display_metadata: Dict[str, Any] | None = None,
 ) -> None:
     from api.models import PersistentAgentToolCall
 
@@ -1541,6 +1545,7 @@ def _finalize_pending_tool_call_step(
                 tool_name=safe_tool_name,
                 tool_params=tool_params,
                 result=normalized_result,
+                display_metadata=display_metadata or None,
                 execution_duration_ms=execution_duration_ms,
                 status=status,
             )
@@ -1549,9 +1554,10 @@ def _finalize_pending_tool_call_step(
             tool_call.tool_name = safe_tool_name
             tool_call.tool_params = tool_params
             tool_call.result = normalized_result
+            tool_call.display_metadata = display_metadata or None
             tool_call.execution_duration_ms = execution_duration_ms
             tool_call.status = status
-            update_fields = ["tool_name", "tool_params", "result", "execution_duration_ms", "status"]
+            update_fields = ["tool_name", "tool_params", "result", "display_metadata", "execution_duration_ms", "status"]
             if parent_tool_call is not None and tool_call.parent_tool_call_id is None:
                 tool_call.parent_tool_call = parent_tool_call
                 update_fields.append("parent_tool_call")
@@ -1732,6 +1738,7 @@ class _ToolExecutionOutcome:
     duration_ms: int
     updated_tools: Optional[List[dict]]
     variable_map: Dict[str, str]
+    display_metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -2146,6 +2153,15 @@ def _sqlite_batch_is_only_agent_config_mutation(tool_params: Dict[str, Any]) -> 
     ) and all(AGENT_CONFIG_TABLE_RE.search(statement) for statement in statements)
 
 
+def _sqlite_batch_mutates_agent_charter(tool_params: Dict[str, Any]) -> bool:
+    return any(
+        AGENT_CONFIG_TABLE_RE.search(statement)
+        and SQLITE_MUTATION_RE.search(statement)
+        and AGENT_CONFIG_CHARTER_ASSIGNMENT_RE.search(statement)
+        for statement in _sqlite_batch_statements(tool_params)
+    )
+
+
 def _user_text_has_durable_config_intent(text: str) -> bool:
     normalized = " ".join((text or "").split())
     if TRANSIENT_CONFIG_SCOPE_RE.search(normalized) and not STRONG_DURABLE_CONFIG_INTENT_RE.search(normalized):
@@ -2489,6 +2505,27 @@ def _tool_result_is_success(result: Any) -> bool:
     return True
 
 
+def _capture_tool_display_metadata(
+    prepared: _PreparedToolExecution,
+    result: Any,
+) -> Dict[str, Any]:
+    if (
+        prepared.tool_name != "sqlite_batch"
+        or not _tool_result_is_success(result)
+        or not _sqlite_batch_mutates_agent_charter(prepared.exec_params)
+    ):
+        return {}
+
+    snapshot = read_sqlite_agent_config_snapshot()
+    if snapshot is None:
+        return {}
+    return {
+        "agent_config": {
+            "charter": snapshot.charter,
+        },
+    }
+
+
 def _mark_tool_outcome_failed(
     outcome: _ToolExecutionOutcome,
     exc: Exception,
@@ -2559,12 +2596,14 @@ def _execute_prepared_tool_call(
         )
         updated_tools = None
     duration_ms = int(round((time.monotonic() - tool_started_at) * 1000))
+    display_metadata = _capture_tool_display_metadata(prepared, result)
     return _ToolExecutionOutcome(
         prepared=prepared,
         result=result,
         duration_ms=duration_ms,
         updated_tools=updated_tools,
         variable_map=get_all_variables(),
+        display_metadata=display_metadata,
     )
 
 
@@ -3236,6 +3275,7 @@ def _finalize_tool_batch(
                 result_content=result_content,
                 execution_duration_ms=outcome.duration_ms,
                 status=tool_status,
+                display_metadata=outcome.display_metadata,
             )
             step = prepared.pending_step
         else:
@@ -3250,6 +3290,7 @@ def _finalize_tool_batch(
                 consumed_credit=prepared.consumed_credit,
                 attach_completion=attach_completion,
                 attach_prompt_archive=attach_prompt_archive,
+                display_metadata=outcome.display_metadata,
             )
         if is_error_status:
             _refund_tool_credit_on_error_if_configured(

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -97,7 +97,12 @@ from ..tools.email_sender import execute_send_email
 from ..tools.sms_sender import execute_send_sms
 from ..tools.spawn_web_task import execute_spawn_web_task
 from ..tools.schedule_updater import execute_update_schedule
-from ..tools.sqlite_agent_config import apply_sqlite_agent_config_updates, read_sqlite_agent_config_snapshot, seed_sqlite_agent_config
+from ..tools.sqlite_agent_config import (
+    apply_sqlite_agent_config_updates,
+    read_sqlite_agent_config_snapshot,
+    seed_sqlite_agent_config,
+    sqlite_statement_assigns_agent_config_field,
+)
 from ..tools.sqlite_skills import apply_sqlite_skill_updates, refresh_skills_for_tool, seed_sqlite_skills
 from ..tools.custom_tools import execute_create_custom_tool
 from ..tools.custom_tool_names import CREATE_CUSTOM_TOOL_NAME
@@ -188,7 +193,6 @@ MESSAGE_TOOL_BODY_KEYS = {
 HUMANIZED_MESSAGE_BODY_KEYS = {**MESSAGE_TOOL_BODY_KEYS, "send_discord_message": "message"}
 SQLITE_MUTATION_RE = re.compile(r"\b(?:insert|update|delete|replace|alter|drop|create)\b", re.IGNORECASE)
 AGENT_CONFIG_TABLE_RE = re.compile(r"\b__agent_config\b", re.IGNORECASE)
-AGENT_CONFIG_CHARTER_ASSIGNMENT_RE = re.compile(r"\bcharter\b\s*=", re.IGNORECASE)
 DURABLE_CONFIG_INTENT_RE = re.compile(
     r"\b(?:going forward|from now on|in the future|next time|always|never|remember|prefer|preference|"
     r"(?:my |this )?feedback:|each time|every time|make (?:that|this|it) a rule|should(?:n'?t| not) have to|"
@@ -2155,9 +2159,7 @@ def _sqlite_batch_is_only_agent_config_mutation(tool_params: Dict[str, Any]) -> 
 
 def _sqlite_batch_mutates_agent_charter(tool_params: Dict[str, Any]) -> bool:
     return any(
-        AGENT_CONFIG_TABLE_RE.search(statement)
-        and SQLITE_MUTATION_RE.search(statement)
-        and AGENT_CONFIG_CHARTER_ASSIGNMENT_RE.search(statement)
+        sqlite_statement_assigns_agent_config_field(statement, "charter")
         for statement in _sqlite_batch_statements(tool_params)
     )
 

--- a/api/agent/tools/sqlite_agent_config.py
+++ b/api/agent/tools/sqlite_agent_config.py
@@ -77,7 +77,7 @@ def apply_sqlite_agent_config_updates(
     """Apply any SQLite config updates to the persistent agent record."""
     updated_fields: list[str] = []
     errors: list[str] = []
-    current = _read_agent_config_snapshot()
+    current = read_sqlite_agent_config_snapshot()
 
     if baseline is None or current is None:
         _drop_agent_config_table()
@@ -101,7 +101,7 @@ def apply_sqlite_agent_config_updates(
     return AgentConfigApplyResult(updated_fields=updated_fields, errors=errors)
 
 
-def _read_agent_config_snapshot() -> Optional[AgentConfigSnapshot]:
+def read_sqlite_agent_config_snapshot() -> Optional[AgentConfigSnapshot]:
     db_path = get_sqlite_db_path()
     if not db_path:
         return None

--- a/api/agent/tools/sqlite_agent_config.py
+++ b/api/agent/tools/sqlite_agent_config.py
@@ -7,6 +7,7 @@ persisting final values to Postgres.
 """
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Optional, Sequence
 
@@ -16,6 +17,17 @@ from .sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_con
 from .sqlite_state import AGENT_CONFIG_TABLE, get_sqlite_db_path
 
 logger = logging.getLogger(__name__)
+
+AGENT_CONFIG_UPDATE_RE = re.compile(
+    r'''\bupdate\s+["`\[]?__agent_config["`\]]?\s+.*?\bset\b'''
+    r'''(?P<assignments>(?:(?:'(?:[^']|'')*'|"(?:[^"]|"")*")|'''
+    r'''(?!(?:\bwhere\b|\breturning\b))[\s\S])*)''',
+    re.IGNORECASE,
+)
+AGENT_CONFIG_INSERT_RE = re.compile(
+    r'\b(?:insert|replace)\s+(?:or\s+\w+\s+)?into\s+["`\[]?__agent_config["`\]]?\s*\((?P<columns>[^)]*)\)',
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 @dataclass(frozen=True)
@@ -28,6 +40,29 @@ class AgentConfigSnapshot:
 class AgentConfigApplyResult:
     updated_fields: Sequence[str]
     errors: Sequence[str]
+
+
+def sqlite_statement_assigns_agent_config_field(statement: str, field_name: str) -> bool:
+    field = field_name.lower()
+    update_match = AGENT_CONFIG_UPDATE_RE.search(statement or "")
+    if update_match:
+        assignments = update_match.group("assignments")
+        return bool(
+            re.search(
+                rf'(?<![\w"`\]])["`\[]?{re.escape(field)}["`\]]?\s*=',
+                assignments,
+                re.IGNORECASE,
+            )
+        )
+
+    insert_match = AGENT_CONFIG_INSERT_RE.search(statement or "")
+    if not insert_match:
+        return False
+    columns = {
+        column.strip().strip('"`[]').lower()
+        for column in insert_match.group("columns").split(",")
+    }
+    return field in columns
 
 
 def seed_sqlite_agent_config(agent) -> Optional[AgentConfigSnapshot]:

--- a/api/evals/stop_policy.py
+++ b/api/evals/stop_policy.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import sqlparse
 
+from api.agent.tools.sqlite_agent_config import sqlite_statement_assigns_agent_config_field
 from api.models import PersistentAgentHumanInputRequest, PersistentAgentToolCall
 
 
@@ -20,14 +21,6 @@ AGENT_CONFIG_FIELD_PATTERNS = {
     "charter": re.compile(r"\bcharter\b", re.IGNORECASE),
     "schedule": re.compile(r"\bschedule\b", re.IGNORECASE),
 }
-AGENT_CONFIG_UPDATE_RE = re.compile(
-    r"\bupdate\s+__agent_config\b.*?\bset\b(?P<assignments>.*?)(?:\bwhere\b|\breturning\b|$)",
-    re.IGNORECASE | re.DOTALL,
-)
-AGENT_CONFIG_INSERT_RE = re.compile(
-    r"\b(?:insert|replace)\s+(?:or\s+\w+\s+)?into\s+__agent_config\s*\((?P<columns>[^)]*)\)",
-    re.IGNORECASE | re.DOTALL,
-)
 
 
 def split_sql_statements(sql: str) -> list[str]:
@@ -123,37 +116,9 @@ def sqlite_batch_mutates_agent_config_field(tool_call, field_name: str) -> bool:
         return False
     return any(
         sql_mutates_planning_state(statement)
-        and _statement_assigns_agent_config_field(statement, field_name)
+        and sqlite_statement_assigns_agent_config_field(statement, field_name)
         for statement in split_sql_statements(sql)
     )
-
-
-def _normalized_sql_identifier(value: str) -> str:
-    return value.strip().strip('"`[]').lower()
-
-
-def _statement_assigns_agent_config_field(statement: str, field_name: str) -> bool:
-    field = field_name.lower()
-    update_match = AGENT_CONFIG_UPDATE_RE.search(statement or "")
-    if update_match:
-        assignments = update_match.group("assignments")
-        return bool(
-            re.search(
-                rf'(?<![\w"`\]])["`\[]?{re.escape(field)}["`\]]?\s*=',
-                assignments,
-                re.IGNORECASE,
-            )
-        )
-
-    insert_match = AGENT_CONFIG_INSERT_RE.search(statement or "")
-    if insert_match:
-        columns = [
-            _normalized_sql_identifier(column)
-            for column in insert_match.group("columns").split(",")
-        ]
-        return field in columns
-
-    return False
 
 
 def _params_match(actual_params: dict[str, Any], expected_params: dict[str, Any]) -> bool:

--- a/api/migrations/0426_persistentagenttoolcall_display_metadata.py
+++ b/api/migrations/0426_persistentagenttoolcall_display_metadata.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0425_persistentagent_contact_approval_mode"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="persistentagenttoolcall",
+            name="display_metadata",
+            field=models.JSONField(
+                blank=True,
+                help_text="Structured metadata used only to render this tool call in user-facing timelines.",
+                null=True,
+            ),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -11706,6 +11706,11 @@ class PersistentAgentToolCall(models.Model):
     tool_name = models.CharField(max_length=256)
     tool_params = models.JSONField(null=True, blank=True)
     result = models.TextField(blank=True, help_text="Raw result or output from the tool call (may be large)")
+    display_metadata = models.JSONField(
+        null=True,
+        blank=True,
+        help_text="Structured metadata used only to render this tool call in user-facing timelines.",
+    )
     execution_duration_ms = models.IntegerField(
         null=True,
         blank=True,

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -759,7 +759,7 @@ def _serialize_step_entry(env: StepEnvelope, labels: Mapping[str, str]) -> dict:
     agent_config = display_metadata.get("agent_config")
     if isinstance(agent_config, dict):
         charter_text = agent_config.get("charter")
-        if isinstance(charter_text, str) and charter_text.strip():
+        if isinstance(charter_text, str):
             entry["charterText"] = charter_text
     preview_url = _extract_tool_preview_url(tool_call)
     if preview_url:

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -755,6 +755,12 @@ def _serialize_step_entry(env: StepEnvelope, labels: Mapping[str, str]) -> dict:
         else tool_call.result,
         "status": status,
     }
+    display_metadata = tool_call.display_metadata if isinstance(tool_call.display_metadata, dict) else {}
+    agent_config = display_metadata.get("agent_config")
+    if isinstance(agent_config, dict):
+        charter_text = agent_config.get("charter")
+        if isinstance(charter_text, str) and charter_text.strip():
+            entry["charterText"] = charter_text
     preview_url = _extract_tool_preview_url(tool_call)
     if preview_url:
         lowered_tool_name = tool_name.lower()

--- a/frontend/src/components/agentChat/ToolClusterCard.tsx
+++ b/frontend/src/components/agentChat/ToolClusterCard.tsx
@@ -13,6 +13,7 @@ import type { StatusExpansionTargets } from './statusExpansion'
 import { isStatusDisplayEntry, resolveEntrySeparation } from './statusExpansion'
 import { useAppSelector } from '../../store/hooks'
 import { selectImmersiveShellViewer } from '../../store/immersiveShellSlice'
+import { buildToolClusterRenderSegments } from './toolClusterSegments'
 
 type ToolClusterCardProps = {
   cluster: ToolClusterEvent
@@ -22,10 +23,6 @@ type ToolClusterCardProps = {
   animateIncoming?: boolean
   onIncomingAnimationConsumed?: (cursor: string) => void
 }
-
-type ToolClusterRenderSegment =
-  | { kind: 'preview', key: string, entries: ToolEntryDisplay[] }
-  | { kind: 'separate', key: string, entry: ToolEntryDisplay }
 
 export const ToolClusterCard = memo(function ToolClusterCard({
   cluster,
@@ -86,36 +83,10 @@ export const ToolClusterCard = memo(function ToolClusterCard({
     () => resolvedTransformed.entries.filter((entry) => !entry.separateFromPreview),
     [resolvedTransformed.entries],
   )
-  const renderSegments = useMemo<ToolClusterRenderSegment[]>(() => {
-    const segments: ToolClusterRenderSegment[] = []
-    let currentPreviewEntries: ToolEntryDisplay[] = []
-    const flushPreview = () => {
-      if (!currentPreviewEntries.length) return
-      segments.push({
-        kind: 'preview',
-        key: `preview:${currentPreviewEntries[0].id}`,
-        entries: currentPreviewEntries,
-      })
-      currentPreviewEntries = []
-    }
-
-    for (const entry of resolvedTransformed.entries) {
-      if (entry.separateFromPreview) {
-        flushPreview()
-        segments.push({ kind: 'separate', key: `separate:${entry.id}`, entry })
-      } else {
-        currentPreviewEntries.push(entry)
-      }
-    }
-    flushPreview()
-    return segments
-  }, [resolvedTransformed.entries])
-  const lastPreviewSegmentIndex = useMemo(() => {
-    for (let index = renderSegments.length - 1; index >= 0; index -= 1) {
-      if (renderSegments[index].kind === 'preview') return index
-    }
-    return -1
-  }, [renderSegments])
+  const renderSegments = useMemo(
+    () => buildToolClusterRenderSegments(resolvedTransformed.entries),
+    [resolvedTransformed.entries],
+  )
 
   const [timelineOpen, setTimelineOpen] = useState(false)
   const [timelineInitialEntryId, setTimelineInitialEntryId] = useState<string | null>(null)
@@ -219,7 +190,7 @@ export const ToolClusterCard = memo(function ToolClusterCard({
       data-earliest={resolvedTransformed.earliestTimestamp}
     >
       <div className="tool-cluster-shell">
-        {renderSegments.map((segment, segmentIndex) => {
+        {renderSegments.map((segment) => {
           if (segment.kind === 'separate') {
             return <div key={segment.key} className="tool-cluster-separate-list">{renderSeparatedEntry(segment.entry)}</div>
           }
@@ -231,7 +202,6 @@ export const ToolClusterCard = memo(function ToolClusterCard({
             collapsible: false,
             collapseThreshold: Infinity,
           }
-          const isTrailingPreview = segmentIndex === lastPreviewSegmentIndex
           return (
             <div key={segment.key} className="tool-cluster-summary">
               {shouldCollapsePreviewEntries && segment.entries.length > 1 ? (
@@ -243,8 +213,8 @@ export const ToolClusterCard = memo(function ToolClusterCard({
               ) : (
                 <ToolClusterLivePreview
                   cluster={segmentCluster}
-                  isLatestEvent={isLatestEvent && isTrailingPreview}
-                  animateIncoming={animateIncoming && isTrailingPreview}
+                  isLatestEvent={isLatestEvent && segment.isTrailing}
+                  animateIncoming={animateIncoming && segment.isTrailing}
                   previewEntryLimit={segment.entries.length}
                   onOpenTimeline={handleToggleCluster}
                   onSelectEntry={handlePreviewEntrySelect}

--- a/frontend/src/components/agentChat/ToolClusterCard.tsx
+++ b/frontend/src/components/agentChat/ToolClusterCard.tsx
@@ -7,7 +7,6 @@ import { ToolClusterLivePreview } from './ToolClusterLivePreview'
 import type { ToolClusterEvent } from './types'
 import type { ToolEntryDisplay } from './tooling/types'
 import { formatRelativeTimestamp } from '../../util/time'
-import { compareTimelineCursors } from '../../util/timelineCursor'
 import { CollapsedActivityCard } from './CollapsedActivityCard'
 import { buildActionCountLabel } from './activityEntryUtils'
 import type { StatusExpansionTargets } from './statusExpansion'
@@ -23,6 +22,10 @@ type ToolClusterCardProps = {
   animateIncoming?: boolean
   onIncomingAnimationConsumed?: (cursor: string) => void
 }
+
+type ToolClusterRenderSegment =
+  | { kind: 'preview', key: string, entries: ToolEntryDisplay[] }
+  | { kind: 'separate', key: string, entry: ToolEntryDisplay }
 
 export const ToolClusterCard = memo(function ToolClusterCard({
   cluster,
@@ -79,41 +82,40 @@ export const ToolClusterCard = memo(function ToolClusterCard({
       entries,
     }
   }, [statusExpansionTargets, transformed])
-  const separatedEntries = useMemo(
-    () => resolvedTransformed.entries.filter((entry) => entry.separateFromPreview),
-    [resolvedTransformed.entries],
-  )
   const previewEntries = useMemo(
     () => resolvedTransformed.entries.filter((entry) => !entry.separateFromPreview),
     [resolvedTransformed.entries],
   )
-  const visiblePreviewEntries = previewEntries
-  const separatedEntryPlacement = useMemo(() => {
-    if (!separatedEntries.length) {
-      return { beforePreview: [] as ToolEntryDisplay[], afterPreview: [] as ToolEntryDisplay[] }
+  const renderSegments = useMemo<ToolClusterRenderSegment[]>(() => {
+    const segments: ToolClusterRenderSegment[] = []
+    let currentPreviewEntries: ToolEntryDisplay[] = []
+    const flushPreview = () => {
+      if (!currentPreviewEntries.length) return
+      segments.push({
+        kind: 'preview',
+        key: `preview:${currentPreviewEntries[0].id}`,
+        entries: currentPreviewEntries,
+      })
+      currentPreviewEntries = []
     }
 
-    const firstVisiblePreviewCursor = visiblePreviewEntries[0]?.cursor
-    if (!firstVisiblePreviewCursor) {
-      return { beforePreview: [] as ToolEntryDisplay[], afterPreview: separatedEntries }
-    }
-
-    const beforePreview: ToolEntryDisplay[] = []
-    const afterPreview: ToolEntryDisplay[] = []
-    for (const entry of separatedEntries) {
-      if (!entry.cursor) {
-        afterPreview.push(entry)
-        continue
-      }
-      if (compareTimelineCursors(entry.cursor, firstVisiblePreviewCursor) <= 0) {
-        beforePreview.push(entry)
+    for (const entry of resolvedTransformed.entries) {
+      if (entry.separateFromPreview) {
+        flushPreview()
+        segments.push({ kind: 'separate', key: `separate:${entry.id}`, entry })
       } else {
-        afterPreview.push(entry)
+        currentPreviewEntries.push(entry)
       }
     }
-    return { beforePreview, afterPreview }
-  }, [separatedEntries, visiblePreviewEntries])
-  const hasPreviewEntries = previewEntries.length > 0
+    flushPreview()
+    return segments
+  }, [resolvedTransformed.entries])
+  const lastPreviewSegmentIndex = useMemo(() => {
+    for (let index = renderSegments.length - 1; index >= 0; index -= 1) {
+      if (renderSegments[index].kind === 'preview') return index
+    }
+    return -1
+  }, [renderSegments])
 
   const [timelineOpen, setTimelineOpen] = useState(false)
   const [timelineInitialEntryId, setTimelineInitialEntryId] = useState<string | null>(null)
@@ -141,8 +143,12 @@ export const ToolClusterCard = memo(function ToolClusterCard({
     () => resolvedTransformed.entries.some((entry) => isStatusDisplayEntry(entry) && entry.separateFromPreview),
     [resolvedTransformed.entries],
   )
+  const hasSeparatedEntry = useMemo(
+    () => resolvedTransformed.entries.some((entry) => entry.separateFromPreview),
+    [resolvedTransformed.entries],
+  )
   const shouldCollapse = useMemo(() => {
-    if (hasExpandedStatusEntry) {
+    if (hasSeparatedEntry) {
       return false
     }
     if (resolvedTransformed.collapsible) {
@@ -152,7 +158,7 @@ export const ToolClusterCard = memo(function ToolClusterCard({
       return false
     }
     return resolvedTransformed.entries.some((entry) => isStatusDisplayEntry(entry) && !entry.separateFromPreview)
-  }, [hasExpandedStatusEntry, resolvedTransformed.collapsible, resolvedTransformed.entries, statusExpansionTargets])
+  }, [hasSeparatedEntry, resolvedTransformed.collapsible, resolvedTransformed.entries, statusExpansionTargets])
   const shouldCollapsePreviewEntries = hasExpandedStatusEntry && previewEntries.length > 1
 
   if (!isClusterRenderable(resolvedTransformed)) {
@@ -213,33 +219,41 @@ export const ToolClusterCard = memo(function ToolClusterCard({
       data-earliest={resolvedTransformed.earliestTimestamp}
     >
       <div className="tool-cluster-shell">
-        {separatedEntryPlacement.beforePreview.length ? (
-          <div className="tool-cluster-separate-list">{separatedEntryPlacement.beforePreview.map(renderSeparatedEntry)}</div>
-        ) : null}
-        {hasPreviewEntries ? (
-          <div className="tool-cluster-summary">
-            {shouldCollapsePreviewEntries ? (
-              <CollapsedActivityCard
-                overlayId={`${resolvedTransformed.cursor}:preview`}
-                entries={previewEntries}
-                label={buildActionCountLabel(previewEntries.length)}
-              />
-            ) : (
-              <ToolClusterLivePreview
-                cluster={resolvedTransformed}
-                isLatestEvent={isLatestEvent}
-                animateIncoming={animateIncoming}
-                previewEntryLimit={previewEntries.length}
-                onOpenTimeline={handleToggleCluster}
-                onSelectEntry={handlePreviewEntrySelect}
-                onIncomingAnimationConsumed={onIncomingAnimationConsumed}
-              />
-            )}
-          </div>
-        ) : null}
-        {separatedEntryPlacement.afterPreview.length ? (
-          <div className="tool-cluster-separate-list">{separatedEntryPlacement.afterPreview.map(renderSeparatedEntry)}</div>
-        ) : null}
+        {renderSegments.map((segment, segmentIndex) => {
+          if (segment.kind === 'separate') {
+            return <div key={segment.key} className="tool-cluster-separate-list">{renderSeparatedEntry(segment.entry)}</div>
+          }
+
+          const segmentCluster = {
+            ...resolvedTransformed,
+            entries: segment.entries,
+            entryCount: segment.entries.length,
+            collapsible: false,
+            collapseThreshold: Infinity,
+          }
+          const isTrailingPreview = segmentIndex === lastPreviewSegmentIndex
+          return (
+            <div key={segment.key} className="tool-cluster-summary">
+              {shouldCollapsePreviewEntries && segment.entries.length > 1 ? (
+                <CollapsedActivityCard
+                  overlayId={`${resolvedTransformed.cursor}:${segment.key}`}
+                  entries={segment.entries}
+                  label={buildActionCountLabel(segment.entries.length)}
+                />
+              ) : (
+                <ToolClusterLivePreview
+                  cluster={segmentCluster}
+                  isLatestEvent={isLatestEvent && isTrailingPreview}
+                  animateIncoming={animateIncoming && isTrailingPreview}
+                  previewEntryLimit={segment.entries.length}
+                  onOpenTimeline={handleToggleCluster}
+                  onSelectEntry={handlePreviewEntrySelect}
+                  onIncomingAnimationConsumed={onIncomingAnimationConsumed}
+                />
+              )}
+            </div>
+          )
+        })}
       </div>
       <ToolClusterTimelineOverlay
         open={timelineOpen}

--- a/frontend/src/components/agentChat/statusExpansion.ts
+++ b/frontend/src/components/agentChat/statusExpansion.ts
@@ -21,6 +21,19 @@ export function isScheduleDisplayEntry(entry: ToolEntryDisplay): boolean {
   return Boolean(parsedUpdate?.updatesSchedule)
 }
 
+export function isAssignmentDisplayEntry(entry: ToolEntryDisplay): boolean {
+  if (entry.toolName === 'update_charter') {
+    return true
+  }
+
+  if (entry.toolName !== 'sqlite_batch' || !entry.sqlStatements?.length) {
+    return false
+  }
+
+  const parsedUpdate = parseAgentConfigUpdates(entry.sqlStatements)
+  return Boolean(parsedUpdate?.updatesCharter)
+}
+
 export function isStatusDisplayEntry(entry: ToolEntryDisplay): boolean {
   return isScheduleDisplayEntry(entry)
 }

--- a/frontend/src/components/agentChat/statusExpansion.ts
+++ b/frontend/src/components/agentChat/statusExpansion.ts
@@ -1,5 +1,4 @@
 import type { TimelineEvent, ToolClusterEvent } from '../../types/agentChat'
-import { parseAgentConfigUpdates } from '../tooling/agentConfigSql'
 import { transformToolCluster } from './tooling/toolRegistry'
 import type { ToolEntryDisplay } from './tooling/types'
 
@@ -13,12 +12,7 @@ export function isScheduleDisplayEntry(entry: ToolEntryDisplay): boolean {
     return true
   }
 
-  if (entry.toolName !== 'sqlite_batch' || !entry.sqlStatements?.length) {
-    return false
-  }
-
-  const parsedUpdate = parseAgentConfigUpdates(entry.sqlStatements)
-  return Boolean(parsedUpdate?.updatesSchedule)
+  return entry.agentConfigUpdate?.updatesSchedule === true
 }
 
 export function isAssignmentDisplayEntry(entry: ToolEntryDisplay): boolean {
@@ -26,12 +20,7 @@ export function isAssignmentDisplayEntry(entry: ToolEntryDisplay): boolean {
     return true
   }
 
-  if (entry.toolName !== 'sqlite_batch' || !entry.sqlStatements?.length) {
-    return false
-  }
-
-  const parsedUpdate = parseAgentConfigUpdates(entry.sqlStatements)
-  return Boolean(parsedUpdate?.updatesCharter)
+  return entry.agentConfigUpdate?.updatesCharter === true
 }
 
 export function isStatusDisplayEntry(entry: ToolEntryDisplay): boolean {

--- a/frontend/src/components/agentChat/toolClusterSegments.test.ts
+++ b/frontend/src/components/agentChat/toolClusterSegments.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { Wrench } from 'lucide-react'
+
+import { buildToolClusterRenderSegments } from './toolClusterSegments'
+import type { ToolEntryDisplay } from './tooling/types'
+import { GenericToolDetail } from './toolDetails/details/common'
+
+function entry(id: string, separateFromPreview = false): ToolEntryDisplay {
+  return {
+    id,
+    clusterCursor: 'cluster',
+    toolName: 'test',
+    label: id,
+    icon: Wrench,
+    iconBgClass: '',
+    iconColorClass: '',
+    parameters: null,
+    rawParameters: null,
+    result: null,
+    detailComponent: GenericToolDetail,
+    separateFromPreview,
+  }
+}
+
+describe('buildToolClusterRenderSegments', () => {
+  it('preserves chronological runs and marks only the trailing activity run active', () => {
+    const segments = buildToolClusterRenderSegments([
+      entry('older-action'),
+      entry('assignment', true),
+      entry('newer-action'),
+      entry('newest-action'),
+    ])
+
+    expect(segments.map((segment) => (
+      segment.kind === 'preview'
+        ? { kind: segment.kind, ids: segment.entries.map((item) => item.id), isTrailing: segment.isTrailing }
+        : { kind: segment.kind, id: segment.entry.id }
+    ))).toEqual([
+      { kind: 'preview', ids: ['older-action'], isTrailing: false },
+      { kind: 'separate', id: 'assignment' },
+      { kind: 'preview', ids: ['newer-action', 'newest-action'], isTrailing: true },
+    ])
+  })
+})

--- a/frontend/src/components/agentChat/toolClusterSegments.ts
+++ b/frontend/src/components/agentChat/toolClusterSegments.ts
@@ -1,0 +1,39 @@
+import type { ToolEntryDisplay } from './tooling/types'
+
+export type ToolClusterRenderSegment =
+  | { kind: 'preview', key: string, entries: ToolEntryDisplay[], isTrailing: boolean }
+  | { kind: 'separate', key: string, entry: ToolEntryDisplay }
+
+export function buildToolClusterRenderSegments(entries: ToolEntryDisplay[]): ToolClusterRenderSegment[] {
+  const segments: ToolClusterRenderSegment[] = []
+  let previewEntries: ToolEntryDisplay[] = []
+  const flushPreview = () => {
+    if (!previewEntries.length) return
+    segments.push({
+      kind: 'preview',
+      key: `preview:${previewEntries[0].id}`,
+      entries: previewEntries,
+      isTrailing: false,
+    })
+    previewEntries = []
+  }
+
+  for (const entry of entries) {
+    if (entry.separateFromPreview) {
+      flushPreview()
+      segments.push({ kind: 'separate', key: `separate:${entry.id}`, entry })
+    } else {
+      previewEntries.push(entry)
+    }
+  }
+  flushPreview()
+
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const segment = segments[index]
+    if (segment.kind === 'preview') {
+      segment.isTrailing = true
+      break
+    }
+  }
+  return segments
+}

--- a/frontend/src/components/agentChat/toolDetails/details/schedule.tsx
+++ b/frontend/src/components/agentChat/toolDetails/details/schedule.tsx
@@ -6,6 +6,7 @@ import { describeSchedule } from '../../../../util/schedule'
 import type { ScheduleDescription } from '../../../../util/schedule'
 import type { ToolDetailProps } from '../../tooling/types'
 import { parseAgentConfigUpdates } from '../../../tooling/agentConfigSql'
+import type { AgentConfigCharterChange } from '../../../tooling/agentConfigSql'
 import { KeyValueList, Section, TruncatedMarkdown } from '../shared'
 import { useAppSelector } from '../../../../store/hooks'
 import { selectImmersiveShellViewer } from '../../../../store/immersiveShellSlice'
@@ -191,12 +192,36 @@ export function UpdateScheduleDetail({ entry }: ToolDetailProps) {
   )
 }
 
+function CharterChangeDetail({ change }: { change: AgentConfigCharterChange }) {
+  const previousText = change.previousText?.trim() || null
+  const replacementText = change.replacementText?.trim() || null
+
+  return (
+    <div className="space-y-2 text-sm">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Change applied</p>
+      {previousText ? (
+        <div className="grid gap-1 sm:grid-cols-[3rem_minmax(0,1fr)]">
+          <span className="text-xs font-medium text-slate-500">From</span>
+          <p className="whitespace-pre-wrap break-words text-slate-500 line-through">{previousText}</p>
+        </div>
+      ) : null}
+      <div className="grid gap-1 sm:grid-cols-[3rem_minmax(0,1fr)]">
+        <span className="text-xs font-medium text-slate-500">{previousText ? 'To' : 'Added'}</span>
+        <p className="whitespace-pre-wrap break-words text-slate-700">
+          {replacementText ?? (previousText ? 'Removed from the assignment.' : 'No assignment text was added.')}
+        </p>
+      </div>
+    </div>
+  )
+}
+
 export function AgentConfigUpdateDetail({ entry }: ToolDetailProps) {
   const timeZone = useAppSelector(selectImmersiveShellViewer).timeZone
   const statements = entry.sqlStatements ?? []
   const parsedUpdate = parseAgentConfigUpdates(statements)
-  const charterText = parsedUpdate?.charterValue ?? entry.charterText ?? null
-  const updatesCharter = parsedUpdate?.updatesCharter ?? Boolean(charterText)
+  const charterText = entry.charterText ?? parsedUpdate?.charterValue ?? null
+  const charterChange = entry.charterChange ?? parsedUpdate?.charterChange ?? null
+  const updatesCharter = Boolean(parsedUpdate?.updatesCharter || charterText || charterChange)
   const updatesSchedule = parsedUpdate?.updatesSchedule ?? false
   const scheduleCleared = parsedUpdate?.scheduleCleared ?? false
   const scheduleRaw = parsedUpdate?.scheduleValue ?? null
@@ -208,17 +233,18 @@ export function AgentConfigUpdateDetail({ entry }: ToolDetailProps) {
 
   return (
     <div className="space-y-4">
-      {/* Schedule - shown first as the hero element when present */}
       {updatesSchedule && scheduleDetails ? renderScheduleCard(scheduleDetails) : null}
-
-      {/* Assignment - truncated with expand */}
+      {updatesCharter && charterChange ? <CharterChangeDetail change={charterChange} /> : null}
       {updatesCharter && charterText ? (
         <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Assignment</p>
-          <div className="rounded-xl bg-slate-50/80 p-3.5 shadow-sm border border-slate-100">
-            <TruncatedMarkdown content={charterText} maxLines={3} />
-          </div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Updated assignment</p>
+          <TruncatedMarkdown content={charterText} maxLines={3} />
         </div>
+      ) : null}
+      {updatesCharter && !charterText && !charterChange ? (
+        <p className="text-sm text-slate-600">
+          The updated assignment text is not available for this historical event.
+        </p>
       ) : null}
     </div>
   )

--- a/frontend/src/components/agentChat/toolDetails/details/schedule.tsx
+++ b/frontend/src/components/agentChat/toolDetails/details/schedule.tsx
@@ -5,7 +5,6 @@ import { CalendarClock, Clock, Repeat } from 'lucide-react'
 import { describeSchedule } from '../../../../util/schedule'
 import type { ScheduleDescription } from '../../../../util/schedule'
 import type { ToolDetailProps } from '../../tooling/types'
-import { parseAgentConfigUpdates } from '../../../tooling/agentConfigSql'
 import type { AgentConfigCharterChange } from '../../../tooling/agentConfigSql'
 import { KeyValueList, Section, TruncatedMarkdown } from '../shared'
 import { useAppSelector } from '../../../../store/hooks'
@@ -217,11 +216,11 @@ function CharterChangeDetail({ change }: { change: AgentConfigCharterChange }) {
 
 export function AgentConfigUpdateDetail({ entry }: ToolDetailProps) {
   const timeZone = useAppSelector(selectImmersiveShellViewer).timeZone
-  const statements = entry.sqlStatements ?? []
-  const parsedUpdate = parseAgentConfigUpdates(statements)
+  const parsedUpdate = entry.agentConfigUpdate
   const charterText = entry.charterText ?? parsedUpdate?.charterValue ?? null
-  const charterChange = entry.charterChange ?? parsedUpdate?.charterChange ?? null
-  const updatesCharter = Boolean(parsedUpdate?.updatesCharter || charterText || charterChange)
+  const charterChange = parsedUpdate?.charterChange ?? null
+  const hasCharterText = charterText !== null
+  const updatesCharter = Boolean(parsedUpdate?.updatesCharter || hasCharterText || charterChange)
   const updatesSchedule = parsedUpdate?.updatesSchedule ?? false
   const scheduleCleared = parsedUpdate?.scheduleCleared ?? false
   const scheduleRaw = parsedUpdate?.scheduleValue ?? null
@@ -235,13 +234,17 @@ export function AgentConfigUpdateDetail({ entry }: ToolDetailProps) {
     <div className="space-y-4">
       {updatesSchedule && scheduleDetails ? renderScheduleCard(scheduleDetails) : null}
       {updatesCharter && charterChange ? <CharterChangeDetail change={charterChange} /> : null}
-      {updatesCharter && charterText ? (
+      {updatesCharter && hasCharterText ? (
         <div className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Updated assignment</p>
-          <TruncatedMarkdown content={charterText} maxLines={3} />
+          {charterText ? (
+            <TruncatedMarkdown content={charterText} maxLines={3} />
+          ) : (
+            <p className="text-sm text-slate-600">The assignment is now empty.</p>
+          )}
         </div>
       ) : null}
-      {updatesCharter && !charterText && !charterChange ? (
+      {updatesCharter && !hasCharterText && !charterChange ? (
         <p className="text-sm text-slate-600">
           The updated assignment text is not available for this historical event.
         </p>

--- a/frontend/src/components/agentChat/tooling/sqliteEntries.ts
+++ b/frontend/src/components/agentChat/tooling/sqliteEntries.ts
@@ -32,10 +32,12 @@ export function buildAgentConfigEntry(
     updatesCharter,
     updatesSchedule,
     charterValue,
+    charterChange,
     scheduleValue,
     scheduleCleared,
   } = parsedUpdate
   const scheduleKnown = scheduleCleared || scheduleValue !== null
+  const resolvedCharter = entry.charterText?.trim() || charterValue
   const normalizedSchedule = scheduleCleared ? null : scheduleValue
   const scheduleSummary = scheduleKnown ? summarizeSchedule(normalizedSchedule, { timeZone: options.timeZone }) : null
   const scheduleCaption = scheduleCleared
@@ -64,7 +66,11 @@ export function buildAgentConfigEntry(
         : 'Assignment and schedule updated.'
   } else if (updatesCharter) {
     label = 'Assignment updated'
-    caption = charterValue ? truncate(charterValue, 48) : 'Assignment updated'
+    caption = resolvedCharter
+      ? truncate(resolvedCharter, 48)
+      : charterChange?.replacementText
+        ? truncate(charterChange.replacementText, 48)
+        : 'Assignment updated'
     summary = 'Assignment updated.'
     icon = FileCheck2
   } else if (updatesSchedule) {
@@ -95,7 +101,8 @@ export function buildAgentConfigEntry(
     rawParameters: entry.parameters,
     result: extractSqliteGroupedResult(entry.result, statementIndexes),
     summary,
-    charterText: charterValue ?? null,
+    charterText: resolvedCharter ?? null,
+    charterChange,
     sqlStatements: statements,
     detailComponent: AgentConfigUpdateDetail,
     meta: entry.meta,

--- a/frontend/src/components/agentChat/tooling/sqliteEntries.ts
+++ b/frontend/src/components/agentChat/tooling/sqliteEntries.ts
@@ -37,7 +37,9 @@ export function buildAgentConfigEntry(
     scheduleCleared,
   } = parsedUpdate
   const scheduleKnown = scheduleCleared || scheduleValue !== null
-  const resolvedCharter = entry.charterText?.trim() || charterValue
+  const hasCharterSnapshot = typeof entry.charterText === 'string'
+  const resolvedCharter = hasCharterSnapshot ? entry.charterText : charterValue
+  const charterCaption = resolvedCharter?.trim() || charterChange?.replacementText?.trim() || null
   const normalizedSchedule = scheduleCleared ? null : scheduleValue
   const scheduleSummary = scheduleKnown ? summarizeSchedule(normalizedSchedule, { timeZone: options.timeZone }) : null
   const scheduleCaption = scheduleCleared
@@ -66,10 +68,10 @@ export function buildAgentConfigEntry(
         : 'Assignment and schedule updated.'
   } else if (updatesCharter) {
     label = 'Assignment updated'
-    caption = resolvedCharter
-      ? truncate(resolvedCharter, 48)
-      : charterChange?.replacementText
-        ? truncate(charterChange.replacementText, 48)
+    caption = charterCaption
+      ? truncate(charterCaption, 48)
+      : hasCharterSnapshot || charterValue === ''
+        ? 'Assignment cleared'
         : 'Assignment updated'
     summary = 'Assignment updated.'
     icon = FileCheck2
@@ -102,7 +104,7 @@ export function buildAgentConfigEntry(
     result: extractSqliteGroupedResult(entry.result, statementIndexes),
     summary,
     charterText: resolvedCharter ?? null,
-    charterChange,
+    agentConfigUpdate: parsedUpdate,
     sqlStatements: statements,
     detailComponent: AgentConfigUpdateDetail,
     meta: entry.meta,

--- a/frontend/src/components/agentChat/tooling/toolRegistry.ts
+++ b/frontend/src/components/agentChat/tooling/toolRegistry.ts
@@ -207,6 +207,7 @@ function buildToolEntryDisplay(
     result: entry.result,
     summary: mergedTransform.summary ?? entry.summary ?? null,
     charterText: mergedTransform.charterText ?? entry.charterText ?? null,
+    charterChange: mergedTransform.charterChange ?? null,
     sqlStatements: mergedTransform.sqlStatements ?? entry.sqlStatements,
     detailComponent: finalDetailComponent,
     meta: entry.meta,

--- a/frontend/src/components/agentChat/tooling/toolRegistry.ts
+++ b/frontend/src/components/agentChat/tooling/toolRegistry.ts
@@ -207,7 +207,6 @@ function buildToolEntryDisplay(
     result: entry.result,
     summary: mergedTransform.summary ?? entry.summary ?? null,
     charterText: mergedTransform.charterText ?? entry.charterText ?? null,
-    charterChange: mergedTransform.charterChange ?? null,
     sqlStatements: mergedTransform.sqlStatements ?? entry.sqlStatements,
     detailComponent: finalDetailComponent,
     meta: entry.meta,

--- a/frontend/src/components/agentChat/tooling/types.ts
+++ b/frontend/src/components/agentChat/tooling/types.ts
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import type { ToolCallEntry } from '../../../types/agentChat'
-import type { AgentConfigCharterChange, SqliteInternalTableKind, SqliteStatementOperation } from '../../tooling/agentConfigSql'
+import type { AgentConfigSqlUpdate, SqliteInternalTableKind, SqliteStatementOperation } from '../../tooling/agentConfigSql'
 
 export type ToolDetailComponent = (props: ToolDetailProps) => ReactElement
 
@@ -23,7 +23,7 @@ export type ToolEntryDisplay = {
   result: unknown
   summary?: string | null
   charterText?: string | null
-  charterChange?: AgentConfigCharterChange | null
+  agentConfigUpdate?: AgentConfigSqlUpdate | null
   sqlStatements?: string[]
   detailComponent: ToolDetailComponent
   meta?: ToolCallEntry['meta']
@@ -74,7 +74,6 @@ export type ToolDescriptorTransform = {
   iconColorClass?: string
   caption?: string | null
   charterText?: string | null
-  charterChange?: AgentConfigCharterChange | null
   sqlStatements?: string[]
   summary?: string | null
   detailComponent?: ToolDetailComponent

--- a/frontend/src/components/agentChat/tooling/types.ts
+++ b/frontend/src/components/agentChat/tooling/types.ts
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import type { ToolCallEntry } from '../../../types/agentChat'
-import type { SqliteInternalTableKind, SqliteStatementOperation } from '../../tooling/agentConfigSql'
+import type { AgentConfigCharterChange, SqliteInternalTableKind, SqliteStatementOperation } from '../../tooling/agentConfigSql'
 
 export type ToolDetailComponent = (props: ToolDetailProps) => ReactElement
 
@@ -23,6 +23,7 @@ export type ToolEntryDisplay = {
   result: unknown
   summary?: string | null
   charterText?: string | null
+  charterChange?: AgentConfigCharterChange | null
   sqlStatements?: string[]
   detailComponent: ToolDetailComponent
   meta?: ToolCallEntry['meta']
@@ -73,6 +74,7 @@ export type ToolDescriptorTransform = {
   iconColorClass?: string
   caption?: string | null
   charterText?: string | null
+  charterChange?: AgentConfigCharterChange | null
   sqlStatements?: string[]
   summary?: string | null
   detailComponent?: ToolDetailComponent

--- a/frontend/src/components/tooling/agentConfigSql.test.ts
+++ b/frontend/src/components/tooling/agentConfigSql.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseAgentConfigUpdates } from './agentConfigSql'
+
+describe('parseAgentConfigUpdates', () => {
+  it('parses patch_text clauses containing escaped quotes, commas, and parentheses', () => {
+    const parsed = parseAgentConfigUpdates([
+      "UPDATE __agent_config SET charter=patch_text(charter, 'Old, where (quoted) ''clause''', 'New) value, ''quoted''') WHERE id=1",
+    ])
+
+    expect(parsed?.charterChange).toEqual({
+      previousText: "Old, where (quoted) 'clause'",
+      replacementText: "New) value, 'quoted'",
+    })
+  })
+
+  it('uses a later patch as the safe fallback instead of an earlier literal value', () => {
+    const parsed = parseAgentConfigUpdates([
+      "UPDATE __agent_config SET charter='Initial assignment' WHERE id=1",
+      "UPDATE __agent_config SET charter=patch_text(charter, 'Initial', 'Revised') WHERE id=1",
+    ])
+
+    expect(parsed?.charterValue).toBeNull()
+    expect(parsed?.charterChange?.replacementText).toBe('Revised')
+  })
+
+  it('does not treat a charter predicate as a charter assignment', () => {
+    const parsed = parseAgentConfigUpdates([
+      "UPDATE __agent_config SET schedule='0 9 * * *' WHERE charter='Unchanged assignment'",
+    ])
+
+    expect(parsed).toMatchObject({ updatesCharter: false, updatesSchedule: true })
+  })
+
+  it('preserves an explicitly empty literal assignment', () => {
+    const parsed = parseAgentConfigUpdates([
+      "UPDATE __agent_config SET charter='' WHERE id=1",
+    ])
+
+    expect(parsed).toMatchObject({ updatesCharter: true, charterValue: '' })
+  })
+})

--- a/frontend/src/components/tooling/agentConfigSql.ts
+++ b/frontend/src/components/tooling/agentConfigSql.ts
@@ -4,8 +4,14 @@ export type AgentConfigSqlUpdate = {
   updatesCharter: boolean
   updatesSchedule: boolean
   charterValue: string | null
+  charterChange: AgentConfigCharterChange | null
   scheduleValue: string | null
   scheduleCleared: boolean
+}
+
+export type AgentConfigCharterChange = {
+  previousText: string | null
+  replacementText: string | null
 }
 
 export type SqliteStatementOperation =
@@ -107,6 +113,85 @@ function extractSqlAssignment(statement: string, field: string): string | null {
     return doubleMatch[1].replace(/""/g, '"')
   }
   return null
+}
+
+function extractFunctionAssignmentArguments(
+  statement: string,
+  field: string,
+  functionName: string,
+): string[] | null {
+  const fieldToken = escapeRegExp(field)
+  const functionToken = escapeRegExp(functionName)
+  const assignment = new RegExp(`\\b${fieldToken}\\b\\s*=\\s*${functionToken}\\s*\\(`, 'i').exec(statement)
+  if (!assignment) {
+    return null
+  }
+
+  const argumentsStart = assignment.index + assignment[0].length
+  let depth = 1
+  let inSingle = false
+  let inDouble = false
+
+  for (let index = argumentsStart; index < statement.length; index += 1) {
+    const char = statement[index]
+    const next = index + 1 < statement.length ? statement[index + 1] : ''
+    if (inSingle) {
+      if (char === "'" && next === "'") {
+        index += 1
+      } else if (char === "'") {
+        inSingle = false
+      }
+      continue
+    }
+    if (inDouble) {
+      if (char === '"' && next === '"') {
+        index += 1
+      } else if (char === '"') {
+        inDouble = false
+      }
+      continue
+    }
+    if (char === "'") {
+      inSingle = true
+      continue
+    }
+    if (char === '"') {
+      inDouble = true
+      continue
+    }
+    if (char === '(') {
+      depth += 1
+      continue
+    }
+    if (char !== ')') {
+      continue
+    }
+    depth -= 1
+    if (depth === 0) {
+      return splitSqlByComma(statement.slice(argumentsStart, index))
+    }
+  }
+
+  return null
+}
+
+function parsePatchTextAssignment(statement: string): AgentConfigCharterChange | null {
+  const args = extractFunctionAssignmentArguments(statement, 'charter', 'patch_text')
+  if (!args || args.length !== 3) {
+    return null
+  }
+
+  const target = args[0].replace(/[`"'\[\]]/g, '').trim().toLowerCase()
+  if (target !== 'charter' && !target.endsWith('.charter')) {
+    return null
+  }
+
+  const previousText = decodeSqlLiteral(args[1] ?? '')
+  const replacementText = decodeSqlLiteral(args[2] ?? '')
+  if (previousText === undefined || replacementText === undefined) {
+    return null
+  }
+  return { previousText, replacementText }
 }
 
 function hasAssignment(statement: string, field: string): boolean {
@@ -468,6 +553,7 @@ export function parseAgentConfigUpdates(statements: string[]): AgentConfigSqlUpd
   let updatesCharter = false
   let updatesSchedule = false
   let charterValue: string | null = null
+  let charterChange: AgentConfigCharterChange | null = null
   let scheduleValue: string | null = null
   let scheduleCleared = false
 
@@ -485,6 +571,9 @@ export function parseAgentConfigUpdates(statements: string[]): AgentConfigSqlUpd
       const parsedCharter = extractSqlAssignment(statement, 'charter')
       if (parsedCharter !== null) {
         charterValue = parsedCharter
+        charterChange = null
+      } else {
+        charterChange = parsePatchTextAssignment(statement) ?? charterChange
       }
     } else {
       const parsedInsertCharter = parseInsertValueAssignment(statement, 'charter')
@@ -531,6 +620,7 @@ export function parseAgentConfigUpdates(statements: string[]): AgentConfigSqlUpd
     updatesCharter,
     updatesSchedule,
     charterValue,
+    charterChange,
     scheduleValue,
     scheduleCleared,
   }

--- a/frontend/src/components/tooling/agentConfigSql.ts
+++ b/frontend/src/components/tooling/agentConfigSql.ts
@@ -115,79 +115,32 @@ function extractSqlAssignment(statement: string, field: string): string | null {
   return null
 }
 
-function extractFunctionAssignmentArguments(
-  statement: string,
-  field: string,
-  functionName: string,
-): string[] | null {
-  const fieldToken = escapeRegExp(field)
-  const functionToken = escapeRegExp(functionName)
-  const assignment = new RegExp(`\\b${fieldToken}\\b\\s*=\\s*${functionToken}\\s*\\(`, 'i').exec(statement)
-  if (!assignment) {
-    return null
-  }
-
-  const argumentsStart = assignment.index + assignment[0].length
-  let depth = 1
-  let inSingle = false
-  let inDouble = false
-
-  for (let index = argumentsStart; index < statement.length; index += 1) {
-    const char = statement[index]
-    const next = index + 1 < statement.length ? statement[index + 1] : ''
-    if (inSingle) {
-      if (char === "'" && next === "'") {
-        index += 1
-      } else if (char === "'") {
-        inSingle = false
-      }
-      continue
-    }
-    if (inDouble) {
-      if (char === '"' && next === '"') {
-        index += 1
-      } else if (char === '"') {
-        inDouble = false
-      }
-      continue
-    }
-    if (char === "'") {
-      inSingle = true
-      continue
-    }
-    if (char === '"') {
-      inDouble = true
-      continue
-    }
-    if (char === '(') {
-      depth += 1
-      continue
-    }
-    if (char !== ')') {
-      continue
-    }
-    depth -= 1
-    if (depth === 0) {
-      return splitSqlByComma(statement.slice(argumentsStart, index))
-    }
-  }
-
-  return null
+function extractUpdateAssignments(statement: string): string | null {
+  const normalized = normalizeSqlForParsing(statement)
+  const update = /\bupdate\s+[`"\[]?__agent_config[`"\]]?\s+[\s\S]*?\bset\b/i.exec(normalized)
+  if (!update) return null
+  const assignmentsStart = update.index + update[0].length
+  const assignmentsTail = normalized.slice(assignmentsStart)
+  const terminator = /\b(?:where|returning)\b/i.exec(assignmentsTail)
+  const assignmentsEnd = assignmentsStart + (terminator?.index ?? assignmentsTail.length)
+  return statement.slice(assignmentsStart, assignmentsEnd)
 }
 
 function parsePatchTextAssignment(statement: string): AgentConfigCharterChange | null {
-  const args = extractFunctionAssignmentArguments(statement, 'charter', 'patch_text')
-  if (!args || args.length !== 3) {
+  const match = statement.match(
+    /\bcharter\b\s*=\s*patch_text\s*\(\s*([`"'\[\]A-Z_][`"'\[\]A-Z0-9_.]*)\s*,\s*(null|'(?:[^']|'')*'|"(?:[^"]|"")*")\s*,\s*(null|'(?:[^']|'')*'|"(?:[^"]|"")*")\s*\)/i,
+  )
+  if (!match) {
     return null
   }
 
-  const target = args[0].replace(/[`"'\[\]]/g, '').trim().toLowerCase()
+  const target = match[1].replace(/[`"'\[\]]/g, '').trim().toLowerCase()
   if (target !== 'charter' && !target.endsWith('.charter')) {
     return null
   }
 
-  const previousText = decodeSqlLiteral(args[1] ?? '')
-  const replacementText = decodeSqlLiteral(args[2] ?? '')
+  const previousText = decodeSqlLiteral(match[2] ?? '')
+  const replacementText = decodeSqlLiteral(match[3] ?? '')
   if (previousText === undefined || replacementText === undefined) {
     return null
   }
@@ -565,17 +518,23 @@ export function parseAgentConfigUpdates(statements: string[]): AgentConfigSqlUpd
     if (!MUTATION_RE.test(statement)) {
       continue
     }
+    const updateAssignments = extractUpdateAssignments(statement)
+    const assignmentSource = updateAssignments ?? ''
 
-    if (hasAssignment(statement, 'charter')) {
+    if (hasAssignment(assignmentSource, 'charter')) {
       updatesCharter = true
-      const parsedCharter = extractSqlAssignment(statement, 'charter')
+      const parsedCharter = extractSqlAssignment(assignmentSource, 'charter')
       if (parsedCharter !== null) {
         charterValue = parsedCharter
         charterChange = null
       } else {
-        charterChange = parsePatchTextAssignment(statement) ?? charterChange
+        const parsedChange = parsePatchTextAssignment(assignmentSource)
+        if (parsedChange) {
+          charterValue = null
+          charterChange = parsedChange
+        }
       }
-    } else {
+    } else if (updateAssignments === null) {
       const parsedInsertCharter = parseInsertValueAssignment(statement, 'charter')
       if (parsedInsertCharter.present) {
         updatesCharter = true
@@ -585,19 +544,19 @@ export function parseAgentConfigUpdates(statements: string[]): AgentConfigSqlUpd
       }
     }
 
-    if (hasAssignment(statement, 'schedule')) {
+    if (hasAssignment(assignmentSource, 'schedule')) {
       updatesSchedule = true
-      if (isClearingAssignment(statement, 'schedule')) {
+      if (isClearingAssignment(assignmentSource, 'schedule')) {
         scheduleCleared = true
         scheduleValue = null
       } else {
-        const parsedSchedule = extractSqlAssignment(statement, 'schedule')
+        const parsedSchedule = extractSqlAssignment(assignmentSource, 'schedule')
         if (parsedSchedule !== null) {
           scheduleValue = parsedSchedule
           scheduleCleared = false
         }
       }
-    } else {
+    } else if (updateAssignments === null) {
       const parsedInsertSchedule = parseInsertValueAssignment(statement, 'schedule')
       if (parsedInsertSchedule.present) {
         updatesSchedule = true

--- a/frontend/src/hooks/useSimplifiedTimeline.test.ts
+++ b/frontend/src/hooks/useSimplifiedTimeline.test.ts
@@ -172,6 +172,28 @@ describe('collapseDetailedStatusRuns', () => {
     expect(result[2]).toBe(scheduleUpdate)
   })
 
+  it('keeps assignment updates expanded between adjacent activity runs', () => {
+    const assignmentUpdate = stepCluster('3:step:assignment', ['sqlite_batch'])
+    assignmentUpdate.entries[0].parameters = {
+      sql: "UPDATE __agent_config SET charter=patch_text(charter, 'Old', 'New') WHERE id=1",
+    }
+    const result = collapseDetailedStatusRuns(
+      [
+        stepCluster('2:step:older', ['search_web']),
+        assignmentUpdate,
+        stepCluster('4:step:newer', ['create_pdf']),
+      ],
+      { latestPlanCursor: null, latestScheduleEntryId: null },
+    )
+
+    expect(result.map((event) => event.kind)).toEqual(['steps', 'steps', 'steps'])
+    expect(result[1]).toMatchObject({
+      cursor: assignmentUpdate.cursor,
+      collapsible: false,
+      collapseThreshold: Infinity,
+    })
+  })
+
   it('drops runs with no visible actions', () => {
     const result = collapseDetailedStatusRuns([stepCluster('1:step:hidden', ['update_plan'])], {
       latestPlanCursor: null,

--- a/frontend/src/hooks/useSimplifiedTimeline.ts
+++ b/frontend/src/hooks/useSimplifiedTimeline.ts
@@ -3,7 +3,7 @@ import type { TimelineEvent, ToolCallEntry, ToolClusterEvent } from '../types/ag
 import { isClusterRenderable, transformToolCluster } from '../components/agentChat/tooling/toolRegistry'
 import { buildActionCountLabel, flattenTimelineEventsToEntries } from '../components/agentChat/activityEntryUtils'
 import type { StatusExpansionTargets } from '../components/agentChat/statusExpansion'
-import { eventHasLatestStatus, isStatusDisplayEntry, resolveEntrySeparation } from '../components/agentChat/statusExpansion'
+import { eventHasLatestStatus, isAssignmentDisplayEntry, isStatusDisplayEntry, resolveEntrySeparation } from '../components/agentChat/statusExpansion'
 import type { ToolEntryDisplay } from '../components/agentChat/tooling/types'
 
 // ---------------------------------------------------------------------------
@@ -305,6 +305,15 @@ export function collapseDetailedStatusRuns(
     }
 
     if (event.kind === 'plan' || event.kind === 'kanban') {
+      continue
+    }
+
+    if (
+      event.kind === 'steps'
+      && transformToolCluster(event).entries.some((entry) => isAssignmentDisplayEntry(entry) && entry.separateFromPreview)
+    ) {
+      flush()
+      result.push(disableStepClusterCollapse(event))
       continue
     }
 

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -1014,6 +1014,22 @@ class AgentChatAPITests(TestCase):
         self.assertEqual(realtime_entry["charterText"], "Full updated assignment")
 
     @tag("batch_agent_chat")
+    def test_timeline_preserves_empty_assignment_display_snapshot(self):
+        step = PersistentAgentStep.objects.create(agent=self.agent, description="Clear assignment")
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="sqlite_batch",
+            tool_params={"sql": "UPDATE __agent_config SET charter='' WHERE id=1"},
+            result=json.dumps({"status": "ok"}),
+            display_metadata={"agent_config": {"charter": ""}},
+        )
+
+        entry = build_tool_cluster_from_steps([step])["entries"][0]
+
+        self.assertIn("charterText", entry)
+        self.assertEqual(entry["charterText"], "")
+
+    @tag("batch_agent_chat")
     def test_agent_profile_endpoint_returns_lightweight_roster_entry(self):
         response = self.client.get(
             reverse("console_agent_profile", kwargs={"agent_id": self.agent.id}),

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -78,7 +78,7 @@ from api.services.pipedream_apps import get_owner_apps_state
 from api.services.web_sessions import heartbeat_web_session, start_web_session
 from config.redis_client import get_redis_client
 from console.agent_chat.plan_events import persist_plan_event
-from console.agent_chat.timeline import build_processing_snapshot
+from console.agent_chat.timeline import build_processing_snapshot, build_tool_cluster_from_steps
 from console.agent_chat.timeline import fetch_timeline_window
 from console.agent_chat.timeline import serialize_plan_event
 from util.onboarding import (
@@ -977,6 +977,41 @@ class AgentChatAPITests(TestCase):
         self.assertIn("accountPause", critical_status)
         self.assertIn("dailyCredits", critical_status)
         self.assertIn("contactCapStatus", critical_status)
+
+    @tag("batch_agent_chat")
+    def test_timeline_serializes_assignment_display_snapshot_for_pages_and_realtime(self):
+        step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="Update assignment",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="sqlite_batch",
+            tool_params={
+                "sql": (
+                    "UPDATE __agent_config "
+                    "SET charter=patch_text(charter, 'old clause', 'new clause') WHERE id=1"
+                ),
+            },
+            result=json.dumps({"status": "ok"}),
+            display_metadata={
+                "agent_config": {
+                    "charter": "Full updated assignment",
+                },
+            },
+        )
+
+        page_entry = next(
+            entry
+            for event in fetch_timeline_window(self.agent).events
+            if event.get("kind") == "steps"
+            for entry in event.get("entries", [])
+            if entry.get("id") == str(step.id)
+        )
+        realtime_entry = build_tool_cluster_from_steps([step])["entries"][0]
+
+        self.assertEqual(page_entry["charterText"], "Full updated assignment")
+        self.assertEqual(realtime_entry["charterText"], "Full updated assignment")
 
     @tag("batch_agent_chat")
     def test_agent_profile_endpoint_returns_lightweight_roster_entry(self):

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -22,6 +22,7 @@ from redis.exceptions import RedisError
 
 from api.agent.core.event_processing import (
     OrchestratorPromptStale,
+    _capture_tool_display_metadata,
     _completion_with_failover,
     _execute_tool_call_runtime,
     _execute_prepared_tool_call,
@@ -145,6 +146,41 @@ from util.personal_signup_preview import GENERIC_STARTER_CHARTER
 from tests.utils.token_usage import make_completion_response
 
 User = get_user_model()
+
+
+@tag("batch_event_processing")
+class ToolDisplayMetadataTests(TestCase):
+    @patch("api.agent.core.event_processing.read_sqlite_agent_config_snapshot")
+    def test_assignment_snapshot_is_captured_only_for_successful_config_mutations(self, mock_read_snapshot):
+        mock_read_snapshot.return_value = SimpleNamespace(charter="Updated full assignment")
+        patch_call = SimpleNamespace(
+            tool_name="sqlite_batch",
+            exec_params={
+                "sql": (
+                    "UPDATE __agent_config "
+                    "SET charter=patch_text(charter, 'old clause', 'new clause') WHERE id=1"
+                ),
+            },
+        )
+
+        self.assertEqual(
+            _capture_tool_display_metadata(patch_call, {"status": "ok"}),
+            {"agent_config": {"charter": "Updated full assignment"}},
+        )
+
+        mock_read_snapshot.reset_mock()
+        self.assertEqual(
+            _capture_tool_display_metadata(patch_call, {"status": "error", "message": "failed"}),
+            {},
+        )
+        mock_read_snapshot.assert_not_called()
+
+        read_call = SimpleNamespace(
+            tool_name="sqlite_batch",
+            exec_params={"sql": "SELECT charter FROM __agent_config WHERE id=1"},
+        )
+        self.assertEqual(_capture_tool_display_metadata(read_call, {"status": "ok"}), {})
+        mock_read_snapshot.assert_not_called()
 
 
 @tag("batch_event_processing")

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -158,13 +158,27 @@ class ToolDisplayMetadataTests(TestCase):
             exec_params={
                 "sql": (
                     "UPDATE __agent_config "
-                    "SET charter=patch_text(charter, 'old clause', 'new clause') WHERE id=1"
+                    "SET charter=patch_text(charter, 'old where clause', 'new clause') WHERE id=1"
                 ),
             },
         )
 
         self.assertEqual(
             _capture_tool_display_metadata(patch_call, {"status": "ok"}),
+            {"agent_config": {"charter": "Updated full assignment"}},
+        )
+
+        insert_call = SimpleNamespace(
+            tool_name="sqlite_batch",
+            exec_params={
+                "sql": (
+                    "INSERT OR REPLACE INTO __agent_config (id, charter, schedule) "
+                    "VALUES (1, 'Replacement assignment', NULL)"
+                ),
+            },
+        )
+        self.assertEqual(
+            _capture_tool_display_metadata(insert_call, {"status": "ok"}),
             {"agent_config": {"charter": "Updated full assignment"}},
         )
 
@@ -180,6 +194,18 @@ class ToolDisplayMetadataTests(TestCase):
             exec_params={"sql": "SELECT charter FROM __agent_config WHERE id=1"},
         )
         self.assertEqual(_capture_tool_display_metadata(read_call, {"status": "ok"}), {})
+        mock_read_snapshot.assert_not_called()
+
+        schedule_call = SimpleNamespace(
+            tool_name="sqlite_batch",
+            exec_params={
+                "sql": (
+                    "UPDATE __agent_config SET schedule='0 9 * * *' "
+                    "WHERE charter='Unchanged assignment'"
+                ),
+            },
+        )
+        self.assertEqual(_capture_tool_display_metadata(schedule_call, {"status": "ok"}), {})
         mock_read_snapshot.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Fix assignment panel timeline grouping and status expansion behavior
- Persist tool-call display metadata for consistent timeline rendering
- Update SQLite agent configuration tooling and related frontend coverage
- Refine stop-policy and event-processing behavior

## Testing
- Not run (not requested)