### PR TITLE
Treat failed tool results as errors

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -603,7 +603,7 @@ def _is_error_status(result: Any) -> bool:
     if not isinstance(result, dict):
         return False
     status = result.get("status")
-    return isinstance(status, str) and status.lower() == "error"
+    return isinstance(status, str) and status.lower() in {"error", "failed", "failure"}
 
 
 def _is_warning_status(result: Any) -> bool:

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -23,6 +23,7 @@ from api.agent.core.event_processing import (
     _ensure_credit_for_tool,
     _process_agent_events_locked,
     _infer_retryable_from_text,
+    _is_error_status,
     _is_warning_status,
     _normalize_error_result,
     _normalize_tool_params,
@@ -209,6 +210,13 @@ class DeepWorkUpdateGateTests(SimpleTestCase):
 
 @tag('batch_event_processing')
 class ToolErrorNormalizationTests(SimpleTestCase):
+    def test_common_failure_statuses_are_errors(self):
+        for status in ("error", "failed", "failure", "FAILED"):
+            with self.subTest(status=status):
+                self.assertTrue(_is_error_status({"status": status}))
+
+        self.assertFalse(_is_error_status({"status": "ok"}))
+
     def test_native_http_error_preserves_response_context(self):
         result = _normalize_error_result(
             {

--- a/api/evals/scenarios/message_quality.py
+++ b/api/evals/scenarios/message_quality.py
@@ -28,6 +28,7 @@ from util.text_sanitizer import has_humanized_message_style_violation
 
 MESSAGE_QUALITY_SUITE_SLUG = "message_quality_reports"
 REPLY_CHANNEL_CONTINUITY_SLUG = "message_quality_reply_stays_in_web_chat"
+FAILED_EMAIL_DELIVERY_RECOVERY_SLUG = "message_quality_failed_email_reports_failure"
 
 
 @dataclass(frozen=True)
@@ -248,6 +249,7 @@ MESSAGE_QUALITY_CASES = (
 MESSAGE_QUALITY_SCENARIO_SLUGS = (
     *(case.slug for case in MESSAGE_QUALITY_CASES),
     REPLY_CHANNEL_CONTINUITY_SLUG,
+    FAILED_EMAIL_DELIVERY_RECOVERY_SLUG,
 )
 
 
@@ -814,6 +816,139 @@ class MessageQualityScenario(EvalScenario, ScenarioExecutionTools):
             if re.search(r"^\s*\|.+\|\s*$", body, re.MULTILINE):
                 failures.append("Email body should use HTML tables, not Markdown pipe tables.")
         return failures
+
+
+@register_scenario
+class FailedEmailDeliveryRecoveryScenario(EvalScenario, ScenarioExecutionTools):
+    slug = FAILED_EMAIL_DELIVERY_RECOVERY_SLUG
+    version = "1.0"
+    description = "A failed email result should remain unfinished and be reported accurately in the active chat."
+    tier = "core"
+    category = "message_quality"
+    expected_runtime = "short"
+    cost_class = "low"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = ("message_quality", "tool_failure", "send_email", "send_chat_message")
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_failed_delivery_recorded", assertion_type="manual"),
+        ScenarioTask(name="verify_owner_notified", assertion_type="manual"),
+    ]
+
+    @staticmethod
+    def _notice_reports_failure(body: str) -> bool:
+        normalized = " ".join(str(body or "").replace("’", "'").lower().split())
+        return "email" in normalized and any(
+            phrase in normalized
+            for phrase in (
+                "could not send",
+                "couldn't send",
+                "did not send",
+                "didn't send",
+                "failed to send",
+                "not delivered",
+                "not sent",
+                "provider rejected",
+                "was rejected",
+            )
+        )
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        agent = PersistentAgent.objects.get(id=agent_id)
+        mark_tool_enabled_without_discovery(agent, "send_email")
+        mark_tool_enabled_without_discovery(agent, "send_chat_message")
+        CommsAllowlistEntry.objects.update_or_create(
+            agent=agent,
+            channel=CommsChannel.EMAIL,
+            address="ops@example.test",
+            defaults={
+                "is_active": True,
+                "allow_inbound": True,
+                "allow_outbound": True,
+                "verified": True,
+            },
+        )
+
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="inject_prompt")
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            inbound = self.inject_message(
+                agent_id,
+                "Email ops@example.test that today's maintenance window moved to 4:30 PM ET.",
+                trigger_processing=True,
+                eval_run_id=run_id,
+                mock_config={
+                    "send_email": {
+                        "status": "failed",
+                        "message": "The email provider rejected the message; nothing was delivered.",
+                        "auto_sleep_ok": True,
+                    },
+                },
+                eval_stop_policy={
+                    "stop_on_tool_names_after_execution": ["send_chat_message"],
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": ["send_email", "send_chat_message", "sqlite_batch", "update_plan"],
+                    "ignored_tool_names": ["sqlite_batch", "update_plan"],
+                    "max_relevant_tool_calls": 4,
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_prompt",
+            observed_summary="Email request injected and real agent processing completed.",
+            artifacts={"message": inbound},
+        )
+
+        calls = MessageQualityScenario._tool_calls_for_run(run_id, after=inbound.timestamp)
+        email_calls = [call for call in calls if call.tool_name == "send_email"]
+        failed_results = [
+            call
+            for call in email_calls
+            if str(MessageQualityScenario._tool_result(call).get("status") or "").lower()
+            in {"error", "failed", "failure"}
+        ]
+        failures_recorded = bool(email_calls) and len(failed_results) == len(email_calls) and all(
+            call.status == "error" for call in email_calls
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if failures_recorded else EvalRunTask.Status.FAILED,
+            task_name="verify_failed_delivery_recorded",
+            expected_summary="Failed delivery results should be persisted as errors, never completed sends.",
+            observed_summary=(
+                f"Saw {len(failed_results)}/{len(email_calls)} failed email result(s); "
+                f"persisted statuses were {[call.status for call in email_calls]}."
+            ),
+            artifacts={"step": email_calls[0].step} if email_calls else {},
+        )
+
+        chat_calls = [call for call in calls if call.tool_name == "send_chat_message"]
+        delivered_chats = [
+            call
+            for call in chat_calls
+            if MessageQualityScenario._tool_result(call).get("skipped") is not True
+            and str(MessageQualityScenario._tool_result(call).get("status") or "").lower()
+            in {"ok", "sent", "success"}
+        ]
+        clear_notice = len(delivered_chats) == 1 and self._notice_reports_failure(
+            str(MessageQualityScenario._tool_params(delivered_chats[0]).get("body") or "")
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if clear_notice else EvalRunTask.Status.FAILED,
+            task_name="verify_owner_notified",
+            expected_summary="Agent should tell the active-chat requester that the email was not delivered.",
+            observed_summary=(
+                "Agent accurately reported the failed email in web chat."
+                if clear_notice
+                else f"Saw {len(delivered_chats)} delivered chat notice(s), without one clear failure report."
+            ),
+            artifacts={"step": delivered_chats[0].step} if delivered_chats else {},
+        )
 
 
 @register_scenario

--- a/api/evals/tests/test_message_quality.py
+++ b/api/evals/tests/test_message_quality.py
@@ -3,6 +3,8 @@ from django.test import SimpleTestCase, tag
 import api.evals.loader  # noqa: F401 - registers scenarios and suites
 from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.message_quality import (
+    FAILED_EMAIL_DELIVERY_RECOVERY_SLUG,
+    FailedEmailDeliveryRecoveryScenario,
     MESSAGE_QUALITY_CASES,
     MESSAGE_QUALITY_SCENARIO_SLUGS,
     MESSAGE_QUALITY_SUITE_SLUG,
@@ -23,8 +25,9 @@ class MessageQualityScenarioTests(SimpleTestCase):
 
         self.assertIsNotNone(suite)
         self.assertEqual(tuple(suite.scenario_slugs), MESSAGE_QUALITY_SCENARIO_SLUGS)
-        self.assertEqual(len(suite.scenario_slugs), 16)
+        self.assertEqual(len(suite.scenario_slugs), 17)
         self.assertIn(REPLY_CHANNEL_CONTINUITY_SLUG, suite.scenario_slugs)
+        self.assertIn(FAILED_EMAIL_DELIVERY_RECOVERY_SLUG, suite.scenario_slugs)
 
     def test_generated_cases_cover_email_and_chat_for_each_real_world_domain(self):
         channels_by_brief = {}
@@ -58,6 +61,23 @@ class MessageQualityScenarioTests(SimpleTestCase):
         self.assertEqual(reply_channel_metadata.category, "message_quality")
         self.assertEqual(reply_channel_metadata.cost_class, "low")
         self.assertIn("reply_channel", reply_channel_metadata.tags)
+
+        failure_metadata = registered[FAILED_EMAIL_DELIVERY_RECOVERY_SLUG].get_metadata()
+        self.assertEqual(failure_metadata.category, "message_quality")
+        self.assertEqual(failure_metadata.cost_class, "low")
+        self.assertIn("tool_failure", failure_metadata.tags)
+
+    def test_failed_delivery_notice_requires_clear_non_delivery_language(self):
+        self.assertTrue(
+            FailedEmailDeliveryRecoveryScenario._notice_reports_failure(
+                "The provider rejected the email, so it was not delivered."
+            )
+        )
+        self.assertFalse(
+            FailedEmailDeliveryRecoveryScenario._notice_reports_failure(
+                "The email was sent successfully."
+            )
+        )
 
     def test_simple_email_prompt_does_not_specify_formatting_style(self):
         case = SIMPLE_EMAIL_QUALITY_CASES[0]


### PR DESCRIPTION
## Summary

- normalize generic tool results with `status: failed` or `status: failure` as errors, matching the existing tool-success helper
- keep the event loop alive after those failures so the agent can accurately notify the active-chat requester
- add a real-harness DeepSeek V4 Flash regression where a mocked email provider rejects delivery with `status: failed`
- no prompt, schema, or UI changes

## Why

Before this change, `_is_error_status` only recognized the literal `error`. A tool result such as `{"status":"failed","auto_sleep_ok":true}` was persisted as complete and could auto-sleep the agent before the user was told that nothing was delivered.

## Verification

- rebased onto latest `main` at `7382b8fe3`
- GitHub CI: every required check passed
- focused unit modules: 83/83 passed
- complexity budgets: passed; prompt sizes unchanged
- exact-SHA preview `650713b4634070534d185ac4557f1783931efa1d`: deployed successfully; homepage, app shell, health endpoint, and immutable frontend manifest passed smoke checks
- before-fix regression: `c2548834-0f54-4390-9951-1d92ab9d0728`, 1/3 tasks; failed result persisted as `complete`, no owner notice
- after-fix regression: `f0f92b55-570d-468b-b492-f291762d5d18`, 3/3 tasks
- affected message-quality slice on the exact rebased full run: 66/66 tasks
- latest-`main` complete DeepSeek V4 Flash baseline: `dfc03170-aafe-4d58-8b5d-576128659380`, 1,419/1,434 tasks (99.0%)
- exact rebased branch complete DeepSeek V4 Flash run: `de7e10f1-f102-4e9e-8b36-d8c8f6ed3b91`, 1,409/1,437 tasks (98.1%); the new scenario passed 3/3

The complete-suite misses are stochastic, unrelated existing behavior cases. A causal audit found no `status: failed` or `status: failure` tool result in any of the branch run's 26 failed scenarios, so the production-code change could not have changed those trajectories. Earlier full branch samples were 99.1% and 98.8%, confirming the current result is within observed model variance rather than a regression.
