### PR TITLE
Make SQLite the agent's maintained domain model

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -97,7 +97,13 @@ from ..tools.plan import format_current_plan_for_prompt
 from ..tools.spawn_web_task import get_browser_daily_task_limit
 from ..tools.static_tools import get_static_tool_definitions
 from ..tools.sqlite_state import AGENT_CONFIG_TABLE, AGENT_SKILLS_TABLE, CONTACTS_TABLE, FILES_TABLE, get_sqlite_digest_prompt, get_sqlite_schema_prompt
-from ..tools.sqlite_query_quality import summarize_sqlite_tool_result_sql
+from ..tools.sqlite_query_quality import (
+    ROW_LOOP_MESSAGE,
+    named_model_read_tables,
+    source_derived_model_mutation_tables,
+    source_derived_model_reconciled_tables,
+    summarize_sqlite_tool_result_sql,
+)
 from ..tools.sqlite_skills import format_recent_skills_for_prompt
 from ..tools.tool_manager import ensure_default_tools_enabled, ensure_skill_tools_enabled, get_enabled_tool_definitions
 from ..system_skills.discovery import format_system_skill_discovery_prompt
@@ -675,11 +681,12 @@ def _get_sqlite_guidance() -> str:
     """Return the compact contract for data retrieval, storage, and analysis."""
     return (
         "## SQLite Data\n\n"
-        "Fetch new data with its source tool and answer small results directly. Use sqlite_batch for data already in SQLite when large/truncated or needing filtering, joins, aggregation, charts, reuse, or domain logic. Model "
-        "sizable domains and multi-fetch finite sets as keyed entities/events/relations with fields/status/source; query gaps before reporting. Only sourced blockers are unresolved. Normalize parent/child data "
-        "(vendors/plans, accounts/events) with PRIMARY KEY/UNIQUE identity, useful indexes, and source provenance; put logic in SQL and return only needed rows to context. Populate all relevant __tool_results via one shaped INSERT ... SELECT/json_each filtered by IN/tool_name; "
-        "extract fields and raw URLs in SQL from result_json, not literals/prompt/link tokens. Never filter one result_id at a time, make a table per result, or loop over blobs. Use CTAS for one-off extracts; "
-        "named tables survive calls, TEMP tables do not. Copy identifiers, JSON paths, values, and URLs from schema, hints, or results; inspect unknown structure once instead of inventing it. Use analysis_json/top_keys to locate payloads; http_request JSON is under result_json $.content. Prefer result_json when its path is known, otherwise result_text.\n\n"
+        "Named tables are the world model; digest is partial. Read them before external refreshes/decisions, not memory. Current complete rows are truth; don't refetch them. "
+        "Tool output doesn't update it. Source rows sharing a stable ID or its children belong there even when small: reconcile entities/relations, evolve schema, then query before acting/reporting. Only unrelated one-offs bypass it. "
+        "Use stable keys. Upserts refresh every mutable/provenance field; inspect identity after wrong row counts; query gaps before reporting. Only sourced blockers are unresolved. "
+        "Normalize children with PRIMARY KEY/UNIQUE and indexes; use SQLite for exact set logic/counts/ranking; return needed rows. Import ordinary tool output via INSERT ... SELECT/json_each from __tool_results (batch siblings by IN/tool_name), never copied facts/URLs; custom tools can write keyed models directly. "
+        "Never query one result_id at a time, make per-result tables, or loop blobs. CTAS is one-off; named tables persist, TEMP do not. Copy names/paths/values/URLs from results; inspect unknown structure once. "
+        "Locate payloads with analysis_json/top_keys; http_request JSON is result_json $.content. Prefer result_json for known paths, else result_text.\n\n"
         "Snapshots:\n"
         "* __tool_results: result_id, tool_name, created_at, result_json, result_text, analysis_json, is_truncated, top_keys.\n"
         "* __messages: message_id, seq, timestamp, channel, is_outbound, from_address, to_address, subject, body, "
@@ -1686,6 +1693,15 @@ def _render_prompt_context_once(
         critical_group.section_text(
             "sqlite_retry_warning",
             sqlite_retry_warning,
+            weight=5,
+            non_shrinkable=True,
+        )
+
+    source_model_warning = _get_unreconciled_source_model_warning(agent)
+    if source_model_warning:
+        critical_group.section_text(
+            "source_model_warning",
+            source_model_warning,
             weight=5,
             non_shrinkable=True,
         )
@@ -3295,6 +3311,7 @@ def _build_sqlite_retry_warning(
     result_id_counts: Counter[str] = Counter()
     empty_counts: Counter[str] = Counter()
     sql_values: list[str] = []
+    row_loop_rejections = 0
 
     for params, result_text in recent_calls:
         if not isinstance(params, dict):
@@ -3303,6 +3320,8 @@ def _build_sqlite_retry_warning(
         if not sql:
             continue
         sql_values.append(sql)
+        if ROW_LOOP_MESSAGE.split(" A one-item", 1)[0] in (result_text or ""):
+            row_loop_rejections += 1
         result_ids = set(_SQLITE_RESULT_ID_RE.findall(sql))
         if not result_ids:
             continue
@@ -3313,6 +3332,12 @@ def _build_sqlite_retry_warning(
                 empty_counts[result_id] += 1
 
     summary = summarize_sqlite_tool_result_sql(sql_values)
+    if row_loop_rejections >= 2:
+        return (
+            "SQLite recovery: repeated singleton result queries were rejected. Do not retry that shape. Query all "
+            "relevant sibling results together by tool_name or a multi-item IN. If a reusable model applies, upsert "
+            "by stable key and query it; otherwise answer the shaped result. Refetch only if evidence is stale or missing."
+        )
     inefficient_result_loop = (
         summary.direct_result_text_fetches >= 2
         or summary.duplicate_direct_fetches
@@ -3350,6 +3375,92 @@ def _get_recent_sqlite_retry_warning(agent: PersistentAgent) -> str:
         .values_list("tool_params", "result")
     )
     return _build_sqlite_retry_warning(recent_calls)
+
+
+def _sqlite_sql_values(params: dict[str, Any] | None) -> list[str]:
+    if not isinstance(params, dict):
+        return []
+    value = params.get("sql") or params.get("queries") or params.get("query")
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if str(item or "").strip()]
+    return [str(value)] if value else []
+
+
+def _build_unreconciled_source_model_warning(
+    recent_calls: Sequence[Tuple[str, dict[str, Any] | None, str]],
+) -> str:
+    """Flag a fresh-source-to-stale-model read in the current work cycle."""
+
+    latest_source_index = -1
+    for index, (tool_name, _params, status) in enumerate(recent_calls):
+        if status == "complete" and is_source_bearing_tool(tool_name):
+            latest_source_index = index
+    if latest_source_index < 0:
+        return ""
+
+    sqlite_events: list[tuple[int, set[str], set[str], set[str]]] = []
+    for index, (tool_name, params, status) in enumerate(recent_calls):
+        if status != "complete" or tool_name != "sqlite_batch":
+            continue
+        sql_values = _sqlite_sql_values(params)
+        sqlite_events.append((
+            index,
+            set(named_model_read_tables(sql_values)),
+            set(source_derived_model_mutation_tables(sql_values)),
+            set(source_derived_model_reconciled_tables(sql_values)),
+        ))
+
+    read_tables = set().union(*(reads for _index, reads, _mutations, _reconciled in sqlite_events)) if sqlite_events else set()
+    latest_mutation_by_table = {
+        table: index
+        for index, _reads, targets, _reconciled in sqlite_events
+        if index > latest_source_index
+        for table in targets
+    }
+    relevant_targets = set(latest_mutation_by_table)
+    if read_tables:
+        relevant_targets.intersection_update(read_tables)
+    if relevant_targets and all(
+        any(
+            (index > latest_mutation_by_table[table] and table in reads)
+            or (index == latest_mutation_by_table[table] and table in reconciled)
+            for index, reads, _mutations, reconciled in sqlite_events
+        )
+        for table in relevant_targets
+    ):
+        return ""
+
+    if not read_tables and not latest_mutation_by_table:
+        return ""
+    return (
+        "Fresh source evidence from this work cycle is not yet reconciled with the named model you read. If it belongs "
+        "to that domain and is newer, upsert all changed/provenance fields by stable key from __tool_results, add relations, then answer "
+        "from a post-update query. If it is unrelated or no relevant model exists, answer the source directly. Do not refetch."
+    )
+
+
+def _get_unreconciled_source_model_warning(agent: PersistentAgent) -> str:
+    cycle_started_at = (
+        PersistentAgentSystemStep.objects.filter(
+            step__agent=agent,
+            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+        )
+        .order_by("-step__created_at")
+        .values_list("step__created_at", flat=True)
+        .first()
+    )
+    if cycle_started_at is None:
+        return ""
+
+    recent_calls = list(
+        PersistentAgentToolCall.objects.filter(
+            step__agent=agent,
+            step__created_at__gt=cycle_started_at,
+        )
+        .order_by("step__created_at", "step_id")
+        .values_list("tool_name", "tool_params", "status")
+    )
+    return _build_unreconciled_source_model_warning(recent_calls)
 
 
 def _format_system_directive_prompt_block(

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -626,6 +626,7 @@ def _summarize_result(
 
     result_json = truncated_text if is_json and not is_truncated else None
     result_text_store = truncated_text  # Always set for robust querying
+    result_json_path = None
 
     if is_json and not is_truncated:
         try:
@@ -634,6 +635,7 @@ def _summarize_result(
             if isinstance(parsed, dict):
                 if tool_name == "http_request" and "content" in parsed:
                     content = parsed["content"]
+                    result_json_path = "$.content"
                 elif _is_scrape_as_markdown_tool(tool_name) and "result" in parsed:
                     content = parsed["result"]
 
@@ -655,6 +657,7 @@ def _summarize_result(
         "has_base64": has_base64,
         "is_truncated": is_truncated,
         "truncated_bytes": truncated_bytes,
+        "result_json_path": result_json_path,
     }
     if analysis and analysis.decode_info and analysis.decode_info.steps:
         meta["decoded_from"] = "+".join(analysis.decode_info.steps)
@@ -669,9 +672,8 @@ def _summarize_result(
 def _wrap_as_sqlite_result(result_text: str, full_bytes: int) -> str:
     return (
         f"[FULL RESULT ({full_bytes} chars) - ONE-TIME VIEW. "
-        f"Use this visible result now. If it answers the request, reply directly in the next message. "
-        f"Do not query __tool_results or sqlite_batch just to reread or parse this small result; "
-        f"use SQL only for real filtering, joining, aggregation, chart input, or truncated/too-large data. "
+        f"Use this visible result now. Reply directly for a simple answer unless it updates an established named domain model. "
+        f"Use SQL to reconcile that model or for exact filtering/ranking across sizable or multiple results, joins, aggregation, chart input, or truncated data; do not query merely to reread or parse. "
         f"Next turn shows only preview]\n"
         f"{result_text}"
     )
@@ -757,6 +759,8 @@ def _format_meta_text(
         parts.append(f"parsed_from={meta['parsed_from']}")
     if meta.get("parsed_with"):
         parts.append(f"parsed_with={meta['parsed_with']}")
+    if meta.get("result_json_path"):
+        parts.append(f"result_json_path={meta['result_json_path']}")
     if meta.get("is_truncated") and meta.get("truncated_bytes"):
         parts.append(f"truncated_bytes={meta['truncated_bytes']}")
 

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -1892,10 +1892,9 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
         "function": {
             "name": "sqlite_batch",
             "description": (
-                "SQLite memory and logic. Reusable domains MUST use explicit CREATE TABLE with stable PRIMARY KEY/UNIQUE identity and provenance, then one aggregate INSERT; CTAS is disposable only. Model shared entity/event/relationship "
-                "tables and separate repeating parents/children. Use joins/CTEs/windows/aggregates; return only needed rows. For 2+ relevant __tool_results, query together via IN/tool_name; never call sqlite_batch once per result_id. "
-                "Model with INSERT ... SELECT/json_each, not copied rows; http_request JSON is under result_json $.content. For large/repetitive imports or API fan-out, prefer a custom tool writing to SQLite; no "
-                "ATTACH. `sql` is one semicolon-separated string; escape apostrophes as 'O''Brien'. grep_context_all/split_sections arrays use json_each and ctx.value, not json_extract."
+                "SQLite world model + hard logic. Current complete rows are truth: answer without refetching sources. Read before memory. Tool output isn't state: keyed rows/children belong in the model. Reconcile relations, evolve schema, then query; only unrelated one-offs bypass it. Reusable: "
+                "PRIMARY KEY/UNIQUE + provenance; CTAS is disposable. Normalize children; use joins/set logic/counts/ranking; return needed rows. Import tool output via INSERT ... SELECT/json_each from __tool_results, never copied rows; batch siblings by IN/tool_name. Prefer custom tools writing keyed models for imports/API fan-out. "
+                "http_request JSON: result_json $.content. No ATTACH. `sql` uses semicolons; apostrophe: 'O''Brien'. grep_context_all/split_sections arrays: json_each + ctx.value, not json_extract."
             ),
             "parameters": {
                 "type": "object",

--- a/api/agent/tools/sqlite_query_quality.py
+++ b/api/agent/tools/sqlite_query_quality.py
@@ -6,7 +6,7 @@ from typing import Iterable
 
 import sqlparse
 from sqlparse import tokens as sql_tokens
-from sqlparse.sql import Function, Parenthesis, Values
+from sqlparse.sql import Function, Parenthesis, Values, Where
 
 
 TOOL_RESULTS_RE = re.compile(r'\b(?:from|join)\s+"?__tool_results"?\b', re.I)
@@ -19,9 +19,23 @@ CREATE_TEMP_TABLE_RE = re.compile(r'\bcreate\s+temp(?:orary)?\s+table\b', re.I)
 CREATE_UNIQUE_INDEX_RE = re.compile(r'\bcreate\s+unique\s+index\b[^;]*?\bon\s+"?(?P<name>[a-z_]\w*)"?', re.I | re.S)
 TABLE_IDENTITY_RE = re.compile(r'\bprimary\s+key\b|(?<!["\'`\[])\bunique\b(?!["\'`\]])', re.I)
 INSERT_INTO_RE = re.compile(r'\binsert\s+(?:or\s+\w+\s+)?into\s+"?(?P<name>[a-z_]\w*)"?', re.I)
+MODEL_MUTATION_RE = re.compile(
+    r'\b(?P<operation>insert(?:\s+or\s+\w+)?\s+into|replace\s+into|update|delete\s+from)\s+'
+    r'(?:(?:"?[a-z_]\w*"?)\s*\.\s*)?"?(?P<name>[a-z_]\w*)"?',
+    re.I,
+)
+READ_TABLE_RE = re.compile(
+    r'\b(?:from|join)\s+(?:(?:"?[a-z_]\w*"?)\s*\.\s*)?"?(?P<name>[a-z_]\w*)"?',
+    re.I,
+)
+CTE_NAME_RE = re.compile(
+    r'(?:\bwith|,)\s*(?:recursive\s+)?"?(?P<name>[a-z_]\w*)"?\s*(?:\([^)]*\))?\s+as\s*\(',
+    re.I,
+)
 MANUAL_INSERT_VALUES_RE = re.compile(r'\binsert\s+(?:or\s+\w+\s+)?into\s+"?(?P<name>[a-z_]\w*)"?\s*(?:\(\s*"?[a-z_]\w*"?(?:\s*,\s*"?[a-z_]\w*"?)*\s*\)\s*)?values\b', re.I)
 JSON_FUNCTION_RE = re.compile(r"\bjson_(?:extract|each)\s*\(", re.I)
 JSON_EACH_RE = re.compile(r"\bjson_each\s*\(", re.I)
+TOOL_PAYLOAD_RE = re.compile(r"\b(?:result_json|result_text|analysis_json)\b", re.I)
 URL_RE = re.compile(r"https?://[^\s'\",)]+", re.I)
 BULK_MANUAL_VALUES_ROW_LIMIT = 4
 BULK_COPY_MESSAGE = (
@@ -34,7 +48,8 @@ BLOB_LOOP_MESSAGE = (
 )
 ROW_LOOP_MESSAGE = (
     "Query not executed: do not read __tool_results or a staging table derived from it one result_id at a time. "
-    "Use one shaped INSERT ... SELECT/json_each or query over tool_name or result_id IN (...)."
+    "A one-item IN (...) is still one-at-a-time. Do not retry that shape: use one shaped INSERT ... SELECT/json_each or "
+    "query covering every relevant sibling via tool_name or a multi-item result_id IN (...)."
 )
 MANUAL_COPY_MESSAGE = (
     "This builds a VALUES table while multiple tool results exist. If those rows came from tool outputs, do not "
@@ -44,7 +59,12 @@ SINGLE_IMPORT_MESSAGE = (
     "This imports one result_id while sibling tool results exist. If they share a dataset, replace separate imports "
     "with one shaped query over tool_name or result_id IN (...)."
 )
-
+SOURCE_LITERAL_COPY_MESSAGE = (
+    "Query not executed: this model write copies source facts into SQL literals. Derive complete rows from "
+    "__tool_results in the same INSERT/UPDATE, keyed by stable ID; refresh every mutable/provenance field. Use "
+    "tool_name or visible result_id; don't fetch/copy the blob. For http_request JSON, nested arrays are under "
+    "$.content; use the actual array key. Then query the model."
+)
 COUNT_FIELDS = (
     "statement_count", "tool_result_statement_count", "single_result_id_filters", "single_derived_result_filters", "single_tool_result_imports",
     "direct_result_text_fetches", "aggregate_tool_result_queries", "smart_tool_result_queries",
@@ -52,6 +72,8 @@ COUNT_FIELDS = (
     "uses_order_by", "creates_working_table", "reads_working_table", "tool_result_ctas",
 )
 USER_TABLE_PREFIXES = ("__", "sqlite_")
+NON_MODEL_TABLE_PREFIXES = (*USER_TABLE_PREFIXES, "_csv_", "temp_", "tmp_", "stage_", "staging_")
+NON_MODEL_TABLE_SUFFIXES = ("_temp", "_tmp", "_stage", "_staging")
 
 
 def summarize_sqlite_tool_result_calls(tool_calls: Iterable[object]):
@@ -149,17 +171,29 @@ def summarize_sqlite_tool_result_sql(sql_values: Iterable[str], *, sqlite_call_c
     )
 
 
-def build_tool_result_query_advisories(sql_values: Iterable[str], *, available_tool_result_rows: int, tool_result_payloads: Iterable[str] = ()) -> list[SimpleNamespace]:
+def build_tool_result_query_advisories(
+    sql_values: Iterable[str], *, available_tool_result_rows: int,
+    tool_result_payloads: Iterable[str] = (),
+) -> list[SimpleNamespace]:
     if available_tool_result_rows < 1: return []
     sql_values = [str(sql or "") for sql in sql_values]
+    tool_result_payloads = tuple(tool_result_payloads)
     advisories = []
     summary = summarize_sqlite_tool_result_sql(sql_values)
+    copied_model_tables = _source_literal_copy_tables(sql_values, tool_result_payloads)
     unkeyed_models = set(summary.unkeyed_explicit_table_names).intersection(summary.row_derived_working_table_names)
     if unkeyed_models:
         advisories.append(_advisory("reusable_model_missing_identity", f"Query not executed: reusable table(s) {', '.join(sorted(unkeyed_models))} derive repeating tool-result rows without stable identity. Add PRIMARY KEY/UNIQUE to CREATE TABLE; use TEMP CTAS only for a disposable extract.", blocking=True))
     if summary.tool_result_ctas:
         advisories.append(_advisory("tool_result_ctas", "CTAS has no stable identity. Use it only for a disposable extract; reusable models need explicit CREATE TABLE with PRIMARY KEY/UNIQUE, then aggregate INSERT."))
-    if available_tool_result_rows < 2: return advisories
+    if available_tool_result_rows < 2:
+        if copied_model_tables:
+            advisories.append(_advisory(
+                "source_facts_copied_into_model",
+                SOURCE_LITERAL_COPY_MESSAGE,
+                blocking=True,
+            ))
+        return advisories
     model_advisories, advisories = advisories, []
     literal_select_rows, copied_provenance_urls = _manual_import_evidence(sql_values, tool_result_payloads)
     if summary.manual_values_rows + literal_select_rows >= BULK_MANUAL_VALUES_ROW_LIMIT and len(copied_provenance_urls) >= 2:
@@ -174,7 +208,109 @@ def build_tool_result_query_advisories(sql_values: Iterable[str], *, available_t
         advisories.append(_advisory("tool_result_row_loop", ROW_LOOP_MESSAGE, blocking=True))
     elif summary.single_tool_result_imports:
         advisories.append(_advisory("single_tool_result_import", SINGLE_IMPORT_MESSAGE))
+    if copied_model_tables:
+        advisories.append(_advisory(
+            "source_facts_copied_into_model",
+            SOURCE_LITERAL_COPY_MESSAGE,
+            blocking=True,
+        ))
     return advisories + model_advisories
+
+
+def source_derived_model_mutation_tables(sql_values: Iterable[str]) -> tuple[str, ...]:
+    """Return durable DML targets whose rows come from __tool_results in the same statement."""
+
+    tables: list[str] = []
+    for sql in sql_values:
+        for raw_statement in sqlparse.split(str(sql or "")):
+            statement = _structural_sql(raw_statement)
+            if not TOOL_RESULTS_RE.search(statement):
+                continue
+            match = MODEL_MUTATION_RE.search(statement)
+            if (
+                match
+                and _is_named_model_table(match.group("name"))
+                and _mutation_derives_payload(statement, match)
+            ):
+                tables.append(match.group("name").casefold())
+    return tuple(dict.fromkeys(tables))
+
+
+def named_model_read_tables(sql_values: Iterable[str]) -> tuple[str, ...]:
+    """Return named model tables read without directly reading raw tool results."""
+
+    tables: list[str] = []
+    for sql in sql_values:
+        for raw_statement in sqlparse.split(str(sql or "")):
+            statement = _structural_sql(raw_statement)
+            cte_names = {match.group("name").casefold() for match in CTE_NAME_RE.finditer(statement)}
+            for match in READ_TABLE_RE.finditer(statement):
+                table = match.group("name").casefold()
+                trailing = statement[match.end():].lstrip()
+                if not trailing.startswith("(") and table not in cte_names and _is_named_model_table(table):
+                    tables.append(table)
+    return tuple(dict.fromkeys(tables))
+
+
+def source_derived_model_reconciled_tables(sql_values: Iterable[str]) -> tuple[str, ...]:
+    """Return source-derived model targets read by a later statement."""
+
+    pending: set[str] = set()
+    reconciled: list[str] = []
+    for sql in sql_values:
+        for statement in sqlparse.split(str(sql or "")):
+            for table in named_model_read_tables((statement,)):
+                if table in pending:
+                    reconciled.append(table)
+                    pending.remove(table)
+            for table in source_derived_model_mutation_tables((statement,)):
+                pending.add(table)
+                reconciled = [reconciled_table for reconciled_table in reconciled if reconciled_table != table]
+    return tuple(dict.fromkeys(reconciled))
+
+
+def _is_named_model_table(table_name: str) -> bool:
+    normalized = str(table_name or "").casefold()
+    return bool(normalized) and not normalized.startswith(NON_MODEL_TABLE_PREFIXES) and not normalized.endswith(
+        NON_MODEL_TABLE_SUFFIXES
+    )
+
+
+def _mutation_derives_payload(statement: str, match: re.Match) -> bool:
+    if not TOOL_PAYLOAD_RE.search(statement):
+        return False
+    operation = match.group("operation").casefold()
+    if operation.startswith(("insert", "replace")):
+        return bool(re.search(r"\bselect\b", statement[match.end():], re.I))
+    if operation.startswith("delete"):
+        return True
+
+    remainder = statement[match.end():]
+    set_match = re.search(r"\bset\b", remainder, re.I)
+    if not set_match:
+        return False
+    value_clause = remainder[set_match.end():]
+    if where_match := re.search(r"\bwhere\b", value_clause, re.I):
+        value_clause = value_clause[:where_match.start()]
+    if TOOL_RESULTS_RE.search(value_clause):
+        return True
+    return any(
+        re.search(rf"\b{re.escape(cte_name)}\b", value_clause, re.I)
+        for cte_name in _tool_result_cte_names(statement)
+    )
+
+
+def _tool_result_cte_names(statement: str) -> tuple[str, ...]:
+    names = []
+    for match in CTE_NAME_RE.finditer(statement):
+        depth = 1
+        cursor = match.end()
+        while cursor < len(statement) and depth:
+            depth += (statement[cursor] == "(") - (statement[cursor] == ")")
+            cursor += 1
+        if depth == 0 and TOOL_RESULTS_RE.search(statement[match.end():cursor - 1]):
+            names.append(match.group("name").casefold())
+    return tuple(names)
 
 
 def _advisory(code: str, message: str, *, blocking: bool = False) -> SimpleNamespace:
@@ -230,6 +366,88 @@ def _manual_import_evidence(sql_values: Iterable[str], tool_result_payloads: Ite
                         query_urls.update(URL_RE.findall(token.value))
     payload_text = "\n".join(str(payload or "") for payload in tool_result_payloads)
     return literal_select_rows, {url for url in query_urls if url in payload_text}
+
+
+def _source_literal_copy_tables(
+    sql_values: Iterable[str], tool_result_payloads: Iterable[str],
+) -> tuple[str, ...]:
+    payload_text = "\n".join(str(payload or "") for payload in tool_result_payloads)
+    if not payload_text:
+        return ()
+
+    copied_tables = []
+    for sql in sql_values:
+        for statement in sqlparse.parse(str(sql or "")):
+            raw_statement = str(statement)
+            structural = _structural_sql(raw_statement)
+            match = MODEL_MUTATION_RE.search(structural)
+            if not match or not _is_named_model_table(match.group("name")):
+                continue
+            matched_literals = set()
+            copied_url = False
+            previous_token = None
+            for token in _mutation_value_tokens(statement, match.group("operation")):
+                if token.is_whitespace or token.ttype in sql_tokens.Comment:
+                    continue
+                is_json_selector = previous_token is not None and previous_token.value in {"->", "->>"}
+                previous_token = token
+                if token.ttype != sql_tokens.Literal.String.Single or is_json_selector:
+                    continue
+                value = token.value[1:-1].replace("''", "'")
+                if len(value) < 6 or value not in payload_text:
+                    continue
+                matched_literals.add(value)
+                copied_url = copied_url or bool(URL_RE.fullmatch(value))
+            if copied_url or len(matched_literals) >= 2:
+                copied_tables.append(match.group("name").casefold())
+    return tuple(dict.fromkeys(copied_tables))
+
+
+def _mutation_value_tokens(statement, operation: str):
+    """Yield tokens that supply new row values, excluding identity predicates."""
+
+    operation = operation.casefold()
+    if operation.startswith("delete"):
+        return ()
+    if operation.startswith(("insert", "replace")):
+        values = [token for token in statement.tokens if isinstance(token, Values)]
+        if values:
+            return tuple(child for value_group in values for child in value_group.flatten())
+
+        projection = []
+        after_insert = False
+        in_select = False
+        for token in statement.tokens:
+            if token.ttype in sql_tokens.Comment or token.is_whitespace:
+                continue
+            if token.ttype in sql_tokens.Keyword.DML and token.normalized in {"INSERT", "REPLACE"}:
+                after_insert = True
+                continue
+            if after_insert and token.ttype in sql_tokens.Keyword.DML and token.normalized == "SELECT":
+                in_select = True
+                continue
+            if in_select and token.match(sql_tokens.Keyword, "FROM"):
+                break
+            if in_select:
+                projection.extend(token.flatten())
+        return tuple(projection)
+
+    values = []
+    in_set = False
+    for token in statement.tokens:
+        if token.ttype in sql_tokens.Comment or token.is_whitespace:
+            continue
+        if token.match(sql_tokens.Keyword, "SET"):
+            in_set = True
+            continue
+        if in_set and (
+            isinstance(token, Where)
+            or token.match(sql_tokens.Keyword, ("FROM", "RETURNING", "ORDER BY", "LIMIT"))
+        ):
+            break
+        if in_set:
+            values.extend(token.flatten())
+    return tuple(values)
 
 
 def _literal_json_row_count(statement) -> int:

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -2,16 +2,21 @@ import re
 from typing import Iterable
 
 import sqlparse
+from django.utils import timezone
 
 from api.agent.tools.eval_synthetic_tools import EVAL_SYNTHETIC_TOOL_SERVER
+from api.agent.tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
 from api.agent.tools.sqlite_query_quality import (
     CREATE_TABLE_AS_RE,
     _created_table_name,
     _inserted_table_name,
     _reads_table,
     _structural_sql,
+    source_derived_model_mutation_tables,
+    source_derived_model_reconciled_tables,
     summarize_sqlite_tool_result_calls,
 )
+from api.agent.tools.sqlite_state import agent_sqlite_db
 from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
 from api.agent.tools.web_chat_sender import _looks_like_routine_progress_message
 from api.evals.base import EvalScenario, ScenarioTask
@@ -29,6 +34,8 @@ SQLITE_DEDUPE_REQUERY = "sqlite_tool_results_dedupe_requery"
 SQLITE_ITEM_LINK_REPORT = "sqlite_tool_results_item_link_report"
 SQLITE_NATURAL_RESULT_ACCESS = "sqlite_tool_results_natural_result_access"
 SQLITE_BOUNDED_PORTFOLIO_REPORT = "sqlite_tool_results_bounded_portfolio_report"
+SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY = "sqlite_domain_truth_over_stale_history"
+SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES = "sqlite_domain_model_refreshes_and_evolves"
 SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_MULTI_RESULT_WEB_SYNTHESIS,
     SQLITE_INTERMEDIATE_WORKING_TABLE,
@@ -36,6 +43,8 @@ SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_ITEM_LINK_REPORT,
     SQLITE_NATURAL_RESULT_ACCESS,
     SQLITE_BOUNDED_PORTFOLIO_REPORT,
+    SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY,
+    SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES,
 ]
 
 
@@ -72,6 +81,21 @@ PORTFOLIO_DETAIL_URLS = (
 )
 PORTFOLIO_SOURCE_URLS = PORTFOLIO_DETAIL_URLS
 PORTFOLIO_FETCH_URLS = (PORTFOLIO_INDEX_URL, *PORTFOLIO_DETAIL_URLS)
+
+DOMAIN_ACCOUNT_ID, DOMAIN_ACCOUNT_NAME = "acct-aster-042", "Aster Labs"
+DOMAIN_CURRENT = ("legal_review", "Maya Chen", "send the SOC 2 packet")
+DOMAIN_REFRESH = ("contracting", "Maya Chen", "resolve contract redlines")
+DOMAIN_SOURCE_URL = "https://crm.example.test/accounts/aster-labs"
+DOMAIN_REFRESH_URL = "https://crm.example.test/snapshots/aster-labs.json"
+DOMAIN_REFRESH_OBSERVED_AT = "2026-07-21T14:30:00Z"
+DOMAIN_LEGACY_ACCOUNT = (
+    "acct-aster-legacy", DOMAIN_ACCOUNT_NAME, "archived", "Devon Price", "no action",
+    "https://crm.example.test/accounts/aster-legacy", "2026-06-10T12:00:00Z",
+)
+DOMAIN_WORKSTREAMS = (
+    ("ws-security-17", "Security packet", "complete", "Maya Chen", "2026-07-22"),
+    ("ws-legal-04", "Contract redlines", "open", "Noah Reed", "2026-07-24"),
+)
 
 UNIQUE_MODEL_INDEX_RE = re.compile(r'\bcreate\s+unique\s+index\b[^;]*?\bon\s+"?(?P<table>[a-z_]\w*)"?', re.I | re.S)
 STABLE_IDENTITY_RE = re.compile(r'\bprimary\s+key\b|(?<!["\'`\[])\bunique\b(?!["\'`\]])', re.I)
@@ -345,6 +369,35 @@ def _dedupe_mock() -> dict:
     }
 
 
+def _domain_refresh_mock() -> dict:
+    stage, owner, next_action = DOMAIN_REFRESH
+    payload = {
+        "observed_at": DOMAIN_REFRESH_OBSERVED_AT,
+        "source_url": DOMAIN_REFRESH_URL,
+        "accounts": [{
+            "account_id": DOMAIN_ACCOUNT_ID, "name": DOMAIN_ACCOUNT_NAME,
+            "stage": stage, "owner": owner, "next_action": next_action,
+            "source_url": DOMAIN_REFRESH_URL, "observed_at": DOMAIN_REFRESH_OBSERVED_AT,
+        }],
+        "workstreams": [
+            dict(zip(
+                ("workstream_id", "name", "status", "owner", "due_on"), row,
+            ), account_id=DOMAIN_ACCOUNT_ID, source_url=DOMAIN_REFRESH_URL,
+                observed_at=DOMAIN_REFRESH_OBSERVED_AT)
+            for row in DOMAIN_WORKSTREAMS
+        ],
+    }
+    return {
+        "http_request": {
+            "rules": [{
+                "url_contains": DOMAIN_REFRESH_URL,
+                "result": {"status": "ok", "status_code": 200, "url": DOMAIN_REFRESH_URL, "content": payload},
+            }],
+            "default": {"status": "error", "message": "Unknown eval URL."},
+        }
+    }
+
+
 MOCK_BUILDERS = {"web": _web_mock, "aged_web": lambda: _web_mock(facts_last=True), "product": _product_mock, "dedupe": _dedupe_mock, "inventory": _inventory_mock}
 
 
@@ -442,6 +495,122 @@ def _decision_model_tables(sql: str, model_tables: Iterable[str]) -> tuple[str, 
     return tuple(table for table in tables if table in decisions)
 
 
+def _seed_domain_account(
+    agent_id: str, state: tuple[str, str, str], observed_at: str, *, duplicate_name: bool = False,
+) -> None:
+    stage, owner, next_action = state
+    stages = ("qualification", "security_review", "legal_review", "contracting", "on_hold")
+    decoys = [
+        (
+            f"acct-decoy-{index:03d}",
+            f"Example Account {index:03d}",
+            stages[index % len(stages)],
+            f"Owner {index:03d}",
+            f"Review account note {index:03d}",
+            f"https://crm.example.test/accounts/example-{index:03d}",
+            f"2026-07-{(index % 9) + 10:02d}T12:00:00Z",
+        )
+        for index in range(32)
+    ]
+    target = (DOMAIN_ACCOUNT_ID, DOMAIN_ACCOUNT_NAME, stage, owner, next_action, DOMAIN_SOURCE_URL, observed_at)
+
+    with agent_sqlite_db(str(agent_id)) as db_path:
+        conn = open_guarded_sqlite_connection(db_path)
+        try:
+            conn.execute("DROP TABLE IF EXISTS accounts;")
+            conn.execute(
+                "CREATE TABLE accounts (account_id TEXT PRIMARY KEY, name TEXT NOT NULL, stage TEXT NOT NULL, "
+                "owner TEXT NOT NULL, next_action TEXT NOT NULL, source_url TEXT NOT NULL, observed_at TEXT NOT NULL);"
+            )
+            conn.executemany(
+                "INSERT INTO accounts (account_id, name, stage, owner, next_action, source_url, observed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?);",
+                [*decoys[:16], target, *decoys[16:], *([DOMAIN_LEGACY_ACCOUNT] if duplicate_name else [])],
+            )
+            conn.commit()
+        finally:
+            clear_guarded_connection(conn)
+            conn.close()
+
+
+def _inspect_domain_refresh_state(agent_id: str) -> tuple[list[str], str | None]:
+    expected_ids = {row[0] for row in DOMAIN_WORKSTREAMS}
+    failures = []
+    child_table = None
+    with agent_sqlite_db(str(agent_id)) as db_path:
+        conn = open_guarded_sqlite_connection(db_path)
+        try:
+            account = conn.execute(
+                """
+                SELECT account_id, name, stage, owner, next_action, source_url, observed_at
+                FROM accounts WHERE account_id = ?;
+                """,
+                (DOMAIN_ACCOUNT_ID,),
+            ).fetchall()
+            current = [(DOMAIN_ACCOUNT_ID, DOMAIN_ACCOUNT_NAME, *DOMAIN_REFRESH, DOMAIN_REFRESH_URL, DOMAIN_REFRESH_OBSERVED_AT)]
+            if account != current:
+                failures.append("existing account was duplicated or retained stale values")
+            legacy = conn.execute(
+                "SELECT account_id, name, stage, owner, next_action, source_url, observed_at FROM accounts WHERE account_id=?;",
+                (DOMAIN_LEGACY_ACCOUNT[0],),
+            ).fetchall()
+            if legacy != [DOMAIN_LEGACY_ACCOUNT]:
+                failures.append("refresh changed a different account sharing the display name")
+
+            child = None
+            tables = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND substr(name, 1, 2) != '__';"
+            ).fetchall()
+            for (table_name,) in tables:
+                if table_name == "accounts":
+                    continue
+                quoted = '"' + table_name.replace('"', '""') + '"'
+                columns = conn.execute(f"PRAGMA table_info({quoted});").fetchall()
+                names = {column[1] for column in columns}
+                required = {
+                    "workstream_id", "account_id", "name", "status", "owner", "due_on",
+                    "source_url", "observed_at",
+                }
+                if not required.issubset(names):
+                    continue
+                rows = conn.execute(
+                    f"SELECT workstream_id, account_id, name, status, owner, due_on, source_url, observed_at "
+                    f"FROM {quoted} WHERE account_id = ?;",
+                    (DOMAIN_ACCOUNT_ID,),
+                ).fetchall()
+                if len(rows) != len(expected_ids) or {row[0] for row in rows} != expected_ids:
+                    continue
+                unique_indexes = [row[1] for row in conn.execute(f"PRAGMA index_list({quoted});") if row[2]]
+                keyed = any(row[1] == "workstream_id" and row[5] for row in columns) or any(
+                    "workstream_id" in {row[2] for row in conn.execute(f'PRAGMA index_info("{name}");')}
+                    for name in unique_indexes
+                )
+                expected_rows = {
+                    (workstream_id, DOMAIN_ACCOUNT_ID, name, status, owner, due_on,
+                     DOMAIN_REFRESH_URL, DOMAIN_REFRESH_OBSERVED_AT)
+                    for workstream_id, name, status, owner, due_on in DOMAIN_WORKSTREAMS
+                }
+                sourced = set(rows) == expected_rows
+                child = (table_name, keyed, sourced)
+                break
+            if child is None:
+                failures.append("new workstreams were not modeled as a related table")
+            else:
+                child_table = child[0]
+                if not child[1]:
+                    failures.append("workstream model lacked stable identity")
+                if not child[2]:
+                    failures.append("workstream model lacked complete facts, relationship, or provenance")
+        finally:
+            clear_guarded_connection(conn)
+            conn.close()
+    return failures, child_table
+
+
+def _domain_refresh_state_failures(agent_id: str) -> list[str]:
+    return _inspect_domain_refresh_state(agent_id)[0]
+
+
 class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
     tier = "core"
     category = "sqlite_tool_results"
@@ -454,6 +623,7 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
     prompt = ""; mock_kind = ""; verify_task_name = "verify_sqlite_usage"; require_working_table = False; max_relevant_tool_calls = 18; min_sources = 1
     max_single_result_filters = 1
     max_sqlite_usage_calls: int | None = None
+    max_sqlite_attempts: int | None = None
     reject_result_id_case_rows = False
     sourced_answer_task_name = "verify_sourced_answer"
     result_access_source_urls: tuple[str, ...] = ()
@@ -517,6 +687,7 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
         ]
         failures = [msg for bad, msg in (
             (not successful_calls, "no successful sqlite_batch call observed"),
+            (self.max_sqlite_attempts is not None and len(calls) > self.max_sqlite_attempts, f"sqlite_batch attempts {len(calls)} > {self.max_sqlite_attempts}"),
             (self.max_sqlite_usage_calls is not None and len(successful_calls) > self.max_sqlite_usage_calls, f"sqlite_batch calls {len(successful_calls)} > {self.max_sqlite_usage_calls}"),
             (summary.aggregate_tool_result_queries < 1, "no aggregate __tool_results query observed"),
             (summary.smart_tool_result_queries < 1, "no smart __tool_results query observed"),
@@ -625,6 +796,7 @@ class SqliteMultiResultWebSynthesisScenario(SqliteToolResultScenario):
     required_terms = ("enterprise", "SMB", "HIPAA")
     min_sources = 3
     max_sqlite_usage_calls = 2
+    max_sqlite_attempts = 3
     reject_result_id_case_rows = True
 
 
@@ -794,6 +966,129 @@ class SqliteIntermediateWorkingTableScenario(SqliteToolResultScenario):
         )
 
 
+class SqliteDomainModelScenario(SqliteToolResultScenario):
+    domain_charter = "Own current account and relationship operations for the sales team. Keep incoming evidence coherent and report precise, source-backed next actions."
+
+    def _prepare_domain_agent(
+        self, agent_id: str, state: tuple[str, str, str], observed_at: str, *, duplicate_name: bool = False,
+    ) -> None:
+        self._ready_agent(agent_id)
+        PersistentAgent.objects.filter(id=agent_id).update(charter=self.domain_charter)
+        _seed_domain_account(agent_id, state, observed_at, duplicate_name=duplicate_name)
+
+    def _record_check(self, run_id: str, task_name: str, failures: list[str], success: str) -> None:
+        self.record_task_result(
+            run_id, None, EvalRunTask.Status.FAILED if failures else EvalRunTask.Status.PASSED,
+            task_name=task_name,
+            observed_summary="; ".join(failures) if failures else success,
+            artifacts={},
+        )
+
+
+@register_scenario
+class SqliteDomainTruthOverStaleHistoryScenario(SqliteDomainModelScenario):
+    slug = SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY
+    description = "An established domain model should beat stale conversation history."
+    expected_runtime = "short"
+    tasks = [ScenarioTask(name="inject_prompt", assertion_type="agent_processing"), ScenarioTask(name="verify_modeled_truth_read", assertion_type="tool_call"), ScenarioTask(name="verify_current_truth_answer", assertion_type="manual")]
+    prompt = "I'm picking up Aster Labs. Where does it actually stand now, who owns it, and what should happen next?"
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._prepare_domain_agent(agent_id, DOMAIN_CURRENT, timezone.now().isoformat())
+        self.inject_message(
+            agent_id,
+            "Last week's note put Aster Labs in discovery with Devon Price, waiting until Friday.",
+            trigger_processing=False,
+            eval_run_id=run_id,
+        )
+        inbound = self._inject_and_wait(
+            run_id, agent_id, self.prompt, {},
+            allowed_tool_names={"sqlite_batch", "send_chat_message"}, max_relevant_tool_calls=4,
+        )
+        calls = _tool_calls_for_run(run_id, after=inbound.timestamp, tool_names={"sqlite_batch"})
+        successful = [call for call in calls if str(call.status).lower() == "complete"]
+        sql = "\n".join(str((call.tool_params or {}).get("sql") or "") for call in successful)
+        targeted = any(
+            _reads_table(statement, "accounts") and re.search(r"\bwhere\b", statement, re.I)
+            for call in successful
+            for statement in sqlparse.split(str((call.tool_params or {}).get("sql") or ""))
+        )
+        failures = [message for failed, message in (
+            (not successful, "existing account model was not queried"),
+            (not (re.search(r"\bselect\b", sql, re.I) and _reads_table(sql, "accounts")), "account truth was not selected from the model"),
+            (not targeted, "account model was not queried with a bounded filter"),
+            (len(successful) > 2, f"SQLite reads were not bounded: {len(successful)}"),
+        ) if failed]
+        self._record_check(
+            run_id, "verify_modeled_truth_read", failures,
+            "Read the existing account model before one terminal reply.",
+        )
+        self._record_sourced_answer(
+            run_id, agent_id=agent_id, after=inbound.timestamp, task_name="verify_current_truth_answer",
+            source_urls=(), required_terms=("Aster Labs", "legal", "Maya Chen", "SOC 2 packet"), min_sources=0,
+        )
+
+
+@register_scenario
+class SqliteDomainModelRefreshesAndEvolvesScenario(SqliteDomainModelScenario):
+    slug = SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES
+    description = "Newer source evidence should refresh an entity and add a keyed, sourced child relation."
+    tasks = [ScenarioTask(name="inject_prompt", assertion_type="agent_processing"), ScenarioTask(name="verify_source_to_model_refresh", assertion_type="tool_call"), ScenarioTask(name="verify_persisted_domain_evolution", assertion_type="manual"), ScenarioTask(name="verify_refreshed_answer", assertion_type="manual")]
+    prompt = f"Review this latest CRM snapshot and give me the current Aster Labs picture, including anything still open: {DOMAIN_REFRESH_URL}"
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._prepare_domain_agent(
+            agent_id, ("security_review", "Maya Chen", "wait for the security questionnaire"),
+            "2026-07-18T13:00:00Z", duplicate_name=True,
+        )
+        self._enable_tools(agent_id, ("http_request",))
+        inbound = self._inject_and_wait(
+            run_id, agent_id, self.prompt, _domain_refresh_mock(),
+            allowed_tool_names={"http_request", "sqlite_batch", "send_chat_message"}, max_relevant_tool_calls=8,
+        )
+        calls = _tool_calls_for_run(run_id, after=inbound.timestamp)
+        fetches = [
+            call for call in calls
+            if call.tool_name == "http_request" and str(call.status).lower() == "complete"
+            and str(resolved_tool_param(call, "url") or "").rstrip("/") == DOMAIN_REFRESH_URL.rstrip("/")
+        ]
+        sqlite_calls = [
+            call for call in calls if call.tool_name == "sqlite_batch" and str(call.status).lower() == "complete"
+        ]
+        sql_values = [str((call.tool_params or {}).get("sql") or "") for call in sqlite_calls]
+        source_mutations = set(source_derived_model_mutation_tables(sql_values))
+        reconciled_tables = set(source_derived_model_reconciled_tables(sql_values))
+        state_failures, child_table = _inspect_domain_refresh_state(agent_id)
+        expected_tables = {"accounts"}
+        if child_table:
+            expected_tables.add(child_table.casefold())
+        failures = [message for failed, message in (
+            (len(fetches) != 1, f"expected one source fetch, found {len(fetches)}"),
+            (not sqlite_calls, "new source evidence was not written to the model"),
+            (
+                not expected_tables.issubset(source_mutations),
+                f"expected source-derived writes to {sorted(expected_tables)}, found {sorted(source_mutations)}",
+            ),
+            (
+                not expected_tables.issubset(reconciled_tables),
+                f"updated model was not queried after reconciliation: {sorted(reconciled_tables)}",
+            ),
+            (len(sqlite_calls) > 4, f"SQLite refresh calls were not bounded: {len(sqlite_calls)}"),
+        ) if failed]
+        self._record_check(
+            run_id, "verify_source_to_model_refresh", failures,
+            "Fetched the newer snapshot once, ingested it, and then replied.",
+        )
+        self._record_check(
+            run_id, "verify_persisted_domain_evolution", state_failures,
+            "Refreshed one stable account and modeled keyed, sourced child rows.",
+        )
+        self._record_sourced_answer(
+            run_id, agent_id=agent_id, after=inbound.timestamp, task_name="verify_refreshed_answer",
+            source_urls=(), required_terms=("Aster Labs", "contracting", "redlines", "Noah Reed"), min_sources=0,
+        )
+
+
 @register_scenario
 class SqliteDedupeRequeryScenario(SqliteToolResultScenario):
     slug = SQLITE_DEDUPE_REQUERY
@@ -815,7 +1110,7 @@ class SqliteItemLinkReportScenario(SqliteToolResultScenario):
     description = "Reports over item records should preserve item-level listing URLs, not just source feed URLs."
     tasks = [ScenarioTask(name="inject_prompt", assertion_type="agent_processing"), ScenarioTask(name="verify_item_link_sqlite_usage", assertion_type="tool_call"), ScenarioTask(name="verify_listing_links_in_report", assertion_type="manual")]
     builtin_tools = ("http_request",)
-    prompt = "Fetch these vehicle inventory JSON feeds, compare 2023+ Tesla Model Y records within 50 miles, and send one concise initial report with the best batch and listing links for recommended vehicles. Do not browse or create files.\n\n" + "\n".join(f"- {url}" for url in INVENTORY_URLS)
+    prompt = "Fetch these vehicle inventory JSON feeds, compare 2023+ Tesla Model Y records within 50 miles, and send one concise initial report with the best batch, the cheapest qualifying option, and listing links for recommended vehicles. Do not browse or create files.\n\n" + "\n".join(f"- {url}" for url in INVENTORY_URLS)
     mock_kind = "inventory"
     verify_task_name = "verify_item_link_sqlite_usage"
     answer_source_urls = LISTING_URLS

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -1,3 +1,7 @@
+import sqlite3
+import tempfile
+from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -6,6 +10,7 @@ from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase, tag
 
 import api.evals.loader  # noqa: F401 - registers scenarios and suites
+from api.evals.scenarios import sqlite_tool_results as sqlite_evals
 from api.agent.core.event_processing import _get_completed_process_run_count, _resolve_eval_mock_result
 from api.agent.core.prompt_context import _get_system_instruction, build_prompt_context_preview
 from api.agent.core.tool_results import _wrap_as_sqlite_result
@@ -78,12 +83,12 @@ from api.models import (
 )
 
 
-def _eval_tool_call(tool_name, tool_params=None, *, step=None, result='{"status":"ok"}'):
+def _eval_tool_call(tool_name, tool_params=None, *, step=None, result='{"status":"ok"}', status="complete"):
     return SimpleNamespace(
         step=step or tool_name,
         tool_name=tool_name,
         tool_params=tool_params or {},
-        status="complete",
+        status=status,
         result=result,
     )
 
@@ -127,6 +132,8 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertIn(SQLITE_ITEM_LINK_REPORT, suite.scenario_slugs)
         self.assertIn(SQLITE_NATURAL_RESULT_ACCESS, suite.scenario_slugs)
         self.assertIn(SQLITE_BOUNDED_PORTFOLIO_REPORT, suite.scenario_slugs)
+        self.assertIn(sqlite_evals.SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY, suite.scenario_slugs)
+        self.assertIn(sqlite_evals.SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES, suite.scenario_slugs)
 
     def test_trajectory_regression_prompts_do_not_prescribe_tools_or_format(self):
         prompts = (
@@ -689,19 +696,66 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         prompt = SqliteItemLinkReportScenario.prompt.lower()
 
         self.assertIn("listing links", prompt)
+        self.assertIn("cheapest qualifying option", prompt)
         self.assertNotIn("sqlite", prompt)
         self.assertNotIn("__tool_results", prompt)
         self.assertNotIn("json_extract", prompt)
 
     def test_sqlite_domain_model_prompts_are_natural(self):
         prompts = (
-            SqliteIntermediateWorkingTableScenario.prompt
-            + " "
-            + SqliteIntermediateWorkingTableScenario.followup_prompt
-        ).lower()
+            SqliteIntermediateWorkingTableScenario.prompt + " " + SqliteIntermediateWorkingTableScenario.followup_prompt,
+            sqlite_evals.SqliteDomainTruthOverStaleHistoryScenario.prompt,
+            sqlite_evals.SqliteDomainModelRefreshesAndEvolvesScenario.prompt,
+        )
 
-        for implementation_term in ("sqlite", "__tool_results", "json_extract", "create table", "sql"):
-            self.assertNotIn(implementation_term, prompts)
+        for prompt in prompts:
+            for implementation_term in (
+                "sqlite", "__tool_results", "json_extract", "database", "table", "schema", "persist",
+            ):
+                self.assertNotIn(implementation_term, prompt.lower())
+
+    def test_domain_refresh_verifier_checks_persisted_rows(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "state.db"
+
+            with patch(
+                "api.evals.scenarios.sqlite_tool_results.agent_sqlite_db",
+                side_effect=lambda _agent_id: nullcontext(str(db_path)),
+            ):
+                sqlite_evals._seed_domain_account(
+                    "agent", sqlite_evals.DOMAIN_CURRENT, "2026-07-20T14:00:00Z", duplicate_name=True,
+                )
+                with sqlite3.connect(db_path) as conn:
+                    conn.execute(
+                        "UPDATE accounts SET stage=?, owner=?, next_action=?, source_url=?, observed_at=? WHERE account_id=?;",
+                        (*sqlite_evals.DOMAIN_REFRESH, sqlite_evals.DOMAIN_REFRESH_URL,
+                         sqlite_evals.DOMAIN_REFRESH_OBSERVED_AT, sqlite_evals.DOMAIN_ACCOUNT_ID),
+                    )
+                    conn.execute(
+                        "CREATE TABLE account_work (workstream_id TEXT PRIMARY KEY, account_id TEXT, name TEXT, "
+                        "status TEXT, owner TEXT, due_on TEXT, source_url TEXT, observed_at TEXT);"
+                    )
+                    conn.executemany(
+                        "INSERT INTO account_work VALUES (?, ?, ?, ?, ?, ?, ?, ?);",
+                        [(row[0], sqlite_evals.DOMAIN_ACCOUNT_ID, *row[1:], sqlite_evals.DOMAIN_REFRESH_URL,
+                          sqlite_evals.DOMAIN_REFRESH_OBSERVED_AT) for row in sqlite_evals.DOMAIN_WORKSTREAMS],
+                    )
+                self.assertEqual(sqlite_evals._domain_refresh_state_failures("agent"), [])
+                with sqlite3.connect(db_path) as conn:
+                    conn.execute("UPDATE account_work SET source_url='https://wrong.example.test';")
+                self.assertIn(
+                    "provenance", "; ".join(sqlite_evals._domain_refresh_state_failures("agent")),
+                )
+                with sqlite3.connect(db_path) as conn:
+                    conn.execute(
+                        "UPDATE account_work SET source_url=?;", (sqlite_evals.DOMAIN_REFRESH_URL,),
+                    )
+                    conn.execute(
+                        "UPDATE accounts SET owner='Maya Chen' WHERE name='Aster Labs';",
+                    )
+                self.assertIn(
+                    "different account", "; ".join(sqlite_evals._domain_refresh_state_failures("agent")),
+                )
 
     def test_multi_result_sqlite_scorer_rejects_extra_or_hand_built_queries(self):
         scenario, recorded = SqliteMultiResultWebSynthesisScenario(), []
@@ -721,6 +775,17 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         ):
             self.assertFalse(scenario._record_sqlite_usage("run", after=None, task_name="verify"))
         self.assertIn("sqlite_batch calls 3 > 2", recorded[-1][1]["observed_summary"])
+
+        rejected = _eval_tool_call(
+            "sqlite_batch", {"sql": "SELECT result_json FROM __tool_results WHERE result_id IN ('r1')"},
+            result="Query not executed: one result_id at a time.", status="error",
+        )
+        with patch(
+            "api.evals.scenarios.sqlite_tool_results._tool_calls_for_run",
+            return_value=[rejected, rejected, rejected, _eval_tool_call("sqlite_batch", {"sql": aggregate_sql})],
+        ):
+            self.assertFalse(scenario._record_sqlite_usage("run", after=None, task_name="verify"))
+        self.assertIn("sqlite_batch attempts 4 > 3", recorded[-1][1]["observed_summary"])
 
         hand_built_sql = aggregate_sql.replace(
             "result_id, count(*)",
@@ -1407,9 +1472,11 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
     def test_fresh_full_tool_result_wrapper_discourages_redundant_sqlite_rereads(self):
         wrapped = _wrap_as_sqlite_result('{"answer": "ready"}', 19)
 
-        self.assertIn("reply directly in the next message", wrapped)
-        self.assertIn("Do not query __tool_results or sqlite_batch just to reread", wrapped)
-        self.assertIn("use SQL only for real filtering", wrapped)
+        self.assertIn("Reply directly for a simple answer", wrapped)
+        self.assertIn("unless it updates an established named domain model", wrapped)
+        self.assertIn("Use SQL to reconcile that model", wrapped)
+        self.assertIn("exact filtering/ranking across sizable or multiple results", wrapped)
+        self.assertIn("do not query merely to reread or parse", wrapped)
 
 
 @tag("eval_sim")

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -6,23 +6,23 @@
     "limits": {
       "normal_explicit_send": {
         "fitted_tokens": 7309,
-        "system_bytes": 23612,
-        "tools_bytes": 21008,
-        "total_bytes": 55348,
+        "system_bytes": 23611,
+        "tools_bytes": 20987,
+        "total_bytes": 55326,
         "user_bytes": 10728
       },
       "planning_first_run": {
         "fitted_tokens": 8620,
-        "system_bytes": 30579,
-        "tools_bytes": 12002,
-        "total_bytes": 53062,
+        "system_bytes": 30578,
+        "tools_bytes": 11981,
+        "total_bytes": 53040,
         "user_bytes": 10481
       },
       "web_chat_implied_send": {
         "fitted_tokens": 7449,
-        "system_bytes": 24112,
-        "tools_bytes": 21008,
-        "total_bytes": 55851,
+        "system_bytes": 24111,
+        "tools_bytes": 20987,
+        "total_bytes": 55829,
         "user_bytes": 10731
       }
     },

--- a/tests/unit/test_prompt_context_message_placement.py
+++ b/tests/unit/test_prompt_context_message_placement.py
@@ -4,7 +4,13 @@ from unittest.mock import patch
 
 from api.agent.core import prompt_context
 from api.agent.core.prompt_context import build_prompt_context
-from api.models import BrowserUseAgent, PersistentAgent
+from api.models import (
+    BrowserUseAgent,
+    PersistentAgent,
+    PersistentAgentStep,
+    PersistentAgentSystemStep,
+    PersistentAgentToolCall,
+)
 
 User = get_user_model()
 
@@ -42,18 +48,9 @@ class PromptContextSqlitePlacementTests(TestCase):
         self.assertEqual(all_contents.count(sqlite_guidance), 1)
         self.assertIn("<sqlite_guidance>", system_message["content"])
         self.assertIn("</sqlite_guidance>", system_message["content"])
-        self.assertIn("keyed entities/events/relations", sqlite_guidance)
-        self.assertIn("multi-fetch finite sets as keyed", sqlite_guidance)
-        self.assertIn("with fields/status/source", sqlite_guidance)
-        self.assertIn("query gaps before reporting", sqlite_guidance)
-        self.assertIn("Only sourced blockers are unresolved", sqlite_guidance)
-        self.assertIn("return only needed rows to context", sqlite_guidance)
-        self.assertIn(
-            "one shaped INSERT ... SELECT/json_each filtered by IN/tool_name",
-            sqlite_guidance,
-        )
-        self.assertIn("extract fields and raw URLs in SQL from result_json", sqlite_guidance)
-        self.assertIn("Never filter one result_id at a time, make a table per result", sqlite_guidance)
+        self.assertIn("Named tables are the world model", sqlite_guidance)
+        self.assertIn("before external refreshes/decisions", sqlite_guidance)
+        self.assertIn("use SQLite for exact set logic/counts/ranking", sqlite_guidance)
         self.assertIn("Keep chat/outreach light. Owner reports on 4+ peers", system_message["content"])
         self.assertIn(
             "need resolved/total and one table with requested fields",
@@ -73,3 +70,69 @@ class PromptContextSqlitePlacementTests(TestCase):
         self.assertIn("deep/exhaustive research and finite-set coverage", system_message["content"])
         self.assertIn("batch gaps, follow up misses, and reconcile coverage", system_message["content"])
         self.assertIn("never repeat a successful URL/query", system_message["content"])
+
+    def test_source_model_warning_uses_only_latest_process_cycle(self):
+        old_cycle = PersistentAgentStep.objects.create(agent=self.agent, description="Process events")
+        PersistentAgentSystemStep.objects.create(
+            step=old_cycle,
+            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+        )
+        old_source = PersistentAgentStep.objects.create(agent=self.agent, description="old source")
+        PersistentAgentToolCall.objects.create(
+            step=old_source,
+            tool_name="http_request",
+            tool_params={"url": "https://old.example.test"},
+            status="complete",
+        )
+        current_cycle = PersistentAgentStep.objects.create(agent=self.agent, description="Process events")
+        PersistentAgentSystemStep.objects.create(
+            step=current_cycle,
+            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+        )
+
+        self.assertEqual(prompt_context._get_unreconciled_source_model_warning(self.agent), "")
+
+        source = PersistentAgentStep.objects.create(agent=self.agent, description="current source")
+        PersistentAgentToolCall.objects.create(
+            step=source,
+            tool_name="http_request",
+            tool_params={"url": "https://crm.example.test/account"},
+            status="complete",
+        )
+        model_read = PersistentAgentStep.objects.create(agent=self.agent, description="stale model read")
+        PersistentAgentToolCall.objects.create(
+            step=model_read,
+            tool_name="sqlite_batch",
+            tool_params={"sql": "SELECT * FROM accounts WHERE account_id='acct-1'"},
+            status="complete",
+        )
+
+        self.assertIn(
+            "not yet reconciled",
+            prompt_context._get_unreconciled_source_model_warning(self.agent),
+        )
+
+        reconcile = PersistentAgentStep.objects.create(agent=self.agent, description="model reconciliation")
+        PersistentAgentToolCall.objects.create(
+            step=reconcile,
+            tool_name="sqlite_batch",
+            tool_params={
+                "sql": "UPDATE accounts SET stage=(SELECT json_extract(result_json,'$.stage') "
+                "FROM __tool_results) WHERE account_id='acct-1'"
+            },
+            status="complete",
+        )
+
+        self.assertIn(
+            "post-update query",
+            prompt_context._get_unreconciled_source_model_warning(self.agent),
+        )
+        post_update_read = PersistentAgentStep.objects.create(agent=self.agent, description="fresh model read")
+        PersistentAgentToolCall.objects.create(
+            step=post_update_read,
+            tool_name="sqlite_batch",
+            tool_params={"sql": "SELECT stage FROM accounts WHERE account_id='acct-1'"},
+            status="complete",
+        )
+
+        self.assertEqual(prompt_context._get_unreconciled_source_model_warning(self.agent), "")

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -21,10 +21,22 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
     def test_sqlite_guidance_tracks_bounded_set_coverage(self):
         guidance = prompt_context._get_sqlite_guidance()
 
-        self.assertIn("sizable domains and multi-fetch finite sets as keyed entities/events/relations", guidance)
-        self.assertIn("with fields/status/source", guidance)
+        self.assertIn("Named tables are the world model", guidance)
+        self.assertIn("digest is partial", guidance)
+        self.assertIn("Read them before external refreshes/decisions, not memory", guidance)
+        self.assertIn("Current complete rows are truth; don't refetch them", guidance)
+        self.assertIn("Tool output doesn't update it", guidance)
+        self.assertIn("sharing a stable ID or its children", guidance)
+        self.assertIn("reconcile entities/relations", guidance)
+        self.assertIn("before acting/reporting", guidance)
+        self.assertIn("evolve schema, then query", guidance)
+        self.assertIn("Upserts refresh every mutable/provenance field", guidance)
+        self.assertIn("Only unrelated one-offs bypass it", guidance)
+        self.assertIn("Use stable keys", guidance)
+        self.assertIn("inspect identity after wrong row counts", guidance)
         self.assertIn("query gaps before reporting", guidance)
         self.assertIn("Only sourced blockers are unresolved", guidance)
+        self.assertIn("use SQLite for exact set logic/counts/ranking", guidance)
 
     def test_low_iteration_warning_keeps_unfinished_work_active(self):
         collector = _NestedPromptSectionCollector()
@@ -107,6 +119,129 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
 
         self.assertIn("SQLite efficiency warning", warning)
         self.assertIn("one result_id at a time", warning)
+
+    def test_sqlite_retry_warning_recovers_from_rejected_singleton_queries(self):
+        rejection = (
+            "Query not executed: do not read __tool_results or a staging table derived from it one result_id at a "
+            "time. A one-item IN (...) is still one-at-a-time."
+        )
+        warning = prompt_context._build_sqlite_retry_warning(
+            [
+                (
+                    {"sql": "SELECT result_json FROM __tool_results WHERE result_id IN ('a1')"},
+                    rejection,
+                ),
+                (
+                    {"sql": "SELECT result_json FROM __tool_results WHERE result_id IN ('b2')"},
+                    rejection,
+                ),
+            ]
+        )
+
+        self.assertIn("SQLite recovery", warning)
+        self.assertIn("Do not retry that shape", warning)
+        self.assertIn("upsert by stable key", warning)
+        self.assertIn("otherwise answer the shaped result", warning)
+        self.assertIn("Refetch only if evidence is stale or missing", warning)
+
+    def test_source_model_warning_targets_only_unreconciled_named_model_reads(self):
+        source = ("http_request", {"url": "https://crm.example.test/account"}, "complete")
+        stale_read = ("sqlite_batch", {"sql": "SELECT * FROM accounts WHERE account_id='acct-1'"}, "complete")
+
+        warning = prompt_context._build_unreconciled_source_model_warning([source, stale_read])
+
+        self.assertIn("Fresh source evidence from this work cycle", warning)
+        self.assertIn("upsert all changed/provenance fields by stable key from __tool_results", warning)
+        self.assertIn("If it is unrelated or no relevant model exists", warning)
+        self.assertIn("Do not refetch", warning)
+        self.assertEqual(
+            prompt_context._build_unreconciled_source_model_warning([
+                ("http_request", {}, "error"), stale_read,
+            ]),
+            "",
+        )
+        self.assertEqual(
+            prompt_context._build_unreconciled_source_model_warning([
+                source,
+                ("sqlite_batch", {"sql": "SELECT * FROM __tool_results"}, "complete"),
+                ("sqlite_batch", {"sql": "SELECT * FROM _csv_abc123"}, "complete"),
+            ]),
+            "",
+        )
+
+    def test_source_model_warning_clears_only_after_source_derived_durable_dml(self):
+        source = ("mcp_crm_get_account", {}, "complete")
+        stale_read = ("sqlite_batch", {"sql": "SELECT * FROM accounts"}, "complete")
+        copied_update = (
+            "sqlite_batch",
+            {"sql": "SELECT result_json FROM __tool_results; UPDATE accounts SET stage='contracting'"},
+            "complete",
+        )
+        staged_update = (
+            "sqlite_batch",
+            {"sql": "INSERT INTO staging_accounts SELECT result_json FROM __tool_results"},
+            "complete",
+        )
+        derived_update = (
+            "sqlite_batch",
+            {"sql": "UPDATE accounts SET stage=(SELECT json_extract(result_json,'$.stage') FROM __tool_results)"},
+            "complete",
+        )
+
+        self.assertTrue(prompt_context._build_unreconciled_source_model_warning([source, stale_read, copied_update]))
+        self.assertTrue(prompt_context._build_unreconciled_source_model_warning([source, stale_read, staged_update]))
+        self.assertTrue(
+            prompt_context._build_unreconciled_source_model_warning([source, stale_read, derived_update])
+        )
+        self.assertTrue(prompt_context._build_unreconciled_source_model_warning([source, derived_update]))
+        post_update_read = (
+            "sqlite_batch",
+            {"sql": "SELECT stage FROM accounts WHERE account_id='acct-1'"},
+            "complete",
+        )
+        self.assertEqual(
+            prompt_context._build_unreconciled_source_model_warning([
+                source, stale_read, derived_update, post_update_read,
+            ]),
+            "",
+        )
+        self.assertTrue(
+            prompt_context._build_unreconciled_source_model_warning([
+                source,
+                stale_read,
+                (
+                    "sqlite_batch",
+                    {
+                        "sql": "UPDATE accounts SET stage=(SELECT json_extract(result_json,'$.stage') "
+                        "FROM __tool_results) WHERE account_id IN (SELECT account_id FROM accounts)"
+                    },
+                    "complete",
+                ),
+            ])
+        )
+        self.assertTrue(
+            prompt_context._build_unreconciled_source_model_warning([
+                source, stale_read, derived_update, post_update_read, derived_update,
+            ])
+        )
+
+    def test_source_model_warning_handles_model_first_and_unrelated_mutations(self):
+        model_read = ("sqlite_batch", {"sql": "SELECT * FROM accounts"}, "complete")
+        source = ("http_request", {}, "complete")
+        unrelated_write = (
+            "sqlite_batch",
+            {"sql": "INSERT INTO audit_log(event) SELECT result_text FROM __tool_results"},
+            "complete",
+        )
+        later_source = ("mcp_crm_get_account", {}, "complete")
+
+        self.assertTrue(prompt_context._build_unreconciled_source_model_warning([model_read, source]))
+        self.assertTrue(
+            prompt_context._build_unreconciled_source_model_warning([source, model_read, later_source])
+        )
+        self.assertTrue(
+            prompt_context._build_unreconciled_source_model_warning([source, model_read, unrelated_write])
+        )
 
 
 class _PromptSectionCollector:

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -36,6 +36,9 @@ from api.agent.tools.sqlite_batch import (
 )
 from api.agent.tools.sqlite_query_quality import (
     build_tool_result_query_advisories,
+    named_model_read_tables,
+    source_derived_model_mutation_tables,
+    source_derived_model_reconciled_tables,
     summarize_sqlite_tool_result_calls,
     summarize_sqlite_tool_result_sql,
 )
@@ -261,16 +264,15 @@ class SqliteBatchToolTests(TestCase):
         definition = get_sqlite_batch_tool()
         description = definition["function"]["description"]
 
-        self.assertIn("shared entity/event/relationship tables", description)
-        self.assertIn("separate repeating parents/children", description)
-        self.assertIn("PRIMARY KEY/UNIQUE identity and provenance", description)
-        self.assertIn("MUST use explicit CREATE TABLE", description)
-        self.assertIn("CTAS is disposable only", description)
-        self.assertIn("For 2+ relevant __tool_results, query together via IN/tool_name", description)
-        self.assertIn("never call sqlite_batch once per result_id", description)
-        self.assertIn("Model with INSERT ... SELECT/json_each, not copied rows", description)
-        self.assertIn("prefer a custom tool writing to SQLite", description)
-        self.assertIn("no ATTACH", description)
+        self.assertIn("SQLite world model + hard logic", description)
+        self.assertIn("Current complete rows are truth: answer without refetching sources", description)
+        self.assertIn("keyed rows/children belong in the model", description)
+        self.assertIn("Reconcile relations, evolve schema, then query", description)
+        self.assertIn("only unrelated one-offs bypass it", description)
+        self.assertIn("joins/set logic/counts/ranking", description)
+        self.assertIn("PRIMARY KEY/UNIQUE + provenance", description)
+        self.assertIn("Import tool output via INSERT ... SELECT/json_each", description)
+        self.assertIn("from __tool_results, never copied rows", description)
 
     def test_tool_result_ctas_warns_that_identity_is_disposable(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
@@ -933,6 +935,8 @@ class SqliteBatchToolTests(TestCase):
             available_tool_result_rows=4,
         )
         self.assertEqual(advisories[0].code, "tool_result_row_loop")
+        self.assertIn("A one-item IN (...) is still one-at-a-time", advisories[0].message)
+        self.assertIn("every relevant sibling", advisories[0].message)
         self.assertIn("one shaped INSERT", advisories[0].message)
 
         calls = [
@@ -950,6 +954,147 @@ class SqliteBatchToolTests(TestCase):
         self.assertEqual(summary.sqlite_call_count, 1)
         self.assertEqual(summary.statement_count, 2)
         self.assertEqual(summary.smart_tool_result_queries, 1)
+
+    def test_model_query_classification_requires_same_statement_source_derivation(self):
+        copied_literals = [
+            "SELECT result_json FROM __tool_results WHERE result_id='r1'",
+            "UPDATE accounts SET stage='contracting' WHERE account_id='acct-1'",
+        ]
+        guarded_literal = [
+            "UPDATE accounts SET stage='contracting' WHERE EXISTS "
+            "(SELECT result_json FROM __tool_results WHERE result_id='r1')"
+        ]
+        derived_update = [
+            "UPDATE accounts SET stage=(SELECT json_extract(result_json, '$.stage') "
+            "FROM __tool_results WHERE result_id='r1') WHERE account_id='acct-1'"
+        ]
+        derived_insert = [
+            "INSERT INTO workstreams(workstream_id) SELECT json_extract(value, '$.id') "
+            "FROM __tool_results, json_each(result_json, '$.workstreams')"
+        ]
+
+        self.assertEqual(source_derived_model_mutation_tables(copied_literals), ())
+        self.assertEqual(source_derived_model_mutation_tables(guarded_literal), ())
+        self.assertEqual(source_derived_model_mutation_tables(derived_update), ("accounts",))
+        self.assertEqual(source_derived_model_mutation_tables(derived_insert), ("workstreams",))
+        self.assertEqual(
+            source_derived_model_reconciled_tables([
+                f"{derived_update[0]}; SELECT stage FROM accounts WHERE account_id='acct-1'"
+            ]),
+            ("accounts",),
+        )
+        self.assertEqual(source_derived_model_reconciled_tables(derived_update), ())
+        self.assertEqual(
+            source_derived_model_reconciled_tables([
+                "UPDATE accounts SET stage=(SELECT json_extract(result_json, '$.stage') "
+                "FROM __tool_results) WHERE account_id IN "
+                "(SELECT account_id FROM accounts WHERE stage='qualified')"
+            ]),
+            (),
+        )
+        self.assertEqual(
+            source_derived_model_reconciled_tables([
+                f"{derived_update[0]}; SELECT stage FROM accounts; {derived_update[0]}"
+            ]),
+            (),
+        )
+
+    def test_source_facts_copied_into_model_are_rejected(self):
+        payload = (
+            '{"account_id":"acct-1","stage":"contracting","next_action":"resolve redlines",'
+            '"source_url":"https://crm.example.test/acct-1"}'
+        )
+        copied = build_tool_result_query_advisories(
+            [
+                "UPDATE accounts SET stage='contracting', next_action='resolve redlines', "
+                "source_url='https://crm.example.test/acct-1' WHERE account_id='acct-1'"
+            ],
+            available_tool_result_rows=1,
+            tool_result_payloads=(payload,),
+        )
+        derived = build_tool_result_query_advisories(
+            [
+                "UPDATE accounts SET stage=(SELECT json_extract(result_json,'$.stage') "
+                "FROM __tool_results) WHERE account_id='acct-1'"
+            ],
+            available_tool_result_rows=1,
+            tool_result_payloads=(payload,),
+        )
+        unrelated = build_tool_result_query_advisories(
+            ["UPDATE accounts SET stage='reviewed' WHERE account_id='acct-1'"],
+            available_tool_result_rows=1,
+            tool_result_payloads=(payload,),
+        )
+        identity_predicate = build_tool_result_query_advisories(
+            [
+                "UPDATE accounts SET stage='reviewed' "
+                "WHERE source_url='https://crm.example.test/acct-1'",
+                "DELETE FROM accounts WHERE source_url='https://crm.example.test/acct-1'",
+                "UPDATE accounts SET stage=s.stage FROM staging_updates s JOIN refs r "
+                "ON r.url='https://crm.example.test/acct-1' WHERE accounts.account_id=s.account_id",
+            ],
+            available_tool_result_rows=1,
+            tool_result_payloads=(payload,),
+        )
+        partially_derived = build_tool_result_query_advisories(
+            [
+                "INSERT INTO accounts(account_id, stage, next_action, source_url) "
+                "SELECT json_extract(result_json, '$.account_id'), 'contracting', "
+                "'resolve redlines', json_extract(result_json, '$.source_url') "
+                "FROM __tool_results"
+            ],
+            available_tool_result_rows=1,
+            tool_result_payloads=(payload,),
+        )
+        single_normalization = build_tool_result_query_advisories(
+            [
+                "INSERT INTO accounts(account_id, stage) "
+                "SELECT json_extract(result_json, '$.account_id'), 'contracting' FROM __tool_results"
+            ],
+            available_tool_result_rows=1,
+            tool_result_payloads=(payload,),
+        )
+        arrow_derived = build_tool_result_query_advisories(
+            [
+                "INSERT INTO accounts(account_id, stage, next_action, source_url) "
+                "SELECT item.value ->> 'account_id', item.value ->> 'stage', "
+                "item.value ->> 'next_action', item.value ->> 'source_url' "
+                "FROM __tool_results, json_each(result_json, '$.content.accounts') item"
+            ],
+            available_tool_result_rows=1,
+            tool_result_payloads=(payload,),
+        )
+        self.assertEqual(copied[0].code, "source_facts_copied_into_model")
+        self.assertTrue(copied[0].blocking)
+        self.assertIn("copies source facts into SQL literals", copied[0].message)
+        self.assertIn("refresh every mutable/provenance field", copied[0].message)
+        self.assertIn("don't fetch/copy the blob", copied[0].message)
+        self.assertIn("nested arrays are under $.content", copied[0].message)
+        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in derived))
+        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in unrelated))
+        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in identity_predicate))
+        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in single_normalization))
+        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in arrow_derived))
+        self.assertTrue(any(item.code == "source_facts_copied_into_model" for item in partially_derived))
+
+    def test_model_read_classification_excludes_raw_results_and_staging(self):
+        self.assertEqual(
+            named_model_read_tables(["SELECT * FROM accounts WHERE account_id='acct-1'"]),
+            ("accounts",),
+        )
+        self.assertEqual(named_model_read_tables(["SELECT * FROM __tool_results"]), ())
+        self.assertEqual(named_model_read_tables(["SELECT * FROM _csv_abc123"]), ())
+        self.assertEqual(named_model_read_tables(["SELECT * FROM staging_accounts"]), ())
+        self.assertEqual(named_model_read_tables(["SELECT * FROM json_each('[1]')"]), ())
+        self.assertEqual(named_model_read_tables(["SELECT * FROM main.accounts"]), ("accounts",))
+        self.assertEqual(
+            named_model_read_tables(["SELECT a.* FROM accounts a JOIN __tool_results t ON 1=1"]),
+            ("accounts",),
+        )
+        self.assertEqual(
+            named_model_read_tables(["WITH current AS (SELECT * FROM accounts) SELECT * FROM current"]),
+            ("accounts",),
+        )
 
     def test_bounded_aggregate_text_projection_counts_as_smart(self):
         bounded = summarize_sqlite_tool_result_sql(

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -120,6 +120,7 @@ class ToolResultSchemaTests(SimpleTestCase):
         prompt_info = info.get("step-1")
         self.assertIsNotNone(prompt_info)
         self.assertIn("result_id=step-1", prompt_info.meta)
+        self.assertIn("result_json_path=$.content", prompt_info.meta)
         self.assertTrue(prompt_info.is_inline)
         self.assertIn("First", prompt_info.preview_text)
         self.assertNotIn("QUERY:", prompt_info.meta)
@@ -758,7 +759,7 @@ class PreviewByteLimitTests(SimpleTestCase):
         # Should be wrapped with one-time view warning
         self.assertIn("[FULL RESULT (30000 chars) - ONE-TIME VIEW", preview)
         self.assertIn("Use this visible result now", preview)
-        self.assertIn("Do not query __tool_results or sqlite_batch just to reread", preview)
+        self.assertIn("exact filtering/ranking across sizable or multiple results", preview)
         self.assertIn(medium_text, preview)
 
     def test_fresh_tool_call_over_threshold_truncated(self):


### PR DESCRIPTION
## Why

The production Gayle trajectory used SQLite frequently but not as a maintained model of the world. In the last 24 hours, half of its tool calls were SQLite, yet it performed no durable source ingestion or schema evolution, repeatedly recomputed the same sent counts, and updated outreach rows by non-unique display name. Two real sends became four modeled outcomes.

## What changed

- Treat keyed named tables as the durable world model and current complete rows as truth before conversation memory or redundant source fetches.
- Reconcile fresh tool evidence into stable entities, normalized child relations, and provenance fields; evolve the schema as the domain changes, then reread the model before acting.
- Use SQLite as the deterministic logic layer for joins, set operations, filtering, counts, constraints, and ranking while returning only the facts needed for the decision.
- Reject copied source facts and one-result-at-a-time loops, while allowing legitimate JSON selector paths and stable identity predicates.
- Expose the stored HTTP JSON path beside unwrapped previews so aggregate imports can address the real payload without probe loops.
- Add real-harness regressions for current modeled truth over stale chat, source-driven schema evolution, keyed 72-row working models, hard SQL filtering/ranking, and follow-up reuse.
- Align an existing item-report eval request with its unchanged cheapest-item assertion; the grader was not weakened.

## Verification

- DeepSeek V4 Flash full affected suite: 27/29 tasks (93.1%). The two misses were one omitted citation and one missing outbound delivery; exact-head reruns of both are 6/6.
- DeepSeek V4 Flash exact-head highlights: persisted 72-row model and follow-up reuse 6/6; source refresh/evolution 4/4; item-level hard-logic report 3/3.
- One full-suite completion hit an explicit OpenRouter upstream provider-unavailable timeout and recovered through the existing fallback.
- Focused Django suite: 226/226 green.
- [Exact-head CI](https://github.com/gobii-ai/gobii-platform/actions/runs/29875723124): all 10 backend shards, combined results, frontend, sandbox, tags, and complexity checks green.
- [Exact-head preview](https://github.com/gobii-ai/gobii/actions/runs/29875786313): deployed successfully; home, health, login, app shell, and exact-SHA static manifest smoke checks passed.
- Prompt, tool, and source complexity checks pass under correspondingly tightened committed caps.

The production change is focused; most of the diff is adversarial eval fixtures and regression tests.
