### PR TITLE
Add GitHub secret retention evaluation

### DIFF
--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -19,6 +19,7 @@ from api.agent.core.promptree import Prompt
 from api.agent.core.token_usage import log_agent_completion
 from api.agent.tools.plan import build_plan_snapshot
 from api.services.prompt_settings import get_prompt_settings
+from api.services.persistent_agent_secrets import build_secret_capability_inventory
 from api.models import (
     LLMRoutingProfile,
     PersistentAgent,
@@ -902,6 +903,7 @@ def _build_current_context_snapshot(
     return {
         "skills": _skill_context(agent, prompt_limits),
         "custom_tool_sources": _custom_tool_sources_context(agent, recent_tool_calls or []),
+        "secret_capabilities": build_secret_capability_inventory(agent),
         "sqlite": _sqlite_context_snapshot(),
     }
 
@@ -1276,6 +1278,11 @@ def _build_judge_user_prompt(
         "capability_manifest",
         _json_section(trajectory.get("capability_manifest") or []),
         weight=2,
+    )
+    medium_priority.section_text(
+        "secret_capabilities",
+        _json_section(current_context.get("secret_capabilities") or []),
+        weight=5,
     )
 
     low_priority = prompt.group("low_priority", weight=2)

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -224,6 +224,13 @@ DIRECT_USER_CORRECTION_RE = re.compile(
     r"(?:dashes|hyphens)\b",
     re.IGNORECASE,
 )
+OPERATIONAL_CAPABILITY_CORRECTION_RE = re.compile(
+    r"\b(?:you|the agent)\s+(?:already\s+|do\s+|should\s+)?"
+    r"(?:have|has|can\s+use|can\s+access|should\s+be\s+able\s+to\s+use)\b"
+    r"[^.!?]{0,120}\b(?:access|credentials?|secrets?|tools?|integrations?|permissions?|"
+    r"environment variables?|env vars?)\b",
+    re.IGNORECASE,
+)
 STRONG_DURABLE_CONFIG_INTENT_RE = re.compile(
     r"\b(?:going forward|from now on|in the future|next time|always|never|remember|"
     r"(?:my |this )?feedback:|each time|every time|make (?:that|this|it) a rule|should(?:n'?t| not) have to|"
@@ -2392,7 +2399,10 @@ def _user_text_is_direct_correction(text: str) -> bool:
     return bool(
         normalized
         and not TRANSIENT_CONFIG_SCOPE_RE.search(normalized)
-        and DIRECT_USER_CORRECTION_RE.search(normalized)
+        and (
+            DIRECT_USER_CORRECTION_RE.search(normalized)
+            or OPERATIONAL_CAPABILITY_CORRECTION_RE.search(normalized)
+        )
     )
 
 

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -38,6 +38,10 @@ from api.services.sandbox_compute import sandbox_compute_enabled_for_agent
 from api.services.user_timezone import is_offpeak_hour, resolve_user_local_time, resolve_user_timezone
 from api.services.agent_owner_custom_instructions import get_custom_instructions_for_organization_id, get_custom_instructions_for_user_id
 from api.services.prompt_archives import archive_agent_prompt
+from api.services.persistent_agent_secrets import (
+    build_secret_capability_inventory,
+    global_secrets_queryset_for_agent,
+)
 
 from ...models import (
     AgentCommPeerState,
@@ -4903,165 +4907,63 @@ def _build_browser_tasks_sections(agent: PersistentAgent, tasks_group) -> None:
             non_shrinkable=True
         )
 
-def _format_credential_secrets(secrets_qs, is_pending: bool) -> list[str]:
-    """Format domain-scoped credential secrets for prompt context."""
-    def _display_domain_pattern(domain_pattern: str) -> str:
-        # Wildcard host patterns are stored with an implicit https:// prefix for
-        # validation consistency, but the agent-facing prompt is easier to scan
-        # when it shows the original host wildcard form.
-        if domain_pattern.startswith("https://*."):
-            return domain_pattern.removeprefix("https://")
-        return domain_pattern
 
-    secret_lines: list[str] = []
-    current_domain: str | None = None
-    for secret in secrets_qs:
-        # Group by domain pattern
-        if secret.domain_pattern != current_domain:
-            if current_domain is not None:
-                secret_lines.append("")  # blank line between domains
-            secret_lines.append(f"Domain: {_display_domain_pattern(secret.domain_pattern)}")
-            current_domain = secret.domain_pattern
-
-        # Format secret info
-        parts = [f"  - Name: {secret.name}"]
-        if secret.description:
-            parts.append(f"Description: {secret.description}")
-        if is_pending:
-            parts.append("Status: awaiting user input")
-        parts.append(f"Key: {secret.key}")
-        secret_lines.append(", ".join(parts))
-    return secret_lines
-
-
-def _format_env_var_secrets(secrets_qs, is_pending: bool) -> list[str]:
-    """Format global env-var secrets for prompt context."""
-    secret_lines: list[str] = []
-    for secret in secrets_qs:
-        parts = [f"  - Name: {secret.name}"]
-        if secret.description:
-            parts.append(f"Description: {secret.description}")
-        if is_pending:
-            parts.append("Status: awaiting user input")
-        parts.append(f"Env Key: {secret.key}")
-        secret_lines.append(", ".join(parts))
-    return secret_lines
-
-
-def _get_global_secrets_for_agent(agent: PersistentAgent):
-    """Return the global secrets queryset for an agent's owner (user or org)."""
-    if agent.organization_id:
-        owner_filter = Q(organization=agent.organization)
-    else:
-        owner_filter = Q(user=agent.user, organization__isnull=True)
-    return GlobalSecret.objects.filter(owner_filter)
+def _format_secret_capability(capability: Mapping[str, str]) -> str:
+    parts = [
+        capability["availability"],
+        capability["secret_type"],
+        f"scope={capability['scope']}",
+        f"name={capability['name']}",
+        f"key={capability['key']}",
+    ]
+    domain_pattern = capability.get("domain_pattern")
+    if domain_pattern:
+        display_domain = (
+            domain_pattern.removeprefix("https://")
+            if domain_pattern.startswith("https://*.")
+            else domain_pattern
+        )
+        parts.append(f"domain={display_domain}")
+    if capability["secret_type"] == PersistentAgentSecret.SecretType.ENV_VAR:
+        parts.append("sandbox=os.environ")
+    return "- " + " | ".join(parts)
 
 
 def _get_secrets_block(agent: PersistentAgent) -> str:
-    """Return a formatted list of available secrets for this agent.
-    The caller is responsible for adding any surrounding instructional text and for
-    wrapping the section with <secrets> tags via Prompt.section_text().
-    """
-    available_credentials = (
-        PersistentAgentSecret.objects.filter(
-            agent=agent,
-            requested=False,
-            secret_type=PersistentAgentSecret.SecretType.CREDENTIAL,
-        ).order_by('domain_pattern', 'name')
+    """Return compact secret capability metadata without exposing values."""
+    capabilities = build_secret_capability_inventory(agent)
+    integrations = list(
+        global_secrets_queryset_for_agent(agent).filter(
+            secret_type=GlobalSecret.SecretType.INTEGRATION,
+        ).order_by("name")
     )
-    pending_credentials = (
-        PersistentAgentSecret.objects.filter(
-            agent=agent,
-            requested=True,
-            secret_type=PersistentAgentSecret.SecretType.CREDENTIAL,
-        ).order_by('domain_pattern', 'name')
-    )
-    available_env_vars = (
-        PersistentAgentSecret.objects.filter(
-            agent=agent,
-            requested=False,
-            secret_type=PersistentAgentSecret.SecretType.ENV_VAR,
-        ).order_by('name')
-    )
-    pending_env_vars = (
-        PersistentAgentSecret.objects.filter(
-            agent=agent,
-            requested=True,
-            secret_type=PersistentAgentSecret.SecretType.ENV_VAR,
-        ).order_by('name')
-    )
-
-    global_qs = _get_global_secrets_for_agent(agent)
-    global_credentials = global_qs.filter(
-        secret_type=GlobalSecret.SecretType.CREDENTIAL,
-    ).order_by('domain_pattern', 'name')
-    global_env_vars = global_qs.filter(
-        secret_type=GlobalSecret.SecretType.ENV_VAR,
-    ).order_by('name')
-    global_integrations = global_qs.filter(
-        secret_type=GlobalSecret.SecretType.INTEGRATION,
-    ).order_by('name')
-
-    has_any = (
-        available_credentials or pending_credentials
-        or available_env_vars or pending_env_vars
-        or global_credentials or global_env_vars
-        or global_integrations
-    )
-    if not has_any:
+    if not capabilities and not integrations:
         return "No secrets configured."
 
+    available = [capability for capability in capabilities if capability["availability"] == "available"]
+    pending = [capability for capability in capabilities if capability["availability"] == "pending"]
+
     lines: list[str] = []
+    if available:
+        lines.append("Available secret capabilities:")
+        lines.extend(_format_secret_capability(capability) for capability in available)
 
-    # Global secrets (shared across all agents for this user/org)
-    if global_credentials or global_env_vars:
-        lines.append("Global secrets (shared across all your agents):")
-        if global_credentials:
-            lines.append("  Domain-scoped credential secrets (placeholders/web auth only):")
-            lines.extend(_format_credential_secrets(global_credentials, is_pending=False))
-        if global_env_vars:
-            lines.append("  Sandbox environment variable secrets (readable via os.environ):")
-            lines.extend(_format_env_var_secrets(global_env_vars, is_pending=False))
-
-    if global_integrations:
+    if integrations:
         if lines:
             lines.append("")
         lines.append("Native integration auth (enable tools/skills before use):")
-        for secret in global_integrations:
+        for integration in integrations:
             lines.append(
-                f"  - {secret.name}: auth exists, but auth is not a tool; if the native skill/tool is not enabled, "
-                f"call `search_tools('{secret.name}')` first. Native auth applies automatically when supported."
+                f"- {integration.name}: auth exists, but auth is not a tool; if the native skill/tool is not "
+                f"enabled, call `search_tools('{integration.name}')` first. Native auth applies automatically."
             )
 
-    # Agent-specific secrets (override globals on key conflict)
-    if available_credentials:
-        if lines:
-            lines.append("")
-        lines.append("Agent-specific domain-scoped credential secrets (placeholders/web auth only; not readable via os.environ in sandbox code):")
-        lines.extend(_format_credential_secrets(available_credentials, is_pending=False))
-
-    if available_env_vars:
-        if lines:
-            lines.append("")
-        lines.append("Agent-specific sandbox environment variable secrets (these ARE readable via os.environ in sandbox code):")
-        lines.extend(_format_env_var_secrets(available_env_vars, is_pending=False))
-
-    if pending_credentials or pending_env_vars:
+    if pending:
         if lines:
             lines.append("")
         lines.append("Pending credential requests (user has not provided these yet):")
-        if pending_credentials:
-            lines.append("Pending domain-scoped credentials (placeholders/web auth only; not readable via os.environ in sandbox code):")
-            lines.extend(_format_credential_secrets(pending_credentials, is_pending=True))
-        if pending_env_vars:
-            if pending_credentials:
-                lines.append("")
-            lines.append("Pending sandbox environment variables (these will be readable via os.environ in sandbox code):")
-            lines.extend(_format_env_var_secrets(pending_env_vars, is_pending=True))
-        lines.append("")
-        lines.append(
-            "If you just requested these, follow up with the user through the appropriate communication channel."
-        )
+        lines.extend(_format_secret_capability(capability) for capability in pending)
+        lines.append("These were already requested; do not request them again; follow up only when needed.")
 
     return "\n".join(lines)
 

--- a/api/evals/scenarios/__init__.py
+++ b/api/evals/scenarios/__init__.py
@@ -32,6 +32,10 @@ from .behavior_micro import (
     ToolChoicePdfDeliverableUsesCreatePdfScenario,
     ToolChoiceMissingRecipientUsesHumanInputScenario,
 )
+from .github_credential_retention import (
+    CharterJudgePreservesCliGithubSecretWorkflowScenario,
+    CharterRecordsCliGithubSecretsCorrectionScenario,
+)
 from .effort_calibration import (
     EFFORT_CALIBRATION_SCENARIO_SLUGS,
     EffortTrivialAnswerStopsScenario,

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -57,6 +57,8 @@ CHARTER_IGNORES_ONE_OFF_PREFERENCE = "charter_ignores_one_off_preference"
 CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION = "charter_adds_feedback_rule_from_correction"
 CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD = "charter_adds_plain_preference_without_save_word"
 CHARTER_PATCHES_DIRECT_STYLE_CORRECTION = "charter_patches_direct_style_correction"
+CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION = "charter_records_cli_github_secrets_correction"
+CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW = "charter_judge_preserves_cli_github_secret_workflow"
 
 TOOL_CHOICE_EXACT_JSON_URL_USES_HTTP_REQUEST = "tool_choice_exact_json_url_uses_http_request"
 TOOL_CHOICE_CSV_DELIVERABLE_USES_CREATE_CSV = "tool_choice_csv_deliverable_uses_create_csv"
@@ -361,6 +363,8 @@ CHARTER_MEMORY_MICRO_SCENARIO_SLUGS = [
     CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION,
     CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD,
     CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
+    CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION,
+    CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
 ]
 
 TOOL_CHOICE_MICRO_SCENARIO_SLUGS = [
@@ -1842,6 +1846,9 @@ class CharterMemoryScenario(BehaviorMicroScenario):
     def _charter_check(self, agent, mutation_calls):
         raise NotImplementedError
 
+    def _additional_charter_check(self, agent, run_id, inbound):
+        return True, ""
+
     def run(self, run_id, agent_id):
         self._seed_charter_agent(agent_id)
         inbound = self._inject_charter_prompt(run_id, agent_id)
@@ -1855,6 +1862,10 @@ class CharterMemoryScenario(BehaviorMicroScenario):
         mutation_calls = self._mutation_calls_for_verification(run_id, inbound)
         agent = PersistentAgent.objects.get(id=agent_id)
         passed, failure_detail = self._charter_check(agent, mutation_calls)
+        additional_passed, additional_detail = self._additional_charter_check(agent, run_id, inbound)
+        passed = passed and additional_passed
+        if additional_detail:
+            failure_detail = "; ".join(detail for detail in (failure_detail, additional_detail) if detail)
         if passed:
             artifacts = {"step": mutation_calls[0].step} if mutation_calls else {}
             self.record_task_result(

--- a/api/evals/scenarios/github_credential_retention.py
+++ b/api/evals/scenarios/github_credential_retention.py
@@ -1,8 +1,11 @@
 import json
+from unittest.mock import patch
 
 from api.agent.core.agent_judge import build_manual_judge_trigger, run_manual_agent_judge
+from api.agent.core.llm_config import get_agent_judge_llm_config
 from api.agent.tools.run_command import get_run_command_tool
 from api.evals.base import ScenarioTask
+from api.evals.execution import get_current_eval_routing_profile
 from api.evals.registry import register_scenario
 from api.evals.scenarios.behavior_micro import (
     CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
@@ -202,6 +205,11 @@ class CharterRecordsCliGithubSecretsCorrectionScenario(CharterMemoryScenario):
     success_summary = "Agent saved the configured GitHub App secret route without weakening the existing PR workflow."
     failure_summary = "Expected one targeted charter patch preserving the docs workflow and recording CLI secret access"
 
+    def _eval_stop_policy(self):
+        policy = super()._eval_stop_policy()
+        policy["stop_on_tool_names"] = ["request_human_input", "secure_credentials_request"]
+        return policy
+
     def _seed_charter_agent(self, agent_id):
         super()._seed_charter_agent(agent_id)
         seed_github_app_env_var_secrets(agent_id)
@@ -396,7 +404,12 @@ class CharterJudgePreservesCliGithubSecretWorkflowScenario(CharterMemoryScenario
         )
 
         self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="run_manual_judge")
-        judge_result = run_manual_agent_judge(agent, tools=tools)
+        routing_profile = get_current_eval_routing_profile()
+        with patch(
+            "api.agent.core.agent_judge.get_agent_judge_llm_config",
+            side_effect=lambda: get_agent_judge_llm_config(routing_profile=routing_profile),
+        ):
+            judge_result = run_manual_agent_judge(agent, tools=tools)
         judge_ran = bool(judge_result.get("ran")) and judge_result.get("status") == "completed"
         sanitized_result = self._sanitized_judge_result(judge_result)
         self.record_task_result(

--- a/api/evals/scenarios/github_credential_retention.py
+++ b/api/evals/scenarios/github_credential_retention.py
@@ -1,0 +1,429 @@
+import json
+
+from api.agent.core.agent_judge import build_manual_judge_trigger, run_manual_agent_judge
+from api.agent.tools.run_command import get_run_command_tool
+from api.evals.base import ScenarioTask
+from api.evals.registry import register_scenario
+from api.evals.scenarios.behavior_micro import (
+    CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
+    CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION,
+    CharterMemoryScenario,
+    get_tool_calls_for_run,
+)
+from api.models import (
+    EvalRunTask,
+    PersistentAgent,
+    PersistentAgentSecret,
+    PersistentAgentStep,
+    PersistentAgentToolCall,
+)
+
+
+GITHUB_APP_ENV_SECRET_FIXTURES = (
+    {
+        "name": "GitHub App ID",
+        "key": "GITHUB_APP_ID",
+        "description": "Numeric App ID for the GitHub App installed on the repository.",
+        "value": "EVAL_GITHUB_APP_ID_VALUE_123456",
+    },
+    {
+        "name": "GitHub App Private Key",
+        "key": "GITHUB_APP_PRIVATE_KEY",
+        "description": "Private key used to mint short-lived GitHub App installation tokens.",
+        "value": "-----BEGIN RSA PRIVATE KEY-----\nEVAL_GITHUB_PRIVATE_KEY_VALUE\n-----END RSA PRIVATE KEY-----",
+    },
+    {
+        "name": "GitHub App Installation ID",
+        "key": "GITHUB_APP_INSTALLATION_ID",
+        "description": "Installation ID for the GitHub App on the repository.",
+        "value": "EVAL_GITHUB_INSTALLATION_ID_VALUE_654321",
+    },
+)
+GITHUB_APP_ENV_KEYS = tuple(fixture["key"] for fixture in GITHUB_APP_ENV_SECRET_FIXTURES)
+GITHUB_DOCS_EXISTING_CHARTER = (
+    "Write user-friendly product documentation by reviewing the application and source code. "
+    "For each change, create a dedicated branch, commit, push, and open a pull request. "
+    "Assign each pull request to Matt as reviewer and assignee. Use command-line git for all GitHub work. "
+    "Never merge without the user's explicit approval."
+)
+GITHUB_DOCS_CORRECTED_CHARTER = (
+    f"{GITHUB_DOCS_EXISTING_CHARTER} "
+    "Authenticate command-line GitHub work with the configured GitHub App environment-variable secrets; "
+    "a disconnected native GitHub integration does not remove that authorized CLI access path."
+)
+
+
+def seed_github_app_env_var_secrets(agent_id):
+    secrets = []
+    for fixture in GITHUB_APP_ENV_SECRET_FIXTURES:
+        secret = PersistentAgentSecret(
+            agent_id=agent_id,
+            name=fixture["name"],
+            description=fixture["description"],
+            key=fixture["key"],
+            secret_type=PersistentAgentSecret.SecretType.ENV_VAR,
+            domain_pattern=PersistentAgentSecret.ENV_VAR_DOMAIN_SENTINEL,
+            requested=False,
+        )
+        secret.set_value(fixture["value"])
+        secret.save()
+        secrets.append(secret)
+    return secrets
+
+
+def sanitized_github_secret_metadata(agent_id):
+    secrets_by_key = {
+        secret.key: secret
+        for secret in PersistentAgentSecret.objects.filter(
+            agent_id=agent_id,
+            key__in=GITHUB_APP_ENV_KEYS,
+            secret_type=PersistentAgentSecret.SecretType.ENV_VAR,
+        )
+    }
+    return [
+        {
+            "name": secrets_by_key[key].name,
+            "key": key,
+            "secret_type": secrets_by_key[key].secret_type,
+            "status": "pending" if secrets_by_key[key].requested else "available",
+        }
+        for key in GITHUB_APP_ENV_KEYS
+        if key in secrets_by_key
+    ]
+
+
+def judge_github_secret_context_check(trajectory):
+    current_context = trajectory.get("current_context") or {}
+    serialized_context = json.dumps(current_context, sort_keys=True, default=str)
+    missing_keys = [key for key in GITHUB_APP_ENV_KEYS if key not in serialized_context]
+    leaked_fixture_values = [
+        fixture["key"]
+        for fixture in GITHUB_APP_ENV_SECRET_FIXTURES
+        if fixture["value"] in serialized_context
+    ]
+    passed = not missing_keys and not leaked_fixture_values
+    detail = (
+        f"missing_keys={missing_keys}, leaked_fixture_values={leaked_fixture_values}, "
+        f"current_context_keys={sorted(current_context)}"
+    )
+    return passed, detail
+
+
+def github_guidance_blocks_configured_cli_path(text):
+    normalized = str(text or "").casefold()
+    blocks_local_path = any(
+        phrase in normalized
+        for phrase in (
+            "do not use local",
+            "don't use local",
+            "stop using local",
+            "do not use cli",
+            "don't use cli",
+            "stop using cli",
+            "do not use shell",
+            "stop using shell",
+        )
+    )
+    reconnect_gated = (
+        ("reconnect" in normalized or "authoriz" in normalized)
+        and any(
+            phrase in normalized
+            for phrase in (
+                "must reconnect",
+                "needs reconnect",
+                "need to reconnect",
+                "until reconnect",
+                "until github is reconnect",
+                "wait for",
+                "only after",
+                "send one reconnect request",
+                "immediately send the connection",
+            )
+        )
+    )
+    claims_missing_credentials = (
+        any(term in normalized for term in ("secret", "credential"))
+        and any(term in normalized for term in ("is missing", "are missing", "not configured", "provide the"))
+    )
+    return blocks_local_path or reconnect_gated or claims_missing_credentials
+
+
+def judge_guidance_preserves_cli_github_path(result):
+    if not result.get("ran"):
+        return False, f"Judge did not run: status={result.get('status')!r}."
+
+    suggestion_type = str(result.get("suggestion_type") or "").casefold()
+    suggestion = result.get("suggestion") or {}
+    if suggestion_type == "no_action" and not suggestion:
+        return True, "Judge returned no_action."
+    if not suggestion:
+        return False, f"Judge returned {suggestion_type or 'unknown'} without a suggestion payload."
+
+    guidance = " ".join(str(suggestion.get(key) or "") for key in ("message", "agentDirective")).strip()
+    if github_guidance_blocks_configured_cli_path(guidance):
+        return False, f"Judge guidance blocks the configured CLI path: {guidance!r}."
+
+    normalized = guidance.casefold()
+    addresses_github_auth = any(
+        term in normalized
+        for term in ("github", "auth", "token", "secret", "credential", "reconnect")
+    )
+    preserves_cli_path = any(
+        term in normalized
+        for term in (
+            "run_command",
+            "command line",
+            "cli",
+            "environment variable",
+            "env var",
+            "github app",
+        )
+    )
+    if addresses_github_auth and not preserves_cli_path:
+        return False, f"GitHub/auth guidance omitted the configured CLI/env-var path: {guidance!r}."
+    return True, "Judge returned no harmful reconnect-only or CLI-blocking guidance."
+
+
+@register_scenario
+class CharterRecordsCliGithubSecretsCorrectionScenario(CharterMemoryScenario):
+    slug = CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION
+    description = "A correction about configured GitHub App secrets should become durable CLI workflow guidance."
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_cli_secret_workflow_saved", assertion_type="manual"),
+    ]
+    existing_charter = GITHUB_DOCS_EXISTING_CHARTER
+    prior_outbound_body = (
+        "One blocker: the GitHub integration is still disconnected, so I cannot push a pull request. "
+        "Please reconnect GitHub before I continue."
+    )
+    prompt = "you should have github secrets that allow you to use github."
+    verification_task_name = "verify_cli_secret_workflow_saved"
+    success_summary = "Agent saved the configured GitHub App secret route without weakening the existing PR workflow."
+    failure_summary = "Expected one targeted charter patch preserving the docs workflow and recording CLI secret access"
+
+    def _seed_charter_agent(self, agent_id):
+        super()._seed_charter_agent(agent_id)
+        seed_github_app_env_var_secrets(agent_id)
+
+    def _charter_check(self, agent, mutation_calls):
+        charter = (agent.charter or "").casefold()
+        sql = "\n".join(json.dumps(call.tool_params or {}) for call in mutation_calls).casefold()
+        preserved_workflow = all(
+            term in charter
+            for term in (
+                "documentation",
+                "branch",
+                "pull request",
+                "reviewer",
+                "assignee",
+                "never merge",
+                "command-line git",
+            )
+        )
+        records_secret_route = (
+            "github app" in charter
+            and any(term in charter for term in ("secret", "credential", "environment"))
+            and any(term in charter for term in ("cli", "command-line", "command line", "git"))
+        )
+        used_one_patch = len(mutation_calls) == 1 and "patch_text" in sql
+        blocks_valid_path = github_guidance_blocks_configured_cli_path(agent.charter)
+        passed = used_one_patch and preserved_workflow and records_secret_route and not blocks_valid_path
+        return (
+            passed,
+            (
+                f"mutation_count={len(mutation_calls)}, used_patch={used_one_patch}, "
+                f"preserved_workflow={preserved_workflow}, records_secret_route={records_secret_route}, "
+                f"blocks_valid_path={blocks_valid_path}, charter={agent.charter!r}."
+            ),
+        )
+
+    def _additional_charter_check(self, agent, run_id, inbound):
+        credential_request_calls = get_tool_calls_for_run(
+            run_id,
+            after=inbound.timestamp,
+            tool_names=["request_human_input", "secure_credentials_request"],
+        )
+        pending_github_secrets = PersistentAgentSecret.objects.filter(
+            agent=agent,
+            key__in=GITHUB_APP_ENV_KEYS,
+            requested=True,
+        ).count()
+        passed = not credential_request_calls and pending_github_secrets == 0
+        return (
+            passed,
+            (
+                f"credential_request_tools={[call.tool_name for call in credential_request_calls]}, "
+                f"pending_github_secrets={pending_github_secrets}."
+            ),
+        )
+
+
+@register_scenario
+class CharterJudgePreservesCliGithubSecretWorkflowScenario(CharterMemoryScenario):
+    slug = CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW
+    description = "The trajectory judge should not replace a user-authorized CLI secret path with reconnect-only guidance."
+    tasks = [
+        ScenarioTask(name="seed_judge_trajectory", assertion_type="manual"),
+        ScenarioTask(name="verify_judge_secret_capability_context", assertion_type="manual"),
+        ScenarioTask(name="run_manual_judge", assertion_type="manual"),
+        ScenarioTask(name="verify_judge_guidance_preserved_cli", assertion_type="manual"),
+    ]
+    existing_charter = GITHUB_DOCS_CORRECTED_CHARTER
+
+    @staticmethod
+    def _seed_tool_call(agent_id, run_id, tool_name, tool_params, result):
+        step = PersistentAgentStep.objects.create(
+            agent_id=agent_id,
+            eval_run_id=run_id,
+            description=f"Seeded GitHub credential-retention trajectory: {tool_name}",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name=tool_name,
+            tool_params=tool_params,
+            result=json.dumps(result),
+            status="complete",
+        )
+        return step
+
+    @staticmethod
+    def _sanitized_judge_result(result):
+        suggestion = result.get("suggestion") or {}
+        return {
+            "ran": bool(result.get("ran")),
+            "status": result.get("status"),
+            "suggestion_type": result.get("suggestion_type"),
+            "completion_id": result.get("completion_id"),
+            "suggestion": {
+                "message": suggestion.get("message"),
+                "agentDirective": suggestion.get("agentDirective"),
+                "status": suggestion.get("status"),
+            } if suggestion else None,
+        }
+
+    def _seed_judge_trajectory(self, run_id, agent_id):
+        self._set_planning_state(agent_id, PersistentAgent.PlanningState.SKIPPED)
+        PersistentAgent.objects.filter(id=agent_id).update(charter=self.existing_charter)
+        self._seed_prior_processing_run(agent_id)
+        self._enable_builtin_tools(agent_id, ["run_command"])
+        seed_github_app_env_var_secrets(agent_id)
+        self._seed_prior_outbound_message(
+            agent_id,
+            "The GitHub integration is disconnected, so I cannot continue until you reconnect it.",
+        )
+        self.inject_message(
+            agent_id,
+            "you should have github secrets that allow you to use github.",
+            trigger_processing=False,
+            eval_run_id=run_id,
+        )
+        self._seed_tool_call(
+            agent_id,
+            run_id,
+            "github-get-pull-request",
+            {"repoFullname": "example/docs", "pullNumber": 241},
+            {
+                "status": "action_required",
+                "result": "Authorization required. Please connect your account.",
+                "connect_url": "https://example.test/connect/github",
+            },
+        )
+        self._seed_tool_call(
+            agent_id,
+            run_id,
+            "python_exec",
+            {"code": "Check whether the configured GitHub App environment variables are present."},
+            {
+                "status": "ok",
+                "stdout": (
+                    "GITHUB_APP_ID present: True\n"
+                    "GITHUB_APP_PRIVATE_KEY present: True\n"
+                    "GITHUB_APP_INSTALLATION_ID present: True"
+                ),
+            },
+        )
+        return self._seed_tool_call(
+            agent_id,
+            run_id,
+            "run_command",
+            {"command": "Use the configured GitHub App env vars to mint an installation token and push the branch."},
+            {
+                "status": "ok",
+                "exit_code": 0,
+                "stdout": "GitHub App installation token created; branch pushed successfully.",
+            },
+        )
+
+    def run(self, run_id, agent_id):
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="seed_judge_trajectory")
+        final_seed_step = self._seed_judge_trajectory(run_id, agent_id)
+        secret_metadata = sanitized_github_secret_metadata(agent_id)
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="seed_judge_trajectory",
+            observed_summary="Seeded the correction, env-var secrets, native auth error, and working CLI fallback.",
+            artifacts={"step": final_seed_step, "secret_metadata": secret_metadata},
+        )
+
+        agent = PersistentAgent.objects.get(id=agent_id)
+        tools = [get_run_command_tool()]
+        trigger = build_manual_judge_trigger(agent, tools=tools)
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="verify_judge_secret_capability_context",
+        )
+        context_passed, context_detail = judge_github_secret_context_check(trigger.trajectory)
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if context_passed else EvalRunTask.Status.FAILED,
+            task_name="verify_judge_secret_capability_context",
+            observed_summary=(
+                "Judge context included all configured GitHub env-var keys without values."
+                if context_passed
+                else f"Judge context did not expose safe GitHub secret capability metadata; {context_detail}"
+            ),
+            artifacts={
+                "secret_metadata": secret_metadata,
+                "current_context_keys": sorted((trigger.trajectory.get("current_context") or {}).keys()),
+            },
+        )
+
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="run_manual_judge")
+        judge_result = run_manual_agent_judge(agent, tools=tools)
+        judge_ran = bool(judge_result.get("ran")) and judge_result.get("status") == "completed"
+        sanitized_result = self._sanitized_judge_result(judge_result)
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if judge_ran else EvalRunTask.Status.FAILED,
+            task_name="run_manual_judge",
+            observed_summary=(
+                "Manual trajectory judge completed in review-only mode."
+                if judge_ran
+                else f"Manual trajectory judge did not complete: {sanitized_result!r}."
+            ),
+            artifacts={"judge_result": sanitized_result},
+        )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="verify_judge_guidance_preserved_cli",
+        )
+        guidance_passed, guidance_detail = judge_guidance_preserves_cli_github_path(judge_result)
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if guidance_passed else EvalRunTask.Status.FAILED,
+            task_name="verify_judge_guidance_preserved_cli",
+            observed_summary=guidance_detail,
+            artifacts={"judge_result": sanitized_result},
+        )

--- a/api/services/persistent_agent_secrets.py
+++ b/api/services/persistent_agent_secrets.py
@@ -121,6 +121,45 @@ def global_secrets_queryset_for_agent(agent: PersistentAgent):
     return GlobalSecret.objects.filter(user=owner_user, organization__isnull=True)
 
 
+def build_secret_capability_inventory(agent: PersistentAgent) -> list[dict[str, str]]:
+    """Return secret metadata that is safe to expose to prompts and diagnostics."""
+
+    capabilities: list[dict[str, str]] = []
+
+    for secret in global_secrets_queryset_for_agent(agent).filter(
+        secret_type__in=(GlobalSecret.SecretType.CREDENTIAL, GlobalSecret.SecretType.ENV_VAR),
+    ).order_by("secret_type", "domain_pattern", "name"):
+        capability = {
+            "name": secret.name,
+            "key": secret.key,
+            "secret_type": secret.secret_type,
+            "availability": "available",
+            "scope": "global",
+        }
+        if secret.secret_type == GlobalSecret.SecretType.CREDENTIAL:
+            capability["domain_pattern"] = secret.domain_pattern
+        capabilities.append(capability)
+
+    for secret in PersistentAgentSecret.objects.filter(agent=agent).order_by(
+        "requested",
+        "secret_type",
+        "domain_pattern",
+        "name",
+    ):
+        capability = {
+            "name": secret.name,
+            "key": secret.key,
+            "secret_type": secret.secret_type,
+            "availability": "pending" if secret.requested else "available",
+            "scope": "agent",
+        }
+        if secret.secret_type == PersistentAgentSecret.SecretType.CREDENTIAL:
+            capability["domain_pattern"] = secret.domain_pattern
+        capabilities.append(capability)
+
+    return capabilities
+
+
 def ensure_global_secret_capacity_for_agent(agent: PersistentAgent, additional_count: int = 1) -> None:
     if additional_count <= 0:
         return

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -36,6 +36,7 @@ from api.models import (
     PersistentAgentCustomTool,
     PersistentAgentJudgeSuggestion,
     PersistentAgentMessage,
+    PersistentAgentSecret,
     PersistentAgentSkill,
     PersistentAgentStep,
     PersistentAgentSystemSkillState,
@@ -522,6 +523,51 @@ class AgentJudgeTests(TestCase):
             trajectory["recent_trajectory"]["system_directives"][-1]["source_type"],
             "system_directive",
         )
+
+    def test_judge_context_includes_secret_capabilities_without_values(self):
+        secret = PersistentAgentSecret(
+            agent=self.agent,
+            name="GitHub App ID",
+            key="GITHUB_APP_ID",
+            secret_type=PersistentAgentSecret.SecretType.ENV_VAR,
+            domain_pattern=PersistentAgentSecret.ENV_VAR_DOMAIN_SENTINEL,
+            requested=False,
+        )
+        secret.set_value("judge-fixture-secret-value")
+        secret.save()
+
+        trigger = build_manual_judge_trigger(self.agent, tools=[])
+
+        capabilities = trigger.trajectory["current_context"]["secret_capabilities"]
+        self.assertIn(
+            {
+                "name": "GitHub App ID",
+                "key": "GITHUB_APP_ID",
+                "secret_type": "env_var",
+                "availability": "available",
+                "scope": "agent",
+            },
+            capabilities,
+        )
+        self.assertNotIn("judge-fixture-secret-value", json.dumps(capabilities))
+        with patch(
+            "api.agent.core.agent_judge._create_token_estimator",
+            return_value=lambda text: len(text.split()),
+        ):
+            messages = _build_judge_messages(
+                trigger.trajectory,
+                model="test-model",
+                prompt_limits=JudgePromptLimits(
+                    prompt_token_budget=5_000,
+                    message_history_limit=2,
+                    tool_call_history_limit=2,
+                    skill_prompt_limit=1,
+                    enabled_tool_limit=1,
+                ),
+            )
+        self.assertIn("secret_capabilities", messages[1]["content"])
+        self.assertIn("GITHUB_APP_ID", messages[1]["content"])
+        self.assertNotIn("judge-fixture-secret-value", messages[1]["content"])
 
     def test_judge_trajectory_uses_prompt_config_ultra_max_limits(self):
         config, _ = PromptConfig.objects.get_or_create(singleton_id=1)

--- a/tests/unit/test_agent_secrets_context.py
+++ b/tests/unit/test_agent_secrets_context.py
@@ -6,6 +6,7 @@ Tests the core logic around:
 2. secure_credentials_request tool execution
 3. Proper filtering of requested vs fulfilled secrets
 """
+import json
 from unittest.mock import Mock, patch
 from django.test import TestCase, tag
 from django.contrib.auth import get_user_model
@@ -21,6 +22,7 @@ from api.agent.tools.secure_credentials_request import (
     execute_secure_credentials_request,
     get_secure_credentials_request_tool,
 )
+from api.services.persistent_agent_secrets import build_secret_capability_inventory
 
 User = get_user_model()
 
@@ -100,7 +102,7 @@ class GetSecretsBlockTests(TestCase):
 
         # Verify requested secrets are surfaced as pending (not as available)
         self.assertIn("Pending credential requests", result)
-        self.assertIn("follow up with the user", result)
+        self.assertIn("already requested; do not request them again", result)
         self.assertIn("pending_secret", result)
         self.assertIn("waiting_secret", result)
         self.assertIn("https://pending.example.com", result)
@@ -150,16 +152,73 @@ class GetSecretsBlockTests(TestCase):
 
         result = _get_secrets_block(self.agent)
 
-        self.assertIn("Agent-specific domain-scoped credential secrets", result)
-        self.assertIn("not readable via os.environ", result)
-        self.assertIn("Agent-specific sandbox environment variable secrets", result)
-        self.assertIn("ARE readable via os.environ", result)
-        self.assertIn("Pending domain-scoped credentials", result)
-        self.assertIn("Pending sandbox environment variables", result)
-        self.assertIn("Key: api_credential", result)
-        self.assertIn("Env Key: SANDBOX_TOKEN", result)
+        self.assertIn("Available secret capabilities", result)
+        self.assertIn("available | credential | scope=agent", result)
+        self.assertIn("available | env_var | scope=agent", result)
+        self.assertIn("pending | credential | scope=agent", result)
+        self.assertIn("pending | env_var | scope=agent", result)
+        self.assertIn("key=api_credential", result)
+        self.assertIn("key=SANDBOX_TOKEN", result)
+        self.assertIn("sandbox=os.environ", result)
         self.assertNotIn("credential-secret-value", result)
         self.assertNotIn("env-var-secret-value", result)
+
+    def test_secret_capability_inventory_exposes_status_without_values(self):
+        agent_env = PersistentAgentSecret(
+            agent=self.agent,
+            secret_type=PersistentAgentSecret.SecretType.ENV_VAR,
+            domain_pattern=PersistentAgentSecret.ENV_VAR_DOMAIN_SENTINEL,
+            name="GitHub App ID",
+            key="GITHUB_APP_ID",
+            requested=False,
+        )
+        agent_env.set_value("agent-env-secret-value")
+        agent_env.save()
+        PersistentAgentSecret.objects.create(
+            agent=self.agent,
+            secret_type=PersistentAgentSecret.SecretType.CREDENTIAL,
+            domain_pattern="https://api.example.com",
+            name="Pending API Key",
+            key="pending_api_key",
+            requested=True,
+            encrypted_value=b"",
+        )
+        global_env = GlobalSecret(
+            user=self.user,
+            secret_type=GlobalSecret.SecretType.ENV_VAR,
+            domain_pattern=GlobalSecret.ENV_VAR_DOMAIN_SENTINEL,
+            name="Shared Token",
+            key="SHARED_TOKEN",
+        )
+        global_env.set_value("global-env-secret-value")
+        global_env.save()
+
+        inventory = build_secret_capability_inventory(self.agent)
+
+        self.assertIn(
+            {
+                "name": "GitHub App ID",
+                "key": "GITHUB_APP_ID",
+                "secret_type": "env_var",
+                "availability": "available",
+                "scope": "agent",
+            },
+            inventory,
+        )
+        self.assertIn(
+            {
+                "name": "Pending API Key",
+                "key": "pending_api_key",
+                "secret_type": "credential",
+                "availability": "pending",
+                "scope": "agent",
+                "domain_pattern": "https://api.example.com",
+            },
+            inventory,
+        )
+        serialized = json.dumps(inventory)
+        self.assertNotIn("agent-env-secret-value", serialized)
+        self.assertNotIn("global-env-secret-value", serialized)
 
     def test_no_secrets_returns_empty_message(self):
         """Test that when no fulfilled secrets exist, appropriate message is returned."""
@@ -212,23 +271,20 @@ class GetSecretsBlockTests(TestCase):
         result = _get_secrets_block(self.agent)
 
         # Check structure
-        self.assertIn("Domain: *.github.com", result)
-        self.assertIn("Domain: *.google.com", result)
+        self.assertIn("domain=*.github.com", result)
+        self.assertIn("domain=*.google.com", result)
 
         # Check that all secrets are present
         self.assertIn("google_api_key", result)
         self.assertIn("google_secret", result)
         self.assertIn("github_token", result)
 
-        # Verify ordering - domains should be alphabetically sorted
+        # Verify ordering - credential capability rows should be alphabetically sorted by domain.
         lines = result.split('\n')
-        # Find domain lines
-        domain_lines = [i for i, line in enumerate(lines) if "Domain:" in line]
-        self.assertEqual(len(domain_lines), 2)
-
-        # GitHub should come before Google alphabetically
-        self.assertIn("*.github.com", lines[domain_lines[0]])
-        self.assertIn("*.google.com", lines[domain_lines[1]])
+        github_line = next(i for i, line in enumerate(lines) if "key=github_token" in line)
+        google_lines = [i for i, line in enumerate(lines) if "domain=*.google.com" in line]
+        self.assertTrue(google_lines)
+        self.assertLess(github_line, min(google_lines))
 
     def test_mixed_requested_and_fulfilled_secrets(self):
         """Test filtering when both requested and fulfilled secrets exist."""

--- a/tests/unit/test_eval_behavior_micro_scenarios.py
+++ b/tests/unit/test_eval_behavior_micro_scenarios.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -29,8 +30,10 @@ from api.evals.scenarios.behavior_micro import (
     CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
     CHARTER_EXPANDS_SPARSE_CHARTER_WITH_DETAIL,
     CHARTER_IGNORES_ONE_OFF_PREFERENCE,
+    CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
     CHARTER_MEMORY_MICRO_SCENARIO_SLUGS,
     CHARTER_NARROWS_SCOPE_PRESERVING_UNRELATED_GUIDANCE,
+    CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION,
     CommonUseCaseEvalDefinition,
     CommonUseCaseToolChoiceScenario,
     COMMON_USE_CASE_EVAL_CASES,
@@ -57,6 +60,15 @@ from api.evals.scenarios.behavior_micro import (
     tool_call_is_plan_activity,
 )
 from api.evals.scenarios.effort_calibration import _hierarchical_report_shape
+from api.evals.scenarios.github_credential_retention import (
+    GITHUB_APP_ENV_KEYS,
+    GITHUB_APP_ENV_SECRET_FIXTURES,
+    GITHUB_DOCS_CORRECTED_CHARTER,
+    judge_github_secret_context_check,
+    judge_guidance_preserves_cli_github_path,
+    sanitized_github_secret_metadata,
+    seed_github_app_env_var_secrets,
+)
 from api.evals.scenarios.monitor_pollution import (
     MonitorPollutionScenario,
     _charter_mentions_pollution_monitoring,
@@ -84,6 +96,7 @@ from api.models import (
     PersistentAgentEnabledTool,
     PersistentAgentHumanInputRequest,
     PersistentAgentMessage,
+    PersistentAgentSecret,
     PersistentAgentStep,
     PersistentAgentSystemStep,
     PersistentAgentToolCall,
@@ -118,6 +131,26 @@ class BehaviorMicroScenarioRegistrationTests(TestCase):
         self.assertIn(CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION, charter_memory_suite.scenario_slugs)
         self.assertIn(CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD, charter_memory_suite.scenario_slugs)
         self.assertIn(CHARTER_PATCHES_DIRECT_STYLE_CORRECTION, charter_memory_suite.scenario_slugs)
+        self.assertIn(CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION, charter_memory_suite.scenario_slugs)
+        self.assertIn(CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW, charter_memory_suite.scenario_slugs)
+
+    def test_github_credential_retention_scenarios_expose_diagnostic_tasks(self):
+        charter_scenario = ScenarioRegistry.get(CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION)
+        judge_scenario = ScenarioRegistry.get(CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW)
+
+        self.assertEqual(
+            [task.name for task in charter_scenario.tasks],
+            ["inject_prompt", "verify_cli_secret_workflow_saved"],
+        )
+        self.assertEqual(
+            [task.name for task in judge_scenario.tasks],
+            [
+                "seed_judge_trajectory",
+                "verify_judge_secret_capability_context",
+                "run_manual_judge",
+                "verify_judge_guidance_preserved_cli",
+            ],
+        )
 
     def test_common_use_case_micro_evals_are_complete_and_registered(self):
         registered = ScenarioRegistry.list_all()
@@ -695,6 +728,101 @@ class BehaviorMicroHelperTests(TestCase):
             options_json=[{"key": "yes", "title": "Yes"}],
             requested_via_channel=CommsChannel.WEB,
         )
+
+    def test_github_secret_fixture_metadata_exposes_names_and_status_without_values(self):
+        seed_github_app_env_var_secrets(self.agent.id)
+
+        metadata = sanitized_github_secret_metadata(self.agent.id)
+        serialized_metadata = json.dumps(metadata, sort_keys=True)
+
+        self.assertEqual([entry["key"] for entry in metadata], list(GITHUB_APP_ENV_KEYS))
+        self.assertTrue(all(entry["secret_type"] == PersistentAgentSecret.SecretType.ENV_VAR for entry in metadata))
+        self.assertTrue(all(entry["status"] == "available" for entry in metadata))
+        self.assertTrue(all("value" not in entry for entry in metadata))
+        for fixture in GITHUB_APP_ENV_SECRET_FIXTURES:
+            self.assertNotIn(fixture["value"], serialized_metadata)
+
+    def test_judge_secret_context_check_requires_keys_and_rejects_values(self):
+        safe_context = {
+            "current_context": {
+                "secrets": [
+                    {"key": key, "secret_type": "env_var", "status": "available"}
+                    for key in GITHUB_APP_ENV_KEYS
+                ]
+            }
+        }
+        safe, safe_detail = judge_github_secret_context_check(safe_context)
+        missing, missing_detail = judge_github_secret_context_check({"current_context": {}})
+        leaked_context = deepcopy(safe_context)
+        leaked_context["current_context"]["secrets"][0]["value"] = GITHUB_APP_ENV_SECRET_FIXTURES[0]["value"]
+        leaked, leaked_detail = judge_github_secret_context_check(leaked_context)
+
+        self.assertTrue(safe, safe_detail)
+        self.assertFalse(missing, missing_detail)
+        self.assertFalse(leaked, leaked_detail)
+
+    def test_judge_guidance_scoring_rejects_observed_reconnect_only_directive(self):
+        harmful = {
+            "ran": True,
+            "status": "completed",
+            "suggestion_type": "strategy_shift",
+            "suggestion": {
+                "message": "Adjust strategy",
+                "agentDirective": (
+                    "Update your charter/config with this GitHub fallback: after an authorization-required "
+                    "result, do not use local tokens, scripts, or gh; send one reconnect request, then sleep."
+                ),
+            },
+        }
+
+        passed, detail = judge_guidance_preserves_cli_github_path(harmful)
+
+        self.assertFalse(passed, detail)
+
+    def test_judge_guidance_scoring_accepts_no_action_and_cli_preserving_guidance(self):
+        no_action = {
+            "ran": True,
+            "status": "completed",
+            "suggestion_type": "no_action",
+            "suggestion": None,
+        }
+        cli_guidance = {
+            "ran": True,
+            "status": "completed",
+            "suggestion_type": "strategy_shift",
+            "suggestion": {
+                "message": "Use the configured authentication path.",
+                "agentDirective": (
+                    "Continue the GitHub workflow through run_command with the available GitHub App "
+                    "environment variables, while preserving the no-merge rule."
+                ),
+            },
+        }
+
+        no_action_passed, no_action_detail = judge_guidance_preserves_cli_github_path(no_action)
+        cli_passed, cli_detail = judge_guidance_preserves_cli_github_path(cli_guidance)
+
+        self.assertTrue(no_action_passed, no_action_detail)
+        self.assertTrue(cli_passed, cli_detail)
+
+    def test_cli_secret_charter_check_requires_one_patch_and_preserves_workflow(self):
+        scenario = ScenarioRegistry.get(CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION)
+        agent = SimpleNamespace(charter=GITHUB_DOCS_CORRECTED_CHARTER)
+        patch_call = SimpleNamespace(tool_params={"operations": [{"op": "patch_text"}]})
+
+        passed, detail = scenario._charter_check(agent, [patch_call])
+        no_patch_passed, no_patch_detail = scenario._charter_check(agent, [])
+        harmful_agent = SimpleNamespace(
+            charter=(
+                f"{GITHUB_DOCS_CORRECTED_CHARTER} Do not use local tokens or CLI; "
+                "send one reconnect request and wait for authorization."
+            )
+        )
+        harmful_passed, harmful_detail = scenario._charter_check(harmful_agent, [patch_call])
+
+        self.assertTrue(passed, detail)
+        self.assertFalse(no_patch_passed, no_patch_detail)
+        self.assertFalse(harmful_passed, harmful_detail)
 
     def test_eval_synthetic_tools_are_catalog_backed_for_eval_agents(self):
         self.agent.execution_environment = "eval"

--- a/tests/unit/test_eval_behavior_micro_scenarios.py
+++ b/tests/unit/test_eval_behavior_micro_scenarios.py
@@ -151,6 +151,10 @@ class BehaviorMicroScenarioRegistrationTests(TestCase):
                 "verify_judge_guidance_preserved_cli",
             ],
         )
+        self.assertEqual(
+            charter_scenario._eval_stop_policy()["stop_on_tool_names"],
+            ["request_human_input", "secure_credentials_request"],
+        )
 
     def test_common_use_case_micro_evals_are_complete_and_registered(self):
         registered = ScenarioRegistry.list_all()

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -127,8 +127,24 @@ class ImpliedSendTests(TestCase):
         self.assertTrue(ep._user_text_is_direct_correction("Lowercase is too informal."))
         self.assertTrue(ep._user_text_is_direct_correction("No more em dashes."))
         self.assertTrue(ep._user_text_is_direct_correction("Don't use em dashes."))
+        self.assertTrue(
+            ep._user_text_is_direct_correction(
+                "you should have github secrets that allow you to use github."
+            )
+        )
+        self.assertTrue(
+            ep._user_text_is_direct_correction(
+                "You already have credentials for that command-line workflow."
+            )
+        )
+        self.assertTrue(
+            ep._user_text_is_direct_correction(
+                "The agent should be able to use the configured environment variables."
+            )
+        )
         self.assertFalse(ep._user_text_is_direct_correction("For this response, don't use headings."))
         self.assertFalse(ep._user_text_is_direct_correction("Don't browse. Just answer the question."))
+        self.assertFalse(ep._user_text_is_direct_correction("You should have a nice day."))
         self.assertFalse(
             ep._user_text_is_direct_correction(
                 "Constraint: do not imply a prior relationship or make unsupported claims. Send the email now."


### PR DESCRIPTION
## Summary

- Add a GitHub credential retention evaluation scenario.
- Improve persistent secret handling across agent prompts, events, and judging.
- Add unit coverage for secret context, event processing, LLM judging, and evaluation scenarios.

## Testing

- Not run (not requested)