### PR TITLE
Fix agent charter updates and enforce exact patch_text replacements

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -17,7 +17,7 @@ from contextvars import copy_context
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Callable, List, Tuple, Union, Optional, Dict, Any, Literal
+from typing import Callable, List, Tuple, Union, Optional, Dict, Any, Literal, Sequence
 from urllib.parse import unquote_plus
 from uuid import UUID
 
@@ -104,6 +104,7 @@ from ..tools.sms_sender import execute_send_sms
 from ..tools.spawn_web_task import execute_spawn_web_task
 from ..tools.schedule_updater import execute_update_schedule
 from ..tools.sqlite_agent_config import (
+    AgentConfigApplyResult,
     apply_sqlite_agent_config_updates,
     read_sqlite_agent_config_snapshot,
     seed_sqlite_agent_config,
@@ -1904,6 +1905,7 @@ class _ToolExecutionOutcome:
     updated_tools: Optional[List[dict]]
     variable_map: Dict[str, str]
     display_metadata: Dict[str, Any] = field(default_factory=dict)
+    persisted_step: Optional["PersistentAgentStep"] = None
 
 
 @dataclass
@@ -2339,6 +2341,83 @@ def _sqlite_batch_mutates_agent_charter(tool_params: Dict[str, Any]) -> bool:
         sqlite_statement_assigns_agent_config_field(statement, "charter")
         for statement in _sqlite_batch_statements(tool_params)
     )
+
+
+def _sqlite_batch_agent_config_attempted_fields(tool_params: Dict[str, Any]) -> tuple[str, ...]:
+    statements = _sqlite_batch_statements(tool_params)
+    return tuple(
+        field
+        for field in ("charter", "schedule")
+        if any(
+            sqlite_statement_assigns_agent_config_field(statement, field)
+            for statement in statements
+        )
+    )
+
+
+def _agent_config_attempted_fields_from_outcomes(
+    outcomes: Sequence[_ToolExecutionOutcome],
+) -> tuple[str, ...]:
+    attempted: set[str] = set()
+    for outcome in outcomes:
+        if outcome.prepared.tool_name != "sqlite_batch":
+            continue
+        attempted.update(
+            _sqlite_batch_agent_config_attempted_fields(outcome.prepared.exec_params)
+        )
+    return tuple(field for field in ("charter", "schedule") if field in attempted)
+
+
+def _persist_agent_config_update_results(
+    outcomes: Sequence[_ToolExecutionOutcome],
+    config_apply: AgentConfigApplyResult,
+) -> None:
+    for outcome in outcomes:
+        if outcome.prepared.tool_name != "sqlite_batch":
+            continue
+        attempted_fields = _sqlite_batch_agent_config_attempted_fields(
+            outcome.prepared.exec_params
+        )
+        if not attempted_fields:
+            continue
+
+        attempted_set = set(attempted_fields)
+        payload = {
+            "attempted_fields": list(attempted_fields),
+            "updated_fields": [
+                field for field in config_apply.updated_fields if field in attempted_set
+            ],
+            "unchanged_fields": [
+                field for field in config_apply.unchanged_fields if field in attempted_set
+            ],
+            "charter_hash_before": config_apply.charter_hash_before,
+            "charter_hash_after": config_apply.charter_hash_after,
+            "errors": list(config_apply.errors),
+        }
+        result = dict(outcome.result) if isinstance(outcome.result, dict) else {
+            "status": "ok",
+            "result": outcome.result,
+        }
+        result["agent_config_update"] = payload
+        outcome.result = result
+
+        step = outcome.persisted_step or outcome.prepared.pending_step
+        if step is None:
+            logger.warning(
+                "Could not enrich sqlite_batch config result for call %s because no persisted step was available.",
+                getattr(outcome.prepared, "call_id", None) or "<none>",
+            )
+            continue
+        try:
+            serialized_result = _normalize_tool_result_content(json.dumps(result))
+            PersistentAgentToolCall.objects.filter(step_id=step.id).update(
+                result=serialized_result
+            )
+        except (DatabaseError, TypeError, ValueError):
+            logger.exception(
+                "Failed to persist reconciled agent config result for step %s.",
+                step.id,
+            )
 
 
 def _user_text_has_durable_config_intent(text: str) -> bool:
@@ -3501,6 +3580,7 @@ def _finalize_tool_batch(
                 attach_prompt_archive=attach_prompt_archive,
                 display_metadata=outcome.display_metadata,
             )
+        outcome.persisted_step = step
         if is_error_status:
             _refund_tool_credit_on_error_if_configured(
                 agent=agent,
@@ -6438,10 +6518,14 @@ def _run_agent_loop(
                     _attach_prompt_archive(step)
                     return step
 
-                def _apply_agent_config_updates() -> bool:
-                    config_apply = apply_sqlite_agent_config_updates(agent, config_snapshot)
-                    if not config_apply.errors:
-                        return False
+                def _apply_agent_config_updates(
+                    attempted_fields: Sequence[str] = (),
+                ) -> AgentConfigApplyResult:
+                    config_apply = apply_sqlite_agent_config_updates(
+                        agent,
+                        config_snapshot,
+                        attempted_fields=attempted_fields,
+                    )
                     for error in config_apply.errors:
                         try:
                             step_kwargs = {
@@ -6457,7 +6541,7 @@ def _run_agent_loop(
                                 agent.id,
                                 exc_info=True,
                             )
-                    return True
+                    return config_apply
 
                 def _apply_skill_updates() -> tuple[bool, bool]:
                     """Apply skill updates and return (had_errors, changed)."""
@@ -6483,7 +6567,9 @@ def _run_agent_loop(
                             )
                     return True, bool(skill_apply.changed)
 
-                def _apply_runtime_updates() -> bool:
+                def _apply_runtime_updates(
+                    attempted_config_fields: Sequence[str] = (),
+                ) -> tuple[bool, AgentConfigApplyResult]:
                     # Some unit tests call _run_agent_loop directly without agent_sqlite_db().
                     # In that mode, reconciliation has no SQLite state to diff against.
                     if not get_sqlite_db_path():
@@ -6491,13 +6577,18 @@ def _run_agent_loop(
                             "Agent %s: skipping runtime SQLite reconciliation (no db path).",
                             agent.id,
                         )
-                        return False
-                    config_errors = _apply_agent_config_updates()
+                        config_apply = apply_sqlite_agent_config_updates(
+                            agent,
+                            None,
+                            attempted_fields=attempted_config_fields,
+                        )
+                        return bool(config_apply.errors), config_apply
+                    config_apply = _apply_agent_config_updates(attempted_config_fields)
                     skill_errors, skills_changed = _apply_skill_updates()
                     if skills_changed:
                         nonlocal tools
                         tools = get_agent_tools(agent)
-                    return config_errors or skill_errors
+                    return bool(config_apply.errors) or skill_errors, config_apply
 
                 msg_content = _extract_message_content(msg)
                 raw_message_text = (msg_content or "").strip()
@@ -6607,7 +6698,8 @@ def _run_agent_loop(
                 reasoning_step = _persist_reasoning_step(reasoning_source)
 
                 if not tool_calls:
-                    if _apply_runtime_updates():
+                    runtime_errors, _config_apply = _apply_runtime_updates()
+                    if runtime_errors:
                         reasoning_only_streak = 0
                         _mark_accepted_human_generation_consumed()
                         continue
@@ -6809,7 +6901,17 @@ def _run_agent_loop(
                     _mark_accepted_human_generation_consumed()
                     return cumulative_token_usage
 
-                if _apply_runtime_updates():
+                attempted_config_fields = _agent_config_attempted_fields_from_outcomes(
+                    executed_batch.execution_outcomes
+                )
+                runtime_errors, config_apply = _apply_runtime_updates(
+                    attempted_config_fields
+                )
+                _persist_agent_config_update_results(
+                    executed_batch.execution_outcomes,
+                    config_apply,
+                )
+                if runtime_errors:
                     followup_required = True
 
                 if _should_stop_for_eval_policy(agent, budget_ctx=budget_ctx, span=iter_span):

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -17,7 +17,7 @@ from contextvars import copy_context
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Callable, List, Tuple, Union, Optional, Dict, Any, Literal, Sequence
+from typing import Callable, List, Tuple, Union, Optional, Dict, Any, Literal
 from urllib.parse import unquote_plus
 from uuid import UUID
 
@@ -1905,7 +1905,6 @@ class _ToolExecutionOutcome:
     updated_tools: Optional[List[dict]]
     variable_map: Dict[str, str]
     display_metadata: Dict[str, Any] = field(default_factory=dict)
-    persisted_step: Optional["PersistentAgentStep"] = None
 
 
 @dataclass
@@ -2336,13 +2335,6 @@ def _sqlite_batch_is_only_agent_config_mutation(tool_params: Dict[str, Any]) -> 
     ) and all(AGENT_CONFIG_TABLE_RE.search(statement) for statement in statements)
 
 
-def _sqlite_batch_mutates_agent_charter(tool_params: Dict[str, Any]) -> bool:
-    return any(
-        sqlite_statement_assigns_agent_config_field(statement, "charter")
-        for statement in _sqlite_batch_statements(tool_params)
-    )
-
-
 def _sqlite_batch_agent_config_attempted_fields(tool_params: Dict[str, Any]) -> tuple[str, ...]:
     statements = _sqlite_batch_statements(tool_params)
     return tuple(
@@ -2355,69 +2347,37 @@ def _sqlite_batch_agent_config_attempted_fields(tool_params: Dict[str, Any]) -> 
     )
 
 
-def _agent_config_attempted_fields_from_outcomes(
-    outcomes: Sequence[_ToolExecutionOutcome],
-) -> tuple[str, ...]:
-    attempted: set[str] = set()
-    for outcome in outcomes:
-        if outcome.prepared.tool_name != "sqlite_batch":
-            continue
-        attempted.update(
-            _sqlite_batch_agent_config_attempted_fields(outcome.prepared.exec_params)
-        )
-    return tuple(field for field in ("charter", "schedule") if field in attempted)
+def _sqlite_batch_mutates_agent_charter(tool_params: Dict[str, Any]) -> bool:
+    return "charter" in _sqlite_batch_agent_config_attempted_fields(tool_params)
 
 
-def _persist_agent_config_update_results(
-    outcomes: Sequence[_ToolExecutionOutcome],
+def _annotate_agent_config_update_result(
+    outcomes: list[_ToolExecutionOutcome],
     config_apply: AgentConfigApplyResult,
 ) -> None:
+    config_outcomes = []
     for outcome in outcomes:
-        if outcome.prepared.tool_name != "sqlite_batch":
-            continue
-        attempted_fields = _sqlite_batch_agent_config_attempted_fields(
-            outcome.prepared.exec_params
-        )
-        if not attempted_fields:
-            continue
+        if outcome.prepared.tool_name == "sqlite_batch":
+            fields = _sqlite_batch_agent_config_attempted_fields(outcome.prepared.exec_params)
+            if fields:
+                config_outcomes.append((outcome, fields))
+    if not config_outcomes:
+        return
 
-        attempted_set = set(attempted_fields)
-        payload = {
-            "attempted_fields": list(attempted_fields),
-            "updated_fields": [
-                field for field in config_apply.updated_fields if field in attempted_set
-            ],
-            "unchanged_fields": [
-                field for field in config_apply.unchanged_fields if field in attempted_set
-            ],
-            "charter_hash_before": config_apply.charter_hash_before,
-            "charter_hash_after": config_apply.charter_hash_after,
-            "errors": list(config_apply.errors),
-        }
-        result = dict(outcome.result) if isinstance(outcome.result, dict) else {
-            "status": "ok",
-            "result": outcome.result,
-        }
-        result["agent_config_update"] = payload
-        outcome.result = result
-
-        step = outcome.persisted_step or outcome.prepared.pending_step
-        if step is None:
-            logger.warning(
-                "Could not enrich sqlite_batch config result for call %s because no persisted step was available.",
-                getattr(outcome.prepared, "call_id", None) or "<none>",
-            )
-            continue
-        try:
-            serialized_result = _normalize_tool_result_content(json.dumps(result))
-            PersistentAgentToolCall.objects.filter(step_id=step.id).update(
-                result=serialized_result
-            )
-        except (DatabaseError, TypeError, ValueError):
-            logger.exception(
-                "Failed to persist reconciled agent config result for step %s.",
-                step.id,
-            )
+    attempted = {field for _outcome, fields in config_outcomes for field in fields}
+    attempted_fields = tuple(field for field in ("charter", "schedule") if field in attempted)
+    updated_fields = list(config_apply.updated_fields)
+    target = max(config_outcomes, key=lambda item: item[0].prepared.idx)[0]
+    result = dict(target.result) if isinstance(target.result, dict) else {
+        "status": "ok",
+        "result": target.result,
+    }
+    result["agent_config_update"] = {
+        "updated_fields": updated_fields,
+        "unchanged_fields": [field for field in attempted_fields if field not in updated_fields],
+        "errors": config_apply.errors,
+    }
+    target.result = result
 
 
 def _user_text_has_durable_config_intent(text: str) -> bool:
@@ -3580,7 +3540,6 @@ def _finalize_tool_batch(
                 attach_prompt_archive=attach_prompt_archive,
                 display_metadata=outcome.display_metadata,
             )
-        outcome.persisted_step = step
         if is_error_status:
             _refund_tool_credit_on_error_if_configured(
                 agent=agent,
@@ -6518,58 +6477,7 @@ def _run_agent_loop(
                     _attach_prompt_archive(step)
                     return step
 
-                def _apply_agent_config_updates(
-                    attempted_fields: Sequence[str] = (),
-                ) -> AgentConfigApplyResult:
-                    config_apply = apply_sqlite_agent_config_updates(
-                        agent,
-                        config_snapshot,
-                        attempted_fields=attempted_fields,
-                    )
-                    for error in config_apply.errors:
-                        try:
-                            step_kwargs = {
-                                "agent": agent,
-                                "description": f"Agent config update failed: {error}",
-                            }
-                            _attach_completion(step_kwargs)
-                            step = PersistentAgentStep.objects.create(**step_kwargs)
-                            _attach_prompt_archive(step)
-                        except Exception:
-                            logger.debug(
-                                "Failed to persist config update error step for agent %s",
-                                agent.id,
-                                exc_info=True,
-                            )
-                    return config_apply
-
-                def _apply_skill_updates() -> tuple[bool, bool]:
-                    """Apply skill updates and return (had_errors, changed)."""
-                    skill_apply = apply_sqlite_skill_updates(agent, skills_snapshot)
-
-                    if not skill_apply.errors:
-                        return False, bool(skill_apply.changed)
-
-                    for error in skill_apply.errors:
-                        try:
-                            step_kwargs = {
-                                "agent": agent,
-                                "description": f"Skill update failed: {error}",
-                            }
-                            _attach_completion(step_kwargs)
-                            step = PersistentAgentStep.objects.create(**step_kwargs)
-                            _attach_prompt_archive(step)
-                        except Exception:
-                            logger.debug(
-                                "Failed to persist skill update error step for agent %s",
-                                agent.id,
-                                exc_info=True,
-                            )
-                    return True, bool(skill_apply.changed)
-
-                def _apply_runtime_updates(
-                    attempted_config_fields: Sequence[str] = (),
-                ) -> tuple[bool, AgentConfigApplyResult]:
+                def _apply_runtime_updates() -> tuple[bool, AgentConfigApplyResult]:
                     # Some unit tests call _run_agent_loop directly without agent_sqlite_db().
                     # In that mode, reconciliation has no SQLite state to diff against.
                     if not get_sqlite_db_path():
@@ -6577,18 +6485,34 @@ def _run_agent_loop(
                             "Agent %s: skipping runtime SQLite reconciliation (no db path).",
                             agent.id,
                         )
-                        config_apply = apply_sqlite_agent_config_updates(
-                            agent,
-                            None,
-                            attempted_fields=attempted_config_fields,
-                        )
-                        return bool(config_apply.errors), config_apply
-                    config_apply = _apply_agent_config_updates(attempted_config_fields)
-                    skill_errors, skills_changed = _apply_skill_updates()
-                    if skills_changed:
+                        return False, AgentConfigApplyResult(updated_fields=(), errors={})
+                    config_apply = apply_sqlite_agent_config_updates(agent, config_snapshot)
+                    skill_apply = apply_sqlite_skill_updates(agent, skills_snapshot)
+                    error_groups = (
+                        ("Agent config", config_apply.errors.values()),
+                        ("Skill", skill_apply.errors),
+                    )
+                    for label, errors in error_groups:
+                        for error in errors:
+                            try:
+                                step_kwargs = {
+                                    "agent": agent,
+                                    "description": f"{label} update failed: {error}",
+                                }
+                                _attach_completion(step_kwargs)
+                                step = PersistentAgentStep.objects.create(**step_kwargs)
+                                _attach_prompt_archive(step)
+                            except Exception:
+                                logger.debug(
+                                    "Failed to persist %s update error step for agent %s",
+                                    label.lower(),
+                                    agent.id,
+                                    exc_info=True,
+                                )
+                    if skill_apply.changed:
                         nonlocal tools
                         tools = get_agent_tools(agent)
-                    return bool(config_apply.errors) or skill_errors, config_apply
+                    return bool(config_apply.errors or skill_apply.errors), config_apply
 
                 msg_content = _extract_message_content(msg)
                 raw_message_text = (msg_content or "").strip()
@@ -6857,6 +6781,12 @@ def _run_agent_loop(
                 )
                 tools = executed_batch.tools
 
+                runtime_errors, config_apply = _apply_runtime_updates()
+                _annotate_agent_config_update_result(
+                    executed_batch.execution_outcomes,
+                    config_apply,
+                )
+
                 finalized_batch = _finalize_tool_batch(
                     agent,
                     executed_batch.execution_outcomes,
@@ -6901,16 +6831,6 @@ def _run_agent_loop(
                     _mark_accepted_human_generation_consumed()
                     return cumulative_token_usage
 
-                attempted_config_fields = _agent_config_attempted_fields_from_outcomes(
-                    executed_batch.execution_outcomes
-                )
-                runtime_errors, config_apply = _apply_runtime_updates(
-                    attempted_config_fields
-                )
-                _persist_agent_config_update_results(
-                    executed_batch.execution_outcomes,
-                    config_apply,
-                )
                 if runtime_errors:
                     followup_required = True
 

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -6351,7 +6351,6 @@ def _run_agent_loop(
                     if heartbeat:
                         heartbeat.touch("llm_response")
 
-                    # Accumulate token usage
                     if token_usage:
                         cumulative_token_usage["prompt_tokens"] += token_usage.get("prompt_tokens", 0)
                         cumulative_token_usage["completion_tokens"] += token_usage.get("completion_tokens", 0)
@@ -6781,11 +6780,12 @@ def _run_agent_loop(
                 )
                 tools = executed_batch.tools
 
-                runtime_errors, config_apply = _apply_runtime_updates()
-                _annotate_agent_config_update_result(
-                    executed_batch.execution_outcomes,
-                    config_apply,
-                )
+                if not executed_batch.abort_after_execution or _get_processing_abort_reason(agent.id) is None:
+                    runtime_errors, config_apply = _apply_runtime_updates()
+                    _annotate_agent_config_update_result(
+                        executed_batch.execution_outcomes,
+                        config_apply,
+                    )
 
                 finalized_batch = _finalize_tool_batch(
                     agent,

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -670,8 +670,8 @@ def _get_sqlite_guidance() -> str:
         "relevance_at. Safe outbound requires status='allowed' and allow_outbound=1; never infer "
         "permission from lead state or an empty request queue.\n\n"
         "SQLite provides csv_headers/csv_parse, extraction/cleaning helpers, and standard JSON/window functions; use names shown by schema/results. "
-        "patch_text(text,old,new) is strict: non-empty old must occur exactly once or the query fails; old='' appends new once. "
-        "Use a longer old value when text repeats. A browser task completion wakes you and adds its result; do "
+        "For patch_text(text,old,new), old='' appends; otherwise old must match exactly once. "
+        "A browser task completion wakes you and adds its result; do "
         "not poll snapshots while it runs. Facts and URLs must come from evidence, not search terms."
     )
 

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -669,8 +669,9 @@ def _get_sqlite_guidance() -> str:
         "* __contacts: channel, address, normalized_address, display_name, status, allow_inbound, allow_outbound, can_configure, "
         "relevance_at. Safe outbound requires status='allowed' and allow_outbound=1; never infer "
         "permission from lead state or an empty request queue.\n\n"
-        "SQLite provides csv_headers/csv_parse, patch_text(text,old,new), extraction/cleaning helpers, and standard JSON/window "
-        "functions; use names shown by schema/results. A browser task completion wakes you and adds its result; do "
+        "SQLite provides csv_headers/csv_parse, extraction/cleaning helpers, and standard JSON/window functions; use names shown by schema/results. "
+        "patch_text(text,old,new) is strict: non-empty old must occur exactly once or the query fails; old='' appends new once. "
+        "Use a longer old value when text repeats. A browser task completion wakes you and adds its result; do "
         "not poll snapshots while it runs. Facts and URLs must come from evidence, not search terms."
     )
 

--- a/api/agent/tools/sqlite_agent_config.py
+++ b/api/agent/tools/sqlite_agent_config.py
@@ -8,9 +8,10 @@ persisting final values to Postgres.
 
 import logging
 import re
+import sqlite3
+from contextlib import contextmanager
 from dataclasses import dataclass
-from hashlib import sha256
-from typing import Optional, Sequence
+from typing import Optional
 
 from .charter_updater import execute_update_charter
 from .schedule_updater import execute_update_schedule
@@ -31,6 +32,16 @@ AGENT_CONFIG_INSERT_RE = re.compile(
 )
 
 
+@contextmanager
+def _guarded_connection(db_path: str):
+    conn = open_guarded_sqlite_connection(db_path)
+    try:
+        yield conn
+    finally:
+        clear_guarded_connection(conn)
+        conn.close()
+
+
 @dataclass(frozen=True)
 class AgentConfigSnapshot:
     charter: str
@@ -39,12 +50,8 @@ class AgentConfigSnapshot:
 
 @dataclass(frozen=True)
 class AgentConfigApplyResult:
-    attempted_fields: Sequence[str]
-    updated_fields: Sequence[str]
-    unchanged_fields: Sequence[str]
-    errors: Sequence[str]
-    charter_hash_before: str
-    charter_hash_after: str
+    updated_fields: tuple[str, ...]
+    errors: dict[str, str]
 
 
 def sqlite_statement_assigns_agent_config_field(statement: str, field_name: str) -> bool:
@@ -77,132 +84,59 @@ def seed_sqlite_agent_config(agent) -> Optional[AgentConfigSnapshot]:
         logger.warning("SQLite DB path unavailable; cannot seed agent config.")
         return None
 
-    conn = None
     try:
-        conn = open_guarded_sqlite_connection(db_path)
-        conn.execute(f'DROP TABLE IF EXISTS "{AGENT_CONFIG_TABLE}";')
-        conn.execute(
-            f"""
-            CREATE TABLE "{AGENT_CONFIG_TABLE}" (
-                id INTEGER PRIMARY KEY CHECK (id = 1),
-                charter TEXT,
-                schedule TEXT
-            );
-            """
-        )
-        charter = agent.charter or ""
-        schedule = agent.schedule
-        conn.execute(
-            f'INSERT INTO "{AGENT_CONFIG_TABLE}" (id, charter, schedule) VALUES (1, ?, ?);',
-            (charter, schedule),
-        )
-        conn.commit()
-        return AgentConfigSnapshot(charter=charter, schedule=schedule)
-    except Exception:
+        with _guarded_connection(db_path) as conn:
+            conn.execute(f'DROP TABLE IF EXISTS "{AGENT_CONFIG_TABLE}";')
+            conn.execute(
+                f"""
+                CREATE TABLE "{AGENT_CONFIG_TABLE}" (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    charter TEXT,
+                    schedule TEXT
+                );
+                """
+            )
+            snapshot = AgentConfigSnapshot(charter=agent.charter or "", schedule=agent.schedule)
+            conn.execute(
+                f'INSERT INTO "{AGENT_CONFIG_TABLE}" (id, charter, schedule) VALUES (1, ?, ?);',
+                (snapshot.charter, snapshot.schedule),
+            )
+            conn.commit()
+            return snapshot
+    except (RuntimeError, sqlite3.Error):
         logger.exception("Failed to seed agent config table for agent %s", getattr(agent, "id", None))
         return None
-    finally:
-        if conn is not None:
-            try:
-                clear_guarded_connection(conn)
-                conn.close()
-            except Exception:
-                pass
 
 
 def apply_sqlite_agent_config_updates(
     agent,
     baseline: Optional[AgentConfigSnapshot],
-    attempted_fields: Sequence[str] = (),
 ) -> AgentConfigApplyResult:
     """Apply any SQLite config updates to the persistent agent record."""
-    field_order = ("charter", "schedule")
-    attempted_field_set = set(attempted_fields)
-    normalized_attempted_fields = tuple(
-        field for field in field_order if field in attempted_field_set
-    )
-    errors: list[str] = []
+    updated_fields: list[str] = []
+    errors: dict[str, str] = {}
     current = read_sqlite_agent_config_snapshot()
-    persisted_before = AgentConfigSnapshot(
-        charter=agent.charter or "",
-        schedule=agent.schedule,
-    )
 
     if baseline is None or current is None:
         _drop_agent_config_table()
-        if normalized_attempted_fields:
-            errors.append("Agent config state was unavailable; no attempted updates were persisted.")
-        return _build_apply_result(
-            attempted_fields=normalized_attempted_fields,
-            before=persisted_before,
-            after=persisted_before,
-            errors=errors,
-        )
+        return AgentConfigApplyResult(updated_fields=(), errors=errors)
 
     if _normalize_charter(current.charter) != _normalize_charter(baseline.charter):
         result = execute_update_charter(agent, {"new_charter": _normalize_charter(current.charter)})
-        if not isinstance(result, dict) or result.get("status") != "ok":
-            errors.append(result.get("message", "Charter update failed.") if isinstance(result, dict) else "Charter update failed.")
+        if isinstance(result, dict) and result.get("status") == "ok":
+            updated_fields.append("charter")
+        else:
+            errors["charter"] = result.get("message", "Charter update failed.") if isinstance(result, dict) else "Charter update failed."
 
     if _normalize_schedule(current.schedule) != _normalize_schedule(baseline.schedule):
         result = execute_update_schedule(agent, {"new_schedule": current.schedule})
-        if not isinstance(result, dict) or result.get("status") != "ok":
-            errors.append(result.get("message", "Schedule update failed.") if isinstance(result, dict) else "Schedule update failed.")
+        if isinstance(result, dict) and result.get("status") == "ok":
+            updated_fields.append("schedule")
+        else:
+            errors["schedule"] = result.get("message", "Schedule update failed.") if isinstance(result, dict) else "Schedule update failed."
 
     _drop_agent_config_table()
-    agent.refresh_from_db(fields=["charter", "schedule"])
-    persisted_after = AgentConfigSnapshot(
-        charter=agent.charter or "",
-        schedule=agent.schedule,
-    )
-    effective_attempted_fields = tuple(
-        field
-        for field in field_order
-        if field in normalized_attempted_fields or _snapshot_field_changed(baseline, current, field)
-    )
-    return _build_apply_result(
-        attempted_fields=effective_attempted_fields,
-        before=persisted_before,
-        after=persisted_after,
-        errors=errors,
-    )
-
-
-def _build_apply_result(
-    *,
-    attempted_fields: Sequence[str],
-    before: AgentConfigSnapshot,
-    after: AgentConfigSnapshot,
-    errors: Sequence[str],
-) -> AgentConfigApplyResult:
-    updated_fields = tuple(
-        field for field in attempted_fields if _snapshot_field_changed(before, after, field)
-    )
-    unchanged_fields = tuple(field for field in attempted_fields if field not in updated_fields)
-    return AgentConfigApplyResult(
-        attempted_fields=tuple(attempted_fields),
-        updated_fields=updated_fields,
-        unchanged_fields=unchanged_fields,
-        errors=tuple(errors),
-        charter_hash_before=_charter_hash(before.charter),
-        charter_hash_after=_charter_hash(after.charter),
-    )
-
-
-def _snapshot_field_changed(
-    before: AgentConfigSnapshot,
-    after: AgentConfigSnapshot,
-    field: str,
-) -> bool:
-    if field == "charter":
-        return _normalize_charter(before.charter) != _normalize_charter(after.charter)
-    if field == "schedule":
-        return _normalize_schedule(before.schedule) != _normalize_schedule(after.schedule)
-    return False
-
-
-def _charter_hash(value: Optional[str]) -> str:
-    return sha256(_normalize_charter(value).encode("utf-8")).hexdigest()
+    return AgentConfigApplyResult(updated_fields=tuple(updated_fields), errors=errors)
 
 
 def read_sqlite_agent_config_snapshot() -> Optional[AgentConfigSnapshot]:
@@ -210,25 +144,15 @@ def read_sqlite_agent_config_snapshot() -> Optional[AgentConfigSnapshot]:
     if not db_path:
         return None
 
-    conn = None
     try:
-        conn = open_guarded_sqlite_connection(db_path)
-        cur = conn.cursor()
-        cur.execute(f'SELECT charter, schedule FROM "{AGENT_CONFIG_TABLE}" WHERE id = 1;')
-        row = cur.fetchone()
-        if not row:
-            return None
-        return AgentConfigSnapshot(charter=row[0] or "", schedule=row[1])
-    except Exception:
+        with _guarded_connection(db_path) as conn:
+            row = conn.execute(
+                f'SELECT charter, schedule FROM "{AGENT_CONFIG_TABLE}" WHERE id = 1;'
+            ).fetchone()
+            return AgentConfigSnapshot(charter=row[0] or "", schedule=row[1]) if row else None
+    except (RuntimeError, sqlite3.Error):
         logger.exception("Failed to read agent config table.")
         return None
-    finally:
-        if conn is not None:
-            try:
-                clear_guarded_connection(conn)
-                conn.close()
-            except Exception:
-                pass
 
 
 def _drop_agent_config_table() -> None:
@@ -236,20 +160,12 @@ def _drop_agent_config_table() -> None:
     if not db_path:
         return
 
-    conn = None
     try:
-        conn = open_guarded_sqlite_connection(db_path)
-        conn.execute(f'DROP TABLE IF EXISTS "{AGENT_CONFIG_TABLE}";')
-        conn.commit()
-    except Exception:
+        with _guarded_connection(db_path) as conn:
+            conn.execute(f'DROP TABLE IF EXISTS "{AGENT_CONFIG_TABLE}";')
+            conn.commit()
+    except (RuntimeError, sqlite3.Error):
         logger.exception("Failed to drop agent config table.")
-    finally:
-        if conn is not None:
-            try:
-                clear_guarded_connection(conn)
-                conn.close()
-            except Exception:
-                pass
 
 
 def _normalize_charter(value: Optional[str]) -> str:
@@ -257,7 +173,4 @@ def _normalize_charter(value: Optional[str]) -> str:
 
 
 def _normalize_schedule(value: Optional[str]) -> Optional[str]:
-    if value is None:
-        return None
-    trimmed = value.strip()
-    return trimmed or None
+    return value.strip() or None if value is not None else None

--- a/api/agent/tools/sqlite_agent_config.py
+++ b/api/agent/tools/sqlite_agent_config.py
@@ -9,6 +9,7 @@ persisting final values to Postgres.
 import logging
 import re
 from dataclasses import dataclass
+from hashlib import sha256
 from typing import Optional, Sequence
 
 from .charter_updater import execute_update_charter
@@ -38,8 +39,12 @@ class AgentConfigSnapshot:
 
 @dataclass(frozen=True)
 class AgentConfigApplyResult:
+    attempted_fields: Sequence[str]
     updated_fields: Sequence[str]
+    unchanged_fields: Sequence[str]
     errors: Sequence[str]
+    charter_hash_before: str
+    charter_hash_after: str
 
 
 def sqlite_statement_assigns_agent_config_field(statement: str, field_name: str) -> bool:
@@ -108,32 +113,96 @@ def seed_sqlite_agent_config(agent) -> Optional[AgentConfigSnapshot]:
 def apply_sqlite_agent_config_updates(
     agent,
     baseline: Optional[AgentConfigSnapshot],
+    attempted_fields: Sequence[str] = (),
 ) -> AgentConfigApplyResult:
     """Apply any SQLite config updates to the persistent agent record."""
-    updated_fields: list[str] = []
+    field_order = ("charter", "schedule")
+    attempted_field_set = set(attempted_fields)
+    normalized_attempted_fields = tuple(
+        field for field in field_order if field in attempted_field_set
+    )
     errors: list[str] = []
     current = read_sqlite_agent_config_snapshot()
+    persisted_before = AgentConfigSnapshot(
+        charter=agent.charter or "",
+        schedule=agent.schedule,
+    )
 
     if baseline is None or current is None:
         _drop_agent_config_table()
-        return AgentConfigApplyResult(updated_fields=updated_fields, errors=errors)
+        if normalized_attempted_fields:
+            errors.append("Agent config state was unavailable; no attempted updates were persisted.")
+        return _build_apply_result(
+            attempted_fields=normalized_attempted_fields,
+            before=persisted_before,
+            after=persisted_before,
+            errors=errors,
+        )
 
     if _normalize_charter(current.charter) != _normalize_charter(baseline.charter):
         result = execute_update_charter(agent, {"new_charter": _normalize_charter(current.charter)})
-        if isinstance(result, dict) and result.get("status") == "ok":
-            updated_fields.append("charter")
-        else:
+        if not isinstance(result, dict) or result.get("status") != "ok":
             errors.append(result.get("message", "Charter update failed.") if isinstance(result, dict) else "Charter update failed.")
 
     if _normalize_schedule(current.schedule) != _normalize_schedule(baseline.schedule):
         result = execute_update_schedule(agent, {"new_schedule": current.schedule})
-        if isinstance(result, dict) and result.get("status") == "ok":
-            updated_fields.append("schedule")
-        else:
+        if not isinstance(result, dict) or result.get("status") != "ok":
             errors.append(result.get("message", "Schedule update failed.") if isinstance(result, dict) else "Schedule update failed.")
 
     _drop_agent_config_table()
-    return AgentConfigApplyResult(updated_fields=updated_fields, errors=errors)
+    agent.refresh_from_db(fields=["charter", "schedule"])
+    persisted_after = AgentConfigSnapshot(
+        charter=agent.charter or "",
+        schedule=agent.schedule,
+    )
+    effective_attempted_fields = tuple(
+        field
+        for field in field_order
+        if field in normalized_attempted_fields or _snapshot_field_changed(baseline, current, field)
+    )
+    return _build_apply_result(
+        attempted_fields=effective_attempted_fields,
+        before=persisted_before,
+        after=persisted_after,
+        errors=errors,
+    )
+
+
+def _build_apply_result(
+    *,
+    attempted_fields: Sequence[str],
+    before: AgentConfigSnapshot,
+    after: AgentConfigSnapshot,
+    errors: Sequence[str],
+) -> AgentConfigApplyResult:
+    updated_fields = tuple(
+        field for field in attempted_fields if _snapshot_field_changed(before, after, field)
+    )
+    unchanged_fields = tuple(field for field in attempted_fields if field not in updated_fields)
+    return AgentConfigApplyResult(
+        attempted_fields=tuple(attempted_fields),
+        updated_fields=updated_fields,
+        unchanged_fields=unchanged_fields,
+        errors=tuple(errors),
+        charter_hash_before=_charter_hash(before.charter),
+        charter_hash_after=_charter_hash(after.charter),
+    )
+
+
+def _snapshot_field_changed(
+    before: AgentConfigSnapshot,
+    after: AgentConfigSnapshot,
+    field: str,
+) -> bool:
+    if field == "charter":
+        return _normalize_charter(before.charter) != _normalize_charter(after.charter)
+    if field == "schedule":
+        return _normalize_schedule(before.schedule) != _normalize_schedule(after.schedule)
+    return False
+
+
+def _charter_hash(value: Optional[str]) -> str:
+    return sha256(_normalize_charter(value).encode("utf-8")).hexdigest()
 
 
 def read_sqlite_agent_config_snapshot() -> Optional[AgentConfigSnapshot]:

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -14,7 +14,15 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING
 import sqlparse
 from sqlparse import tokens as sql_tokens
 from sqlparse.sql import Statement
-from .sqlite_guardrails import clear_guarded_connection, get_blocked_statement_reason, open_guarded_sqlite_connection, start_query_timer, stop_query_timer
+from .sqlite_guardrails import (
+    clear_guarded_connection,
+    clear_patch_text_error,
+    consume_patch_text_error,
+    get_blocked_statement_reason,
+    open_guarded_sqlite_connection,
+    start_query_timer,
+    stop_query_timer,
+)
 from .sqlite_autocorrect import build_cte_column_candidates, build_sqlglot_candidates
 from .sqlite_query_quality import build_tool_result_query_advisories
 from .sqlite_state import EPHEMERAL_TABLES, _sqlite_db_path_var  # type: ignore
@@ -1356,6 +1364,7 @@ def _execute_with_autocorrections(
         current_query, corrections = queue_items.popleft()
         attempts += 1
         try:
+            clear_patch_text_error()
             start_query_timer(conn)
             cur.execute(current_query)
             if cur.description is not None:
@@ -1389,7 +1398,7 @@ def _execute_with_autocorrections(
                     result_entry["warning_code"] = "zero_rows_affected"
             return result_entry, current_query, corrections, None
         except Exception as orig_exc:
-            last_error_message = str(orig_exc)
+            last_error_message = consume_patch_text_error() or str(orig_exc)
             last_error_query = current_query
             conn.rollback()
             for updated_sql, fixes in _build_autocorrection_candidates(current_query, last_error_message, conn):

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -16,7 +16,6 @@ from sqlparse import tokens as sql_tokens
 from sqlparse.sql import Statement
 from .sqlite_guardrails import (
     clear_guarded_connection,
-    clear_patch_text_error,
     consume_patch_text_error,
     get_blocked_statement_reason,
     open_guarded_sqlite_connection,
@@ -1364,7 +1363,7 @@ def _execute_with_autocorrections(
         current_query, corrections = queue_items.popleft()
         attempts += 1
         try:
-            clear_patch_text_error()
+            consume_patch_text_error()
             start_query_timer(conn)
             cur.execute(current_query)
             if cur.description is not None:

--- a/api/agent/tools/sqlite_guardrails.py
+++ b/api/agent/tools/sqlite_guardrails.py
@@ -39,31 +39,18 @@ def _patch_text(value: Optional[str], old: Optional[str], new: Optional[str]) ->
             return text
         return "\n".join(filter(None, (text.rstrip(), replacement)))
 
-    if old is None:
+    match_count = text.count(old or "")
+    if old is None or match_count != 1:
         message = "patch_text requires old='' for append or a non-null exact replacement target."
-        _PATCH_TEXT_ERROR.set(message)
-        raise sqlite3.OperationalError(message)
-
-    match_count = text.count(old)
-    if match_count == 0:
-        message = (
-            "patch_text replacement target was not found. "
-            "Read the relevant text and retry with an exact target, or use old='' to append."
-        )
-        _PATCH_TEXT_ERROR.set(message)
-        raise sqlite3.OperationalError(message)
-    if match_count > 1:
-        message = (
-            f"patch_text replacement target matched {match_count} times. "
-            "Retry with a longer target that occurs exactly once."
-        )
+        if old is not None:
+            message = (
+                "patch_text replacement target was not found. Read the text and retry with an exact target."
+                if match_count == 0
+                else f"patch_text replacement target matched {match_count} times; retry with a longer target."
+            )
         _PATCH_TEXT_ERROR.set(message)
         raise sqlite3.OperationalError(message)
     return text.replace(old, replacement, 1)
-
-
-def clear_patch_text_error() -> None:
-    _PATCH_TEXT_ERROR.set(None)
 
 
 def consume_patch_text_error() -> Optional[str]:
@@ -1139,7 +1126,7 @@ def clear_guarded_connection(conn: sqlite3.Connection) -> None:
     conn_id = id(conn)
     _QUERY_STARTS.pop(conn_id, None)
     _QUERY_TIMEOUTS.pop(conn_id, None)
-    clear_patch_text_error()
+    consume_patch_text_error()
 
 
 def _make_progress_handler(conn_id: int):

--- a/api/agent/tools/sqlite_guardrails.py
+++ b/api/agent/tools/sqlite_guardrails.py
@@ -6,11 +6,14 @@ import math
 import re
 import sqlite3
 import time
+from contextvars import ContextVar
 from typing import Optional
 
 from ..core.csv_utils import build_csv_sample, detect_csv_dialect, normalize_csv_text, read_csv_rows
 
 logger = logging.getLogger(__name__)
+
+_PATCH_TEXT_ERROR: ContextVar[Optional[str]] = ContextVar("sqlite_patch_text_error", default=None)
 
 
 # ---------------------------------------------------------------------------
@@ -28,18 +31,45 @@ def _regexp(pattern: str, string: Optional[str]) -> bool:
 
 
 def _patch_text(value: Optional[str], old: Optional[str], new: Optional[str]) -> str:
-    """Apply one exact replacement, otherwise append the new text once."""
+    """Apply one unambiguous replacement, or append once when old is empty."""
     text = value or ""
     replacement = (new or "").strip()
-    if not old:
+    if old == "":
         if not replacement or replacement in text:
             return text
         return "\n".join(filter(None, (text.rstrip(), replacement)))
-    if old not in text:
-        if not replacement or replacement in text:
-            return text
-        return "\n".join(filter(None, (text.rstrip(), replacement)))
+
+    if old is None:
+        message = "patch_text requires old='' for append or a non-null exact replacement target."
+        _PATCH_TEXT_ERROR.set(message)
+        raise sqlite3.OperationalError(message)
+
+    match_count = text.count(old)
+    if match_count == 0:
+        message = (
+            "patch_text replacement target was not found. "
+            "Read the relevant text and retry with an exact target, or use old='' to append."
+        )
+        _PATCH_TEXT_ERROR.set(message)
+        raise sqlite3.OperationalError(message)
+    if match_count > 1:
+        message = (
+            f"patch_text replacement target matched {match_count} times. "
+            "Retry with a longer target that occurs exactly once."
+        )
+        _PATCH_TEXT_ERROR.set(message)
+        raise sqlite3.OperationalError(message)
     return text.replace(old, replacement, 1)
+
+
+def clear_patch_text_error() -> None:
+    _PATCH_TEXT_ERROR.set(None)
+
+
+def consume_patch_text_error() -> Optional[str]:
+    message = _PATCH_TEXT_ERROR.get()
+    _PATCH_TEXT_ERROR.set(None)
+    return message
 
 
 def _regexp_extract(string: Optional[str], pattern: str, group: int = 0) -> Optional[str]:
@@ -1109,6 +1139,7 @@ def clear_guarded_connection(conn: sqlite3.Connection) -> None:
     conn_id = id(conn)
     _QUERY_STARTS.pop(conn_id, None)
     _QUERY_TIMEOUTS.pop(conn_id, None)
+    clear_patch_text_error()
 
 
 def _make_progress_handler(conn_id: int):

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "9ecc81b24f865d8d5cebea9c1af7d7ec46de7096",
+  "baseline_sha": "d020ed61862dd880e048910e56c9fbbfd0000193",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 6805,
-        "system_bytes": 21774,
+        "fitted_tokens": 6852,
+        "system_bytes": 21833,
         "tools_bytes": 21239,
-        "total_bytes": 53425,
+        "total_bytes": 53484,
         "user_bytes": 10412
       },
       "planning_first_run": {
-        "fitted_tokens": 8121,
-        "system_bytes": 28741,
+        "fitted_tokens": 8183,
+        "system_bytes": 28800,
         "tools_bytes": 12233,
-        "total_bytes": 51139,
+        "total_bytes": 51198,
         "user_bytes": 10165
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 6960,
-        "system_bytes": 22274,
+        "fitted_tokens": 7007,
+        "system_bytes": 22333,
         "tools_bytes": 21239,
-        "total_bytes": 53928,
+        "total_bytes": 53987,
         "user_bytes": 10415
       }
     },
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 246927
+    "limit": 246950
   }
 }

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import sqlite3
 import shutil
@@ -5851,7 +5852,7 @@ class EventProcessingDeletedAgentAbortTests(TestCase):
     @patch("api.agent.core.event_processing._attempt_cycle_close_for_sleep")
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_enabled_tool")
-    @patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=MagicMock(errors=[]))
+    @patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=MagicMock(errors={}))
     @patch("api.agent.core.event_processing.seed_sqlite_agent_config", return_value=None)
     @patch("api.agent.core.event_processing._enforce_tool_rate_limit", return_value=True)
     @patch("api.agent.core.event_processing.extract_reasoning_content", return_value=None)
@@ -5916,7 +5917,7 @@ class EventProcessingDeletedAgentAbortTests(TestCase):
     @patch("api.agent.core.event_processing._attempt_cycle_close_for_sleep")
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_enabled_tool")
-    @patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=MagicMock(errors=[]))
+    @patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=MagicMock(errors={}))
     @patch("api.agent.core.event_processing.seed_sqlite_agent_config", return_value=None)
     @patch("api.agent.core.event_processing._enforce_tool_rate_limit", return_value=True)
     @patch("api.agent.core.event_processing.extract_reasoning_content", return_value=None)
@@ -6037,9 +6038,8 @@ class EventProcessingStopRequestTests(TestCase):
     @patch("api.agent.core.event_processing._attempt_cycle_close_for_sleep")
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_enabled_tool")
-    @patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=MagicMock(errors=[]))
+    @patch("api.agent.core.event_processing.apply_sqlite_skill_updates", return_value=SimpleNamespace(errors=[], changed=False))
     @patch("api.agent.core.event_processing.seed_sqlite_skills", return_value=None)
-    @patch("api.agent.core.event_processing.seed_sqlite_agent_config", return_value=None)
     @patch("api.agent.core.event_processing._enforce_tool_rate_limit", return_value=True)
     @patch("api.agent.core.event_processing.extract_reasoning_content", return_value=None)
     @patch("api.agent.core.event_processing.get_agent_tools", return_value=[{"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {}}}}])
@@ -6050,18 +6050,20 @@ class EventProcessingStopRequestTests(TestCase):
         _mock_prompt,
         _mock_failover,
         _mock_tools,
-        _mock_rate,
-        _mock_seed_config,
-        _mock_seed_skills,
-        _mock_apply_config,
         _mock_reasoning,
+        _mock_rate,
+        _mock_seed_skills,
+        _mock_apply_skills,
         mock_execute_tool,
         _mock_credit,
         mock_close_cycle,
     ):
         tool_call_one = {
             "id": "call-1",
-            "function": {"name": "sqlite_batch", "arguments": '{"sql":"SELECT 1","will_continue_work":true}'},
+            "function": {
+                "name": "sqlite_batch",
+                "arguments": '{"sql":"UPDATE __agent_config SET charter = \'Updated before stop\' WHERE id = 1","will_continue_work":true}',
+            },
         }
         tool_call_two = {
             "id": "call-2",
@@ -6083,22 +6085,37 @@ class EventProcessingStopRequestTests(TestCase):
             "cached_tokens": 0,
         }
 
-        def _first_call_requests_stop(*_args, **_kwargs):
+        def _first_call_requests_stop(*_args, **kwargs):
+            conn = sqlite3.connect(kwargs["current_sqlite_db_path"])
+            try:
+                conn.execute(
+                    "UPDATE __agent_config SET charter = 'Updated before stop' WHERE id = 1"
+                )
+                conn.commit()
+            finally:
+                conn.close()
             set_processing_stop_requested(self.agent.id)
             return {"status": "ok"}
 
         mock_execute_tool.side_effect = _first_call_requests_stop
 
-        with patch("api.agent.core.event_processing._completion_with_failover", return_value=(response, token_usage)):
-            from api.agent.core import event_processing as ep
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            token = set_sqlite_db_path(os.path.join(tmp_dir, "state.db"))
+            try:
+                with patch("api.agent.core.event_processing._completion_with_failover", return_value=(response, token_usage)):
+                    from api.agent.core import event_processing as ep
 
-            with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
-                usage = _run_agent_loop(self.agent, is_first_run=False)
+                    with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
+                        usage = _run_agent_loop(self.agent, is_first_run=False)
+            finally:
+                reset_sqlite_db_path(token)
 
         self.assertEqual(mock_execute_tool.call_count, 1)
         mock_close_cycle.assert_called_once()
         self.assertFalse(is_processing_stop_requested(self.agent.id))
         self.assertEqual(usage.get("total_tokens"), 10)
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.charter, "Updated before stop")
 
 
 @tag("batch_event_processing")

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -5864,10 +5864,10 @@ class EventProcessingDeletedAgentAbortTests(TestCase):
         _mock_prompt,
         _mock_failover,
         _mock_tools,
+        _mock_reasoning,
         _mock_rate,
         _mock_seed_config,
-        _mock_apply_config,
-        _mock_reasoning,
+        mock_apply_config,
         mock_execute_tool,
         _mock_credit,
         mock_close_cycle,
@@ -5902,15 +5902,28 @@ class EventProcessingDeletedAgentAbortTests(TestCase):
 
         mock_execute_tool.side_effect = _first_call_deletes_agent
 
-        with patch("api.agent.core.event_processing._completion_with_failover", return_value=(response, token_usage)):
-            from api.agent.core import event_processing as ep
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            token = set_sqlite_db_path(os.path.join(tmp_dir, "state.db"))
+            try:
+                with patch(
+                    "api.agent.core.event_processing.apply_sqlite_skill_updates",
+                    return_value=SimpleNamespace(errors=[], changed=False),
+                ) as mock_apply_skills, patch(
+                    "api.agent.core.event_processing._completion_with_failover",
+                    return_value=(response, token_usage),
+                ):
+                    from api.agent.core import event_processing as ep
 
-            with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
-                usage = _run_agent_loop(self.agent, is_first_run=False)
+                    with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
+                        usage = _run_agent_loop(self.agent, is_first_run=False)
+            finally:
+                reset_sqlite_db_path(token)
 
         self.agent.refresh_from_db()
         self.assertTrue(self.agent.is_deleted)
         self.assertEqual(mock_execute_tool.call_count, 1)
+        mock_apply_config.assert_not_called()
+        mock_apply_skills.assert_not_called()
         mock_close_cycle.assert_called_once()
         self.assertEqual(usage.get("total_tokens"), 10)
 
@@ -5929,10 +5942,10 @@ class EventProcessingDeletedAgentAbortTests(TestCase):
         _mock_prompt,
         _mock_failover,
         _mock_tools,
+        _mock_reasoning,
         _mock_rate,
         _mock_seed_config,
-        _mock_apply_config,
-        _mock_reasoning,
+        mock_apply_config,
         mock_execute_tool,
         _mock_credit,
         mock_close_cycle,
@@ -5967,15 +5980,28 @@ class EventProcessingDeletedAgentAbortTests(TestCase):
 
         mock_execute_tool.side_effect = _first_call_deactivates_agent
 
-        with patch("api.agent.core.event_processing._completion_with_failover", return_value=(response, token_usage)):
-            from api.agent.core import event_processing as ep
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            token = set_sqlite_db_path(os.path.join(tmp_dir, "state.db"))
+            try:
+                with patch(
+                    "api.agent.core.event_processing.apply_sqlite_skill_updates",
+                    return_value=SimpleNamespace(errors=[], changed=False),
+                ) as mock_apply_skills, patch(
+                    "api.agent.core.event_processing._completion_with_failover",
+                    return_value=(response, token_usage),
+                ):
+                    from api.agent.core import event_processing as ep
 
-            with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
-                usage = _run_agent_loop(self.agent, is_first_run=False)
+                    with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
+                        usage = _run_agent_loop(self.agent, is_first_run=False)
+            finally:
+                reset_sqlite_db_path(token)
 
         self.agent.refresh_from_db()
         self.assertFalse(self.agent.is_active)
         self.assertEqual(mock_execute_tool.call_count, 1)
+        mock_apply_config.assert_not_called()
+        mock_apply_skills.assert_not_called()
         mock_close_cycle.assert_called_once()
         self.assertEqual(usage.get("total_tokens"), 10)
 

--- a/tests/unit/test_event_processing_parallel_tools.py
+++ b/tests/unit/test_event_processing_parallel_tools.py
@@ -2,7 +2,9 @@
 Tests for guarded parallel execution of safe tool batches.
 """
 import json
+import os
 import threading
+import tempfile
 import time
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -105,6 +107,59 @@ class TestParallelToolCallsExecution(TestCase):
             mock_completion.return_value = _completion_response(tool_calls)
             with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
                 return ep._run_agent_loop(self.agent, is_first_run=False)
+
+    def _run_single_iteration_with_sqlite(self, tool_calls: list[dict]):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            token = set_sqlite_db_path(os.path.join(tmp_dir, "state.db"))
+            try:
+                return self._run_single_iteration(tool_calls)
+            finally:
+                reset_sqlite_db_path(token)
+
+    def test_noop_agent_config_update_is_persisted_in_tool_result(self):
+        self._run_single_iteration_with_sqlite([
+            _tool_call(
+                "sqlite_batch",
+                '{"sql": "UPDATE __agent_config SET charter = charter WHERE id = 1"}',
+            ),
+        ])
+
+        result = json.loads(PersistentAgentToolCall.objects.get(step__agent=self.agent).result)
+        self.assertEqual(
+            result["agent_config_update"],
+            {
+                "updated_fields": [],
+                "unchanged_fields": ["charter"],
+                "errors": {},
+            },
+        )
+
+    def test_config_reconciliation_is_aggregated_with_field_errors(self):
+        self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
+        self.agent.schedule = "0 9 * * *"
+        self.agent.save(update_fields=["planning_state", "schedule", "updated_at"])
+
+        self._run_single_iteration_with_sqlite([
+            _tool_call(
+                "sqlite_batch",
+                '{"sql": "UPDATE __agent_config SET charter = \'Updated charter\' WHERE id = 1"}',
+            ),
+            _tool_call(
+                "sqlite_batch",
+                '{"sql": "UPDATE __agent_config SET schedule = \'0 10 * * *\' WHERE id = 1"}',
+            ),
+        ])
+
+        tool_calls = list(
+            PersistentAgentToolCall.objects.filter(step__agent=self.agent).order_by("step__created_at")
+        )
+        first_result, second_result = (json.loads(call.result) for call in tool_calls)
+        self.assertNotIn("agent_config_update", first_result)
+        reconciliation = second_result["agent_config_update"]
+        self.assertEqual(reconciliation["updated_fields"], ["charter"])
+        self.assertEqual(reconciliation["unchanged_fields"], ["schedule"])
+        self.assertEqual(set(reconciliation["errors"]), {"schedule"})
+        self.assertIn("planning mode", reconciliation["errors"]["schedule"].lower())
 
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_send_sms", return_value={"status": "success", "auto_sleep_ok": True})
@@ -627,7 +682,7 @@ class TestParallelToolCallsExecution(TestCase):
         self.assertEqual(mock_execute_enabled.call_count, 2)
         self.assertTrue(all(not call.kwargs.get("isolated_mcp", False) for call in mock_execute_enabled.call_args_list))
 
-    @patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=SimpleNamespace(errors=[]))
+    @patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=SimpleNamespace(errors={}))
     @patch("api.agent.core.event_processing.apply_sqlite_skill_updates", return_value=SimpleNamespace(errors=[], changed=False))
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_enabled_tool")

--- a/tests/unit/test_event_processing_tool_errors.py
+++ b/tests/unit/test_event_processing_tool_errors.py
@@ -93,7 +93,7 @@ class ToolErrorHandlingTests(TestCase):
              patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None}), \
              patch("api.agent.core.event_processing._enforce_tool_rate_limit", return_value=True), \
              patch("api.agent.core.event_processing.seed_sqlite_agent_config", return_value=None), \
-             patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=SimpleNamespace(errors=[])), \
+             patch("api.agent.core.event_processing.apply_sqlite_agent_config_updates", return_value=SimpleNamespace(errors={})), \
              execute_patch:
             with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
                 ep._run_agent_loop(self.agent, is_first_run=False)

--- a/tests/unit/test_sqlite_agent_config.py
+++ b/tests/unit/test_sqlite_agent_config.py
@@ -1,16 +1,27 @@
+import json
 import os
 import sqlite3
 import tempfile
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 
 from api.agent.tools.sqlite_agent_config import (
+    AgentConfigApplyResult,
     apply_sqlite_agent_config_updates,
     seed_sqlite_agent_config,
 )
+from api.agent.core.event_processing import _persist_agent_config_update_results
+from api.agent.tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
 from api.agent.tools.sqlite_state import AGENT_CONFIG_TABLE, reset_sqlite_db_path, set_sqlite_db_path
-from api.models import BrowserUseAgent, PersistentAgent
+from api.models import (
+    BrowserUseAgent,
+    PersistentAgent,
+    PersistentAgentStep,
+    PersistentAgentToolCall,
+)
 
 
 @tag("batch_sqlite")
@@ -71,8 +82,11 @@ class SqliteAgentConfigTests(TestCase):
         self.assertEqual(self.agent.charter, "Updated charter")
         self.assertEqual(self.agent.schedule, "0 10 * * *")
         self.assertFalse(result.errors)
+        self.assertEqual(result.attempted_fields, ("charter", "schedule"))
         self.assertIn("charter", result.updated_fields)
         self.assertIn("schedule", result.updated_fields)
+        self.assertFalse(result.unchanged_fields)
+        self.assertNotEqual(result.charter_hash_before, result.charter_hash_after)
 
     def test_sqlite_agent_config_blocks_schedule_updates_during_planning(self):
         self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
@@ -108,3 +122,112 @@ class SqliteAgentConfigTests(TestCase):
         self.assertNotIn("schedule", result.updated_fields)
         self.assertEqual(len(result.errors), 1)
         self.assertIn("planning mode", result.errors[0].lower())
+
+    def test_sqlite_agent_config_reports_attempted_noop(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = os.path.join(tmp_dir, "state.db")
+            token = set_sqlite_db_path(db_path)
+            try:
+                snapshot = seed_sqlite_agent_config(self.agent)
+                conn = sqlite3.connect(db_path)
+                try:
+                    conn.execute(
+                        f'UPDATE "{AGENT_CONFIG_TABLE}" SET charter = charter WHERE id = 1;'
+                    )
+                    conn.commit()
+                finally:
+                    conn.close()
+
+                result = apply_sqlite_agent_config_updates(
+                    self.agent,
+                    snapshot,
+                    attempted_fields=("charter",),
+                )
+            finally:
+                reset_sqlite_db_path(token)
+
+        self.assertEqual(result.attempted_fields, ("charter",))
+        self.assertFalse(result.updated_fields)
+        self.assertEqual(result.unchanged_fields, ("charter",))
+        self.assertEqual(result.charter_hash_before, result.charter_hash_after)
+
+    def test_failed_patch_does_not_persist_or_schedule_charter_update(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = os.path.join(tmp_dir, "state.db")
+            token = set_sqlite_db_path(db_path)
+            try:
+                snapshot = seed_sqlite_agent_config(self.agent)
+                conn = open_guarded_sqlite_connection(db_path)
+                try:
+                    with self.assertRaises(sqlite3.OperationalError):
+                        conn.execute(
+                            f'''UPDATE "{AGENT_CONFIG_TABLE}"
+                                SET charter = patch_text(charter, 'Missing clause', 'New clause')
+                                WHERE id = 1;'''
+                        )
+                    conn.rollback()
+                finally:
+                    clear_guarded_connection(conn)
+                    conn.close()
+
+                with patch("api.agent.tools.sqlite_agent_config.execute_update_charter") as update_charter:
+                    result = apply_sqlite_agent_config_updates(
+                        self.agent,
+                        snapshot,
+                        attempted_fields=("charter",),
+                    )
+            finally:
+                reset_sqlite_db_path(token)
+
+        update_charter.assert_not_called()
+        self.agent.refresh_from_db()
+        self.assertEqual(self.agent.charter, "Original charter")
+        self.assertFalse(result.updated_fields)
+        self.assertEqual(result.unchanged_fields, ("charter",))
+        self.assertEqual(result.charter_hash_before, result.charter_hash_after)
+
+    def test_reconciled_config_result_is_persisted_for_next_prompt(self):
+        step = PersistentAgentStep.objects.create(agent=self.agent)
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="sqlite_batch",
+            tool_params={"sql": "UPDATE __agent_config SET charter = charter WHERE id = 1"},
+            result=json.dumps({"status": "ok", "results": [{"message": "Query 0 affected 1 rows."}]}),
+        )
+        outcome = SimpleNamespace(
+            prepared=SimpleNamespace(
+                tool_name="sqlite_batch",
+                exec_params={"sql": "UPDATE __agent_config SET charter = charter WHERE id = 1"},
+                pending_step=step,
+            ),
+            persisted_step=step,
+            result={"status": "ok", "results": [{"message": "Query 0 affected 1 rows."}]},
+        )
+        config_apply = AgentConfigApplyResult(
+            attempted_fields=("charter",),
+            updated_fields=(),
+            unchanged_fields=("charter",),
+            errors=(),
+            charter_hash_before="before-hash",
+            charter_hash_after="before-hash",
+        )
+
+        _persist_agent_config_update_results([outcome], config_apply)
+
+        persisted = json.loads(PersistentAgentToolCall.objects.get(step=step).result)
+        self.assertEqual(persisted["status"], "ok")
+        self.assertEqual(
+            persisted["results"],
+            [{"message": "Query 0 affected 1 rows."}],
+        )
+        self.assertEqual(
+            persisted["agent_config_update"],
+            {
+                "attempted_fields": ["charter"],
+                "updated_fields": [],
+                "unchanged_fields": ["charter"],
+                "charter_hash_before": "before-hash",
+                "charter_hash_after": "before-hash",
+                "errors": [],
+            },
+        )

--- a/tests/unit/test_sqlite_agent_config.py
+++ b/tests/unit/test_sqlite_agent_config.py
@@ -1,27 +1,18 @@
-import json
 import os
 import sqlite3
 import tempfile
-from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 
 from api.agent.tools.sqlite_agent_config import (
-    AgentConfigApplyResult,
     apply_sqlite_agent_config_updates,
     seed_sqlite_agent_config,
 )
-from api.agent.core.event_processing import _persist_agent_config_update_results
 from api.agent.tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
 from api.agent.tools.sqlite_state import AGENT_CONFIG_TABLE, reset_sqlite_db_path, set_sqlite_db_path
-from api.models import (
-    BrowserUseAgent,
-    PersistentAgent,
-    PersistentAgentStep,
-    PersistentAgentToolCall,
-)
+from api.models import BrowserUseAgent, PersistentAgent
 
 
 @tag("batch_sqlite")
@@ -82,11 +73,8 @@ class SqliteAgentConfigTests(TestCase):
         self.assertEqual(self.agent.charter, "Updated charter")
         self.assertEqual(self.agent.schedule, "0 10 * * *")
         self.assertFalse(result.errors)
-        self.assertEqual(result.attempted_fields, ("charter", "schedule"))
         self.assertIn("charter", result.updated_fields)
         self.assertIn("schedule", result.updated_fields)
-        self.assertFalse(result.unchanged_fields)
-        self.assertNotEqual(result.charter_hash_before, result.charter_hash_after)
 
     def test_sqlite_agent_config_blocks_schedule_updates_during_planning(self):
         self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
@@ -121,7 +109,7 @@ class SqliteAgentConfigTests(TestCase):
         self.assertIn("charter", result.updated_fields)
         self.assertNotIn("schedule", result.updated_fields)
         self.assertEqual(len(result.errors), 1)
-        self.assertIn("planning mode", result.errors[0].lower())
+        self.assertIn("planning mode", result.errors["schedule"].lower())
 
     def test_sqlite_agent_config_reports_attempted_noop(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -141,15 +129,12 @@ class SqliteAgentConfigTests(TestCase):
                 result = apply_sqlite_agent_config_updates(
                     self.agent,
                     snapshot,
-                    attempted_fields=("charter",),
                 )
             finally:
                 reset_sqlite_db_path(token)
 
-        self.assertEqual(result.attempted_fields, ("charter",))
         self.assertFalse(result.updated_fields)
-        self.assertEqual(result.unchanged_fields, ("charter",))
-        self.assertEqual(result.charter_hash_before, result.charter_hash_after)
+        self.assertFalse(result.errors)
 
     def test_failed_patch_does_not_persist_or_schedule_charter_update(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -174,7 +159,6 @@ class SqliteAgentConfigTests(TestCase):
                     result = apply_sqlite_agent_config_updates(
                         self.agent,
                         snapshot,
-                        attempted_fields=("charter",),
                     )
             finally:
                 reset_sqlite_db_path(token)
@@ -183,51 +167,4 @@ class SqliteAgentConfigTests(TestCase):
         self.agent.refresh_from_db()
         self.assertEqual(self.agent.charter, "Original charter")
         self.assertFalse(result.updated_fields)
-        self.assertEqual(result.unchanged_fields, ("charter",))
-        self.assertEqual(result.charter_hash_before, result.charter_hash_after)
-
-    def test_reconciled_config_result_is_persisted_for_next_prompt(self):
-        step = PersistentAgentStep.objects.create(agent=self.agent)
-        PersistentAgentToolCall.objects.create(
-            step=step,
-            tool_name="sqlite_batch",
-            tool_params={"sql": "UPDATE __agent_config SET charter = charter WHERE id = 1"},
-            result=json.dumps({"status": "ok", "results": [{"message": "Query 0 affected 1 rows."}]}),
-        )
-        outcome = SimpleNamespace(
-            prepared=SimpleNamespace(
-                tool_name="sqlite_batch",
-                exec_params={"sql": "UPDATE __agent_config SET charter = charter WHERE id = 1"},
-                pending_step=step,
-            ),
-            persisted_step=step,
-            result={"status": "ok", "results": [{"message": "Query 0 affected 1 rows."}]},
-        )
-        config_apply = AgentConfigApplyResult(
-            attempted_fields=("charter",),
-            updated_fields=(),
-            unchanged_fields=("charter",),
-            errors=(),
-            charter_hash_before="before-hash",
-            charter_hash_after="before-hash",
-        )
-
-        _persist_agent_config_update_results([outcome], config_apply)
-
-        persisted = json.loads(PersistentAgentToolCall.objects.get(step=step).result)
-        self.assertEqual(persisted["status"], "ok")
-        self.assertEqual(
-            persisted["results"],
-            [{"message": "Query 0 affected 1 rows."}],
-        )
-        self.assertEqual(
-            persisted["agent_config_update"],
-            {
-                "attempted_fields": ["charter"],
-                "updated_fields": [],
-                "unchanged_fields": ["charter"],
-                "charter_hash_before": "before-hash",
-                "charter_hash_after": "before-hash",
-                "errors": [],
-            },
-        )
+        self.assertFalse(result.errors)

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -119,6 +119,22 @@ class SqliteBatchToolTests(TestCase):
             finally:
                 conn.close()
 
+    def test_patch_text_reports_missing_and_ambiguous_targets(self):
+        with self._with_temp_db() as (db_path, token, tmp):
+            missing = execute_sqlite_batch(
+                self.agent,
+                {"sql": "SELECT patch_text('Keep A.', 'Missing B.', 'Use C.')"},
+            )
+            ambiguous = execute_sqlite_batch(
+                self.agent,
+                {"sql": "SELECT patch_text('Keep A. Keep A.', 'Keep A.', 'Use B.')"},
+            )
+
+        self.assertEqual(missing.get("status"), "error")
+        self.assertIn("replacement target was not found", missing.get("message", ""))
+        self.assertEqual(ambiguous.get("status"), "error")
+        self.assertIn("matched 2 times", ambiguous.get("message", ""))
+
     def test_single_query_field_is_normalized(self):
         with self._with_temp_db():
             out = execute_sqlite_batch(self.agent, {"sql": "SELECT 42 AS answer"})

--- a/tests/unit/test_sqlite_guardrails.py
+++ b/tests/unit/test_sqlite_guardrails.py
@@ -70,16 +70,25 @@ class SqliteGuardrailsMaintenanceTests(SimpleTestCase):
         self.assertEqual(appended, "Research leads. Send daily.\nKeep outreach natural.")
         self.assertEqual(duplicate, appended)
 
-    def test_patch_text_appends_when_replacement_target_is_missing(self):
+    def test_patch_text_rejects_missing_replacement_target(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             conn = open_guarded_sqlite_connection(os.path.join(tmp_dir, "state.db"))
             try:
-                patched = conn.execute("SELECT patch_text('Keep A.', 'Missing B.', 'Use C.')").fetchone()[0]
+                with self.assertRaises(sqlite3.OperationalError):
+                    conn.execute("SELECT patch_text('Keep A.', 'Missing B.', 'Use C.')")
             finally:
                 clear_guarded_connection(conn)
                 conn.close()
 
-        self.assertEqual(patched, "Keep A.\nUse C.")
+    def test_patch_text_rejects_ambiguous_replacement_target(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conn = open_guarded_sqlite_connection(os.path.join(tmp_dir, "state.db"))
+            try:
+                with self.assertRaises(sqlite3.OperationalError):
+                    conn.execute("SELECT patch_text('Keep A. Keep A.', 'Keep A.', 'Use B.')")
+            finally:
+                clear_guarded_connection(conn)
+                conn.close()
 
     def test_statistical_aggregates_match_sample_and_population_semantics(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- Reconcile charter and schedule changes after SQLite tool batches and report update results.
- Preserve runtime config reconciliation when stop requests interrupt the agent loop.
- Require `patch_text` replacement targets to match exactly once, with actionable errors.
- Improve guarded SQLite connection cleanup and error handling.

## Testing
- Not run (not requested)