### PR TITLE
Wait for terminating Kubernetes sandbox pods before recreation

### DIFF
--- a/api/services/sandbox_kubernetes.py
+++ b/api/services/sandbox_kubernetes.py
@@ -5,7 +5,7 @@ import re
 import time
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 from urllib.parse import quote
 
 import requests
@@ -306,35 +306,32 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
                 workspace_reset = workspace_reset or not self._uses_pvc_workspace()
             else:
                 phase = (pod.get("status") or {}).get("phase")
-                if not _sandbox_pod_matches(
-                    pod,
-                    image=self._pod_image,
-                    resources=self._pod_resources,
-                    workspace_volume_mode=self._workspace_volume_mode,
-                    pvc_name=pvc_name,
-                    emptydir_size_limit=self._workspace_emptydir_size,
-                    egress_service_name=egress_service_name,
-                    http_proxy_port=self._egress_proxy_service_port,
-                    socks_proxy_port=self._egress_proxy_socks_service_port,
-                    no_proxy=no_proxy,
-                ):
-                    self._delete_pod(pod_name)
-                    self._create_pod(
-                        pod_name,
-                        pvc_name,
-                        agent_id=str(agent.id),
+                needs_replacement = (
+                    _pod_is_terminating(pod)
+                    or phase not in {"Running", "Pending"}
+                    or not _sandbox_pod_matches(
+                        pod,
+                        image=self._pod_image,
+                        resources=self._pod_resources,
+                        workspace_volume_mode=self._workspace_volume_mode,
+                        pvc_name=pvc_name,
+                        emptydir_size_limit=self._workspace_emptydir_size,
                         egress_service_name=egress_service_name,
+                        http_proxy_port=self._egress_proxy_service_port,
+                        socks_proxy_port=self._egress_proxy_socks_service_port,
                         no_proxy=no_proxy,
                     )
-                    workspace_reset = workspace_reset or not self._uses_pvc_workspace()
-                elif phase not in {"Running", "Pending"}:
-                    self._delete_pod(pod_name)
-                    self._create_pod(
+                )
+                if needs_replacement:
+                    self._replace_pod(
                         pod_name,
-                        pvc_name,
-                        agent_id=str(agent.id),
-                        egress_service_name=egress_service_name,
-                        no_proxy=no_proxy,
+                        lambda: self._create_pod(
+                            pod_name,
+                            pvc_name,
+                            agent_id=str(agent.id),
+                            egress_service_name=egress_service_name,
+                            no_proxy=no_proxy,
+                        ),
                     )
                     workspace_reset = workspace_reset or not self._uses_pvc_workspace()
         except KubernetesApiError as exc:
@@ -707,10 +704,13 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
 
     def _get_pod(self, pod_name: str) -> Optional[Dict[str, Any]]:
         try:
-            return self._client.request_json("GET", _pod_path(self._namespace, pod_name), allow_404=True)
+            return self._read_pod(pod_name)
         except KubernetesApiError as exc:
             logger.warning("Failed to fetch pod %s: %s", pod_name, exc)
             return None
+
+    def _read_pod(self, pod_name: str) -> Optional[Dict[str, Any]]:
+        return self._client.request_json("GET", _pod_path(self._namespace, pod_name), allow_404=True)
 
     def _get_service(self, service_name: str) -> Optional[Dict[str, Any]]:
         try:
@@ -743,18 +743,26 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
                 self._create_egress_proxy_pod(pod_name, agent_id=str(agent.id), proxy_server=proxy_server)
             else:
                 phase = (pod.get("status") or {}).get("phase")
-                if not _egress_proxy_pod_matches(
-                    pod,
-                    proxy_server=proxy_server,
-                    resources=self._egress_proxy_resources,
-                    http_listen_port=self._egress_proxy_port,
-                    socks_listen_port=self._egress_proxy_socks_port,
-                ):
-                    self._delete_pod(pod_name)
-                    self._create_egress_proxy_pod(pod_name, agent_id=str(agent.id), proxy_server=proxy_server)
-                elif phase not in {"Running", "Pending"}:
-                    self._delete_pod(pod_name)
-                    self._create_egress_proxy_pod(pod_name, agent_id=str(agent.id), proxy_server=proxy_server)
+                needs_replacement = (
+                    _pod_is_terminating(pod)
+                    or phase not in {"Running", "Pending"}
+                    or not _egress_proxy_pod_matches(
+                        pod,
+                        proxy_server=proxy_server,
+                        resources=self._egress_proxy_resources,
+                        http_listen_port=self._egress_proxy_port,
+                        socks_listen_port=self._egress_proxy_socks_port,
+                    )
+                )
+                if needs_replacement:
+                    self._replace_pod(
+                        pod_name,
+                        lambda: self._create_egress_proxy_pod(
+                            pod_name,
+                            agent_id=str(agent.id),
+                            proxy_server=proxy_server,
+                        ),
+                    )
         except KubernetesApiError as exc:
             raise SandboxComputeUnavailable(f"Egress proxy provisioning failed: {exc}") from exc
 
@@ -790,11 +798,7 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
             socks_proxy_port=self._egress_proxy_socks_service_port,
             no_proxy=no_proxy,
         )
-        try:
-            self._client.request_json("POST", _pod_collection_path(self._namespace), json_body=body)
-        except KubernetesApiError as exc:
-            if exc.status_code != 409:
-                raise
+        self._create_named_pod(pod_name, body)
 
     def _create_egress_proxy_pod(self, pod_name: str, *, agent_id: str, proxy_server) -> None:
         body = _build_egress_proxy_pod_manifest(
@@ -809,11 +813,99 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
             http_listen_port=self._egress_proxy_port,
             socks_listen_port=self._egress_proxy_socks_port,
         )
-        try:
-            self._client.request_json("POST", _pod_collection_path(self._namespace), json_body=body)
-        except KubernetesApiError as exc:
-            if exc.status_code != 409:
-                raise
+        self._create_named_pod(pod_name, body)
+
+    def _create_named_pod(self, pod_name: str, body: Dict[str, Any]) -> None:
+        started_at = time.monotonic()
+        deadline = started_at + max(float(self._pod_ready_timeout), 0.0)
+        attempts = 0
+        while True:
+            attempts += 1
+            try:
+                self._client.request_json("POST", _pod_collection_path(self._namespace), json_body=body)
+                return
+            except KubernetesApiError as exc:
+                if exc.status_code != 409:
+                    raise
+
+            pod = self._read_pod(pod_name)
+            if pod and not _pod_is_terminating(pod):
+                logger.info(
+                    "Pod create conflict resolved by concurrent live pod pod=%s attempts=%s elapsed_ms=%s",
+                    pod_name,
+                    attempts,
+                    _elapsed_ms(started_at),
+                )
+                return
+
+            if pod:
+                logger.info(
+                    "Pod create conflict found terminating pod pod=%s attempts=%s elapsed_ms=%s",
+                    pod_name,
+                    attempts,
+                    _elapsed_ms(started_at),
+                )
+                self._wait_for_pod_absent(pod_name, deadline=deadline, started_at=started_at)
+                continue
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self._raise_pod_deletion_timeout(pod_name, started_at)
+            time.sleep(min(2.0, remaining))
+
+    def _replace_pod(self, pod_name: str, create_pod: Callable[[], None]) -> None:
+        started_at = time.monotonic()
+        logger.info("Replacing sandbox pod pod=%s", pod_name)
+        self._client.request_json("DELETE", _pod_path(self._namespace, pod_name), allow_404=True)
+        self._wait_for_pod_absent(pod_name, started_at=started_at)
+        create_pod()
+        logger.info(
+            "Sandbox pod replacement submitted pod=%s elapsed_ms=%s",
+            pod_name,
+            _elapsed_ms(started_at),
+        )
+
+    def _wait_for_pod_absent(
+        self,
+        pod_name: str,
+        *,
+        deadline: Optional[float] = None,
+        started_at: Optional[float] = None,
+    ) -> None:
+        wait_started_at = time.monotonic() if started_at is None else started_at
+        wait_deadline = (
+            wait_started_at + max(float(self._pod_ready_timeout), 0.0)
+            if deadline is None
+            else deadline
+        )
+        attempts = 0
+        while True:
+            attempts += 1
+            if not self._read_pod(pod_name):
+                logger.info(
+                    "Sandbox pod deletion confirmed pod=%s attempts=%s elapsed_ms=%s",
+                    pod_name,
+                    attempts,
+                    _elapsed_ms(wait_started_at),
+                )
+                return
+
+            remaining = wait_deadline - time.monotonic()
+            if remaining <= 0:
+                self._raise_pod_deletion_timeout(pod_name, wait_started_at, attempts=attempts)
+            time.sleep(min(2.0, remaining))
+
+    def _raise_pod_deletion_timeout(self, pod_name: str, started_at: float, *, attempts: int = 0) -> None:
+        logger.warning(
+            "Sandbox pod deletion timeout pod=%s attempts=%s elapsed_ms=%s timeout_seconds=%s",
+            pod_name,
+            attempts,
+            _elapsed_ms(started_at),
+            self._pod_ready_timeout,
+        )
+        raise SandboxComputeUnavailable(
+            f"Kubernetes pod {pod_name} was not deleted within {self._pod_ready_timeout} seconds."
+        )
 
     def _create_egress_proxy_service(self, service_name: str, *, agent_id: str) -> None:
         body = _build_egress_proxy_service_manifest(
@@ -927,6 +1019,7 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
             summary = _pod_readiness_summary(pod)
             status = pod.get("status") or {}
             phase = status.get("phase")
+            terminating = _pod_is_terminating(pod)
             if phase != last_phase or summary != last_summary:
                 logger.info(
                     "Sandbox pod readiness progress pod=%s phase=%s attempts=%s elapsed_ms=%s summary=%s",
@@ -938,7 +1031,7 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
                 )
                 last_phase = phase
                 last_summary = summary
-            if phase == "Running":
+            if phase == "Running" and not terminating:
                 for condition in status.get("conditions", []):
                     if condition.get("type") == "Ready" and condition.get("status") == "True":
                         logger.info(
@@ -1022,9 +1115,15 @@ class KubernetesSandboxBackend(SandboxComputeBackend):
         return False
 
 
+def _pod_is_terminating(pod: Dict[str, Any]) -> bool:
+    return bool((pod.get("metadata") or {}).get("deletionTimestamp"))
+
+
 def _pod_readiness_summary(pod: Dict[str, Any]) -> str:
     status = pod.get("status") or {}
     parts = [f"phase={status.get('phase') or 'unknown'}"]
+    if _pod_is_terminating(pod):
+        parts.append("terminating=true")
 
     conditions = []
     for condition in status.get("conditions") or []:

--- a/tests/unit/test_sandbox_kubernetes.py
+++ b/tests/unit/test_sandbox_kubernetes.py
@@ -5,18 +5,22 @@ import requests
 from django.test import SimpleTestCase, override_settings, tag
 
 from api.services.sandbox_kubernetes import (
-    _container_resources_match,
-    _build_sandbox_service_manifest,
+    KubernetesApiError,
     KubernetesSandboxBackend,
     _build_egress_proxy_pod_manifest,
     _build_egress_proxy_service_manifest,
-    _build_proxy_env,
     _build_pod_manifest,
+    _build_proxy_env,
+    _build_sandbox_service_manifest,
+    _container_resources_match,
     _normalize_workspace_volume_mode,
-    _pod_readiness_summary,
     _pod_name,
+    _pod_readiness_summary,
 )
-from api.services.sandbox_compute import _SANDBOX_PROXY_CLEARED_ATTR
+from api.services.sandbox_compute import (
+    SandboxComputeUnavailable,
+    _SANDBOX_PROXY_CLEARED_ATTR,
+)
 
 SANDBOX_POD_RESOURCES = {
     "requests": {"cpu": "500m", "memory": "1Gi"},
@@ -372,19 +376,148 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
                 },
             }
         )
-        backend._delete_pod = Mock()
+        backend._replace_pod = Mock(side_effect=lambda _pod_name, create_pod: create_pod())
         backend._create_egress_proxy_pod = Mock()
         backend._wait_for_pod_ready = Mock(return_value=True)
 
         service_name = backend._ensure_egress_proxy(agent, proxy_server)
 
         self.assertEqual(service_name, "sandbox-egress-agent-stale")
-        backend._delete_pod.assert_called_once_with("sandbox-egress-agent-stale")
+        backend._replace_pod.assert_called_once()
+        self.assertEqual(backend._replace_pod.call_args.args[0], "sandbox-egress-agent-stale")
         backend._create_egress_proxy_pod.assert_called_once_with(
             "sandbox-egress-agent-stale",
             agent_id="agent-stale",
             proxy_server=proxy_server,
         )
+
+    def test_compute_replacement_waits_for_deleted_pod_before_create(self):
+        backend = self._backend()
+        agent = SimpleNamespace(id="agent-terminating")
+        session = SimpleNamespace(proxy_server=None, workspace_snapshot=None)
+        existing_pod = _build_pod_manifest(
+            pod_name="sandbox-agent-agent-terminating",
+            pvc_name="sandbox-workspace-agent-terminating",
+            namespace="default",
+            image=backend._pod_image,
+            runtime_class=backend._pod_runtime_class,
+            service_account=backend._pod_service_account,
+            configmap_name=backend._pod_configmap,
+            secret_name=backend._pod_secret,
+            agent_id="agent-terminating",
+            resources=backend._pod_resources,
+            workspace_volume_mode=backend._workspace_volume_mode,
+        )
+        existing_pod["metadata"]["deletionTimestamp"] = "2026-07-21T12:00:00Z"
+        existing_pod["status"] = {"phase": "Running"}
+        backend._get_pod = Mock(return_value=existing_pod)
+        backend._create_service = Mock()
+        backend._create_pvc = Mock()
+        backend._wait_for_pod_ready = Mock(return_value=True)
+        events = []
+        deletion_reads = iter([existing_pod, None])
+
+        def request_json(method, _path, **_kwargs):
+            events.append(method)
+            if method == "DELETE":
+                return {}
+            return next(deletion_reads)
+
+        backend._client.request_json.side_effect = request_json
+        backend._create_pod = Mock(side_effect=lambda *_args, **_kwargs: events.append("CREATE"))
+
+        with patch("api.services.sandbox_kubernetes._resource_exists", side_effect=[True, True]), patch(
+            "api.services.sandbox_kubernetes.time.sleep",
+            return_value=None,
+        ):
+            result = backend.deploy_or_resume(agent, session)
+
+        self.assertEqual(result.state, "running")
+        self.assertEqual(events, ["DELETE", "GET", "GET", "CREATE"])
+
+    def test_egress_replacement_waits_for_deleted_pod_before_create(self):
+        backend = self._backend()
+        agent = SimpleNamespace(id="agent-egress-race")
+        proxy_server = SimpleNamespace(
+            id="proxy-race",
+            host="proxy.example",
+            port=8080,
+            proxy_type="HTTP",
+            username="",
+            password="",
+        )
+        stale_pod = {
+            "metadata": {"labels": {"proxy_id": "old-proxy"}},
+            "status": {"phase": "Running"},
+            "spec": {"containers": []},
+        }
+        backend._get_service = Mock(return_value={"metadata": {"name": "sandbox-egress-agent-egress-race"}})
+        backend._get_pod = Mock(return_value=stale_pod)
+        backend._wait_for_pod_ready = Mock(return_value=True)
+        events = []
+        deletion_reads = iter([stale_pod, None])
+
+        def request_json(method, _path, **_kwargs):
+            events.append(method)
+            if method == "DELETE":
+                return {}
+            return next(deletion_reads)
+
+        backend._client.request_json.side_effect = request_json
+        backend._create_egress_proxy_pod = Mock(
+            side_effect=lambda *_args, **_kwargs: events.append("CREATE")
+        )
+
+        with patch("api.services.sandbox_kubernetes.time.sleep", return_value=None):
+            service_name = backend._ensure_egress_proxy(agent, proxy_server)
+
+        self.assertEqual(service_name, "sandbox-egress-agent-egress-race")
+        self.assertEqual(events, ["DELETE", "GET", "GET", "CREATE"])
+
+    def test_create_conflict_with_terminating_pod_waits_and_retries(self):
+        backend = self._backend()
+        terminating_pod = {"metadata": {"deletionTimestamp": "2026-07-21T12:00:00Z"}}
+        backend._client.request_json.side_effect = [
+            KubernetesApiError(409, "already exists"),
+            terminating_pod,
+            terminating_pod,
+            None,
+            {},
+        ]
+
+        with patch("api.services.sandbox_kubernetes.time.sleep", return_value=None):
+            backend._create_named_pod("sandbox-agent-agent-conflict", {"kind": "Pod"})
+
+        methods = [call.args[0] for call in backend._client.request_json.call_args_list]
+        self.assertEqual(methods, ["POST", "GET", "GET", "GET", "POST"])
+
+    def test_create_conflict_with_live_pod_is_idempotent_success(self):
+        backend = self._backend()
+        backend._client.request_json.side_effect = [
+            KubernetesApiError(409, "already exists"),
+            {"metadata": {"name": "sandbox-agent-agent-live"}},
+        ]
+
+        backend._create_named_pod("sandbox-agent-agent-live", {"kind": "Pod"})
+
+        methods = [call.args[0] for call in backend._client.request_json.call_args_list]
+        self.assertEqual(methods, ["POST", "GET"])
+
+    def test_replacement_timeout_does_not_create_pod(self):
+        backend = self._backend()
+        backend._pod_ready_timeout = 0
+        terminating_pod = {"metadata": {"deletionTimestamp": "2026-07-21T12:00:00Z"}}
+        backend._client.request_json.side_effect = [{}, terminating_pod]
+        create_pod = Mock()
+
+        with self.assertRaises(SandboxComputeUnavailable) as raised:
+            backend._replace_pod("sandbox-agent-agent-timeout", create_pod)
+
+        self.assertIn("sandbox-agent-agent-timeout", str(raised.exception))
+        self.assertIn("0 seconds", str(raised.exception))
+        create_pod.assert_not_called()
+        methods = [call.args[0] for call in backend._client.request_json.call_args_list]
+        self.assertEqual(methods, ["DELETE", "GET"])
 
     def test_deploy_or_resume_creates_agent_service_when_missing(self):
         backend = self._backend()
@@ -475,7 +608,7 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
                 },
             }
         )
-        backend._delete_pod = Mock()
+        backend._replace_pod = Mock(side_effect=lambda _pod_name, create_pod: create_pod())
         backend._create_pod = Mock()
         backend._wait_for_pod_ready = Mock(return_value=True)
 
@@ -484,7 +617,8 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
 
         self.assertEqual(result.state, "running")
         self.assertTrue(result.workspace_reset)
-        backend._delete_pod.assert_called_once_with("sandbox-agent-agent-emptydir-recreate")
+        backend._replace_pod.assert_called_once()
+        self.assertEqual(backend._replace_pod.call_args.args[0], "sandbox-agent-agent-emptydir-recreate")
         backend._create_pod.assert_called_once()
 
     def test_deploy_or_resume_keeps_sandbox_service_separate_from_egress_service(self):
@@ -539,7 +673,7 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
                 },
             }
         )
-        backend._delete_pod = Mock()
+        backend._replace_pod = Mock(side_effect=lambda _pod_name, create_pod: create_pod())
         backend._create_pod = Mock()
         backend._wait_for_pod_ready = Mock(return_value=True)
 
@@ -547,7 +681,8 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
             result = backend.deploy_or_resume(agent, session)
 
         self.assertEqual(result.state, "running")
-        backend._delete_pod.assert_called_once_with("sandbox-agent-agent-stale-image")
+        backend._replace_pod.assert_called_once()
+        self.assertEqual(backend._replace_pod.call_args.args[0], "sandbox-agent-agent-stale-image")
         backend._create_pod.assert_called_once_with(
             "sandbox-agent-agent-stale-image",
             "sandbox-workspace-agent-stale-image",
@@ -591,7 +726,7 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
                 },
             }
         )
-        backend._delete_pod = Mock()
+        backend._replace_pod = Mock(side_effect=lambda _pod_name, create_pod: create_pod())
         backend._create_pod = Mock()
         backend._wait_for_pod_ready = Mock(return_value=True)
 
@@ -599,7 +734,8 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
             result = backend.deploy_or_resume(agent, session)
 
         self.assertEqual(result.state, "running")
-        backend._delete_pod.assert_called_once_with("sandbox-agent-agent-proxy-drift")
+        backend._replace_pod.assert_called_once()
+        self.assertEqual(backend._replace_pod.call_args.args[0], "sandbox-agent-agent-proxy-drift")
         backend._create_pod.assert_called_once_with(
             "sandbox-agent-agent-proxy-drift",
             "sandbox-workspace-agent-proxy-drift",
@@ -630,7 +766,7 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
         backend._create_pvc = Mock()
         backend._create_service = Mock()
         backend._get_pod = Mock(return_value=existing_pod)
-        backend._delete_pod = Mock()
+        backend._replace_pod = Mock(side_effect=lambda _pod_name, create_pod: create_pod())
         backend._create_pod = Mock()
         backend._wait_for_pod_ready = Mock(return_value=True)
 
@@ -664,7 +800,7 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
                 },
             }
         )
-        backend._delete_pod = Mock()
+        backend._replace_pod = Mock(side_effect=lambda _pod_name, create_pod: create_pod())
         backend._create_pod = Mock()
         backend._wait_for_pod_ready = Mock(return_value=True)
 
@@ -672,7 +808,8 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
             result = backend.deploy_or_resume(agent, session)
 
         self.assertEqual(result.state, "running")
-        backend._delete_pod.assert_called_once_with("sandbox-agent-agent-resource-drift")
+        backend._replace_pod.assert_called_once()
+        self.assertEqual(backend._replace_pod.call_args.args[0], "sandbox-agent-agent-resource-drift")
         backend._create_pod.assert_called_once_with(
             "sandbox-agent-agent-resource-drift",
             "sandbox-workspace-agent-resource-drift",
@@ -874,6 +1011,31 @@ class KubernetesSandboxMCPDiscoveryTests(SimpleTestCase):
         self.assertEqual(len(pending_progress_logs), 2)
         self.assertIn("Unschedulable", pending_progress_logs[0].args[-1])
         self.assertIn("ContainerCreating", pending_progress_logs[1].args[-1])
+
+    def test_wait_for_pod_ready_rejects_terminating_running_pod(self):
+        backend = object.__new__(KubernetesSandboxBackend)
+        backend._pod_ready_timeout = 10
+        terminating_ready = {
+            "metadata": {"deletionTimestamp": "2026-07-21T12:00:00Z"},
+            "status": {
+                "phase": "Running",
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+        }
+        replacement_ready = {
+            "metadata": {},
+            "status": {
+                "phase": "Running",
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+        }
+        backend._get_pod = Mock(side_effect=[terminating_ready, replacement_ready])
+
+        with patch("api.services.sandbox_kubernetes.time.sleep", return_value=None):
+            result = backend._wait_for_pod_ready("sandbox-agent-agent-replaced")
+
+        self.assertTrue(result)
+        self.assertEqual(backend._get_pod.call_count, 2)
 
     @override_settings(
         SANDBOX_COMPUTE_API_TOKEN="test-token",


### PR DESCRIPTION
## Summary
- Detect terminating pods as invalid for sandbox and egress proxy provisioning.
- Wait for pod deletion before recreating resources to avoid name conflicts.
- Handle concurrent create conflicts and reject terminating pods during readiness checks.
- Add coverage for replacement races, conflicts, timeouts, and readiness behavior.

## Testing
- Not run (not requested)