### PR TITLE
Preserve raw URLs alongside link reference tokens in prompts

### DIFF
--- a/api/agent/core/link_references.py
+++ b/api/agent/core/link_references.py
@@ -67,7 +67,7 @@ def _reference_map(agent, urls: Iterable[str], *, create: bool) -> dict[str, str
     return {ref.url: f"$[link:{ref.public_id}]" for ref in references if urls_by_hash.get(ref.url_hash) == ref.url}
 
 
-def rewrite_prompt_urls(text: str, agent, *, create: bool) -> str:
+def _render_prompt_urls(text: str, agent, *, create: bool, include_raw: bool) -> str:
     urls = extract_http_urls(text)
     if not urls:
         return text
@@ -79,9 +79,27 @@ def rewrite_prompt_urls(text: str, agent, *, create: bool) -> str:
 
     def replace(match: re.Match) -> str:
         url, suffix = _split_url_suffix(match.group())
-        return references.get(url, url) + suffix
+        reference = references.get(url)
+        if not reference:
+            return url + suffix
+        if not include_raw:
+            return reference + suffix
+        paired_suffix = f" [link_ref: {reference}]"
+        if text[match.end():].startswith(paired_suffix):
+            return match.group()
+        if match.start() >= 2 and text[match.start() - 2:match.start()] == "](" and suffix.startswith(")"):
+            return f"{url}){paired_suffix}{suffix[1:]}"
+        return f"{url}{paired_suffix}{suffix}"
 
     return _HTTP_URL_RE.sub(replace, text)
+
+
+def rewrite_prompt_urls(text: str, agent, *, create: bool) -> str:
+    return _render_prompt_urls(text, agent, create=create, include_raw=False)
+
+
+def pair_prompt_urls(text: str, agent, *, create: bool) -> str:
+    return _render_prompt_urls(text, agent, create=create, include_raw=True)
 
 
 def resolve_link_references(text: str, agent) -> str:

--- a/api/agent/core/link_references.py
+++ b/api/agent/core/link_references.py
@@ -11,6 +11,10 @@ from api.models import PersistentAgentLinkReference
 logger = logging.getLogger(__name__)
 
 _HTTP_URL_RE = re.compile(r'''https?://[^\s<>"'`\[\]\\]+''', re.IGNORECASE)
+_HTML_HREF_TAG_RE = re.compile(
+    r'''<[^>]*\bhref\s*=\s*(?:(?P<quote>["'])(?P<quoted_url>https?://[^\s<>"'`\[\]\\]+)(?P=quote)|(?P<bare_url>https?://[^\s<>"'`\[\]\\]+))[^>]*>''',
+    re.IGNORECASE,
+)
 _REFERENCE_RE = re.compile(r"\$\[link:([^\]]*)\]", re.IGNORECASE)
 _REFERENCE_PREFIX_RE = re.compile(r"\$\[link:", re.IGNORECASE)
 _PUBLIC_ID_PATTERN = r"L[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{16}"
@@ -42,6 +46,13 @@ def _split_url_suffix(raw_url: str) -> tuple[str, str]:
 
 def extract_http_urls(text: str) -> tuple[str, ...]:
     return tuple(dict.fromkeys(_split_url_suffix(match.group())[0] for match in _HTTP_URL_RE.finditer(text or "")))
+
+
+def _is_html_href_url(text: str, start: int) -> bool:
+    tag_start = text.rfind("<", 0, start)
+    if tag_start <= text.rfind(">", 0, start):
+        return False
+    return bool(re.search(r'''\bhref\s*=\s*["']?\s*$''', text[tag_start:start], re.IGNORECASE))
 
 
 def is_source_bearing_tool(tool_name: str) -> bool:
@@ -84,6 +95,8 @@ def _render_prompt_urls(text: str, agent, *, create: bool, include_raw: bool) ->
             return url + suffix
         if not include_raw:
             return reference + suffix
+        if _is_html_href_url(text, match.start()):
+            return match.group()
         paired_suffix = f" [link_ref: {reference}]"
         if text[match.end():].startswith(paired_suffix):
             return match.group()
@@ -91,7 +104,22 @@ def _render_prompt_urls(text: str, agent, *, create: bool, include_raw: bool) ->
             return f"{url}){paired_suffix}{suffix[1:]}"
         return f"{url}{paired_suffix}{suffix}"
 
-    return _HTTP_URL_RE.sub(replace, text)
+    rendered = _HTTP_URL_RE.sub(replace, text)
+    if not include_raw:
+        return rendered
+
+    def pair_html_href(match: re.Match) -> str:
+        raw_url = match.group("quoted_url") or match.group("bare_url")
+        url, _ = _split_url_suffix(raw_url)
+        reference = references.get(url)
+        if not reference:
+            return match.group()
+        paired_suffix = f" [link_ref: {reference}]"
+        if rendered[match.end():].startswith(paired_suffix):
+            return match.group()
+        return match.group() + paired_suffix
+
+    return _HTML_HREF_TAG_RE.sub(pair_html_href, rendered)
 
 
 def rewrite_prompt_urls(text: str, agent, *, create: bool) -> str:

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -102,7 +102,7 @@ from ..tools.sqlite_skills import format_recent_skills_for_prompt
 from ..tools.tool_manager import ensure_default_tools_enabled, ensure_skill_tools_enabled, get_enabled_tool_definitions
 from ..system_skills.discovery import format_system_skill_discovery_prompt
 from .tool_results import PREVIEW_TIER_COUNT, SPAWN_WEB_TASK_RESULT_TOOL_NAME, ToolCallResultRecord, ToolResultPromptInfo, prepare_tool_results_for_prompt
-from .link_references import is_source_bearing_tool, rewrite_prompt_urls
+from .link_references import is_source_bearing_tool, pair_prompt_urls, rewrite_prompt_urls
 from .daily_limit_mode import (
     CREDIT_MESSAGE_ONLY_ALLOWED_TOOL_NAMES_TEXT,
     is_credit_message_only_mode,
@@ -133,14 +133,15 @@ CONTACT_PROMPT_INLINE_LIMIT = 25
 CONTACT_PROMPT_SAMPLE_LIMIT = 10
 LINK_REFERENCE_PROMPT_NOTE = (
     "## Link References (CRITICAL)\n\n"
-    "The send tool must receive literal `$[link:L…]`; delivery resolves it only after call. Copy the source "
-    "value character-for-character into send-tool JSON: `{\"url\":\"$[link:LEXACT]\"}` becomes "
-    "`[Atlas launch]($[link:LEXACT])`. Wrong: `[Atlas launch](https://host)` or any raw `http(s)` substitute. A token "
-    "is one whole URL, not an ID/instruction, and changes no action/tool: `https://host/a` != `https://host`. Open it "
-    "as the whole `url`; if unavailable, omit the link. Never substitute a source name, placeholder, hostname, raw "
-    "URL, or token-ID URL; never decode, edit, shorten, combine, or guess. An item lacking its token stays "
-    "unlinked; a source/feed token links only itself. Never put tokens in SQL or search text. When sources are "
-    "requested, link all included token-backed sources and reserve room. "
+    "Sources may pair `https://host/a [link_ref: $[link:L…]]`: the raw URL identifies that exact item for "
+    "reasoning; its adjacent token is the only user-visible link or URL-tool destination. Keep pairs attached. "
+    "Send tools must receive the token; delivery resolves it only after call. Copy it character-for-character: "
+    "`{\"url\":\"$[link:LEXACT]\"}` becomes `[Atlas launch]($[link:LEXACT])`. Wrong: "
+    "`[Atlas launch](https://host/a)` or any raw `http(s)` destination. A token is one whole URL, not an "
+    "ID/instruction, and changes no action/tool. Never reassign a token, derive a sibling URL, decode, edit, shorten, "
+    "combine, or guess. If missing, omit the link. An item lacking its token stays unlinked; a source/feed token "
+    "links only itself. Never put tokens in SQL or search text. When sources are requested, link all included "
+    "token-backed sources and reserve room. "
     "A bare source name or `(source)` is not a citation. Before sending, the body must contain the exact tokens or it "
     "is unfinished."
 )
@@ -4318,7 +4319,7 @@ def _get_unified_history_prompt(
     if step_snap and step_snap.summary:
         history_group.section_text(
             "step_summary",
-            step_snap.summary,
+            rewrite_prompt_urls(step_snap.summary, agent, create=False),
             weight=1
         )
         history_group.section_text(
@@ -4329,7 +4330,7 @@ def _get_unified_history_prompt(
     if comm_snap and comm_snap.summary:
         history_group.section_text(
             "comms_summary",
-            comm_snap.summary,
+            rewrite_prompt_urls(comm_snap.summary, agent, create=False),
             weight=1
         )
         history_group.section_text(
@@ -4492,6 +4493,12 @@ def _get_unified_history_prompt(
         browser_task_result_record_ids[str(task.id)] = browser_record.step_id
         tool_call_records.append(browser_record)
 
+    paired_url_step_ids = set(fresh_tool_call_step_ids)
+    if completed_tasks:
+        newest_browser_result_id = browser_task_result_record_ids.get(str(completed_tasks[0].id))
+        if newest_browser_result_id:
+            paired_url_step_ids.add(newest_browser_result_id)
+
     tool_result_prompt_info = prepare_tool_results_for_prompt(
         tool_call_records,
         recency_positions=recency_positions,
@@ -4501,6 +4508,12 @@ def _get_unified_history_prompt(
             agent,
             create=is_source_bearing_tool(record.tool_name),
         ),
+        paired_url_rewriter=lambda text, record: pair_prompt_urls(
+            text,
+            agent,
+            create=is_source_bearing_tool(record.tool_name),
+        ),
+        paired_url_step_ids=paired_url_step_ids,
     )
 
     # format steps (group meta/params/result components together)
@@ -4591,11 +4604,10 @@ def _get_unified_history_prompt(
 
         channel = m.from_endpoint.channel
         body = _redact_signed_filespace_urls(m.body or "", agent)
-        body = rewrite_prompt_urls(
-            body,
-            agent,
-            create=not m.is_outbound,
-        )
+        if m.is_outbound:
+            body = rewrite_prompt_urls(body, agent, create=False)
+        else:
+            body = pair_prompt_urls(body, agent, create=True)
         subject = ""
         raw_payload = m.raw_payload if isinstance(m.raw_payload, dict) else {}
         if raw_payload:
@@ -4749,11 +4761,12 @@ def _get_unified_history_prompt(
             elif not result_summary and t.status == BrowserUseAgentTask.StatusChoices.CANCELLED:
                 result_summary = "Browser task was cancelled."
             if result_summary:
-                components["result_summary"] = rewrite_prompt_urls(
-                    result_summary,
-                    agent,
-                    create=True,
+                result_renderer = (
+                    pair_prompt_urls
+                    if browser_task_result_record_ids.get(str(t.id)) in paired_url_step_ids
+                    else rewrite_prompt_urls
                 )
+                components["result_summary"] = result_renderer(result_summary, agent, create=True)
             if (
                 result_info.preview_text
                 and not files

--- a/api/agent/core/tests/test_link_references.py
+++ b/api/agent/core/tests/test_link_references.py
@@ -9,11 +9,13 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.db import DatabaseError
 from django.test import TestCase, override_settings, tag
+from django.utils import timezone as django_timezone
 
 from api.agent.core.link_references import (
     LinkReferenceResolutionError,
     extract_http_urls,
     is_source_bearing_tool,
+    pair_prompt_urls,
     resolve_link_reference_params,
     resolve_link_references,
     resolve_link_references_for_display,
@@ -46,6 +48,7 @@ from api.models import (
     BrowserUseAgent,
     CommsChannel,
     PersistentAgent,
+    PersistentAgentCommsSnapshot,
     PersistentAgentCommsEndpoint,
     PersistentAgentLinkReference,
     PersistentAgentMessage,
@@ -152,12 +155,42 @@ class LinkReferenceTests(TestCase):
         self.assertEqual(first, f"[Item]({token})")
         self.assertEqual(second, f"<a href='{token}'>Item</a>")
 
+    def test_pairing_keeps_similar_raw_urls_attached_to_distinct_references(self):
+        first_url = "https://items.example.test/id/1?view=full#details"
+        second_url = "https://items.example.test/id/2?view=full#details"
+
+        rendered = pair_prompt_urls(
+            f"First: {first_url}\nSecond: {second_url}",
+            self.agent,
+            create=True,
+        )
+
+        references = {
+            reference.url: f"$[link:{reference.public_id}]"
+            for reference in PersistentAgentLinkReference.objects.filter(agent=self.agent)
+        }
+        self.assertEqual(len(references), 2)
+        self.assertIn(f"{first_url} [link_ref: {references[first_url]}]", rendered)
+        self.assertIn(f"{second_url} [link_ref: {references[second_url]}]", rendered)
+        self.assertEqual(pair_prompt_urls(rendered, self.agent, create=False), rendered)
+
+    def test_pairing_keeps_markdown_destination_valid(self):
+        url = "https://items.example.test/id/7?view=full#details"
+
+        rendered = pair_prompt_urls(f"[Item]({url}).", self.agent, create=True)
+
+        reference = PersistentAgentLinkReference.objects.get(agent=self.agent)
+        token = f"$[link:{reference.public_id}]"
+        self.assertEqual(rendered, f"[Item]({url}) [link_ref: {token}].")
+        self.assertEqual(pair_prompt_urls(rendered, self.agent, create=False), rendered)
+
     def test_lookup_only_does_not_create_provenance(self):
         url = "https://derived.example.test/records/9"
         self.assertEqual(
             rewrite_prompt_urls(url, self.agent, create=False),
             url,
         )
+        self.assertEqual(pair_prompt_urls(url, self.agent, create=False), url)
         self.assertFalse(PersistentAgentLinkReference.objects.exists())
 
         registered = rewrite_prompt_urls(
@@ -166,6 +199,7 @@ class LinkReferenceTests(TestCase):
             create=True,
         )
         self.assertEqual(rewrite_prompt_urls(url, self.agent, create=False), registered)
+        self.assertIn(registered, pair_prompt_urls(url, self.agent, create=False))
 
     def test_reference_resolves_across_calls_in_markdown_html_and_plain_text(self):
         url = "https://profiles.example.test/avery?campaign=q3#experience"
@@ -571,7 +605,7 @@ class LinkReferenceTests(TestCase):
             "api.agent.core.link_references.PersistentAgentLinkReference.objects.filter",
             side_effect=DatabaseError("unavailable"),
         ):
-            rendered = rewrite_prompt_urls(
+            rendered = pair_prompt_urls(
                 url,
                 self.agent,
                 create=True,
@@ -587,7 +621,7 @@ class LinkReferenceTests(TestCase):
         self.assertFalse(is_source_bearing_tool("sqlite_batch"))
         self.assertFalse(is_source_bearing_tool("python_exec"))
 
-    def test_source_result_preview_uses_reference_without_mutating_raw_result(self):
+    def test_source_result_preview_pairs_raw_url_with_reference_without_mutating_result(self):
         url = "https://profiles.example.test/avery?view=full#bio"
         raw_result = f'{{"results":[{{"name":"Avery Chen","profile_url":"{url}"}}]}}'
         record = ToolCallResultRecord(
@@ -606,15 +640,40 @@ class LinkReferenceTests(TestCase):
                 self.agent,
                 create=is_source_bearing_tool(item.tool_name),
             ),
+            paired_url_rewriter=lambda text, item: pair_prompt_urls(
+                text,
+                self.agent,
+                create=is_source_bearing_tool(item.tool_name),
+            ),
+            paired_url_step_ids={record.step_id},
         )[record.step_id]
 
         reference = PersistentAgentLinkReference.objects.get(agent=self.agent)
         token = f"$[link:{reference.public_id}]"
         self.assertIn("Avery Chen", prompt_info.meta)
         self.assertIn(token, prompt_info.meta)
-        self.assertNotIn(url, prompt_info.meta)
+        self.assertIn(f"{url} [link_ref: {token}]", prompt_info.meta)
+        self.assertIn(f"{url} [link_ref: {token}]", prompt_info.preview_text)
         self.assertIn(token, prompt_info.preview_text)
         self.assertEqual(record.result_text, raw_result)
+
+        older_prompt_info = prepare_tool_results_for_prompt(
+            [record],
+            recency_positions={},
+            url_rewriter=lambda text, item: rewrite_prompt_urls(
+                text,
+                self.agent,
+                create=is_source_bearing_tool(item.tool_name),
+            ),
+            paired_url_rewriter=lambda text, item: pair_prompt_urls(
+                text,
+                self.agent,
+                create=is_source_bearing_tool(item.tool_name),
+            ),
+            paired_url_step_ids=set(),
+        )[record.step_id]
+        self.assertIn(token, older_prompt_info.preview_text)
+        self.assertNotIn(url, older_prompt_info.preview_text)
 
     def test_source_result_marks_sparse_item_link_field_as_not_provided(self):
         raw_result = (
@@ -637,6 +696,12 @@ class LinkReferenceTests(TestCase):
                 self.agent,
                 create=is_source_bearing_tool(item.tool_name),
             ),
+            paired_url_rewriter=lambda text, item: pair_prompt_urls(
+                text,
+                self.agent,
+                create=is_source_bearing_tool(item.tool_name),
+            ),
+            paired_url_step_ids={record.step_id},
         )[record.step_id]
 
         self.assertIn(
@@ -669,10 +734,19 @@ class LinkReferenceTests(TestCase):
                 self.agent,
                 create=is_source_bearing_tool(item.tool_name),
             ),
+            paired_url_rewriter=lambda text, item: pair_prompt_urls(
+                text,
+                self.agent,
+                create=is_source_bearing_tool(item.tool_name),
+            ),
+            paired_url_step_ids={record.step_id},
         )[record.step_id]
 
+        reference = PersistentAgentLinkReference.objects.get(agent=self.agent, url=url)
+        token = f"$[link:{reference.public_id}]"
         self.assertIn("FOCUS:", prompt_info.meta)
         self.assertIn("name: Alice", prompt_info.meta)
+        self.assertIn(f"{url} [link_ref: {token}]", prompt_info.meta)
         self.assertNotIn("CSV DATA", prompt_info.meta)
         self.assertNotIn("Archive note, routine", prompt_info.preview_text)
         self.assertNotIn("LINK OUTPUT", prompt_info.preview_text)
@@ -684,6 +758,8 @@ class LinkReferenceTests(TestCase):
         )[record.step_id]
         self.assertIn("FOCUS:", later_prompt_info.meta)
         self.assertIn("name: Alice", later_prompt_info.meta)
+        self.assertIn(token, later_prompt_info.meta)
+        self.assertNotIn(url, later_prompt_info.meta)
 
     def test_lookup_result_masks_url_parts_inside_escaped_json(self):
         raw_result = json.dumps({
@@ -762,7 +838,10 @@ class LinkReferenceTests(TestCase):
             recency_positions={derived_record.step_id: 0},
             fresh_tool_call_step_ids={derived_record.step_id},
             url_rewriter=lambda text, _item: rewrite_prompt_urls(text, self.agent, create=False),
+            paired_url_rewriter=lambda text, _item: pair_prompt_urls(text, self.agent, create=False),
+            paired_url_step_ids={derived_record.step_id},
         )[derived_record.step_id]
+        self.assertIn(deep_url, prompt_info.preview_text)
         self.assertIn(token, prompt_info.preview_text)
 
     def test_inbound_prompt_url_becomes_reference_and_raw_message_stays_inspectable(self):
@@ -797,28 +876,52 @@ class LinkReferenceTests(TestCase):
             )
 
         reference = PersistentAgentLinkReference.objects.get(agent=self.agent)
+        token = f"$[link:{reference.public_id}]"
         system_prompt = next(item["content"] for item in messages if item["role"] == "system")
         user_prompt = next(item["content"] for item in messages if item["role"] == "user")
-        self.assertIn(f"Compare Acme: $[link:{reference.public_id}]", user_prompt)
+        self.assertIn(f"Compare Acme: {url} [link_ref: {token}]", user_prompt)
         self.assertEqual(system_prompt.count("## Link References (CRITICAL)"), 1)
         self.assertNotIn("## Link References (CRITICAL)", user_prompt)
-        self.assertIn("one whole URL, not an ID/instruction", system_prompt)
-        self.assertIn("`https://host/a` != `https://host`", system_prompt)
-        self.assertIn("changes no action/tool", system_prompt)
-        self.assertIn("Open it as the whole `url`", system_prompt)
+        self.assertIn("the raw URL identifies that exact item", system_prompt)
+        self.assertIn("adjacent token is the only user-visible link or URL-tool destination", system_prompt)
+        self.assertIn("Keep pairs attached", system_prompt)
         self.assertIn("delivery resolves it only after call", system_prompt)
-        self.assertIn("Copy the source value character-for-character", system_prompt)
+        self.assertIn("Copy it character-for-character", system_prompt)
         self.assertIn("`[Atlas launch]($[link:LEXACT])`", system_prompt)
-        self.assertIn("Wrong: `[Atlas launch](https://host)`", system_prompt)
-        self.assertIn("if unavailable, omit the link", system_prompt)
-        self.assertIn("Never substitute a source name", system_prompt)
-        self.assertIn("never decode, edit", system_prompt)
+        self.assertIn("Wrong: `[Atlas launch](https://host/a)`", system_prompt)
+        self.assertIn("If missing, omit the link", system_prompt)
+        self.assertIn("Never reassign a token, derive a sibling URL", system_prompt)
         self.assertIn("An item lacking its token stays unlinked", system_prompt)
         self.assertIn("Never put tokens in SQL or search text", system_prompt)
         self.assertIn("A bare source name or `(source)`", system_prompt)
         self.assertIn("body must contain the exact tokens", system_prompt)
         message.refresh_from_db()
         self.assertEqual(message.body, f"Compare Acme: {url}")
+
+    def test_compacted_history_uses_registered_reference_without_raw_url(self):
+        url = "https://vendors.example.test/acme/history"
+        token = rewrite_prompt_urls(url, self.agent, create=True)
+        PersistentAgentCommsSnapshot.objects.create(
+            agent=self.agent,
+            snapshot_until=django_timezone.now(),
+            summary=f"Previously reviewed Acme at {url}",
+        )
+
+        with patch("api.agent.core.prompt_context.ensure_steps_compacted"), patch(
+            "api.agent.core.prompt_context.ensure_comms_compacted"
+        ), patch(
+            "api.agent.core.prompt_context.get_llm_config_with_failover",
+            return_value=[("endpoint", "openai/gpt-4o-mini", {})],
+        ):
+            messages, _, _ = build_prompt_context(
+                self.agent,
+                daily_credit_state={},
+                task_credit_available=Decimal("0"),
+            )
+
+        prompt = "\n".join(item["content"] for item in messages)
+        self.assertIn(f"Previously reviewed Acme at {token}", prompt)
+        self.assertNotIn(url, prompt)
 
     def test_prompt_reference_is_stable_across_renders(self):
         url = "https://profiles.example.test/avery?view=full#bio"

--- a/api/agent/core/tests/test_link_references.py
+++ b/api/agent/core/tests/test_link_references.py
@@ -184,6 +184,19 @@ class LinkReferenceTests(TestCase):
         self.assertEqual(rendered, f"[Item]({url}) [link_ref: {token}].")
         self.assertEqual(pair_prompt_urls(rendered, self.agent, create=False), rendered)
 
+    def test_pairing_keeps_html_href_valid(self):
+        url = "https://items.example.test/id/7?view=full&amp;region=west#details"
+        for quote in ('"', "'", ""):
+            with self.subTest(quote=quote or "unquoted"):
+                source = f"<a class='item' href={quote}{url}{quote}>Item</a>."
+                rendered = pair_prompt_urls(source, self.agent, create=True)
+
+                reference = PersistentAgentLinkReference.objects.get(agent=self.agent)
+                token = f"$[link:{reference.public_id}]"
+                expected = f"<a class='item' href={quote}{url}{quote}> [link_ref: {token}]Item</a>."
+                self.assertEqual(rendered, expected)
+                self.assertEqual(pair_prompt_urls(rendered, self.agent, create=False), rendered)
+
     def test_lookup_only_does_not_create_provenance(self):
         url = "https://derived.example.test/records/9"
         self.assertEqual(

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -53,7 +53,11 @@ BARBELL_TEXT_FORMATS = frozenset({"html", "markdown", "plain", "log"})
 _UUID_RESULT_ID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
 )
-_LINK_FIELD_RE = re.compile(r"\b([A-Za-z_][\w-]*(?:url|link|href))\s*([:=])\s*\$\[link:", re.IGNORECASE)
+_LINK_FIELD_RE = re.compile(
+    r"\b([A-Za-z_][\w-]*(?:url|link|href))\s*([:=])\s*"
+    r"(?:https?://\S+\s+\[link_ref:\s*)?\$\[link:",
+    re.IGNORECASE,
+)
 _URL_PART_FIELD_RE = re.compile(
     r"(\b[\w-]*(?:host|path|route|slug|public_identifier|profile_id)\s*[:=]\s*)([^|\n]*?\S)(?=\s*(?:\||\\n|$))",
     re.IGNORECASE,
@@ -149,6 +153,8 @@ def prepare_tool_results_for_prompt(
     fresh_tool_call_step_id: Optional[str] = None,
     fresh_tool_call_step_ids: Optional[Set[str]] = None,
     url_rewriter: Optional[Callable[[str, ToolCallResultRecord], str]] = None,
+    paired_url_rewriter: Optional[Callable[[str, ToolCallResultRecord], str]] = None,
+    paired_url_step_ids: Optional[Set[str]] = None,
 ) -> Dict[str, ToolResultPromptInfo]:
     prompt_info: Dict[str, ToolResultPromptInfo] = {}
     rows: List[Tuple] = []
@@ -156,6 +162,7 @@ def prepare_tool_results_for_prompt(
     fresh_step_ids = set(fresh_tool_call_step_ids or ())
     if fresh_tool_call_step_id:
         fresh_step_ids.add(fresh_tool_call_step_id)
+    paired_step_ids = set(paired_url_step_ids or ())
     short_id_map = _build_short_result_id_map(
         [
             record.step_id
@@ -225,11 +232,16 @@ def prepare_tool_results_for_prompt(
         has_focus = "\nFOCUS:\n" in (context_hint or "")
         if has_focus and not is_inline:
             preview_text = None
-        if url_rewriter:
+        active_url_rewriter = (
+            paired_url_rewriter
+            if paired_url_rewriter and record.step_id in paired_step_ids
+            else url_rewriter
+        )
+        if active_url_rewriter:
             if context_hint:
-                context_hint = url_rewriter(context_hint, record)
+                context_hint = active_url_rewriter(context_hint, record)
             if preview_text:
-                preview_text = url_rewriter(preview_text, record)
+                preview_text = active_url_rewriter(preview_text, record)
         if "$[link:" in f"{context_hint or ''}{preview_text or ''}":
             context_hint = _mark_missing_item_links(context_hint or "") or None
             preview_text = _mark_missing_item_links(preview_text or "")

--- a/tests/unit/test_prompt_context_message_placement.py
+++ b/tests/unit/test_prompt_context_message_placement.py
@@ -60,6 +60,8 @@ class PromptContextSqlitePlacementTests(TestCase):
             system_message["content"],
         )
         self.assertIn("## Link References (CRITICAL)", system_message["content"])
+        self.assertIn("the raw URL identifies that exact item", system_message["content"])
+        self.assertIn("adjacent token is the only user-visible link", system_message["content"])
         self.assertIn("An item lacking its token stays unlinked", system_message["content"])
         self.assertIn("a source/feed token links only itself", system_message["content"])
         self.assertIn("resolve/source each requested field", system_message["content"])


### PR DESCRIPTION
## Summary
- Pair source URLs with adjacent link reference tokens for agent reasoning.
- Keep compacted and older history token-only while preserving raw URLs for fresh source results.
- Update link-field detection and prompt guidance for paired references.
- Add regression coverage for markdown, similar URLs, tool results, and compacted history.

## Testing
- Not run (not requested)