### PR TITLE
Preserve spacing before inline email HTML

### DIFF
--- a/tests/unit/test_text_sanitization.py
+++ b/tests/unit/test_text_sanitization.py
@@ -57,6 +57,33 @@ class TextSanitizationTests(TestCase):
             '<p>Daily update, everything landed.</p>',
         )
 
+    def test_humanized_message_style_preserves_boundary_before_inline_html(self):
+        text = (
+            "<p>Here's your sourced prospect list — "
+            "<strong style='color: #1a73e8;'>22 qualified individuals</strong>"
+            " in sales leadership.</p>"
+        )
+
+        self.assertEqual(
+            normalize_humanized_message_style(text),
+            "<p>Here's your sourced prospect list, "
+            "<strong style='color: #1a73e8;'>22 qualified individuals</strong>"
+            " in sales leadership.</p>",
+        )
+
+        edge_cases = (
+            ("<p><strong>Update —</strong></p>", "<p><strong>Update</strong></p>"),
+            ("<p><strong>— update</strong></p>", "<p><strong>update</strong></p>"),
+            ("<p>Done — <span></span></p>", "<p>Done<span></span></p>"),
+            (
+                "<p>Nested — <span><strong>22 qualified</strong></span></p>",
+                "<p>Nested, <span><strong>22 qualified</strong></span></p>",
+            ),
+        )
+        for rich_html, expected in edge_cases:
+            with self.subTest(rich_html=rich_html):
+                self.assertEqual(normalize_humanized_message_style(rich_html), expected)
+
     def test_strip_control_chars_removes_disallowed_characters(self):
         dirty = "Hello\x00World\u0019"
 

--- a/util/text_sanitizer.py
+++ b/util/text_sanitizer.py
@@ -40,27 +40,27 @@ _FORBIDDEN_DASH_RE = re.compile(
     r"(?:[ \t]*(?:[\u2012\u2013\u2014\u2015\u2e3a\u2e3b]+|--+|&(?:mdash|ndash|#8211|#8212|#x2013|#x2014);)[ \t]*|[ \t]+-[ \t]+)",
     re.IGNORECASE,
 )
+_OPENING_INLINE_HTML_TEXT_RE = re.compile(r"(?:<(?:a|b|em|i|span|strong)\b[^>]*>\s*)+[^<\s]", re.IGNORECASE)
 
 
 def normalize_humanized_message_style(value: str | None) -> str:
     text = value or ""
 
-    def normalize_prose(prose: str) -> str:
+    def normalize_prose(prose: str, offset: int) -> str:
         def punctuate(match):
             before = prose[:match.start()].rstrip(" \t")
             after = prose[match.end():].lstrip(" \t")
-            if not before or not after or before.endswith("\n") or after.startswith("\n"):
-                return ""
-            return ", "
+            visible_after = bool(after) or bool(_OPENING_INLINE_HTML_TEXT_RE.match(text[offset + match.end():]))
+            return ", " if before and visible_after and not (before.endswith("\n") or after.startswith("\n")) else ""
 
         return _FORBIDDEN_DASH_RE.sub(punctuate, prose)
 
     parts = []
     cursor = 0
     for match in _NON_PROSE_RE.finditer(text):
-        parts.extend((normalize_prose(text[cursor:match.start()]), match.group(0)))
+        parts.extend((normalize_prose(text[cursor:match.start()], cursor), match.group(0)))
         cursor = match.end()
-    parts.append(normalize_prose(text[cursor:]))
+    parts.append(normalize_prose(text[cursor:], cursor))
     return "".join(parts)
 
 


### PR DESCRIPTION
## Why

A staging prospect email rendered `prospect list22 qualified individuals`. The persisted `send_email.mobile_first_html`, stored message body, browser display cache, and provider payload all contained the same adjacent `list<strong>22` boundary, so downstream rendering was preserving malformed input rather than removing whitespace.

The earliest durable tool params are post-normalization. Raw provider arguments are not retained, so we cannot prove whether the model omitted the separator or emitted the common `list — <strong>22` form. We can prove that `normalize_humanized_message_style` turned the latter into the exact stored malformed shape because HTML tags were excluded from prose context.

## Change

- Let dash normalization see populated opening inline HTML as following visible text, including nested inline tags.
- Keep empty tags and dashes at the start/end of formatted text from inventing leading or trailing commas.
- Add the staging-shaped regression plus nested, empty, leading, and trailing edge cases.

This is deliberately bounded to the proven opening-tag failure. It is not a universal HTML whitespace rewriter. Production source LoC stays unchanged, and prompt sizes stay unchanged.

## Verification

- `TextSanitizationTests`: 10/10 passed. The new case was confirmed red before the fix.
- Built-in delivery-channel normalization wrapper: 1/1 passed.
- Exact HTML-to-email plaintext check: `prospect list — <strong>22...` becomes visible `prospect list, 22...`; `list22` is absent.
- Complexity guardrails: source LoC 246927/246927; all prompt byte budgets unchanged and green.
- Test tag guard: 5415 tests tagged; all tags registered in CI.
- DeepSeek V4 Flash, `message_quality_reports`, suite `57436ee5-0a3a-48e8-980e-648d6cb3e458`: 72/73 tasks. One stochastic Quonset email added forbidden html/head/body wrapper tags; all other tasks passed.
- Unchanged Quonset rerun, suite `37cbdb47-8d66-4cf0-9136-920c777c3913`: 4/4 passed.
- Eight exact-head eval email tool params inspected: zero observed collapsed word-to-highlighted-count boundaries.
