### PR TITLE
Gate automatic email contact approval behind a rollout flag

### DIFF
--- a/api/migrations/0427_add_contact_auto_approve_email_flag.py
+++ b/api/migrations/0427_add_contact_auto_approve_email_flag.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.db import migrations
+
+
+FLAG_NAME = "contact_auto_approve_email"
+
+
+def add_flag(apps, schema_editor):
+    Flag = apps.get_model("waffle", "Flag")
+    if Flag.objects.filter(name=FLAG_NAME).exists():
+        return
+
+    default_everyone = None if settings.GOBII_PROPRIETARY_MODE else True
+    Flag.objects.create(
+        name=FLAG_NAME,
+        everyone=default_everyone,
+        percent=0,
+        superusers=False,
+        staff=False,
+        authenticated=False,
+        note="Allow users to opt agents into automatically allowing new email contacts.",
+    )
+
+
+def noop(apps, schema_editor):
+    """Keep the rollout flag when reversing this migration."""
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0426_persistentagenttoolcall_display_metadata"),
+        ("waffle", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_flag, noop),
+    ]

--- a/api/migrations/0427_add_contact_auto_approve_email_flag.py
+++ b/api/migrations/0427_add_contact_auto_approve_email_flag.py
@@ -29,7 +29,7 @@ def noop(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("api", "0426_persistentagenttoolcall_display_metadata"),
+        ("api", "0425_persistentagent_contact_approval_mode"),
         ("waffle", "0001_initial"),
     ]
 

--- a/console/agent_settings/service.py
+++ b/console/agent_settings/service.py
@@ -12,6 +12,8 @@ from console.mixins import AgentOwnerContextOverrideMixin
 from console.agent_chat.access import resolve_manageable_agent_for_request, user_can_manage_agent, user_is_collaborator
 from api.agent.tasks.process_events import process_agent_events_task
 from api.models import CommsAllowlistEntry, UserPhoneNumber
+from constants.feature_flags import CONTACT_AUTO_APPROVE_EMAIL
+
 
 class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, DetailView):
     """Shared backend for agent settings payloads and mutations."""
@@ -1066,6 +1068,7 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
 
         features = {
             'organizations': flag_is_active(request, 'organizations'),
+            'contactAutoApproveEmail': flag_is_active(request, CONTACT_AUTO_APPROVE_EMAIL),
         }
 
         can_reassign = bool(context.get('can_reassign'))
@@ -1633,6 +1636,12 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
         ).strip()
         if new_contact_approval_mode not in PersistentAgent.ContactApprovalMode.values:
             return _general_error("Select a valid contact approval option.")
+        if (
+            new_contact_approval_mode == PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+            and agent.contact_approval_mode != PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+            and not flag_is_active(request, CONTACT_AUTO_APPROVE_EMAIL)
+        ):
+            return _general_error("Automatic email contact approval is not available.")
 
         avatar_file = request.FILES.get('avatar')
         clear_avatar_flag = (request.POST.get('clear_avatar') or '').strip().lower() in {'1', 'true', 'yes', 'on'}

--- a/constants/feature_flags.py
+++ b/constants/feature_flags.py
@@ -2,6 +2,9 @@
 PERSISTENT_AGENTS = "persistent_agents"
 ORGANIZATIONS = "organizations"
 
+# Controls whether users may opt agents into automatically allowing new email contacts.
+CONTACT_AUTO_APPROVE_EMAIL = "contact_auto_approve_email"
+
 # Soft-expiration for free-plan agents that go inactive
 AGENT_SOFT_EXPIRATION = "agent_soft_expiration"
 

--- a/frontend/src/screens/AgentDetailScreen.tsx
+++ b/frontend/src/screens/AgentDetailScreen.tsx
@@ -2300,7 +2300,10 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
               state={savedAllowlistState}
               rows={allowlistRows}
               projectedSlotsUsed={projectedContactSlots}
-              contactAutoApproveEmailEnabled={initialData.features.contactAutoApproveEmail}
+              contactAutoApproveEmailEnabled={
+                initialData.features.contactAutoApproveEmail
+                || savedFormState.contactApprovalMode === 'auto_approve_email'
+              }
               contactApprovalMode={formState.contactApprovalMode}
               saving={saving}
               onAddContact={openAddContactModal}

--- a/frontend/src/screens/AgentDetailScreen.tsx
+++ b/frontend/src/screens/AgentDetailScreen.tsx
@@ -2300,6 +2300,7 @@ const toggleOrganizationServer = useCallback((serverId: string) => {
               state={savedAllowlistState}
               rows={allowlistRows}
               projectedSlotsUsed={projectedContactSlots}
+              contactAutoApproveEmailEnabled={initialData.features.contactAutoApproveEmail}
               contactApprovalMode={formState.contactApprovalMode}
               saving={saving}
               onAddContact={openAddContactModal}
@@ -2569,6 +2570,7 @@ type AllowlistManagerProps = {
   state: AllowlistState
   rows: AllowlistTableRow[]
   projectedSlotsUsed: number
+  contactAutoApproveEmailEnabled: boolean
   contactApprovalMode: ContactApprovalMode
   saving: boolean
   onAddContact: () => void
@@ -2583,6 +2585,7 @@ function AllowlistManager({
   state,
   rows,
   projectedSlotsUsed,
+  contactAutoApproveEmailEnabled,
   contactApprovalMode,
   saving,
   onAddContact,
@@ -2600,53 +2603,55 @@ function AllowlistManager({
 
   return (
     <div className="space-y-5">
-      <fieldset className="space-y-3">
-        <legend className="text-sm font-semibold text-slate-700">New contact approval</legend>
-        <p className="text-xs text-slate-500">Choose how this agent handles email addresses that are not already listed.</p>
-        <div className="grid gap-3 lg:grid-cols-2">
-          {CONTACT_APPROVAL_OPTIONS.map((option) => {
-            const Icon = option.icon
-            const Badge = option.badge
-            const selected = contactApprovalMode === option.value
-            return (
-              <label
-                key={option.value}
-                className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-4 text-left transition-colors ${
-                  selected
-                    ? 'border-blue-400/60 bg-blue-950/30'
-                    : 'border-slate-200/20 bg-transparent hover:border-slate-300/40'
-                } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
-              >
-                <span className="relative flex size-9 shrink-0 items-center justify-center rounded-lg border border-slate-200/20 bg-slate-900/45 text-slate-300">
-                  <Icon className="size-4" aria-hidden="true" />
-                  {Badge && <Badge className="absolute -right-1 -top-1 size-3 text-amber-300" aria-hidden="true" />}
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block text-sm font-semibold text-slate-100">{option.title}</span>
-                  <span className="mt-1 block text-xs leading-5 text-slate-400">{option.description}</span>
-                </span>
-                <input
-                  type="radio"
-                  name="contact-approval-mode-choice"
-                  value={option.value}
-                  checked={selected}
-                  disabled={saving}
-                  onChange={() => onContactApprovalModeChange(option.value)}
-                  className="mt-2 size-4 shrink-0 accent-blue-500"
-                />
-              </label>
-            )
-          })}
-        </div>
-        {contactApprovalMode === 'auto_approve_email' && (
-          <div className="flex items-start gap-2 rounded-lg border border-amber-300/20 bg-amber-950/30 px-4 py-3 text-xs leading-5 text-amber-100">
-            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-400" aria-hidden="true" />
-            <p>
-              This agent can add email contacts without asking you first. New contacts remain visible and removable below. SMS contacts always require approval.
-            </p>
+      {contactAutoApproveEmailEnabled && (
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-semibold text-slate-700">New contact approval</legend>
+          <p className="text-xs text-slate-500">Choose how this agent handles email addresses that are not already listed.</p>
+          <div className="grid gap-3 lg:grid-cols-2">
+            {CONTACT_APPROVAL_OPTIONS.map((option) => {
+              const Icon = option.icon
+              const Badge = option.badge
+              const selected = contactApprovalMode === option.value
+              return (
+                <label
+                  key={option.value}
+                  className={`flex cursor-pointer items-start gap-3 rounded-xl border px-4 py-4 text-left transition-colors ${
+                    selected
+                      ? 'border-blue-400/60 bg-blue-950/30'
+                      : 'border-slate-200/20 bg-transparent hover:border-slate-300/40'
+                  } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
+                >
+                  <span className="relative flex size-9 shrink-0 items-center justify-center rounded-lg border border-slate-200/20 bg-slate-900/45 text-slate-300">
+                    <Icon className="size-4" aria-hidden="true" />
+                    {Badge && <Badge className="absolute -right-1 -top-1 size-3 text-amber-300" aria-hidden="true" />}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-semibold text-slate-100">{option.title}</span>
+                    <span className="mt-1 block text-xs leading-5 text-slate-400">{option.description}</span>
+                  </span>
+                  <input
+                    type="radio"
+                    name="contact-approval-mode-choice"
+                    value={option.value}
+                    checked={selected}
+                    disabled={saving}
+                    onChange={() => onContactApprovalModeChange(option.value)}
+                    className="mt-2 size-4 shrink-0 accent-blue-500"
+                  />
+                </label>
+              )
+            })}
           </div>
-        )}
-      </fieldset>
+          {contactApprovalMode === 'auto_approve_email' && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-300/20 bg-amber-950/30 px-4 py-3 text-xs leading-5 text-amber-100">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-400" aria-hidden="true" />
+              <p>
+                This agent can add email contacts without asking you first. New contacts remain visible and removable below. SMS contacts always require approval.
+              </p>
+            </div>
+          )}
+        </fieldset>
+      )}
 
       {!state.emailVerified && (
         <div className={embeddedInfoBannerClassName}>

--- a/frontend/src/types/agentSettings.ts
+++ b/frontend/src/types/agentSettings.ts
@@ -232,6 +232,7 @@ export type AgentSettingsData = {
   inboundWebhooks: AgentInboundWebhook[]
   features: {
     organizations: boolean
+    contactAutoApproveEmail: boolean
   }
   reassignment: AgentSettingsReassignmentInfo
   llmIntelligence: LlmIntelligenceConfig | null

--- a/tests/unit/test_agent_settings_contact_approval.py
+++ b/tests/unit/test_agent_settings_contact_approval.py
@@ -1,8 +1,12 @@
+from importlib import import_module
 from unittest.mock import patch
 
+from django.apps import apps
 from django.contrib.auth import get_user_model
-from django.test import TestCase, tag
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
+from waffle import get_waffle_flag_model
+from waffle.testutils import override_flag
 
 from api.models import (
     BrowserUseAgent,
@@ -11,6 +15,7 @@ from api.models import (
     CommsChannel,
     PersistentAgent,
 )
+from constants.feature_flags import CONTACT_AUTO_APPROVE_EMAIL
 
 
 @tag("batch_console_allowlist")
@@ -59,6 +64,17 @@ class AgentSettingsContactApprovalTests(TestCase):
         self.assertEqual(response.status_code, 200, response.content.decode())
         self.assertEqual(response.json()["agent"]["contactApprovalMode"], "require_approval")
 
+    def test_settings_payload_reports_contact_auto_approve_flag(self):
+        self.client.force_login(self.owner)
+
+        with override_flag(CONTACT_AUTO_APPROVE_EMAIL, active=False):
+            disabled_response = self.client.get(self.url)
+        with override_flag(CONTACT_AUTO_APPROVE_EMAIL, active=True):
+            enabled_response = self.client.get(self.url)
+
+        self.assertFalse(disabled_response.json()["features"]["contactAutoApproveEmail"])
+        self.assertTrue(enabled_response.json()["features"]["contactAutoApproveEmail"])
+
     def test_settings_update_changes_mode_without_resolving_pending_requests(self):
         pending = CommsAllowlistRequest.objects.create(
             agent=self.agent,
@@ -69,11 +85,12 @@ class AgentSettingsContactApprovalTests(TestCase):
         )
         self.client.force_login(self.owner)
 
-        response = self.client.post(
-            self.url,
-            self._settings_form(contact_approval_mode="auto_approve_email"),
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-        )
+        with override_flag(CONTACT_AUTO_APPROVE_EMAIL, active=True):
+            response = self.client.post(
+                self.url,
+                self._settings_form(contact_approval_mode="auto_approve_email"),
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
 
         self.assertEqual(response.status_code, 200, response.content.decode())
         self.agent.refresh_from_db()
@@ -81,6 +98,63 @@ class AgentSettingsContactApprovalTests(TestCase):
         self.assertEqual(self.agent.contact_approval_mode, "auto_approve_email")
         self.assertEqual(pending.status, CommsAllowlistRequest.RequestStatus.PENDING)
         self.assertEqual(response.json()["contactApprovalMode"], "auto_approve_email")
+
+    def test_settings_update_rejects_new_auto_approve_opt_in_when_flag_disabled(self):
+        self.client.force_login(self.owner)
+
+        with override_flag(CONTACT_AUTO_APPROVE_EMAIL, active=False):
+            response = self.client.post(
+                self.url,
+                self._settings_form(contact_approval_mode="auto_approve_email"),
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+
+        self.assertEqual(response.status_code, 400, response.content.decode())
+        self.assertIn("not available", response.json()["error"])
+        self.agent.refresh_from_db()
+        self.assertEqual(
+            self.agent.contact_approval_mode,
+            PersistentAgent.ContactApprovalMode.REQUIRE_APPROVAL,
+        )
+
+    def test_existing_auto_approve_mode_is_preserved_when_flag_disabled(self):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+        self.client.force_login(self.owner)
+
+        with override_flag(CONTACT_AUTO_APPROVE_EMAIL, active=False):
+            response = self.client.post(
+                self.url,
+                self._settings_form(name="Updated while rollout disabled"),
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.name, "Updated while rollout disabled")
+        self.assertEqual(
+            self.agent.contact_approval_mode,
+            PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL,
+        )
+
+    def test_existing_auto_approve_mode_can_be_disabled_when_flag_is_off(self):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+        self.client.force_login(self.owner)
+
+        with override_flag(CONTACT_AUTO_APPROVE_EMAIL, active=False):
+            response = self.client.post(
+                self.url,
+                self._settings_form(contact_approval_mode="require_approval"),
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        self.agent.refresh_from_db()
+        self.assertEqual(
+            self.agent.contact_approval_mode,
+            PersistentAgent.ContactApprovalMode.REQUIRE_APPROVAL,
+        )
 
     def test_settings_update_rejects_invalid_mode(self):
         self.client.force_login(self.owner)
@@ -114,6 +188,33 @@ class AgentSettingsContactApprovalTests(TestCase):
             self.agent.contact_approval_mode,
             PersistentAgent.ContactApprovalMode.REQUIRE_APPROVAL,
         )
+
+    def test_flag_migration_defaults_by_deployment_mode_and_preserves_existing_rows(self):
+        migration = import_module("api.migrations.0427_add_contact_auto_approve_email_flag")
+        Flag = get_waffle_flag_model()
+        Flag.objects.filter(name=CONTACT_AUTO_APPROVE_EMAIL).delete()
+
+        with override_settings(GOBII_PROPRIETARY_MODE=True):
+            migration.add_flag(apps, None)
+
+        proprietary_flag = Flag.objects.get(name=CONTACT_AUTO_APPROVE_EMAIL)
+        self.assertIsNone(proprietary_flag.everyone)
+        self.assertEqual(proprietary_flag.percent, 0)
+        self.assertFalse(proprietary_flag.superusers)
+        self.assertFalse(proprietary_flag.staff)
+        self.assertFalse(proprietary_flag.authenticated)
+
+        proprietary_flag.everyone = False
+        proprietary_flag.save(update_fields=["everyone"])
+        with override_settings(GOBII_PROPRIETARY_MODE=False):
+            migration.add_flag(apps, None)
+        proprietary_flag.refresh_from_db()
+        self.assertFalse(proprietary_flag.everyone)
+
+        proprietary_flag.delete()
+        with override_settings(GOBII_PROPRIETARY_MODE=False):
+            migration.add_flag(apps, None)
+        self.assertTrue(Flag.objects.get(name=CONTACT_AUTO_APPROVE_EMAIL).everyone)
 
     @patch("console.agent_settings.service.process_agent_events_task.delay")
     def test_allowlist_ajax_returns_structured_payload_without_legacy_html(self, _mock_process_events):

--- a/tests/unit/test_outbound_whitelist_gating.py
+++ b/tests/unit/test_outbound_whitelist_gating.py
@@ -6,6 +6,7 @@ from allauth.account.models import EmailAddress
 from django.db import connection
 from django.test import TransactionTestCase, tag
 from django.contrib.auth import get_user_model
+from waffle.testutils import override_flag
 
 from api.models import (
     PersistentAgent,
@@ -17,6 +18,7 @@ from api.models import (
 from api.agent.tools.email_sender import execute_send_email
 from api.agent.tools.sms_sender import execute_send_sms
 from config import settings
+from constants.feature_flags import CONTACT_AUTO_APPROVE_EMAIL
 
 
 User = get_user_model()
@@ -126,6 +128,32 @@ class OutboundWhitelistGatingTests(TransactionTestCase):
         ])
         self.assertTrue(all(entry.allow_inbound and entry.allow_outbound for entry in entries))
         self.assertTrue(all(not entry.can_configure for entry in entries))
+        mock_deliver_email.assert_called_once()
+
+    @patch("api.agent.tools.email_sender.deliver_agent_email")
+    @tag("batch_outbound_email")
+    def test_existing_auto_approval_continues_when_rollout_flag_is_disabled(
+        self,
+        mock_deliver_email,
+        mock_close_old_connections,
+    ):
+        self.agent.contact_approval_mode = PersistentAgent.ContactApprovalMode.AUTO_APPROVE_EMAIL
+        self.agent.save(update_fields=["contact_approval_mode"])
+
+        with override_flag(CONTACT_AUTO_APPROVE_EMAIL, active=False):
+            result = execute_send_email(self.agent, {
+                "to_address": "existing-opt-in@example.com",
+                "subject": "Existing opt-in",
+                "mobile_first_html": "<p>Hello</p>",
+            })
+
+        self.assertEqual(result.get("status"), "ok")
+        self.assertTrue(
+            CommsAllowlistEntry.objects.filter(
+                agent=self.agent,
+                address="existing-opt-in@example.com",
+            ).exists()
+        )
         mock_deliver_email.assert_called_once()
 
     @patch("api.agent.tools.email_sender.deliver_agent_email")


### PR DESCRIPTION
## Summary
- Add a Waffle rollout flag for automatic email contact approval.
- Hide and server-gate the opt-in setting when disabled while preserving existing opt-ins.
- Add migration defaults and coverage for flag behavior and outbound email handling.

## Testing
- Added and updated targeted Django unit tests for settings, migration defaults, rollout gating, and existing auto-approval behavior.