### PR TITLE
Require prior outbound context for direct correction patches

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -215,7 +215,7 @@ TRANSIENT_CONFIG_SCOPE_RE = re.compile(
     re.IGNORECASE,
 )
 DIRECT_USER_CORRECTION_RE = re.compile(
-    r"\b(?:stop|quit)\b[^.!?]{0,100}\b(?:writ\w*|say\w*|send\w*|sound\w*|use(?:d|s|ing)?|"
+    r"\b(?:stop|quit)\s+(?:writ\w*|say\w*|send\w*|sound\w*|use(?:d|s|ing)?|"
     r"includ\w*|format\w*|reply\w*|respond\w*|messag\w*|introduc\w*)\b|"
     r"\b(?:sound(?:s|ed)?|reads?|feels?|looks?)\b.{0,60}\b(?:automated|templated|robotic|generic|formal|"
     r"informal|spammy|salesy|corporate|product[ -]?y)\b|"
@@ -2394,6 +2394,26 @@ def _user_text_is_direct_correction(text: str) -> bool:
         and not TRANSIENT_CONFIG_SCOPE_RE.search(normalized)
         and DIRECT_USER_CORRECTION_RE.search(normalized)
     )
+
+
+def _should_require_direct_correction_patch(agent: PersistentAgent) -> bool:
+    if agent.planning_state == PersistentAgent.PlanningState.PLANNING:
+        return False
+
+    latest_inbound = (
+        PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=False)
+        .order_by("-timestamp", "-seq")
+        .values("timestamp", "body")
+        .first()
+    )
+    if latest_inbound is None or not _user_text_is_direct_correction(latest_inbound["body"]):
+        return False
+
+    return PersistentAgentMessage.objects.filter(
+        owner_agent=agent,
+        is_outbound=True,
+        timestamp__lt=latest_inbound["timestamp"],
+    ).exists()
 
 
 def _tool_calls_patch_correction_before_reply(tool_calls: list[Any]) -> bool:
@@ -6523,7 +6543,7 @@ def _run_agent_loop(
                 direct_correction_patch_this_response = False
                 direct_correction_pending = (
                     not direct_correction_patch_seen
-                    and _user_text_is_direct_correction(_latest_inbound_message_text(agent))
+                    and _should_require_direct_correction_patch(agent)
                 )
                 if direct_correction_pending:
                     direct_correction_patch_this_response = _tool_calls_patch_correction_before_reply(raw_tool_calls)

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -31,7 +31,7 @@ from redis.exceptions import RedisError
 from django.apps import apps
 from django.conf import settings as django_settings
 from django.db import DatabaseError, transaction, close_old_connections
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.db.utils import OperationalError
 from django.utils import timezone as dj_timezone
 
@@ -215,7 +215,8 @@ TRANSIENT_CONFIG_SCOPE_RE = re.compile(
     re.IGNORECASE,
 )
 DIRECT_USER_CORRECTION_RE = re.compile(
-    r"\b(?:stop|quit)\s+(?:writ\w*|say\w*|send\w*|sound\w*|use(?:d|s|ing)?|"
+    r"\b(?:stop|quit)[\s,:;-]+(?:(?:always|automatically|constantly|continually|continuously|frequently|"
+    r"just|regularly|repeatedly|routinely)[\s,:;-]+){0,2}(?:writ\w*|say\w*|send\w*|sound\w*|use(?:d|s|ing)?|"
     r"includ\w*|format\w*|reply\w*|respond\w*|messag\w*|introduc\w*)\b|"
     r"\b(?:sound(?:s|ed)?|reads?|feels?|looks?)\b.{0,60}\b(?:automated|templated|robotic|generic|formal|"
     r"informal|spammy|salesy|corporate|product[ -]?y)\b|"
@@ -2403,7 +2404,7 @@ def _should_require_direct_correction_patch(agent: PersistentAgent) -> bool:
     latest_inbound = (
         PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=False)
         .order_by("-timestamp", "-seq")
-        .values("timestamp", "body")
+        .values("timestamp", "seq", "body")
         .first()
     )
     if latest_inbound is None or not _user_text_is_direct_correction(latest_inbound["body"]):
@@ -2412,7 +2413,9 @@ def _should_require_direct_correction_patch(agent: PersistentAgent) -> bool:
     return PersistentAgentMessage.objects.filter(
         owner_agent=agent,
         is_outbound=True,
-        timestamp__lt=latest_inbound["timestamp"],
+    ).filter(
+        Q(timestamp__lt=latest_inbound["timestamp"])
+        | Q(timestamp=latest_inbound["timestamp"], seq__lt=latest_inbound["seq"])
     ).exists()
 
 

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -131,6 +131,12 @@ class ImpliedSendTests(TestCase):
         self.assertFalse(ep._user_text_is_direct_correction("Don't browse. Just answer the question."))
         self.assertFalse(
             ep._user_text_is_direct_correction(
+                "Continue daily sourcing until the recruiter instructs you to pause, stop, "
+                "change search criteria, change format, or close the role."
+            )
+        )
+        self.assertFalse(
+            ep._user_text_is_direct_correction(
                 "Constraint: do not imply a prior relationship or make unsupported claims. Send the email now."
             )
         )
@@ -181,6 +187,54 @@ class ImpliedSendTests(TestCase):
             conversation=conversation,
             body=body,
         )
+
+    def _add_outbound_web_message(self, conversation, body="Previous agent reply"):
+        agent_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.WEB,
+            address=build_web_agent_address(self.agent.id),
+            is_primary=True,
+        )
+        return PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=True,
+            from_endpoint=agent_endpoint,
+            conversation=conversation,
+            body=body,
+        )
+
+    def test_direct_correction_patch_requires_prior_outbound_message(self):
+        self._add_inbound_web_message("You sound robotic.")
+
+        self.assertFalse(ep._should_require_direct_correction_patch(self.agent))
+
+    def test_direct_correction_patch_is_disabled_in_planning_mode(self):
+        initial = self._add_inbound_web_message("Initial request")
+        self._add_outbound_web_message(initial.conversation)
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=initial.from_endpoint,
+            conversation=initial.conversation,
+            body="You sound robotic.",
+        )
+        self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
+        self.agent.save(update_fields=["planning_state", "updated_at"])
+
+        self.assertFalse(ep._should_require_direct_correction_patch(self.agent))
+
+    def test_direct_correction_patch_is_required_for_followup_feedback(self):
+        initial = self._add_inbound_web_message("Initial request")
+        self._add_outbound_web_message(initial.conversation)
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=initial.from_endpoint,
+            conversation=initial.conversation,
+            body="You sound robotic.",
+        )
+
+        self.assertTrue(ep._should_require_direct_correction_patch(self.agent))
 
     def test_eval_mock_result_supports_url_rules(self):
         mock_config = {

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -127,6 +127,9 @@ class ImpliedSendTests(TestCase):
         self.assertTrue(ep._user_text_is_direct_correction("Lowercase is too informal."))
         self.assertTrue(ep._user_text_is_direct_correction("No more em dashes."))
         self.assertTrue(ep._user_text_is_direct_correction("Don't use em dashes."))
+        self.assertTrue(ep._user_text_is_direct_correction("Please stop - writing like a template."))
+        self.assertTrue(ep._user_text_is_direct_correction("Please stop always writing like a template."))
+        self.assertTrue(ep._user_text_is_direct_correction("Stop repeatedly sending generic replies."))
         self.assertFalse(ep._user_text_is_direct_correction("For this response, don't use headings."))
         self.assertFalse(ep._user_text_is_direct_correction("Don't browse. Just answer the question."))
         self.assertFalse(
@@ -232,6 +235,28 @@ class ImpliedSendTests(TestCase):
             from_endpoint=initial.from_endpoint,
             conversation=initial.conversation,
             body="You sound robotic.",
+        )
+
+        self.assertTrue(ep._should_require_direct_correction_patch(self.agent))
+
+    def test_direct_correction_patch_uses_seq_to_break_timestamp_ties(self):
+        initial = self._add_inbound_web_message("Initial request")
+        outbound = self._add_outbound_web_message(initial.conversation)
+        correction = PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=initial.from_endpoint,
+            conversation=initial.conversation,
+            body="You sound robotic.",
+        )
+        shared_timestamp = timezone.now()
+        PersistentAgentMessage.objects.filter(id=outbound.id).update(
+            timestamp=shared_timestamp,
+            seq="01AAAAAAAAAAAAAAAAAAAAAAAA",
+        )
+        PersistentAgentMessage.objects.filter(id=correction.id).update(
+            timestamp=shared_timestamp,
+            seq="01BBBBBBBBBBBBBBBBBBBBBBBB",
         )
 
         self.assertTrue(ep._should_require_direct_correction_patch(self.agent))


### PR DESCRIPTION
## Summary
- Prevents correction-patch behavior for initial user requests and while the agent is planning.
- Tightens direct-correction matching to avoid false positives in broader instructions.
- Adds coverage for follow-up feedback, planning mode, and initial requests.

## Testing
- Added and ran focused unit tests for event processing corrections.