### PR TITLE
Keep live Thinking from reclaiming manual scroll

### DIFF
--- a/frontend/src/components/agentChat/useTimelineScrollController.test.tsx
+++ b/frontend/src/components/agentChat/useTimelineScrollController.test.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react'
+import { act, fireEvent, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTimelineScrollController } from './useTimelineScrollController'
+
+type HarnessProps = {
+  contentVersion: string
+}
+
+let animationFrameCallbacks: Map<number, FrameRequestCallback>
+let nextAnimationFrameId: number
+
+function createScrollViewport({
+  clientHeight = 400,
+  scrollHeight = 1_000,
+  scrollTop = 500,
+} = {}): HTMLDivElement {
+  const viewport = document.createElement('div')
+  const currentScrollHeight = scrollHeight
+  let currentScrollTop = scrollTop
+
+  Object.defineProperties(viewport, {
+    clientHeight: {
+      configurable: true,
+      get: () => clientHeight,
+    },
+    scrollHeight: {
+      configurable: true,
+      get: () => currentScrollHeight,
+    },
+    scrollTop: {
+      configurable: true,
+      get: () => currentScrollTop,
+      set: (value: number) => {
+        currentScrollTop = Math.max(0, Math.min(value, currentScrollHeight - clientHeight))
+      },
+    },
+  })
+
+  return viewport
+}
+
+function flushNextAnimationFrame() {
+  const next = animationFrameCallbacks.entries().next().value as [number, FrameRequestCallback] | undefined
+  if (!next) {
+    return
+  }
+  animationFrameCallbacks.delete(next[0])
+  act(() => next[1](0))
+}
+
+function flushAnimationFrames() {
+  for (let frame = 0; frame < 20 && animationFrameCallbacks.size > 0; frame += 1) {
+    const callbacks = Array.from(animationFrameCallbacks.values())
+    animationFrameCallbacks.clear()
+    act(() => callbacks.forEach((callback) => callback(frame)))
+  }
+  expect(animationFrameCallbacks.size).toBe(0)
+}
+
+function useScrollHarness({ contentVersion }: HarnessProps) {
+  const [pinned, setPinned] = useState(true)
+  const controller = useTimelineScrollController({
+    activeAgentId: 'agent-1',
+    autoScrollPinned: pinned,
+    contentVersion,
+    eventCount: 1,
+    fetchPreviousPage: async () => undefined,
+    hasPreviousPage: false,
+    initialLoading: false,
+    isFetchPreviousPageError: false,
+    isFetchingPreviousPage: false,
+    isNewAgent: false,
+    pageCount: 1,
+    setAutoScrollPinned: setPinned,
+    switchingAgentId: null,
+  })
+  return { controller, pinned }
+}
+
+describe('useTimelineScrollController', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    animationFrameCallbacks = new Map()
+    nextAnimationFrameId = 0
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      nextAnimationFrameId += 1
+      animationFrameCallbacks.set(nextAnimationFrameId, callback)
+      return nextAnimationFrameId
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+      animationFrameCallbacks.delete(id)
+    })
+    vi.stubGlobal('ResizeObserver', class ResizeObserver {
+      observe() {}
+      disconnect() {}
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not re-pin when an upward wheel overtakes a live Thinking scroll event', () => {
+    const { result, rerender } = renderHook(
+      ({ contentVersion }: HarnessProps) => useScrollHarness({ contentVersion }),
+      { initialProps: { contentVersion: 'thinking:1' } },
+    )
+    const viewport = createScrollViewport()
+
+    act(() => result.current.controller.timelineRef(viewport))
+    flushNextAnimationFrame()
+    expect(viewport.scrollTop).toBe(600)
+
+    // The bottom assignment has landed, but its queued scroll event has not.
+    fireEvent.wheel(viewport, { deltaY: -40 })
+    expect(result.current.pinned).toBe(false)
+    viewport.scrollTop = 550
+    fireEvent.scroll(viewport)
+
+    expect(result.current.pinned).toBe(false)
+    rerender({ contentVersion: 'thinking:2' })
+    flushAnimationFrames()
+    expect(viewport.scrollTop).toBe(550)
+  })
+
+  it('preserves a native manual position through Thinking updates and resumes at the live edge', () => {
+    const { result, rerender } = renderHook(
+      ({ contentVersion }: HarnessProps) => useScrollHarness({ contentVersion }),
+      { initialProps: { contentVersion: 'thinking:1' } },
+    )
+    const viewport = createScrollViewport()
+
+    act(() => result.current.controller.timelineRef(viewport))
+    flushNextAnimationFrame()
+    expect(viewport.scrollTop).toBe(600)
+
+    viewport.scrollTop = 300
+    fireEvent.scroll(viewport)
+
+    expect(result.current.pinned).toBe(false)
+    rerender({ contentVersion: 'thinking:2' })
+    flushAnimationFrames()
+    expect(viewport.scrollTop).toBe(300)
+
+    rerender({ contentVersion: 'thinking:done' })
+    flushAnimationFrames()
+    expect(viewport.scrollTop).toBe(300)
+
+    viewport.scrollTop = 550
+    fireEvent.scroll(viewport)
+    expect(result.current.pinned).toBe(true)
+
+    rerender({ contentVersion: 'reply:1' })
+    flushAnimationFrames()
+    expect(viewport.scrollTop).toBe(600)
+  })
+})

--- a/frontend/src/components/agentChat/useTimelineScrollController.ts
+++ b/frontend/src/components/agentChat/useTimelineScrollController.ts
@@ -103,6 +103,7 @@ export function useTimelineScrollController({
     }
     programmaticScrollUntilRef.current = Date.now() + PROGRAMMATIC_SCROLL_MS
     container.scrollTop = container.scrollHeight
+    lastScrollTopRef.current = container.scrollTop
     setIsNearBottom(true)
   }, [])
 
@@ -309,15 +310,20 @@ export function useTimelineScrollController({
         suspendAutoFollow()
       }
 
+      const distance = bottomDistance(container)
+      // A bottom-follow write cannot leave the viewport beyond the live-edge threshold.
+      const movedAwayFromLiveEdge = meaningfulScrollUp && distance > NEAR_BOTTOM_PX
       if (
-        Date.now() < programmaticScrollUntilRef.current
+        (
+          Date.now() < programmaticScrollUntilRef.current
+          && !movedAwayFromLiveEdge
+        )
         || Date.now() < ignorePinUntilRef.current
         || prependAnchorRef.current
       ) {
         return
       }
 
-      const distance = bottomDistance(container)
       if (meaningfulScrollUp) {
         suspendAutoFollow()
       } else if (scrollingDown && distance <= NEAR_BOTTOM_PX) {


### PR DESCRIPTION
## Summary

- Synchronize the timeline's scroll baseline at each live-edge write so a closely timed upward gesture cannot be misread as downward and re-pin.
- Let a meaningful native upward move beyond the live-edge threshold override the short programmatic-scroll guard used during streaming.
- Add controller-level regressions for the wheel/write race, continuing Thinking deltas, the Thinking-to-complete transition, and deliberate return to the live edge.

## Evidence

Bug #235 is concentrated in live Thinking: every reasoning delta changes `timelineScrollContentVersion`, which schedules multi-frame bottom writes while pinned. PR #1332 added the correct wheel/touch/pointer ownership transition, but it shipped without controller tests and left two timing gaps:

1. A bottom assignment did not update `lastScrollTopRef`, so an upward gesture arriving before the assignment's queued `scroll` event could look downward and re-pin near the bottom.
2. A native upward `scroll` event could still be swallowed by the continuously renewed 180 ms programmatic guard.

Both new tests failed on current `main` before the implementation change (`2 failed`) and pass after it (`2 passed`).

## Tests

- `npm test -- src/components/agentChat/useTimelineScrollController.test.tsx` — 2 passed
- `npx eslint src/components/agentChat/useTimelineScrollController.ts src/components/agentChat/useTimelineScrollController.test.tsx` — passed
- `npm run build:app` — passed
- `uv run python scripts/check_complexity_budgets.py --loc-only` — 246408 / 246939, passed

Per repository guidance, the broad local suite was not run; CI is the broad-suite gate.

## Scope

This is a deterministic browser-state fix, so there are no prompt changes or model evals. It does not redesign the Thinking card, alter the nested three-line Thinking preview, or add speculative keyboard handlers. The PR should remain open after CI/preview for Andrew's manual preview test; do not auto-merge.
