### PR TITLE
Improve durable feedback learning and SQLite modeling

### DIFF
--- a/api/agent/core/daily_limit_mode.py
+++ b/api/agent/core/daily_limit_mode.py
@@ -9,6 +9,7 @@ CREDIT_MESSAGE_TOOL_NAMES = frozenset(
         "send_email",
         "send_sms",
         "send_chat_message",
+        "send_discord_message",
         "send_agent_message",
     }
 )
@@ -16,7 +17,8 @@ CREDIT_MESSAGE_ONLY_ALLOWED_TOOL_NAMES = CREDIT_MESSAGE_TOOL_NAMES | frozenset(
     {"sleep_until_next_trigger"}
 )
 CREDIT_MESSAGE_ONLY_ALLOWED_TOOL_NAMES_TEXT = (
-    "send_email, send_sms, send_chat_message, send_agent_message, and sleep_until_next_trigger"
+    "send_email, send_sms, send_chat_message, send_discord_message, send_agent_message, "
+    "and sleep_until_next_trigger"
 )
 
 

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -69,6 +69,7 @@ from ..tags import maybe_schedule_agent_tags
 from ..comms.routing import (
     bind_inbound_routing_scope,
     capture_inbound_routing_scope,
+    get_current_inbound_message,
     reset_inbound_routing_scope,
 )
 from tasks.services import TaskCreditService
@@ -90,7 +91,7 @@ from .daily_limit_mode import (
 )
 from .period_events import DAILY_HARD_LIMIT_BLOCKED_EVENT, DAILY_HARD_LIMIT_EXCEEDED_EVENT, DAILY_SOFT_LIMIT_EXCEEDED_EVENT, should_emit_daily_agent_event
 from .agent_judge import maybe_run_agent_judge
-from .prompt_context import build_prompt_context, get_agent_daily_credit_state, get_agent_tools
+from .prompt_context import _ConfigAuthorityResolver, build_prompt_context, get_agent_daily_credit_state, get_agent_tools
 from .prompt_run_cache import (
     PromptRunCache,
     bind_prompt_run_cache,
@@ -197,38 +198,124 @@ def _coerce_loop_iteration_limit(value: int | None) -> int:
 
 TOOL_ERROR_TYPE_MAX_BYTES = 120
 PREFERRED_PROVIDER_MAX_AGE = timedelta(hours=1)
-MESSAGE_TOOL_NAMES = set(CREDIT_MESSAGE_TOOL_NAMES)
+MESSAGE_TOOL_NAMES = set(CREDIT_MESSAGE_TOOL_NAMES) | {"send_discord_message"}
 MESSAGE_SUCCESS_STATUSES = {"ok", "queued", "sent", "success"}
 MESSAGE_TOOL_BODY_KEYS = {
     "send_email": "mobile_first_html",
     "send_sms": "body",
     "send_chat_message": "body",
     "send_agent_message": "message",
+    "send_discord_message": "message",
 }
-HUMANIZED_MESSAGE_BODY_KEYS = {**MESSAGE_TOOL_BODY_KEYS, "send_discord_message": "message"}
+REPLY_TOOL_BY_CHANNEL = {CommsChannel.EMAIL: "send_email", CommsChannel.SMS: "send_sms", CommsChannel.WEB: "send_chat_message", CommsChannel.DISCORD: "send_discord_message"}
 SQLITE_MUTATION_RE = re.compile(r"\b(?:insert|update|delete|replace|alter|drop|create)\b", re.IGNORECASE)
 AGENT_CONFIG_TABLE_RE = re.compile(r"\b__agent_config\b", re.IGNORECASE)
-DURABLE_CONFIG_INTENT_RE = re.compile(
-    r"\b(?:going forward|from now on|in the future|next time|always|never|remember|prefer|preference|"
-    r"(?:my |this )?feedback:|each time|every time|make (?:that|this|it) a rule|should(?:n'?t| not) have to|"
-    r"update (?:your )?(?:charter|schedule|instructions)|change (?:your )?(?:charter|schedule|instructions)|"
-    r"charter|schedule|scheduled|recurring|ongoing|proactive|monitor|track|alert|digest|cadence|"
-    r"setup|set up|role|scope|process|workflow|customer context|client context|operating boundary)\b",
+MCP_ACTION_NAME_RE = re.compile(
+    r"(?:^|_)(?:add|archive|cancel|comment|create|delete|edit|invite|merge|move|post|publish|react|remove|"
+    r"rename|reply|schedule|send|set|update|upload|write)(?:_|$)",
+    re.IGNORECASE,
+)
+MCP_READ_NAME_RE = re.compile(
+    r"(?:^|_)(?:fetch|find|get|inspect|list|lookup|query|read|retrieve|scrape|search|view)(?:_|$)",
     re.IGNORECASE,
 )
 TRANSIENT_CONFIG_SCOPE_RE = re.compile(
-    r"\b(?:for this (?:answer|response|report|task|time)|this time|just this once|today only|for now)\b",
+    r"\b(?:(?:just\s+)?for (?:this|today['’]s) (?:answer|response|report|message|email|note|draft|outreach|task|project|renewal|deal|case|ticket|campaign|meeting|time|batch|run)|"
+    r"(?:in|to) (?:this|today['’]s) (?:answer|response|report|message|email|note|draft|meeting)|(?:just )?for today(?: only)?|"
+    r"(?:only|just) today|(?:only|just) (?:this|today['’]s) (?:answer|response|report|message|email|note|draft|outreach|task|batch|run)|"
+    r"(?:this|today['’]s) (?:answer|response|report|message|email|note|draft|outreach|task|batch|run) only|this time|just this once|today only|for now|"
+    r"(?:this is\s+)?(?:just\s+)?(?:a\s+)?one[- ]time (?:exception|request|case)|"
+    r"(?:stop|quit)\s+(?:sending|using)\s+(?:this|the current)\s+(?:email|message|report|batch|source|file|draft|campaign|task|run)|"
+    r"never\s+(?:store|persist|remember|record|share|send|include|reveal|expose)\b[^.!?]{0,80}\b(?:this|that)\s+"
+    r"(?:(?:confidential|customer|client|private|api|access)\s+)?(?:email|message|report|file|document|data|record|secrets?|credentials?|passwords?|tokens?|keys?))\b",
+    re.IGNORECASE,
+)
+NO_DURABLE_CONFIG_RE = re.compile(
+    r"\b(?:do not|don['’]?t|never)\s+(?:(?:save|remember|store|record|persist)\s+"
+    r"(?:this|that|it)(?:\s+(?:feedback|preference|instruction)(?:\s+(?:as\s+(?:(?:a|an)\s+)?(?:rule|preference|instruction)|(?:in|to)\s+(?:your\s+)?(?:charter|instructions)))?|"
+    r"\s+(?:as\s+(?:(?:a|an)\s+)?(?:rule|preference|instruction)|(?:in|to)\s+(?:your\s+)?(?:charter|instructions))|(?=\s*(?:[.!?;,]|$)))|"
+    r"make\s+(?:this|that|it)(?:\s+feedback)?\s+(?:(?:a|an)\s+)?(?:(?:standing|permanent|durable)\s+)?(?:rule|preference|instruction)|"
+    r"(?:update|edit|change|patch)\s+(?:your\s+)?(?:charter|instructions|preferences?))\b",
     re.IGNORECASE,
 )
 DIRECT_USER_CORRECTION_RE = re.compile(
     r"\b(?:stop|quit)[\s,:;-]+(?:(?:always|automatically|constantly|continually|continuously|frequently|"
-    r"just|regularly|repeatedly|routinely)[\s,:;-]+){0,2}(?:writ\w*|say\w*|send\w*|sound\w*|use(?:d|s|ing)?|"
+    r"just|regularly|repeatedly|routinely)[\s,:;-]+){0,2}(?:writ\w*|say\w*|send\w*|sound\w*|us(?:e|ed|es|ing)|"
     r"includ\w*|format\w*|reply\w*|respond\w*|messag\w*|introduc\w*)\b|"
-    r"\b(?:sound(?:s|ed)?|reads?|feels?|looks?)\b.{0,60}\b(?:automated|templated|robotic|generic|formal|"
-    r"informal|spammy|salesy|corporate|product[ -]?y)\b|"
     r"\b(?:too|overly)\s+(?:formal|informal|generic|spammy|salesy|corporate|product[ -]?y)\b|"
     r"\b(?:no\s+(?:more\s+)?|(?:don'?t|do not|never)\s+use\s+)(?:em|en|unicode|double)[ -]?"
-    r"(?:dashes|hyphens)\b",
+    r"(?:dashes|hyphens)\b|"
+    r"\b(?:just|only)\s+(?:come back|report|send|tell|update)\b.{0,100}"
+    r"\b(?:changed|changes|blockers?|next (?:move|step|action))\b|"
+    r"(?:^|[.!?]\s+)never\s+(?:store|share|send|include|reveal|expose)\b[^.!?]{0,80}"
+    r"\b(?:secrets?|credentials?|passwords?|private|confidential|customer data)\b|"
+    r"\b(?:make (?:that|this|it) a rule|do i have to\b.{0,80}\b(?:each|every) time)\b",
+    re.IGNORECASE,
+)
+QUOTED_OUTPUT_FEEDBACK_RE = re.compile(
+    r'["“](?P<quote>[^"”\n]{6,240})["”].{0,60}\b(?:(?:is|are|was|were)\s+(?:not|never)\s+'
+    r"(?:so\s+|very\s+|really\s+)?(?:good|great|useful|helpful)|(?:isn['’]?t|aren['’]?t|wasn['’]?t|weren['’]?t)\s+(?:good|great|useful|helpful)|"
+    r"(?:is|are|was|were)\s+(?:bad|unhelpful|counterproductive))\b",
+    re.IGNORECASE,
+)
+EVALUATIVE_BEHAVIOR_FEEDBACK_RE = re.compile(
+    r"\byour\b.{0,50}\b(?:updates?|messages?|emails?|replies?|answers?|reports?|questions?|headings?|notes?)\b.{0,30}\b(?:"
+    r"(?:is|are|was|were)\s+(?:not|never)\s+(?:so\s+|very\s+|really\s+)?(?:good|great|useful|helpful)|"
+    r"(?:isn['’]?t|aren['’]?t|wasn['’]?t|weren['’]?t)\s+(?:good|great|useful|helpful)|"
+    r"(?:is|are|was|were)\s+(?:bad|unhelpful|counterproductive))\b|"
+    r"\b(?:this|that|it)\s+(?:felt|feels?|sounded|sounds?|read|reads|looked|looks?)\b.{0,30}"
+    r"\b(?:stiff|awkward|off|formal|generic|robotic|templated|salesy|corporate)\b|"
+    r"\b(?:love|like|prefer)\s+(?:this|that|it)\b.{0,140}\b(?:opener|opening|observation|pitch|"
+    r"format|approach|pattern|structure|tone|style)\b|"
+    r"\b(?:nice|great|good)\b.{0,40}\b(?:this|that|the)\s+(?:format|approach|pattern|structure|tone|"
+    r"style)\b.{0,40}\b(?:natural|better|works?|useful|right)\b|"
+    r"\b(?:this|that|it)\s+(?:is|was)\s+(?:really\s+)?(?:good|great)\b.{0,120}"
+    r"\b(?:opener|opening|observation|no pitch|format|approach|pattern|structure|tone|style)\b|"
+    r"\b(?:this|that)(?:['’]s| is)\b.{0,25}\b(?:good|great|better)\s+"
+    r"(?:format|structure|tone|style)\b|"
+    r"\b(?:these|those)\b.{0,50}\b(?:updates?|notes?|replies?)\b.{0,30}\b(?:aren['’]?t|are not|weren['’]?t|were not)\s+(?:useful|helpful|good)\b|"
+    r"\byou\b.{0,30}\b(?:did not|didn['’]?t|failed to)\s+include\b.{0,30}\b(?:links?|urls?|sources?)\b|"
+    r"\bit\s+makes?\b.{0,30}\b(?:person|recipient|reader|user)\b.{0,30}\b(?:do|carry|figure out)\b.{0,20}\bwork\b",
+    re.IGNORECASE,
+)
+TONE_CORRECTION_RE = re.compile(
+    r"\b(?:you|(?:this|that|it)(?:\s+(?:message|email|reply|answer|report|update|note|draft))?)\s+"
+    r"(?:sound(?:s|ed)?|reads?|feels?|looks?)\b.{0,60}\b(?:automated|templated|robotic|generic|formal|"
+    r"informal|spammy|salesy|corporate|product[ -]?y|stiff|awkward|off)\b",
+    re.IGNORECASE,
+)
+BEHAVIOR_OUTPUT_NOUN_RE = re.compile(
+    r"\b(?:message|email|repl(?:y|ies)|response|answer|report|update|note|draft|question|heading|format|tone|style|opener|"
+    r"opening|pitch|structure|wording|communication|table|bullet|takeaway|layout|visual|reporting|workflow|"
+    r"process|outreach|research|sourcing|routing|follow[ -]?up)s?\b",
+    re.IGNORECASE,
+)
+DOMAIN_CONTENT_RE = re.compile(
+    r"\b(?:compan(?:y|ies)|customer|prospect|product|revenue|sales|pricing|funding|market|deal|account|"
+    r"lead|candidate|founder|portfolio|strategy)\b",
+    re.IGNORECASE,
+)
+SEPARATE_FEEDBACK_TASK_RE = re.compile(
+    r"(?:^|[.!?;]\s+|\b(?:also|then|now)\b[:,]?\s+)(?!(?:do not|don['’]?t|never)\b)(?:please\s+)?(?:rewrite|edit|draft|send|email|message|contact|research|find|look up|fetch|export|create|run|check|summari[sz]e|show|give|tell|pause|delete|upload|download|schedule|cancel|call|book|publish|deploy|open|compare|review|investigate|analy[sz]e|collect|gather|verify|build|prepare|make\s+(?:me|us|a|an|the))\b|"
+    r",\s+(?:(?:please\s+)?(?:research|find|look up|fetch|export|create|run|check|show|pause|delete|upload|download|schedule|cancel|call|book|publish|deploy|open|compare|review|investigate|analy[sz]e|collect|gather|verify|build|prepare|make\s+(?:me|us|a|an|the))|please\s+(?:rewrite|edit|draft|send|email|message))\b|"
+    r"(?<!going forward)(?<!from now on)(?<!in the future)(?<!next time)(?<!each time)(?<!every time),\s+"
+    r"(?:please\s+)?(?:send|email|message|contact)\s+"
+    r"(?:it|that|this|[\w'-]+|the\s+(?:rewrite|draft|message|email|note|report))\b|"
+    r"\band\s+(?:please\s+)?(?:(?:rewrite|edit|draft|send|email|message|contact)\s+"
+    r"(?:it|that|this|[\w'-]+|the\s+(?:rewrite|draft|message|email|note|report))\b|"
+    r"(?:research|investigate|analy[sz]e|review|compare|find)\s+(?:(?:me|us)\s+)?(?:[\w-]+\s+){0,3}"
+    r"(?:companies|peers|vendors|options|plans|products|accounts|records|items|prospects|leads|candidates|founders|people|contacts|targets|sources|alternatives)\b|"
+    r"(?:summari[sz]e|export|create|run|check)\s+(?:it|this|that|the\s+(?:rest|results?|findings?|report|analysis|list|table|file|export))\b|"
+    r"pause\s+(?:(?:the|this|that|my|our|your)\s+)?(?:schedule|monitoring|outreach|campaign|work|task|job|run)\b)",
+    re.IGNORECASE,
+)
+DIRECT_FEEDBACK_REPLY_TASK_RE = re.compile(
+    r"(?:^|[.!?,;]\s+|,\s+and\s+|\band\s+|\bthen\b[:,]?\s+)(?:(?:can|could|would)\s+you\s+|(?:please\s+)?)?"
+    r"(?:(?:rewrite|rephrase|revise|shorten|tighten|polish)\b|edit\s+(?:it|this|that|the\s+(?:message|reply|email|note|draft))\b)",
+    re.IGNORECASE,
+)
+DIRECT_FEEDBACK_DELIVERY_TASK_RE = re.compile(
+    r"(?:[,;.!?]|\b(?:and|then)\b)\s*(?:please\s+)?(?:email|text|send|message|contact)\b",
     re.IGNORECASE,
 )
 OPERATIONAL_CAPABILITY_CORRECTION_RE = re.compile(
@@ -240,11 +327,22 @@ OPERATIONAL_CAPABILITY_CORRECTION_RE = re.compile(
     re.IGNORECASE,
 )
 STRONG_DURABLE_CONFIG_INTENT_RE = re.compile(
-    r"\b(?:going forward|from now on|in the future|next time|always|never|remember|"
+    r"\b(?:going forward|from now on|in the future|next time|always|never(?!\s+mind\b)|remember|"
     r"(?:my |this )?feedback:|each time|every time|make (?:that|this|it) a rule|should(?:n'?t| not) have to|"
     r"update (?:your )?(?:charter|schedule|instructions)|change (?:your )?(?:charter|schedule|instructions)|"
     r"charter|schedule|scheduled|recurring|ongoing|proactive|monitor|track|alert|digest|cadence|"
     r"setup|set up|role|scope|process|workflow|customer context|client context|operating boundary)\b",
+    re.IGNORECASE,
+)
+PREFERENCE_CONFIG_INTENT_RE = re.compile(r"\bprefer(?:ence)?\b", re.IGNORECASE)
+DURABLE_SCOPE_SWITCH_RE = re.compile(
+    r"\b(?:going forward|from now on|in the future|next time|each time|every time|make (?:that|this|it) a rule|"
+    r"update (?:your )?(?:charter|instructions)|change (?:your )?(?:charter|instructions))\b",
+    re.IGNORECASE,
+)
+EXPLICIT_DURABLE_SCOPE_RE = re.compile(
+    r"\b(?:going forward|from now on|in the future|next time|each time|every time|always|never(?!\s+mind\b)|remember|prefer(?:ence)?|"
+    r"make (?:that|this|it) a rule|update (?:your )?(?:charter|instructions)|change (?:your )?(?:charter|instructions))\b",
     re.IGNORECASE,
 )
 ONE_OFF_TASK_RE = re.compile(
@@ -353,6 +451,12 @@ def _tool_call_is_progress_update(call: Any, expected_tool_name: str) -> bool:
     )
 
 
+def _same_channel_reply_tool_name(inbound: PersistentAgentMessage | None) -> str | None:
+    if inbound is None or inbound.conversation is None:
+        return None
+    return "send_agent_message" if inbound.conversation.is_peer_dm else REPLY_TOOL_BY_CHANNEL.get(inbound.conversation.channel)
+
+
 def _deep_work_update_gate_context(
     agent: PersistentAgent,
     tool_calls: list[Any],
@@ -368,14 +472,7 @@ def _deep_work_update_gate_context(
     )
     if latest_inbound is None or latest_inbound.conversation is None:
         return None
-    if latest_inbound.conversation.is_peer_dm:
-        expected_message_tool = "send_agent_message"
-    else:
-        expected_message_tool = {
-            CommsChannel.EMAIL: "send_email",
-            CommsChannel.SMS: "send_sms",
-            CommsChannel.WEB: "send_chat_message",
-        }.get(latest_inbound.conversation.channel)
+    expected_message_tool = _same_channel_reply_tool_name(latest_inbound)
     if expected_message_tool is None:
         return None
 
@@ -452,9 +549,7 @@ def _record_deep_work_update_correction(
         "agent": agent,
         "description": f"{DEEP_WORK_UPDATE_CORRECTION_PREFIX} {reason}: {instruction}",
     }
-    attach_completion(step_kwargs)
-    step = PersistentAgentStep.objects.create(**step_kwargs)
-    attach_prompt_archive(step)
+    step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
 
 
 def _user_asked_for_setup_question(text: str) -> bool:
@@ -591,32 +686,16 @@ def _record_defaultable_setup_question_correction(
             "charter/schedule with sqlite_batch, and stop unless a real blocker remains."
         ),
     }
-    attach_completion(step_kwargs)
-    step = PersistentAgentStep.objects.create(**step_kwargs)
-    attach_prompt_archive(step)
+    step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
     logger.info(
         "Agent %s: rejected defaultable setup question and requested sqlite_batch configuration.",
         agent.id,
     )
 
 
-def _record_missing_direct_correction_patch(
-    agent: PersistentAgent,
-    *,
-    attach_completion: Any,
-    attach_prompt_archive: Any,
-) -> None:
-    step_kwargs = {
-        "agent": agent,
-        "description": (
-            "Tool policy: persist this direct user correction before replying. Call sqlite_batch now with one "
-            "UPDATE __agent_config SET charter=patch_text(charter, old, new) WHERE id=1, changing only the "
-            "relevant clause and preserving unrelated charter guidance."
-        ),
-    }
-    attach_completion(step_kwargs)
-    step = PersistentAgentStep.objects.create(**step_kwargs)
-    attach_prompt_archive(step)
+def _record_policy_step(agent: PersistentAgent, description: str, *, attach_completion: Any, attach_prompt_archive: Any) -> None:
+    step_kwargs = {"agent": agent, "description": description}
+    _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
 
 
 def _truncate_text_bytes(text: str, max_bytes: int) -> str:
@@ -1346,34 +1425,73 @@ def _normalize_tool_calls(message: Any) -> list[Any]:
     return _tool_calls_from_content(message)
 
 
-def _defer_tool_calls_behind_discovery(tool_calls: list[Any]) -> list[Any]:
+def _defer_tool_calls_behind_dependencies(tool_calls: list[Any]) -> list[Any]:
     discovery_calls = [call for call in tool_calls if _get_tool_call_name(call) == "search_tools"]
-    if not discovery_calls or len(discovery_calls) == len(tool_calls):
-        return tool_calls
-    return discovery_calls
+    if discovery_calls and len(discovery_calls) != len(tool_calls):
+        return discovery_calls
+    source_calls = [call for call in tool_calls if _is_dependency_source_tool(call)]
+    if source_calls and any(_get_tool_call_name(call) == "sqlite_batch" for call in tool_calls):
+        return source_calls
+    approval_reads = [call for call in tool_calls if _is_sqlite_read_call(call)]
+    if approval_reads and any(_is_potentially_mutating_external_call(call) for call in tool_calls):
+        return approval_reads
+    return tool_calls
+
+
+def _is_dependency_source_tool(call: Any) -> bool:
+    tool_name = _get_tool_call_name(call) or ""
+    if tool_name == "spawn_web_task_result":
+        return True
+    if tool_name == "http_request":
+        try:
+            _raw_args, params = _parse_tool_call_params(_get_tool_call_arguments(call))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return False
+        return isinstance(params, dict) and str(params.get("method") or "GET").upper() == "GET"
+    if not tool_name.startswith("mcp_") or MCP_ACTION_NAME_RE.search(tool_name):
+        return False
+    return tool_name.startswith("mcp_brightdata_") or bool(MCP_READ_NAME_RE.search(tool_name))
+
+
+def _is_sqlite_read_call(call: Any) -> bool:
+    if _get_tool_call_name(call) != "sqlite_batch":
+        return False
+    try:
+        _raw_args, params = _parse_tool_call_params(_get_tool_call_arguments(call))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return False
+    if not isinstance(params, dict):
+        return False
+    statements = _sqlite_batch_statements(params)
+    return bool(statements) and all(
+        sqlparse.parse(statement)[0].get_type() == "SELECT"
+        for statement in statements
+    )
+
+
+def _is_potentially_mutating_external_call(call: Any) -> bool:
+    tool_name = _get_tool_call_name(call) or ""
+    return tool_name == "http_request" or tool_name.startswith("mcp_") and not _is_dependency_source_tool(call)
+
+
+_MISSING_TOOL_CALL_FIELD = object()
+
+
+def _tool_call_field(call: Any, field: str, *, skip_empty: bool = False) -> Any:
+    function = call.get("function") if isinstance(call, dict) else getattr(call, "function", None)
+    for container in (function, call):
+        if isinstance(container, dict):
+            value = container.get(field, _MISSING_TOOL_CALL_FIELD)
+        else:
+            value = getattr(container, field, _MISSING_TOOL_CALL_FIELD)
+        if value is not _MISSING_TOOL_CALL_FIELD and (value or not skip_empty):
+            return value
+    return None
 
 
 def _get_tool_call_name(call: Any) -> Optional[str]:
-    if call is None:
-        return None
-    function = getattr(call, "function", None)
-    if function is not None:
-        name = getattr(function, "name", None)
-        if name:
-            return _sanitize_tool_name(name)
-    if isinstance(call, dict):
-        function = call.get("function")
-        if isinstance(function, dict):
-            name = function.get("name")
-            if name:
-                return _sanitize_tool_name(name)
-        name = call.get("name")
-        if name:
-            return _sanitize_tool_name(name)
-    name = getattr(call, "name", None)
-    if name:
-        return _sanitize_tool_name(name)
-    return None
+    name = _tool_call_field(call, "name", skip_empty=True)
+    return _sanitize_tool_name(name) if name else None
 
 
 def _sanitize_tool_name(name: str) -> str:
@@ -1476,6 +1594,13 @@ def _completion_from_step_kwargs(step_kwargs: dict[str, Any]) -> PersistentAgent
     return completion if isinstance(completion, PersistentAgentCompletion) else None
 
 
+def _persist_attached_step(step_kwargs: dict[str, Any], attach_completion: Any, attach_prompt_archive: Any) -> PersistentAgentStep:
+    attach_completion(step_kwargs)
+    step = PersistentAgentStep.objects.create(**step_kwargs)
+    attach_prompt_archive(step)
+    return step
+
+
 def _agent_from_step(step: PersistentAgentStep) -> PersistentAgent | None:
     try:
         return step.agent
@@ -1484,17 +1609,92 @@ def _agent_from_step(step: PersistentAgentStep) -> PersistentAgent | None:
 
 
 def _tool_definition_names_for_completion(tools: list[dict] | None) -> list[str]:
-    names: list[str] = []
-    for tool in tools or []:
-        if not isinstance(tool, dict):
-            continue
-        function = tool.get("function")
-        if not isinstance(function, dict):
-            continue
-        name = function.get("name")
-        if isinstance(name, str) and name:
-            names.append(name)
-    return names
+    return [
+        function["name"] for tool in tools or []
+        if isinstance(tool, dict) and isinstance((function := tool.get("function")), dict)
+        and isinstance(function.get("name"), str) and function["name"]
+    ]
+
+
+def _focused_tool_completion_request(
+    tools, failover_configs, tool_name: str, description: str | None, *, parameters=None, fixed_continue: bool | None = None,
+):
+    tool = next(tool for tool in tools if tool.get("function", {}).get("name") == tool_name)
+    description = description or tool["function"].get("description", "")
+    function = {**tool["function"], "description": description}
+    if parameters is not None:
+        function["parameters"] = parameters
+    body_key = MESSAGE_TOOL_BODY_KEYS.get(tool_name)
+    if body_key:
+        parameters, properties = function.get("parameters", {}), function.get("parameters", {}).get("properties", {})
+        body_schema = properties.get(body_key, {})
+        body_description = "\n\n".join(filter(None, (body_schema.get("description"), description)))
+        function["parameters"] = {**parameters, "properties": {**properties, body_key: {**body_schema, "description": body_description}}}
+    if fixed_continue is not None:
+        parameters, properties = function.get("parameters", {}), function.get("parameters", {}).get("properties", {})
+        function["parameters"] = {**parameters, "properties": {**properties, "will_continue_work": {**properties.get("will_continue_work", {}), "const": fixed_continue}}}
+    return [{**tool, "function": function}], [
+        (provider, model, {**(params or {}), "use_parallel_tool_calls": False, **({"tool_choice": {"type": "function", "function": {"name": tool_name}}} if (params or {}).get("supports_tool_choice", True) else {})})
+        for provider, model, params in failover_configs
+    ]
+
+
+def _focused_charter_patch_history(
+    history: list[dict[str, Any]], current_charter: str, lasting_feedback: tuple[str, ...], prior_output: str,
+) -> list[dict[str, Any]]:
+    system_messages = [message for message in history if message.get("role") == "system"]
+    return system_messages + [{
+        "role": "user",
+        "content": (
+            "<charter>" + current_charter + "</charter>\n"
+            "<lasting_feedback>" + json.dumps(lasting_feedback) + "</lasting_feedback>\n"
+            "<prior_output_context>" + prior_output[:1000] + "</prior_output_context>\n"
+            "Patch only lasting_feedback. Every listed item is mandatory; combine them into one conflict-free patch. Other wording from the original turn is out of scope."
+        ),
+    }]
+
+
+def _promote_source_reconciliation_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    user_content = "\n".join(
+        str(message.get("content") or "") for message in history if message.get("role") == "user"
+    )
+    directives = re.findall(r"\[SOURCE ARRAYS[^\]]+\]", user_content)
+    if not directives:
+        return history
+    promoted = [dict(message) for message in history]
+    promoted[0]["content"] = (
+        str(promoted[0].get("content") or "")
+        + "\n\n## Current Fresh Source Contract (CRITICAL)\n\n"
+        + "\n".join(directives)
+        + "\nThis overrides general read-first guidance: write from the listed source paths before any model SELECT."
+    )
+    return promoted
+
+
+def _source_reconciliation_parameters(directive: str) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "sql": {
+                "type": "string",
+                "description": directive + " Start with source-derived model DDL/upserts; end with bounded task-relevant rows. No pre-read or copied values.",
+            },
+            "will_continue_work": {"type": "boolean", "const": True},
+        },
+        "required": ["sql", "will_continue_work"],
+        "additionalProperties": False,
+    }
+
+
+CHARTER_PATCH_PARAMETERS = {
+    "type": "object",
+    "properties": {
+        "target_charter_text": {"type": "string", "description": "Smallest exact contiguous span copied from <charter> that covers every adjacent rule conflicting with the lasting feedback. Preserve lookalikes for other actors/contexts. A general role/workflow and prior output are not targets. Empty if no charter rule controls the behavior."},
+        "replacement_charter_text": {"type": "string", "description": "Complete operational replacement for the target. Apply only the listed lasting clauses, leave no contradiction, and preserve unrelated text inside the target span verbatim."},
+    },
+    "required": ["target_charter_text", "replacement_charter_text"],
+    "additionalProperties": False,
+}
 
 
 def _persist_tool_call_step(
@@ -1537,9 +1737,7 @@ def _persist_tool_call_step(
 
     def _try_create_step() -> Optional[PersistentAgentStep]:
         """Attempt to create the step and tool call record."""
-        attach_completion(step_kwargs)
-        step = PersistentAgentStep.objects.create(**step_kwargs)
-        attach_prompt_archive(step)
+        step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
         tool_call_status = status or "complete"
         PersistentAgentToolCall.objects.create(
             step=step,
@@ -1655,9 +1853,7 @@ def _create_pending_tool_call_step(
     }
 
     try:
-        attach_completion(step_kwargs)
-        step = PersistentAgentStep.objects.create(**step_kwargs)
-        attach_prompt_archive(step)
+        step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
         PersistentAgentToolCall.objects.create(
             step=step,
             parent_tool_call=parent_tool_call,
@@ -1868,21 +2064,7 @@ def _refund_tool_credit_on_error_if_configured(
 
 
 def _get_tool_call_arguments(call: Any) -> Any:
-    if call is None:
-        return None
-    function = getattr(call, "function", None)
-    if function is not None:
-        arguments = getattr(function, "arguments", None)
-        if arguments is not None:
-            return arguments
-    if isinstance(call, dict):
-        function = call.get("function")
-        if isinstance(function, dict) and "arguments" in function:
-            return function.get("arguments")
-        if "arguments" in call:
-            return call.get("arguments")
-    arguments = getattr(call, "arguments", None)
-    return arguments
+    return _tool_call_field(call, "arguments")
 
 
 def _parse_tool_call_params(raw_args: Any) -> tuple[Any, Any]:
@@ -1981,24 +2163,6 @@ def _plan_has_unfinished_items(agent: PersistentAgent) -> bool:
         logger.debug("Failed to build plan snapshot for terminal-send check.", exc_info=True)
         return False
     return snapshot.todo_count > 0 or snapshot.doing_count > 0
-
-
-def _record_terminal_send_unfinished_plan_correction(
-    agent: PersistentAgent,
-    *,
-    attach_completion: Any,
-    attach_prompt_archive: Any,
-) -> None:
-    step_kwargs = {
-        "agent": agent,
-        "description": (
-            "Terminal message delivery requested stop, but the current plan still has unfinished items. "
-            "Call update_plan with the complete current plan state before stopping."
-        ),
-    }
-    attach_completion(step_kwargs)
-    step = PersistentAgentStep.objects.create(**step_kwargs)
-    attach_prompt_archive(step)
 
 
 def _should_skip_stale_planning_mode_after_terminal_delivery(
@@ -2377,10 +2541,6 @@ def _sqlite_batch_agent_config_attempted_fields(tool_params: Dict[str, Any]) -> 
     )
 
 
-def _sqlite_batch_mutates_agent_charter(tool_params: Dict[str, Any]) -> bool:
-    return "charter" in _sqlite_batch_agent_config_attempted_fields(tool_params)
-
-
 def _annotate_agent_config_update_result(
     outcomes: list[_ToolExecutionOutcome],
     config_apply: AgentConfigApplyResult,
@@ -2414,59 +2574,170 @@ def _user_text_has_durable_config_intent(text: str) -> bool:
     normalized = " ".join((text or "").split())
     if TRANSIENT_CONFIG_SCOPE_RE.search(normalized) and not STRONG_DURABLE_CONFIG_INTENT_RE.search(normalized):
         return False
-    return bool(DURABLE_CONFIG_INTENT_RE.search(normalized))
+    return bool(STRONG_DURABLE_CONFIG_INTENT_RE.search(normalized) or PREFERENCE_CONFIG_INTENT_RE.search(normalized))
 
 
-def _user_text_is_direct_correction(text: str) -> bool:
+def _matches_behavior_feedback(text: str, prior_outbound_text: str = "") -> bool:
+    quote = QUOTED_OUTPUT_FEEDBACK_RE.search(text or "")
+    if prior_outbound_text and quote and " ".join(quote.group("quote").casefold().split()) in " ".join(prior_outbound_text.casefold().split()):
+        return True
+    direct = DIRECT_USER_CORRECTION_RE.search(text) or OPERATIONAL_CAPABILITY_CORRECTION_RE.search(text)
+    tone = TONE_CORRECTION_RE.search(text)
+    evaluative = EVALUATIVE_BEHAVIOR_FEEDBACK_RE.search(text)
+    preference = PREFERENCE_CONFIG_INTENT_RE.search(text) and BEHAVIOR_OUTPUT_NOUN_RE.search(text)
+    durable_directive = EXPLICIT_DURABLE_SCOPE_RE.match(text) and BEHAVIOR_OUTPUT_NOUN_RE.search(text)
+    if DOMAIN_CONTENT_RE.search(text) and not BEHAVIOR_OUTPUT_NOUN_RE.search(text):
+        evaluative = None
+        if not re.search(r"\b(?:automated|templated|robotic|formal|informal|spammy|salesy|corporate|product[ -]?y|stiff|awkward)\b", text, re.I):
+            tone = None
+    return bool(direct or tone or evaluative or preference or durable_directive)
+
+
+@dataclass(frozen=True)
+class _FeedbackTurn:
+    lasting: tuple[str, ...]
+    behavior: bool
+    transient_only: bool
+    feedback_only: bool
+    direct_reply_task: bool
+    separate_task: bool
+
+
+def _analyze_feedback_turn(text: str, prior_outbound_text: str = "") -> _FeedbackTurn:
     normalized = " ".join((text or "").split())
-    return bool(
-        normalized
-        and not TRANSIENT_CONFIG_SCOPE_RE.search(normalized)
-        and (
-            DIRECT_USER_CORRECTION_RE.search(normalized)
-            or OPERATIONAL_CAPABILITY_CORRECTION_RE.search(normalized)
-        )
-    )
+    clauses = tuple(" ".join(clause.split()) for clause in re.split(r"(?<=[.!?;])\s+|[\r\n]+", text or "") if clause.strip())
+    behavior = _matches_behavior_feedback(normalized, prior_outbound_text)
+    no_save_marker = NO_DURABLE_CONFIG_RE.search(normalized)
+    transient_marker = TRANSIENT_CONFIG_SCOPE_RE.search(normalized)
+    lasting: list[str] = []
+    temporary_scope = durable_scope_active = saw_feedback = direct_reply_task = separate_task = False
+    feedback_only = True
+    for clause in clauses:
+        direct_reply = DIRECT_FEEDBACK_REPLY_TASK_RE.search(clause)
+        separate_matches = tuple(SEPARATE_FEEDBACK_TASK_RE.finditer(clause))
+        if separate_matches and EXPLICIT_DURABLE_SCOPE_RE.fullmatch(
+            clause[:separate_matches[0].start()].strip(" ,:;")
+        ):
+            separate_matches = separate_matches[1:]
+        separate = separate_matches[0] if separate_matches else None
+        distinct_task = bool(separate and (direct_reply is None or len(separate_matches) > 1))
+        task = direct_reply or separate
+        candidate = clause[:task.start()].rstrip(" ,;") if task else clause
+        candidate_behavior = _matches_behavior_feedback(candidate, prior_outbound_text)
+        continuation = bool(durable_scope_active and re.match(
+            r"\s*(?:and\s+)?(?:routine\b|only\b|just\b|never\b|always\b|remember\b|keep\b|do not\b|don['’]?t\b|no\b|the\b|these\b|those\b|my\b|your\b|i\b|when\b|if\b|for\b)",
+            candidate, re.IGNORECASE,
+        ))
+        direct_reply_task = direct_reply_task or bool(direct_reply)
+        separate_task = separate_task or distinct_task
+        if direct_reply:
+            saw_feedback = saw_feedback or candidate_behavior
+            if distinct_task:
+                feedback_only = False
+        elif separate:
+            feedback_only = False
+        elif candidate_behavior:
+            saw_feedback = True
+            durable_scope_active = durable_scope_active or bool(EXPLICIT_DURABLE_SCOPE_RE.search(clause))
+        elif NO_DURABLE_CONFIG_RE.search(clause) or TRANSIENT_CONFIG_SCOPE_RE.search(clause):
+            saw_feedback = True
+        elif DURABLE_SCOPE_SWITCH_RE.search(clause):
+            saw_feedback = True
+            durable_scope_active = True
+        elif continuation:
+            saw_feedback = True
+        else:
+            feedback_only = False
 
-
-def _should_require_direct_correction_patch(agent: PersistentAgent) -> bool:
-    if agent.planning_state == PersistentAgent.PlanningState.PLANNING:
-        return False
-
-    latest_inbound = (
-        PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=False)
-        .order_by("-timestamp", "-seq")
-        .values("timestamp", "seq", "body")
-        .first()
-    )
-    if latest_inbound is None or not _user_text_is_direct_correction(latest_inbound["body"]):
-        return False
-
-    return PersistentAgentMessage.objects.filter(
-        owner_agent=agent,
-        is_outbound=True,
-    ).filter(
-        Q(timestamp__lt=latest_inbound["timestamp"])
-        | Q(timestamp=latest_inbound["timestamp"], seq__lt=latest_inbound["seq"])
-    ).exists()
-
-
-def _tool_calls_patch_correction_before_reply(tool_calls: list[Any]) -> bool:
-    patch_seen = False
-    for call in tool_calls:
-        tool_name = _get_tool_call_name(call)
-        if tool_name in MESSAGE_TOOL_NAMES and not patch_seen:
-            return False
-        if tool_name != "sqlite_batch":
+        if not candidate:
             continue
-        try:
-            _raw_args, tool_params = _parse_tool_call_params(_get_tool_call_arguments(call))
-        except (TypeError, ValueError, json.JSONDecodeError):
+        if not (candidate_behavior or continuation or NO_DURABLE_CONFIG_RE.search(candidate)
+                or TRANSIENT_CONFIG_SCOPE_RE.search(candidate) or EXPLICIT_DURABLE_SCOPE_RE.search(candidate)):
             continue
-        sql = "\n".join(_sqlite_batch_statements(tool_params))
-        if _sqlite_batch_is_only_agent_config_mutation(tool_params) and "patch_text" in sql.lower():
-            patch_seen = True
-    return patch_seen
+        no_save = NO_DURABLE_CONFIG_RE.search(candidate)
+        durable_after_veto = EXPLICIT_DURABLE_SCOPE_RE.search(candidate, no_save.end()) if no_save else None
+        if no_save and not durable_after_veto:
+            temporary_scope = True
+            continue
+        candidate = candidate[durable_after_veto.start():] if durable_after_veto else candidate
+        transient = TRANSIENT_CONFIG_SCOPE_RE.search(candidate)
+        durable = DURABLE_SCOPE_SWITCH_RE.search(candidate, transient.end()) if transient else EXPLICIT_DURABLE_SCOPE_RE.search(candidate)
+        if not durable and (transient or temporary_scope):
+            temporary_scope = True
+            continue
+        temporary_scope = False
+        lasting.append(candidate[durable.start():] if transient and transient.start() < durable.start() else candidate)
+    if behavior and not lasting and not separate_task and not (no_save_marker or transient_marker):
+        lasting.append(normalized)
+        feedback_only = saw_feedback = True
+    vetoes_persistence = bool(no_save_marker and not EXPLICIT_DURABLE_SCOPE_RE.search(normalized, no_save_marker.end()))
+    transient_only = vetoes_persistence or bool(transient_marker and not lasting)
+    return _FeedbackTurn(tuple(lasting), behavior, transient_only, feedback_only and saw_feedback, direct_reply_task, separate_task)
+
+
+def _user_text_has_only_transient_config_scope(text: str) -> bool:
+    return _analyze_feedback_turn(text).transient_only
+
+
+def _user_text_is_direct_correction(text: str, *, prior_outbound_text: str = "") -> bool:
+    analysis = _analyze_feedback_turn(text, prior_outbound_text)
+    return bool(analysis.lasting and analysis.behavior and not analysis.transient_only)
+
+
+def _direct_correction_context(agent: PersistentAgent, latest_inbound=None):
+    latest_inbound = latest_inbound or get_current_inbound_message(agent)
+    normalized = " ".join(latest_inbound.body.split()) if latest_inbound is not None else ""
+    if latest_inbound is None or not (
+        QUOTED_OUTPUT_FEEDBACK_RE.search(normalized)
+        or _matches_behavior_feedback(normalized)
+    ):
+        return None
+    if agent.planning_state == PersistentAgent.PlanningState.PLANNING or not _ConfigAuthorityResolver(agent).endpoint_can_configure(latest_inbound.from_endpoint):
+        return None
+    prior_outbound = PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=True, conversation_id=latest_inbound.conversation_id).filter(
+        Q(timestamp__lt=latest_inbound.timestamp)
+        | Q(timestamp=latest_inbound.timestamp, seq__lt=latest_inbound.seq)
+    ).order_by("-timestamp", "-seq").values_list("body", flat=True).first()
+    analysis = _analyze_feedback_turn(latest_inbound.body, prior_outbound or "")
+    if prior_outbound is None or not (analysis.lasting and analysis.behavior and not analysis.transient_only):
+        return None
+    return latest_inbound, prior_outbound, analysis
+
+
+def _compile_charter_patch_tool_call(tool_call: Any, current_charter: str | None = None) -> Any | None:
+    if _get_tool_call_name(tool_call) != "sqlite_batch":
+        return None
+    try:
+        _raw_args, params = _parse_tool_call_params(_get_tool_call_arguments(tool_call))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(params, dict):
+        return None
+    old = params.get("target_charter_text")
+    new = params.get("replacement_charter_text")
+    if not all(isinstance(value, str) for value in (old, new)):
+        return None
+    if any("\x00" in value for value in (old, new)) or not new.strip() or old == new:
+        return None
+    normalized_charter = (current_charter or "").strip()
+    if normalized_charter[-1:] in ".!?" and (not old or old == normalized_charter) and new.startswith(normalized_charter):
+        appended_rule = new[len(normalized_charter):].strip()
+        if appended_rule:
+            old, new = "", appended_rule
+        elif not old:
+            return None
+
+    quoted_old = old.replace("'", "''")
+    quoted_new = new.replace("'", "''")
+    arguments = json.dumps({
+        "sql": (
+            "UPDATE __agent_config SET charter=patch_text(charter, "
+            f"'{quoted_old}', '{quoted_new}') WHERE id=1"
+        ),
+        "will_continue_work": True,
+    })
+    call_id = tool_call.get("id") if isinstance(tool_call, dict) else getattr(tool_call, "id", None)
+    return {"id": call_id, "type": "function", "function": {"name": "sqlite_batch", "arguments": arguments}}
 
 
 def _looks_like_one_off_user_task(text: str) -> bool:
@@ -2489,7 +2760,7 @@ def _message_tool_body_from_params(tool_name: str, tool_params: Dict[str, Any]) 
 
 
 def _normalize_humanized_message_params(tool_name: str, tool_params: Dict[str, Any]) -> Dict[str, Any]:
-    body_key = HUMANIZED_MESSAGE_BODY_KEYS.get(tool_name)
+    body_key = MESSAGE_TOOL_BODY_KEYS.get(tool_name)
     if not body_key:
         return tool_params
     normalized = dict(tool_params)
@@ -2541,30 +2812,21 @@ def _should_skip_irrelevant_agent_config_mutation(
     *,
     batch_has_terminal_message: bool,
 ) -> bool:
-    if tool_name != "sqlite_batch" or not batch_has_terminal_message:
+    if tool_name != "sqlite_batch":
         return False
+    routed_inbound = get_current_inbound_message(agent)
+    latest_user_text = routed_inbound.body if routed_inbound is not None else _latest_inbound_message_text(agent)
+    if (
+        "charter" in _sqlite_batch_agent_config_attempted_fields(tool_params)
+        and _user_text_has_only_transient_config_scope(latest_user_text)
+        and not _user_text_has_durable_config_intent(latest_user_text)
+    ):
+        return True
     if not _sqlite_batch_is_only_agent_config_mutation(tool_params):
         return False
-    latest_user_text = _latest_inbound_message_text(agent)
+    if not batch_has_terminal_message:
+        return False
     return _looks_like_one_off_user_task(latest_user_text)
-
-
-def _record_irrelevant_agent_config_mutation_skip(
-    agent: PersistentAgent,
-    *,
-    attach_completion: Any,
-    attach_prompt_archive: Any,
-) -> None:
-    step_kwargs = {
-        "agent": agent,
-        "description": (
-            "Skipped unrelated __agent_config mutation attached to a one-off final answer. "
-            "Deliver the requested answer without changing durable charter or schedule."
-        ),
-    }
-    attach_completion(step_kwargs)
-    step = PersistentAgentStep.objects.create(**step_kwargs)
-    attach_prompt_archive(step)
 
 
 def _resolve_tool_for_execution(
@@ -2659,26 +2921,6 @@ def _find_successful_duplicate_http_request(
         ):
             return prior_call
     return None
-
-
-def _record_duplicate_http_request_skip(
-    agent: PersistentAgent,
-    prior_call: PersistentAgentToolCall,
-    *,
-    attach_completion: Any,
-    attach_prompt_archive: Any,
-) -> None:
-    step_kwargs = {
-        "agent": agent,
-        "description": (
-            "Skipped duplicate http_request: this exact request already succeeded in this task. "
-            f"Use the prior tool result from step {prior_call.step_id}. "
-            "If it answers the request, send the final message next; do not refetch or inspect __tool_results just to reread it."
-        ),
-    }
-    attach_completion(step_kwargs)
-    step = PersistentAgentStep.objects.create(**step_kwargs)
-    attach_prompt_archive(step)
 
 
 _ToolExecutor = Callable[[PersistentAgent, Dict[str, Any]], Any]
@@ -2788,7 +3030,7 @@ def _capture_tool_display_metadata(
     if (
         prepared.tool_name != "sqlite_batch"
         or not _tool_result_is_success(result)
-        or not _sqlite_batch_mutates_agent_charter(prepared.exec_params)
+        or "charter" not in _sqlite_batch_agent_config_attempted_fields(prepared.exec_params)
     ):
         return {}
 
@@ -2883,7 +3125,7 @@ def _execute_prepared_tool_call(
     )
 
 
-def _prepare_tool_batch_impl(
+def _prepare_tool_batch(
     agent: PersistentAgent,
     *,
     tool_calls: list[Any],
@@ -2897,8 +3139,15 @@ def _prepare_tool_batch_impl(
     has_user_facing_message: bool,
     attach_completion: Any,
     attach_prompt_archive: Any,
-    rate_limit_batch: Optional[_ToolRateLimitBatch] = None,
 ) -> _PreparedToolBatch:
+    rate_limit_batch = (
+        _build_tool_rate_limit_batch(
+            agent,
+            [name for call in tool_calls if (name := _get_tool_call_name(call))],
+        )
+        if len(tool_calls) > 1
+        else None
+    )
     prepared_calls: list[_PreparedToolExecution] = []
     followup_required = False
     all_calls_sleep = not has_non_sleep_calls
@@ -2927,9 +3176,7 @@ def _prepare_tool_batch_impl(
                 "separate reads."
             ),
         }
-        attach_completion(step_kwargs)
-        step = PersistentAgentStep.objects.create(**step_kwargs)
-        attach_prompt_archive(step)
+        step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
         return _PreparedToolBatch([], True, False, False, "sqlite_result_fanout_gate")
     batch_has_planning_gate = any(_get_tool_call_name(call) in {"end_planning", "request_human_input"} for call in tool_calls)
     batch_has_terminal_message = any(_tool_call_likely_terminal_message(call) for call in tool_calls)
@@ -2963,9 +3210,7 @@ def _prepare_tool_batch_impl(
                             "Re-send the SAME tool call with a valid 'name' and JSON arguments."
                         ),
                     }
-                    attach_completion(step_kwargs)
-                    step = PersistentAgentStep.objects.create(**step_kwargs)
-                    attach_prompt_archive(step)
+                    step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
                     logger.info(
                         "Agent %s: added correction step_id=%s for missing tool name",
                         agent.id,
@@ -3014,9 +3259,7 @@ def _prepare_tool_batch_impl(
                             f"Do not call {tool_name}; message the user with the relevant billing or limit guidance."
                         ),
                     }
-                    attach_completion(step_kwargs)
-                    step = PersistentAgentStep.objects.create(**step_kwargs)
-                    attach_prompt_archive(step)
+                    step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
                     logger.info(
                         "Agent %s: rejected %s in credit message-only mode.",
                         agent.id,
@@ -3056,9 +3299,7 @@ def _prepare_tool_batch_impl(
                     "credits_cost": credits_consumed if isinstance(credits_consumed, Decimal) else None,
                     "task_credit": consumed_credit,
                 }
-                attach_completion(step_kwargs)
-                step = PersistentAgentStep.objects.create(**step_kwargs)
-                attach_prompt_archive(step)
+                step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
                 logger.info("Agent %s: sleep_until_next_trigger recorded (will sleep after batch)", agent.id)
                 continue
 
@@ -3083,9 +3324,7 @@ def _prepare_tool_batch_impl(
                         "For HTML content, use single quotes for all attributes to avoid JSON conflicts."
                     )
                     step_kwargs = {"agent": agent, "description": step_text}
-                    attach_completion(step_kwargs)
-                    step = PersistentAgentStep.objects.create(**step_kwargs)
-                    attach_prompt_archive(step)
+                    step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
                     logger.info(
                         "Agent %s: added correction step_id=%s to request a retried tool call",
                         agent.id,
@@ -3100,9 +3339,7 @@ def _prepare_tool_batch_impl(
                 message_body = str(tool_params.get("body") or "")
                 if not batch_has_planning_gate and agent.planning_state == PersistentAgent.PlanningState.PLANNING and _coerce_optional_bool(tool_params.get("will_continue_work")) is True and PLANNING_READY_WITHOUT_GATE_RE.search(message_body):
                     step_kwargs = {"agent": agent, "description": "Planning Mode is active and the plan appears clear. Call end_planning(full_plan=...) before ready/start-work chat."}
-                    attach_completion(step_kwargs)
-                    step = PersistentAgentStep.objects.create(**step_kwargs)
-                    attach_prompt_archive(step)
+                    step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
                     followup_required = True
                     break
                 if _should_reject_defaultable_setup_question(agent, message_body):
@@ -3145,9 +3382,7 @@ def _prepare_tool_batch_impl(
                         "agent": agent,
                         "description": skipped_plan_result["message"],
                     }
-                    attach_completion(step_kwargs)
-                    step = PersistentAgentStep.objects.create(**step_kwargs)
-                    attach_prompt_archive(step)
+                    step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
                     logger.info(
                         "Agent %s: skipped redundant research plan update before execution.",
                         agent.id,
@@ -3171,9 +3406,7 @@ def _prepare_tool_batch_impl(
                             "so first call end_planning(full_plan=...) if the plan is sufficient, or request_human_input if blocked."
                         ),
                     }
-                    attach_completion(step_kwargs)
-                    step = PersistentAgentStep.objects.create(**step_kwargs)
-                    attach_prompt_archive(step)
+                    step = _persist_attached_step(step_kwargs, attach_completion, attach_prompt_archive)
                     logger.info(
                         "Agent %s: skipped search_tools before planning gate for execute-now prompt.",
                         agent.id,
@@ -3196,15 +3429,20 @@ def _prepare_tool_batch_impl(
                 tool_params,
                 batch_has_terminal_message=batch_has_terminal_message,
             ):
-                _record_irrelevant_agent_config_mutation_skip(
+                _record_policy_step(
                     agent,
+                    "Skipped unrelated __agent_config mutation or explicitly temporary charter change. "
+                    "Keep one-off/task/batch/day/response state in the current conversation; change durable config only "
+                    "for lasting guidance. Do not retry this mutation; apply temporary guidance in the current reply now.",
                     attach_completion=attach_completion,
                     attach_prompt_archive=attach_prompt_archive,
                 )
                 logger.info(
-                    "Agent %s: skipped irrelevant __agent_config mutation attached to one-off final answer.",
+                    "Agent %s: skipped unrelated or temporary __agent_config mutation.",
                     agent.id,
                 )
+                if not batch_has_terminal_message:
+                    followup_required = True
                 continue
             explicit_continue = _coerce_optional_bool(tool_params.get("will_continue_work"))
             inferred_continue = False
@@ -3261,9 +3499,11 @@ def _prepare_tool_batch_impl(
                     eval_run_id=eval_run_id,
                 )
                 if duplicate_call is not None:
-                    _record_duplicate_http_request_skip(
+                    _record_policy_step(
                         agent,
-                        duplicate_call,
+                        "Skipped duplicate http_request: this exact request already succeeded in this task. "
+                        f"Use the prior tool result from step {duplicate_call.step_id}. If it answers the request, "
+                        "send the final message next; do not refetch or inspect __tool_results just to reread it.",
                         attach_completion=attach_completion,
                         attach_prompt_archive=attach_prompt_archive,
                     )
@@ -3338,44 +3578,6 @@ def _prepare_tool_batch_impl(
         ),
         abort_after_execution=abort_after_execution,
         parallel_ineligible_reason=_parallel_batch_ineligible_reason(prepared_calls),
-    )
-
-
-def _prepare_tool_batch(
-    agent: PersistentAgent,
-    *,
-    tool_calls: list[Any],
-    budget_ctx: Optional[BudgetContext],
-    eval_run_id: Optional[str],
-    heartbeat: Any,
-    lock_extender: Any,
-    credit_snapshot: Any,
-    allow_inferred_message_continue: bool,
-    has_non_sleep_calls: bool,
-    has_user_facing_message: bool,
-    attach_completion: Any,
-    attach_prompt_archive: Any,
-) -> _PreparedToolBatch:
-    rate_limit_batch = None
-    if len(tool_calls) > 1:
-        rate_limit_batch = _build_tool_rate_limit_batch(
-            agent,
-            [name for call in tool_calls if (name := _get_tool_call_name(call))],
-        )
-    return _prepare_tool_batch_impl(
-        agent,
-        tool_calls=tool_calls,
-        budget_ctx=budget_ctx,
-        eval_run_id=eval_run_id,
-        heartbeat=heartbeat,
-        lock_extender=lock_extender,
-        credit_snapshot=credit_snapshot,
-        allow_inferred_message_continue=allow_inferred_message_continue,
-        has_non_sleep_calls=has_non_sleep_calls,
-        has_user_facing_message=has_user_facing_message,
-        attach_completion=attach_completion,
-        attach_prompt_archive=attach_prompt_archive,
-        rate_limit_batch=rate_limit_batch,
     )
 
 
@@ -3660,8 +3862,10 @@ def _finalize_tool_batch(
         and not is_credit_message_only_mode(daily_credit_state, task_credit_available)
         and _plan_has_unfinished_items(agent)
     ):
-        _record_terminal_send_unfinished_plan_correction(
+        _record_policy_step(
             agent,
+            "Terminal message delivery requested stop, but the current plan still has unfinished items. "
+            "Call update_plan with the complete current plan state before stopping.",
             attach_completion=attach_completion,
             attach_prompt_archive=attach_prompt_archive,
         )
@@ -6030,7 +6234,9 @@ def _run_agent_loop(
     continuation_notice: Optional[str] = None
     stale_prompt_system_directive_block = ""
     empty_response_loop_retries = 0
-    direct_correction_patch_seen = False
+    direct_correction_reply_pending = False
+    direct_feedback_reply_completed = False
+    direct_correction_prior_output = ""
     explicit_prefer_low_latency = prefer_low_latency
 
     def _current_human_inbound_generation() -> int:
@@ -6051,11 +6257,12 @@ def _run_agent_loop(
         routing_scope_tokens.append(bind_inbound_routing_scope(initial_routing_scope))
 
         def _refresh_inbound_routing_scope(generation: int) -> None:
-            nonlocal routing_scope_generation
-            routing_scope_tokens.append(
-                bind_inbound_routing_scope(capture_inbound_routing_scope(agent, pending_inbound=True))
-            )
+            nonlocal routing_scope_generation, direct_correction_reply_pending, direct_feedback_reply_completed, direct_correction_prior_output
+            routing_scope_tokens.append(bind_inbound_routing_scope(capture_inbound_routing_scope(agent, pending_inbound=True)))
             routing_scope_generation = generation
+            direct_correction_reply_pending = False
+            direct_feedback_reply_completed = False
+            direct_correction_prior_output = ""
 
         prompt_run_cache = PromptRunCache(
             agent_id=str(agent.id),
@@ -6195,6 +6402,59 @@ def _run_agent_loop(
                 continuation_notice = None
                 routing_profile = get_current_eval_routing_profile()
                 prefer_low_latency = iteration_prefers_low_latency
+                tool_names = _tool_definition_names_for_completion(iteration_tools)
+                feedback_inbound = get_current_inbound_message(agent)
+                feedback_text = feedback_inbound.body if feedback_inbound is not None else ""
+                direct_correction_context = None if direct_correction_reply_pending else _direct_correction_context(agent, feedback_inbound)
+                if direct_correction_context:
+                    direct_correction_prior_output = direct_correction_context[1]
+                feedback_analysis = direct_correction_context[2] if direct_correction_context else _analyze_feedback_turn(feedback_text, direct_correction_prior_output)
+                feedback_only = feedback_analysis.feedback_only
+                direct_correction_pending = bool(
+                    "sqlite_batch" in tool_names
+                    and not direct_correction_reply_pending
+                    and direct_correction_context is not None
+                )
+                transient_feedback_reply_pending = bool(
+                    not direct_correction_reply_pending
+                    and feedback_only
+                    and feedback_analysis.transient_only
+                    and feedback_analysis.behavior
+                )
+                separate_feedback_task = bool(not feedback_only or (
+                    transient_feedback_reply_pending and feedback_analysis.direct_reply_task
+                ))
+                direct_feedback_reply_pending = bool(
+                    direct_correction_reply_pending and feedback_analysis.direct_reply_task
+                    and not DIRECT_FEEDBACK_DELIVERY_TASK_RE.search(feedback_text) and not direct_feedback_reply_completed
+                )
+                direct_feedback_reply_will_continue = bool(direct_feedback_reply_pending and feedback_analysis.separate_task)
+                feedback_reply_pending = direct_feedback_reply_pending or ((direct_correction_reply_pending or transient_feedback_reply_pending) and not separate_feedback_task)
+                feedback_reply_instruction = (
+                    "Rewrite the prior outbound message from scratch and send only the complete replacement. Honor the critique, preserve supported facts, and materially change the wording and structure. No acknowledgement, apology, preface, or explanation. "
+                    + ("Use will_continue_work=true, then execute the distinct remaining request."
+                       if direct_feedback_reply_will_continue else "Use will_continue_work=false.")
+                    if direct_feedback_reply_pending else
+                    "Current-turn feedback acknowledgement only. Send one brief natural first-person reply on this inbound channel with will_continue_work=false. " + ("Use exactly one sentence: begin 'For this <stated scope>,'; state the requested changes inside that finite scope, then end without another timing phrase. " if transient_feedback_reply_pending else "State what you will do and cover each distinct adjustment, for example 'Got it. I'll <specific behaviors>.' ") + "Do not mention saving, config, charter, instructions, or tools; do not research, ask a question, or promise more work."
+                ) if feedback_reply_pending else ""
+                prompt_notice = current_notice
+                if direct_correction_pending:
+                    charter_patch_instruction = (
+                        "Return only target_charter_text and replacement_charter_text; never SQL or will_continue_work. Patch ONLY the lasting clauses listed for this turn; all other current-turn text is temporary or separate and must not appear in the replacement. CURRENT CHARTER (<charter>), the only source for a nonempty target: "
+                        + json.dumps(agent.charter or "")
+                        + ". Default scope is exactly the criticized output's actor, audience, workflow, and condition; never generalize unless the feedback says all, always, or across contexts. Preserve lookalikes for other contexts. A role/workflow is not a target merely because its output was criticized. If no charter rule explicitly controls that behavior, target_charter_text is empty and replacement_charter_text is one concise operational rule, not copied feedback or prior output. Otherwise target the smallest exact contiguous span covering every adjacent conflicting rule, then replace it without contradictions while preserving unrelated text in that span verbatim."
+                    )
+                    prompt_notice = "\n\n".join(filter(None, (
+                        prompt_notice,
+                        "Current-turn lasting feedback to patch, excluding temporary scope and separate tasks: "
+                        + json.dumps(feedback_analysis.lasting),
+                        "PRIOR OUTPUT (context only; never use its text as target_charter_text or replacement_charter_text): "
+                        + json.dumps(direct_correction_prior_output[:1000]),
+                    )))
+                elif feedback_reply_pending:
+                    prompt_notice = "\n\n".join(filter(None, (prompt_notice, feedback_reply_instruction)))
+                elif separate_feedback_task and (direct_correction_reply_pending or transient_feedback_reply_pending):
+                    prompt_notice = "\n\n".join(filter(None, (prompt_notice, "Current turn: feedback scope is resolved. Execute the remaining explicit request now; acknowledge the adjustment naturally within the completed result, not as a separate progress message.")))
                 try:
                     prompt_context_result = build_prompt_context(
                         agent,
@@ -6204,13 +6464,27 @@ def _run_agent_loop(
                         is_first_run=is_first_run,
                         daily_credit_state=daily_state,
                         task_credit_available=task_credit_available,
-                        continuation_notice=current_notice,
+                        continuation_notice=prompt_notice,
                         routing_profile=routing_profile,
                         prefer_low_latency=prefer_low_latency,
                         include_metadata=True,
                         system_directive_block=stale_prompt_system_directive_block,
                         routing_token_seed=routing_token_seed,
                         run_cache=prompt_run_cache,
+                        prompt_message_transform=(
+                            (
+                                lambda prompt_history: _focused_charter_patch_history(
+                                    prompt_history,
+                                    agent.charter or "",
+                                    feedback_analysis.lasting,
+                                    direct_correction_prior_output,
+                                )
+                            )
+                            if direct_correction_pending else None
+                        ) or (
+                            _promote_source_reconciliation_history
+                            if "sqlite_batch" in tool_names else None
+                        ),
                     )
                 except Exception as exc:
                     log_prompt_construction_error(
@@ -6357,10 +6631,7 @@ def _run_agent_loop(
                 request_history = history
                 request_failover_configs = failover_configs
                 fresh_tool_call_step_ids = prompt_metadata.get("fresh_tool_call_step_ids") or []
-                image_attachments = collect_fresh_read_file_image_attachments(
-                    agent,
-                    fresh_tool_call_step_ids,
-                )
+                image_attachments = [] if direct_correction_pending else collect_fresh_read_file_image_attachments(agent, fresh_tool_call_step_ids)
                 if image_attachments:
                     (
                         request_history,
@@ -6387,6 +6658,37 @@ def _run_agent_loop(
                             "Agent %s: read_file image context available but no vision-capable orchestrator endpoint found",
                             agent.id,
                         )
+                request_tools = iteration_tools
+                focused_feedback_reply_tool_name = None
+                source_reconciliation_directive = prompt_metadata.get("source_reconciliation_directive")
+                if direct_correction_pending:
+                    if not prompt_metadata.get("prompt_message_transform_applied"):
+                        request_history = _focused_charter_patch_history(
+                            history, agent.charter or "", feedback_analysis.lasting, direct_correction_prior_output,
+                        )
+                    request_tools, request_failover_configs = _focused_tool_completion_request(
+                        iteration_tools,
+                        request_failover_configs,
+                        "sqlite_batch",
+                        charter_patch_instruction,
+                        parameters=CHARTER_PATCH_PARAMETERS,
+                    )
+                elif source_reconciliation_directive and "sqlite_batch" in tool_names:
+                    request_tools, request_failover_configs = _focused_tool_completion_request(
+                        iteration_tools, request_failover_configs, "sqlite_batch",
+                        source_reconciliation_directive,
+                        parameters=_source_reconciliation_parameters(source_reconciliation_directive),
+                        fixed_continue=True,
+                    )
+                elif feedback_reply_pending:
+                    reply_tool_name = _same_channel_reply_tool_name(feedback_inbound)
+                    if reply_tool_name in tool_names:
+                        focused_feedback_reply_tool_name = reply_tool_name
+                        request_tools, request_failover_configs = _focused_tool_completion_request(
+                            iteration_tools, request_failover_configs, reply_tool_name,
+                            feedback_reply_instruction,
+                            fixed_continue=direct_feedback_reply_will_continue if direct_feedback_reply_pending else False,
+                        )
                 stream_broadcaster = None
                 try:
                     stream_target = resolve_web_stream_target(agent)
@@ -6398,13 +6700,13 @@ def _run_agent_loop(
                 try:
                     response, token_usage = _completion_with_failover(
                         messages=request_history,
-                        tools=iteration_tools,
+                        tools=request_tools,
                         failover_configs=request_failover_configs,
                         agent_id=str(agent.id),
                         safety_identifier=agent.user.id if agent.user else None,
                         preferred_config=preferred_config,
-                        stream_broadcaster=stream_broadcaster,
-                        allow_streamed_content=prompt_allows_implied_send,
+                        stream_broadcaster=None if direct_correction_pending or feedback_reply_pending or source_reconciliation_directive else stream_broadcaster,
+                        allow_streamed_content=prompt_allows_implied_send and not source_reconciliation_directive,
                         stale_prompt_checker=_is_orchestrator_prompt_stale,
                     )
                     empty_response_loop_retries = 0
@@ -6499,7 +6801,7 @@ def _run_agent_loop(
                             agent=agent,
                             eval_run_id=eval_run_id,
                             prompt_archive_id=prompt_archive_id,
-                            llm_tool_names=_tool_definition_names_for_completion(iteration_tools),
+                            llm_tool_names=_tool_definition_names_for_completion(request_tools),
                             thinking_content=thinking_content,
                             **billing_snapshot,
                             **token_usage_fields,
@@ -6531,10 +6833,7 @@ def _run_agent_loop(
                         "agent": agent,
                         "description": internal_reasoning.build_internal_reasoning_description(reasoning_text),
                     }
-                    _attach_completion(step_kwargs)
-                    step = PersistentAgentStep.objects.create(**step_kwargs)
-                    _attach_prompt_archive(step)
-                    return step
+                    return _persist_attached_step(step_kwargs, _attach_completion, _attach_prompt_archive)
 
                 def _apply_runtime_updates() -> tuple[bool, AgentConfigApplyResult]:
                     # Some unit tests call _run_agent_loop directly without agent_sqlite_db().
@@ -6558,9 +6857,7 @@ def _run_agent_loop(
                                     "agent": agent,
                                     "description": f"{label} update failed: {error}",
                                 }
-                                _attach_completion(step_kwargs)
-                                step = PersistentAgentStep.objects.create(**step_kwargs)
-                                _attach_prompt_archive(step)
+                                _persist_attached_step(step_kwargs, _attach_completion, _attach_prompt_archive)
                             except Exception:
                                 logger.debug(
                                     "Failed to persist %s update error step for agent %s",
@@ -6581,28 +6878,28 @@ def _run_agent_loop(
 
                 raw_tool_calls = _normalize_tool_calls(msg)
                 direct_correction_patch_this_response = False
-                direct_correction_pending = (
-                    not direct_correction_patch_seen
-                    and _should_require_direct_correction_patch(agent)
-                )
                 if direct_correction_pending:
-                    direct_correction_patch_this_response = _tool_calls_patch_correction_before_reply(raw_tool_calls)
-                    direct_correction_patch_seen = direct_correction_patch_this_response
-                    if not direct_correction_patch_seen:
-                        _record_missing_direct_correction_patch(
+                    compiled_call = _compile_charter_patch_tool_call(raw_tool_calls[0], agent.charter) if len(raw_tool_calls) == 1 else None
+                    direct_correction_patch_this_response = compiled_call is not None
+                    if compiled_call is not None:
+                        raw_tool_calls = [compiled_call]
+                    if not direct_correction_patch_this_response:
+                        _record_policy_step(
                             agent,
+                            "Tool policy: persist this direct user correction before replying. Return the required "
+                            "exact target/replacement charter span now, changing only the relevant clause and preserving unrelated guidance.",
                             attach_completion=_attach_completion,
                             attach_prompt_archive=_attach_prompt_archive,
                         )
                         _mark_accepted_human_generation_consumed()
                         continue
-                discovery_tool_calls = _defer_tool_calls_behind_discovery(raw_tool_calls)
-                if len(discovery_tool_calls) != len(raw_tool_calls):
+                ready_tool_calls = _defer_tool_calls_behind_dependencies(raw_tool_calls)
+                if len(ready_tool_calls) != len(raw_tool_calls):
                     logger.info(
-                        "Agent %s: deferring non-discovery tool calls until search_tools updates the prompt.",
+                        "Agent %s: deferring tool calls until discovery or fresh source context is available.",
                         agent.id,
                     )
-                    raw_tool_calls = discovery_tool_calls
+                    raw_tool_calls = ready_tool_calls
                 raw_tool_names = [_get_tool_call_name(call) for call in raw_tool_calls]
                 has_explicit_send = any(name in MESSAGE_TOOL_NAMES for name in raw_tool_names if name)
                 has_explicit_sleep = any(name == "sleep_until_next_trigger" for name in raw_tool_names if name)
@@ -6623,7 +6920,10 @@ def _run_agent_loop(
                     implied_send_disabled_reason = "Implied send disabled by prompt configuration."
                 elif not selected_model_allows_implied_send:
                     implied_send_disabled_reason = "Implied send disabled for the selected model."
-                if message_text and not has_explicit_send:
+                if (
+                    message_text and not has_explicit_send and not direct_correction_patch_this_response
+                    and not source_reconciliation_directive
+                ):
                     # Default: STOP. Agent must explicitly request continuation with "CONTINUE_WORK_SIGNAL".
                     # This is safer—agent won't keep running unexpectedly.
                     implied_will_continue = _should_imply_continue(
@@ -6642,10 +6942,7 @@ def _run_agent_loop(
                     if implied_call:
                         implied_send = True
                         implied_stop_after_send = not implied_will_continue  # Stop unless continuation phrase
-                        if direct_correction_patch_this_response:
-                            tool_calls.append(implied_call)
-                        else:
-                            tool_calls = [implied_call] + tool_calls
+                        tool_calls = [implied_call] + tool_calls
                         logger.info(
                             "Agent %s: treating message content as implied %s send.",
                             agent.id,
@@ -6667,15 +6964,16 @@ def _run_agent_loop(
                                         f"UNDLIVERED ANSWER:\n{message_text}"
                                     ),
                                 }
-                                _attach_completion(step_kwargs)
-                                step = PersistentAgentStep.objects.create(**step_kwargs)
-                                _attach_prompt_archive(step)
+                                _persist_attached_step(step_kwargs, _attach_completion, _attach_prompt_archive)
                             except Exception:
                                 logger.debug("Failed to persist implied-send correction step", exc_info=True)
                         # Don't continue here - still execute any other tool calls that were returned
 
                 reasoning_source = thinking_content
-                if not reasoning_source and not implied_send:
+                if (
+                    not reasoning_source and not implied_send and not direct_correction_patch_this_response
+                    and not source_reconciliation_directive
+                ):
                     reasoning_source = msg_content
 
                 reasoning_step = _persist_reasoning_step(reasoning_source)
@@ -6842,6 +7140,11 @@ def _run_agent_loop(
 
                 if not executed_batch.abort_after_execution or _get_processing_abort_reason(agent.id) is None:
                     runtime_errors, config_apply = _apply_runtime_updates()
+                    if direct_correction_patch_this_response:
+                        direct_correction_reply_pending = not config_apply.errors and any(
+                            outcome.prepared.tool_name == "sqlite_batch" and _tool_result_is_success(outcome.result)
+                            for outcome in executed_batch.execution_outcomes
+                        )
                     _annotate_agent_config_update_result(
                         executed_batch.execution_outcomes,
                         config_apply,
@@ -6864,8 +7167,10 @@ def _run_agent_loop(
                     attach_prompt_archive=_attach_prompt_archive,
                 )
                 executed_calls = finalized_batch.executed_calls
-                followup_required = followup_required or finalized_batch.followup_required
+                followup_required = followup_required or finalized_batch.followup_required or direct_correction_patch_this_response
                 message_delivery_ok = finalized_batch.message_delivery_ok
+                if direct_feedback_reply_pending and focused_feedback_reply_tool_name and message_delivery_ok:
+                    direct_feedback_reply_completed = True
                 last_explicit_continue = finalized_batch.last_explicit_continue
                 inferred_message_continue_this_iteration = (
                     finalized_batch.inferred_message_continue_this_iteration

--- a/api/agent/core/link_references.py
+++ b/api/agent/core/link_references.py
@@ -212,7 +212,7 @@ def resolve_link_reference_params(value, agent, *, tool_name: str = "", _path=()
         return value[: len(value) - len(value.lstrip())] + resolved + value[len(value.rstrip()):]
     if tool_name and _contains_reference_syntax(value):
         location = f"{tool_name}.{_param_path(_path)}" if tool_name else _param_path(_path) or "this value"
-        guidance = "Select raw values/URLs from __tool_results result_json/result_text; never replace tokens with literals." if tool_name == "sqlite_batch" else "Use a standalone token only where URL input is supported, move it to supported message/document content, or omit it."
+        guidance = "Derive raw values/URLs inside INSERT ... SELECT from __tool_results; never copy a blob or replace tokens with literals." if tool_name == "sqlite_batch" else "Use a standalone token only where URL input is supported, move it to supported message/document content, or omit it."
         raise LinkReferenceResolutionError(
             f"Query not executed: link references are unsupported in {location}. {guidance}")
     return value

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -102,12 +102,13 @@ from ..tools.sqlite_query_quality import (
     named_model_read_tables,
     source_derived_model_mutation_tables,
     source_derived_model_reconciled_tables,
+    _sql_values_from_params,
     summarize_sqlite_tool_result_sql,
 )
 from ..tools.sqlite_skills import format_recent_skills_for_prompt
 from ..tools.tool_manager import ensure_default_tools_enabled, ensure_skill_tools_enabled, get_enabled_tool_definitions
 from ..system_skills.discovery import format_system_skill_discovery_prompt
-from .tool_results import PREVIEW_TIER_COUNT, SPAWN_WEB_TASK_RESULT_TOOL_NAME, ToolCallResultRecord, ToolResultPromptInfo, prepare_tool_results_for_prompt
+from .tool_results import PREVIEW_TIER_COUNT, SPAWN_WEB_TASK_RESULT_TOOL_NAME, ToolCallResultRecord, ToolResultPromptInfo, build_short_result_id_map, entity_name_stem, prepare_tool_results_for_prompt, source_array_entity_groups
 from .link_references import is_source_bearing_tool, pair_prompt_urls, rewrite_prompt_urls
 from .daily_limit_mode import (
     CREDIT_MESSAGE_ONLY_ALLOWED_TOOL_NAMES_TEXT,
@@ -139,17 +140,15 @@ CONTACT_PROMPT_INLINE_LIMIT = 25
 CONTACT_PROMPT_SAMPLE_LIMIT = 10
 LINK_REFERENCE_PROMPT_NOTE = (
     "## Link References (CRITICAL)\n\n"
-    "Sources may pair `https://host/a [link_ref: $[link:L…]]`: the raw URL identifies that exact item for "
-    "reasoning; its adjacent token is the only user-visible link or URL-tool destination. Keep pairs attached. "
-    "Send tools must receive the token; delivery resolves it only after call. Copy it character-for-character: "
-    "`{\"url\":\"$[link:LEXACT]\"}` becomes `[Atlas launch]($[link:LEXACT])`. Wrong: "
-    "`[Atlas launch](https://host/a)` or any raw `http(s)` destination. A token is one whole URL, not an "
-    "ID/instruction, and changes no action/tool. Never reassign a token, derive a sibling URL, decode, edit, shorten, "
-    "combine, or guess. If missing, omit the link. An item lacking its token stays unlinked; a source/feed token "
-    "links only itself. Never put tokens in SQL or search text. When sources are requested, link all included "
-    "token-backed sources and reserve room. "
-    "A bare source name or `(source)` is not a citation. Before sending, the body must contain the exact tokens or it "
-    "is unfinished."
+    "Sources may pair `raw URL [link_ref: $[link:L…]]`: the raw URL is evidence; its adjacent token is only a "
+    "display/fetch handle. Keep pairs attached. Final Markdown is exactly `[item]($[link:LEXACT])`; HTML uses "
+    "`<a href=\"$[link:LEXACT]\">item</a>`; URL tools use `{\"url\":\"$[link:LEXACT]\"}`. The token is the whole "
+    "destination. Never encode, edit, reassign, combine, or guess it; never put it inside `[]`, SQL/state/search, or "
+    "replace it with a raw URL. Items without a token stay plain; source/feed tokens link only themselves. A report "
+    "is unfinished while a token-backed entity name is plain: `Atlas URL [link_ref: $[link:L1]]` becomes "
+    "`[Atlas]($[link:L1])`. Outreach links only if useful/requested. Cite beside the supported "
+    "claim; a source name alone is not a citation. Before sending, the "
+    "body must contain the exact tokens for linked claims."
 )
 SQLITE_EFFICIENCY_WARNING = (
     "SQLite efficiency warning: you've been handling __tool_results one result_id at a time. "
@@ -164,7 +163,6 @@ TOOL_RESULT_LOOKUP_COMPONENTS = frozenset({
     "parent_result_id",
     "result_id",
     "result_meta",
-    "result_schema",
 })
 
 
@@ -209,12 +207,6 @@ def _prompt_render_settings_from_failover_configs(
         for _, _, params_with_hints in failover_configs
     )
     return model, allow_implied_send
-
-
-def _prompt_render_signature_from_failover_configs(
-    failover_configs: Sequence[Tuple[str, str, Mapping[str, Any]]] | None,
-) -> Tuple[str, bool]:
-    return _prompt_render_settings_from_failover_configs(failover_configs)
 
 
 def _prompt_routing_range_from_failover_configs(
@@ -598,6 +590,14 @@ def _extract_spawn_web_task_task_id(result_text: object) -> Optional[str]:
     return str(task_id) if task_id else None
 
 
+def _tool_result_status_is_ok(result: object) -> bool:
+    try:
+        payload = result if isinstance(result, dict) else json.loads(str(result or ""))
+    except (TypeError, ValueError):
+        return False
+    return isinstance(payload, dict) and str(payload.get("status") or "").casefold() == "ok"
+
+
 def _build_browser_task_tool_result_record(
     task: BrowserUseAgentTask,
     result_step: Optional[BrowserUseAgentTaskStep],
@@ -681,11 +681,12 @@ def _get_sqlite_guidance() -> str:
     """Return the compact contract for data retrieval, storage, and analysis."""
     return (
         "## SQLite Data\n\n"
-        "Named tables are the world model; digest is partial. Read them before external refreshes/decisions, not memory. Current complete rows are truth; don't refetch them. "
+        "Named tables are the world model; digest is partial. Use queried rows, not memory, for decisions. Current complete rows are truth; don't refetch them. "
+        "Explicit fresh source: fetch once, then reconcile and SELECT the model in one SQLite batch. Otherwise read the model first and fetch only stale/missing facts. "
         "Tool output doesn't update it. Source rows sharing a stable ID or its children belong there even when small: reconcile entities/relations, evolve schema, then query before acting/reporting. Only unrelated one-offs bypass it. "
         "Use stable keys. Upserts refresh every mutable/provenance field; inspect identity after wrong row counts; query gaps before reporting. Only sourced blockers are unresolved. "
-        "Normalize children with PRIMARY KEY/UNIQUE and indexes; use SQLite for exact set logic/counts/ranking; return needed rows. Import ordinary tool output via INSERT ... SELECT/json_each from __tool_results (batch siblings by IN/tool_name), never copied facts/URLs; custom tools can write keyed models directly. "
-        "Never query one result_id at a time, make per-result tables, or loop blobs. CTAS is one-off; named tables persist, TEMP do not. Copy names/paths/values/URLs from results; inspect unknown structure once. "
+        "Normalize children with PRIMARY KEY/UNIQUE + indexes; use SQLite for exact set logic/counts/ranking. "
+        "No sibling-by-sibling result/table/blob loops. Custom tools may write keyed models directly. CTAS is one-off; named tables persist, TEMP do not. Inspect unknown structure once. "
         "Locate payloads with analysis_json/top_keys; http_request JSON is result_json $.content. Prefer result_json for known paths, else result_text.\n\n"
         "Snapshots:\n"
         "* __tool_results: result_id, tool_name, created_at, result_json, result_text, analysis_json, is_truncated, top_keys.\n"
@@ -1327,6 +1328,7 @@ def _render_prompt_context_once(
     system_directive_block: str = "",
     skip_compaction: bool = False,
     run_cache: PromptRunCache | None = None,
+    prompt_message_transform: Callable[[List[dict]], List[dict]] | None = None,
 ) -> PromptRenderResult:
     max_iterations = _resolve_max_iterations(max_iterations)
     planning_mode_active = agent.planning_state == PersistentAgent.PlanningState.PLANNING
@@ -1350,10 +1352,8 @@ def _render_prompt_context_once(
         prompt_failover_configs
     )
 
-    # Create token estimator for the specific model
     token_estimator = _create_token_estimator(model, run_cache)
 
-    # Initialize promptree with the token estimator
     prompt = Prompt(token_estimator=token_estimator)
     config_authority = _ConfigAuthorityResolver(agent)
 
@@ -1421,14 +1421,14 @@ def _render_prompt_context_once(
         if agent.schedule:
             important_group.section_text(
                 "schedule_note",
-                "UPDATE YOUR SCHEDULE if the timing no longer matches the job. User wants it more/less frequent? Change it now. Task scope changed? Adjust timing to match.",
+                "Current schedule is durable. Change it only for an authorized lasting cadence request; temporary task scope never changes it.",
                 weight=1,
                 non_shrinkable=True
             )
         else:
             important_group.section_text(
                 "schedule_note",
-                "⚠️ NO SCHEDULE SET. When in doubt, set one—default '0 9 * * *'. Without a schedule, you die when you stop.",
+                "No schedule is set. Leave it NULL unless the user requests recurrence.",
                 weight=1,
                 non_shrinkable=True
             )
@@ -1544,7 +1544,7 @@ def _render_prompt_context_once(
                 "Planning Mode is active; end_planning(full_plan=...) replaces your runtime charter."
                 if planning_mode_active
                 else (
-                    "Charter is durable memory. Merge ongoing role/scope, recurrence, and user corrections; preserve unrelated guidance and omit one-offs, completed work, or guesses."
+                    "Charter is durable memory. Keep ongoing role/scope/recurrence; apply unscoped corrections, preserve unrelated guidance; omit task/batch/day/response scope, completed work, and guesses."
                 )
             ),
             weight=2,
@@ -1577,20 +1577,25 @@ def _render_prompt_context_once(
             records=lambda snapshot: snapshot.records,
         )
 
+    sqlite_schema_block = get_sqlite_schema_prompt()
+    named_model_tables = {
+        match.group(1)
+        for match in re.finditer(r"^Table ([^\s(]+)", sqlite_schema_block, re.MULTILINE)
+        if not match.group(1).startswith("__")
+    }
+
     # Unified history follows the important context (order within user prompt: important -> unified_history -> critical)
     unified_history_group = prompt.group("unified_history", weight=3)
-    fresh_tool_call_step_ids, has_link_references = _get_unified_history_prompt(
+    fresh_tool_call_step_ids, has_link_references, source_reconciliation_directives = _get_unified_history_prompt(
         agent,
         unified_history_group,
         config_authority,
         run_cache=run_cache,
+        named_model_tables=named_model_tables,
     )
 
-    # Variable priority sections (weight=4) - can be heavily shrunk with smart truncation
     variable_group = prompt.group("variable", weight=4)
 
-    # SQLite schema - always available
-    sqlite_schema_block = get_sqlite_schema_prompt()
     variable_group.section_text(
         "sqlite_schema",
         sqlite_schema_block,
@@ -1634,11 +1639,7 @@ def _render_prompt_context_once(
             "Planning questions must use request_human_input."
         )
     else:
-        agent_config_note = (
-            f"Write {AGENT_CONFIG_TABLE} id=1 via sqlite_batch; clear schedule with NULL or ''. "
-            "Before replying to a direct correction, make one partial charter UPDATE with patch_text; do not wait for explicit save wording. "
-            "Setup: update config first; fetch targets only if asked to run now."
-        )
+        agent_config_note = f"{AGENT_CONFIG_TABLE} id=1: patch_text for lasting owner behavior feedback only; temporary feedback/ordinary tasks never config."
     variable_group.section_text(
         "agent_config_note",
         agent_config_note,
@@ -1807,9 +1808,25 @@ def _render_prompt_context_once(
     token_misses_before = run_cache.token_counts.misses if run_cache is not None else 0
     with tracer.start_as_current_span("Promptree Render") as render_span:
         user_content = prompt.render(user_token_budget)
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content},
+        ]
+        original_messages = messages
+        if prompt_message_transform is not None:
+            transformed = prompt_message_transform(messages)
+            if (
+                len(transformed) != 2
+                or transformed[0].get("role") != "system"
+                or transformed[1].get("role") != "user"
+            ):
+                raise ValueError("prompt_message_transform must return one system and one user message")
+            messages = transformed
+            system_prompt = str(messages[0].get("content") or "")
+            user_content = str(messages[1].get("content") or "")
         render_span.set_attribute("prompt.fast_path", prompt.used_fast_path())
         render_span.set_attribute("prompt.characters", len(user_content))
-        render_span.set_attribute("prompt.fitted_tokens", prompt.get_tokens_after_fitting())
+        render_span.set_attribute("prompt.fitted_tokens", token_estimator(user_content))
         if run_cache is not None:
             render_span.set_attribute(
                 "prompt.token_cache.hits",
@@ -1821,15 +1838,17 @@ def _render_prompt_context_once(
             )
 
     # Get token counts before and after fitting
-    tokens_before = prompt.get_tokens_before_fitting() + system_tokens
-    tokens_after = prompt.get_tokens_after_fitting() + system_tokens
+    original_tokens_before = prompt.get_tokens_before_fitting() + system_tokens
+    system_tokens = token_estimator(system_prompt)
+    tokens_after = token_estimator(user_content) + system_tokens
+    tokens_before = max(original_tokens_before, tokens_after)
     tokens_saved = tokens_before - tokens_after
+    source_reconciliation_directive = "\n".join(
+        directive for directive in source_reconciliation_directives if directive in user_content
+    ) or None
 
     return PromptRenderResult(
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_content},
-        ],
+        messages=messages,
         tokens_before=tokens_before,
         tokens_after=tokens_after,
         tokens_saved=tokens_saved,
@@ -1837,7 +1856,9 @@ def _render_prompt_context_once(
         system_tokens=system_tokens,
         metadata={
             "prompt_allows_implied_send": prompt_allows_implied_send,
-            "prompt_render_signature": _prompt_render_signature_from_failover_configs(
+            "prompt_message_transform_applied": messages != original_messages,
+            "source_reconciliation_directive": source_reconciliation_directive,
+            "prompt_render_signature": _prompt_render_settings_from_failover_configs(
                 prompt_failover_configs
             ),
             "prompt_routing_range": _prompt_routing_range_from_failover_configs(
@@ -1952,7 +1973,7 @@ def _stabilize_prompt_render(
             routing_profile=routing_profile,
             prefer_low_latency=prefer_low_latency,
         )
-        if _prompt_render_signature_from_failover_configs(resolved) == result.metadata["prompt_render_signature"]:
+        if _prompt_render_settings_from_failover_configs(resolved) == result.metadata["prompt_render_signature"]:
             return result, resolved, render_count
         configs = resolved
 
@@ -1961,7 +1982,7 @@ def _stabilize_prompt_render(
         " preview" if preview else "",
         agent.id,
     )
-    if _prompt_render_signature_from_failover_configs(configs) != result.metadata["prompt_render_signature"]:
+    if _prompt_render_settings_from_failover_configs(configs) != result.metadata["prompt_render_signature"]:
         result = _render_prompt_context_once(
             agent,
             prompt_failover_configs=configs,
@@ -1988,6 +2009,7 @@ def build_prompt_context(
     system_directive_block: str = "",
     routing_token_seed: Optional[int] = None,
     run_cache: PromptRunCache | None = None,
+    prompt_message_transform: Callable[[List[dict]], List[dict]] | None = None,
 ) -> tuple[List[dict], int, Optional[UUID]] | tuple[List[dict], int, Optional[UUID], dict[str, Any]]:
     """
     Return a system + user message for the LLM using promptree for token budget management.
@@ -2005,6 +2027,7 @@ def build_prompt_context(
         prefer_low_latency: Optional low-latency routing hint used to match the
             prompt against the same failover set the completion call will use.
         include_metadata: When true, include prompt capability metadata in the return value.
+        prompt_message_transform: Optional final shaping applied before routing metrics and archival.
 
     Returns:
         Tuple of (messages, fitted_token_count, prompt_archive_id) where
@@ -2038,6 +2061,7 @@ def build_prompt_context(
             routing_profile=routing_profile,
             system_directive_block=system_directive_block,
             run_cache=run_cache,
+            prompt_message_transform=prompt_message_transform,
         ),
     )
     render_result.metadata["prompt_failover_configs"] = list(prompt_failover_configs or [])
@@ -2319,13 +2343,6 @@ def _recent_contact_records_for_prompt(
     )
     ordered.sort(key=lambda record: record.relevance_at or "", reverse=True)
     return ordered[:CONTACT_PROMPT_SAMPLE_LIMIT]
-
-
-def _allowed_communication_channels(
-    agent_endpoints: Sequence[PersistentAgentCommsEndpoint],
-) -> list[str]:
-    channels = {endpoint.channel for endpoint in agent_endpoints if endpoint.channel}
-    return sorted(channels)
 
 
 def _build_contacts_block(
@@ -2700,7 +2717,7 @@ def _build_contacts_block(
     )
     
     # Explicitly list allowed communication channels
-    allowed_channels = _allowed_communication_channels(agent_eps)
+    allowed_channels = sorted({endpoint.channel for endpoint in agent_eps if endpoint.channel})
 
     if allowed_channels:
         contacts_group.section_text(
@@ -3226,35 +3243,6 @@ def _get_implied_send_context(
 
     return None
 
-def _get_web_chat_formatting_guidance() -> str:
-    """Return rich Markdown guidance for chat surfaces with full rendering support."""
-
-    return (
-        "Web chat and peer DMs:\n"
-        "Start with the answer/main finding. Address known recipients once around actions; avoid generic delivery logs and agent-name self-intros unless asked. "
-        "Use whitespace, not separators. Charts: paste create_chart result.inline; don't attach/read/rebuild."
-    )
-
-
-def _get_sms_formatting_guidance() -> str:
-    """Return plain-text guidance for SMS replies."""
-
-    return (
-        "SMS formatting (plain text, short):\n"
-        "No Markdown or HTML. Aim for one direct sentence and <=160 chars when practical."
-    )
-
-
-def _get_email_formatting_guidance() -> str:
-    """Return HTML formatting guidance for email replies."""
-
-    return (
-        "Email formatting (rich, expressive HTML):\n"
-        "Use body-only HTML, not Markdown. For reports/dashboards, avoid bare HTML: put inline style attrs on section headers, tables/cells, and key-value spans so important numbers, statuses, and value changes are visibly highlighted with color, badges, or icons. Do not leave report metrics/statuses in plain <ul>/<p> blocks; use styled tables, metric blocks, or badge-like spans. "
-        "For charts, copy <img> src from create_chart result.inline_html or returned $[/path]; never construct paths/download URLs."
-    )
-
-
 def _get_formatting_guidance() -> str:
     """Return shared formatting guidance for all delivery surfaces."""
 
@@ -3262,13 +3250,18 @@ def _get_formatting_guidance() -> str:
         "Formatting guidance:\n"
         "Use the matching surface; be direct and sourced.\n\n"
         "<web_chat>\n"
-        f"{_get_web_chat_formatting_guidance()}\n"
+        "Web chat and peer DMs:\n"
+        "Start with the answer/main finding. Address known recipients once around actions; avoid generic delivery logs and agent-name self-intros unless asked. "
+        "Use whitespace, not separators. Charts: paste create_chart result.inline; don't attach/read/rebuild.\n"
         "</web_chat>\n\n"
         "<email>\n"
-        f"{_get_email_formatting_guidance()}\n"
+        "Email formatting (rich, expressive HTML):\n"
+        "Use body-only HTML, not Markdown. For reports/dashboards, avoid bare HTML: put inline style attrs on section headers, tables/cells, and key-value spans so important numbers, statuses, and value changes are visibly highlighted with color, badges, or icons. Do not leave report metrics/statuses in plain <ul>/<p> blocks; use styled tables, metric blocks, or badge-like spans. "
+        "For charts, copy <img> src from create_chart result.inline_html or returned $[/path]; never construct paths/download URLs.\n"
         "</email>\n\n"
         "<sms>\n"
-        f"{_get_sms_formatting_guidance()}\n"
+        "SMS formatting (plain text, short):\n"
+        "No Markdown or HTML. Aim for one direct sentence and <=160 chars when practical.\n"
         "</sms>\n\n"
         "<fallback>\n"
         "If mixed/unknown, use actual delivery surface: web chat Markdown, email HTML, SMS plain text.\n"
@@ -3283,8 +3276,7 @@ def _get_reasoning_streak_prompt(reasoning_only_streak: int, *, implied_send_act
         return ""
 
     streak_label = "reply" if reasoning_only_streak == 1 else f"{reasoning_only_streak} consecutive replies"
-    # MAX_NO_TOOL_STREAK=1, so any no-tool response triggers auto-stop warning
-    urgency = "Auto-stop imminent! " if reasoning_only_streak >= 1 else ""
+    urgency = "Auto-stop imminent! "
     if implied_send_active:
         patterns = (
             "(1) More work? Include a tool call, or end message with \"CONTINUE_WORK_SIGNAL\" (stripped) "
@@ -3331,7 +3323,7 @@ def _build_sqlite_retry_warning(
             if is_empty:
                 empty_counts[result_id] += 1
 
-    summary = summarize_sqlite_tool_result_sql(sql_values)
+    call_summaries = [summarize_sqlite_tool_result_sql([sql]) for sql in sql_values]
     if row_loop_rejections >= 2:
         return (
             "SQLite recovery: repeated singleton result queries were rejected. Do not retry that shape. Query all "
@@ -3339,9 +3331,8 @@ def _build_sqlite_retry_warning(
             "by stable key and query it; otherwise answer the shaped result. Refetch only if evidence is stale or missing."
         )
     inefficient_result_loop = (
-        summary.direct_result_text_fetches >= 2
-        or summary.duplicate_direct_fetches
-        or summary.single_tool_result_imports >= 2
+        sum(summary.direct_result_text_fetches > 0 for summary in call_summaries) >= 2
+        or sum(summary.single_tool_result_imports > 0 for summary in call_summaries) >= 2
     )
     if not result_id_counts:
         if inefficient_result_loop:
@@ -3377,15 +3368,6 @@ def _get_recent_sqlite_retry_warning(agent: PersistentAgent) -> str:
     return _build_sqlite_retry_warning(recent_calls)
 
 
-def _sqlite_sql_values(params: dict[str, Any] | None) -> list[str]:
-    if not isinstance(params, dict):
-        return []
-    value = params.get("sql") or params.get("queries") or params.get("query")
-    if isinstance(value, (list, tuple)):
-        return [str(item) for item in value if str(item or "").strip()]
-    return [str(value)] if value else []
-
-
 def _build_unreconciled_source_model_warning(
     recent_calls: Sequence[Tuple[str, dict[str, Any] | None, str]],
 ) -> str:
@@ -3402,7 +3384,7 @@ def _build_unreconciled_source_model_warning(
     for index, (tool_name, params, status) in enumerate(recent_calls):
         if status != "complete" or tool_name != "sqlite_batch":
             continue
-        sql_values = _sqlite_sql_values(params)
+        sql_values = _sql_values_from_params(params or {})
         sqlite_events.append((
             index,
             set(named_model_read_tables(sql_values)),
@@ -3417,25 +3399,23 @@ def _build_unreconciled_source_model_warning(
         if index > latest_source_index
         for table in targets
     }
-    relevant_targets = set(latest_mutation_by_table)
-    if read_tables:
-        relevant_targets.intersection_update(read_tables)
-    if relevant_targets and all(
+    if latest_mutation_by_table and all(
         any(
             (index > latest_mutation_by_table[table] and table in reads)
             or (index == latest_mutation_by_table[table] and table in reconciled)
             for index, reads, _mutations, reconciled in sqlite_events
         )
-        for table in relevant_targets
+        for table in latest_mutation_by_table
     ):
         return ""
 
     if not read_tables and not latest_mutation_by_table:
         return ""
     return (
-        "Fresh source evidence from this work cycle is not yet reconciled with the named model you read. If it belongs "
-        "to that domain and is newer, upsert all changed/provenance fields by stable key from __tool_results, add relations, then answer "
-        "from a post-update query. If it is unrelated or no relevant model exists, answer the source directly. Do not refetch."
+        "Fresh source evidence is not reconciled with the named model you read. If it belongs there, the next SQLite "
+        "call must use INSERT ... SELECT or UPDATE ... FROM __tool_results/json_each. Every sourced field, including IDs, "
+        "names, dates, and URLs, must be extracted; only JSON paths and current result_id/tool_name may be literals. "
+        "Refresh mutable/provenance fields, add relations, and query the model in that batch. Otherwise answer it directly."
     )
 
 
@@ -3833,9 +3813,10 @@ def _get_system_instruction(
         "\n\n"
         f"{continuation_mode_block}"
         "## CRITICAL: Tool Call Format — READ THIS FIRST\n\n"
-        "**Use the API's native `tool_calls` field.** Tool calls are separate API fields, not message text.\n"
-        "NEVER write XML (`<function_calls>`, `<invoke>`, `<parameter>`) or text-call syntax (`sqlite_batch(sql=\"...\")`, `http_request(url=\"...\")`) in content; those are ignored and may be sent literally to the user.\n"
-        "Tool arguments are JSON objects with exact schema keys, e.g. `{\"sql\": \"SELECT * FROM table\", \"will_continue_work\": true}`. Never invent keys with punctuation such as `will_continue_work=` or put tool syntax in send-message bodies.\n\n"
+        "Use native `tool_calls`, never XML/text-call syntax. With work calls, content must be empty; only explicit "
+        "send_* calls deliver required updates/finals. Arguments are JSON objects with exact schema keys, e.g. "
+        "`{\"sql\": \"SELECT * FROM table\", \"will_continue_work\": true}`; no keys like `will_continue_work=` "
+        "or tool syntax in send bodies.\n\n"
         "Language policy:\n"
         "- Default to English; switch only if the user asks or starts in another language. Summarize/translate tool output as needed.\n\n"
 
@@ -3848,8 +3829,9 @@ def _get_system_instruction(
         "\n\n"
         "## Durable Config (CRITICAL)\n\n"
 
-        "Direct behavior/output corrections are durable unless explicitly one-response. Before replying, use one sqlite_batch patch_text UPDATE on the smallest exact charter phrase; preserve every unrelated word/setting verbatim, never wait for 'update your charter', and never mention the patch. "
-        "Otherwise mutate config only for durable role, scope, preferences, monitoring, recurrence, or memory; never save transient facts, completed work, or guesses.\n\n"
+        "Scope veto: finite task/batch/day/run/project/renewal/deal/case feedback is temporary. If it gives no separate task, only acknowledge briefly; do not research or change config. In mixed feedback, scope carries forward until another marker; persist only lasting clauses. Otherwise authorized behavior feedback is lasting: before any reply, first call sqlite_batch with one patch_text UPDATE of the related clause. "
+        "Replace conflicts/softened absolutes; preserve unrelated text; append only if no related clause; don't reread/ask. "
+        "Confirm naturally; invite correction if unsure; never mention internals or save transient facts/results/guesses.\n\n"
 
         f"{schedule_updates_guidance}"
 
@@ -3886,7 +3868,7 @@ def _get_system_instruction(
         "Do not invent work, results, preferences, or personal experiences.\n\n"
 
         "## Output Rules\n\n"
-        "Keep chat/outreach light. Owner reports on 4+ peers need resolved/total and one table with requested fields. For finite sets, grouped discovery isn't coverage: resolve/source each requested field. Label blockers partial; separate sourced unavailability from research gaps. Ground facts, numbers, units, and URLs in tool results; never relabel/convert units unless asked. Present requested data directly; omit unrelated/unavailable fields and follow-up offers after simple facts, prices, statuses, or lookups. "
+        "Keep chat/outreach light. For finite sets, grouped discovery isn't coverage: resolve/source each requested field. Label blockers partial; separate sourced unavailability from research gaps. An owner report on 4+ items is unfinished without `Covered N/N` and every item/requested field in one channel-appropriate table. Ground facts, numbers, units, and URLs in tool results; never relabel/convert units unless asked. Present requested data directly; omit unrelated/unavailable fields and follow-up offers after simple facts, prices, statuses, or lookups. "
         "Charts: create only when requested/materially useful. "
         "Paste create_chart result.inline/result.inline_html in the message; do not attach/read charts or invent paths, hashes, image tags, or <img> URLs. "
         "Use create_csv for tabular exports, create_pdf for PDFs, and create_file for other text/doc formats; create_file query mode must return exactly one row and one column.\n\n"
@@ -3897,8 +3879,8 @@ def _get_system_instruction(
         "Do not download or upload files unless absolutely necessary or explicitly requested by the user. "
 
         "## Tool Rules\n\n```\nopaque identifiers -> copy exposed tool names and supplied endpoints/paths/IDs/placeholders character-for-character; never shorten or normalize\n"
-        "small result -> answer; exact URL -> requested tool; build/create custom tool -> create_custom_tool first; supplied URLs -> opaque runtime inputs, no prefetch/inspect/browser\n"
-        "public exact URL + http/scrape tool callable -> http_request or scrape directly; spawn_web_task only after access/render/login blockage\n"
+        "unrelated small result -> answer; build/create custom tool -> create_custom_tool first; supplied URLs -> opaque runtime inputs, no prefetch/inspect/browser\n"
+        "named model + explicit fresh source/URL -> http_request only, no text/send/plan; WAIT; next completion exactly one reconcile+SELECT sqlite_batch; then report\n"
         "exact docs/blog/changelog/release-notes URL -> scrape_as_markdown or http_request first; never spawn_web_task first just because it is a webpage or app URL\n"
         "explicit SQLite/database request and sqlite_batch is callable -> use sqlite_batch directly; do not search for a SQLite/database tool\n"
         "recurring setup with URL -> sqlite_batch charter+schedule first; no URL search/read/fetch unless asked to run now\n"
@@ -3906,7 +3888,7 @@ def _get_system_instruction(
         "localhost/private/rendered/login page -> spawn_web_task (or retry with it after scrape/http cannot access)\n"
         "webpage screenshot/visual capture/PDF/rendered artifact -> spawn_web_task\n"
         "provided filespace path -> pass directly to the requested tool; read_file only when contents are needed, never for http(s) URLs\n"
-        "data/api/feed/file URL -> http_request (PDF may need read_file; browser only if blocked or rendered/login needed)\n"
+        "data/api/feed/file URL -> http_request; if it belongs to a named model, reconcile+SELECT there before use; PDF may need read_file; spawn_web_task only after access/render/login blockage\n"
         "HTML page to read -> scrape_as_markdown or structured extractor; known platforms/social -> structured extractor first\n"
         "local reviews/maps lead screen -> structured Maps/reviews tool directly; omitted city -> representative market/broad query, not human input\n"
         "weather geocoding -> forecast/current API before replying\n"
@@ -3914,7 +3896,7 @@ def _get_system_instruction(
         "create/launch/deploy/manage agent, specialist-agent, or entire research/analyst/scout team -> only search_tools('meta gobii control plane') first; never batch with update_plan/research/config\n"
         "discovery hint -> search_tools(exact query); enabled tool fits -> use directly; no fit or task evolved -> search_tools(domain)\n"
         "interactive/login/JS-only -> spawn_web_task; if active_browser_tasks >= 3 -> sleep_until_next_trigger\n"
-        "store/query data only when reuse, joins, filtering, chart input, aggregation, or size makes direct reading unreliable\n"
+        "store/query ad hoc data only when reuse, joins, filtering, chart input, aggregation, or size makes direct reading unreliable\n"
         "same URLs/items returned twice -> no new evidence; report result/shortfall, stop; no query variants\n"
         "```\n"
 
@@ -3932,7 +3914,7 @@ def _get_system_instruction(
         f"{_get_formatting_guidance()}\n\n"
 
         "The fetch→report rhythm: fetch data, then deliver it to the user. "
-        "If the latest tool result is a small JSON, CSV, text, scrape, or API payload that contains the answer, answer from it directly. "
+        "If the latest tool result is an unrelated small JSON, CSV, text, scrape, or API payload that contains the answer, answer from it directly. "
         "Do not use sqlite_batch to reread __tool_results, create a temporary table, or parse a small result unless you need SQL for real filtering, joining, aggregation, or chart input. "
         "Show requested detail, summarize overflow, and for multi-step research investigate only leads needed to satisfy the stated scope.\n\n"
 
@@ -3944,17 +3926,16 @@ def _get_system_instruction(
         "config first. Never send 'I'll save/update it' with will_continue_work=false; do it first.\n\n"
         f"{LINK_REFERENCE_PROMPT_NOTE}\n\n"
         "## Bounded Current Research (CRITICAL)\n\n"
-        "For one-off latest/current company/batch/funding/pricing/product/news/status asks except finite sets: use bounded research mode. Do one focused search or structured lookup; scrape 1-3 top sources if snippets are insufficient; then send one answer with takeaways and cite at least two distinct source URLs compactly. After one result set plus 1-2 strong pages, final answer is next, not another query. Use at most one web search query unless empty/contradictory. Do not run alternate query variants, call update_plan, send progress-only messages, create files/charts, build SQLite, or keep searching once sources can answer. Escalate only for explicit deep/exhaustive work, market maps, exports, list-all, outreach, monitoring, or scope that truly needs it.\n\n"
+        "For one-off latest/current company/batch/funding/pricing/product/news/status asks except finite sets: use bounded research mode. Do one focused search or structured lookup; scrape 1-3 top sources if snippets are insufficient; then send one answer with takeaways and cite at least two distinct source URLs compactly. After one result set plus 1-2 strong pages, final answer is next, not another query. Use at most one web search query unless empty/contradictory. Do not run alternate query variants, call update_plan, send progress-only messages, create files/charts, build an ad hoc SQLite model, or keep searching once sources can answer. Escalate only for explicit deep/exhaustive work, market maps, exports, list-all, outreach, monitoring, or scope that truly needs it.\n\n"
 
         "## Deep Research Source Budget (CRITICAL)\n\n"
-        "For explicit deep/exhaustive research and finite-set coverage, do not finalize from search results: after discovery, scrape/open at least 4 promising URLs (or every useful URL if fewer), then synthesize. Snippets are leads, not sources. Start with one broad search, two if it misses an angle. For named sets, batch gaps, follow up misses, and reconcile coverage; never repeat a successful URL/query. If sources support the memo, final next with linked evidence; keep chat deep memos under about 5,000 chars unless asked otherwise.\n\n"
+        "For explicit deep/exhaustive research and finite-set coverage, do not finalize from search results: after discovery, scrape/open at least 4 promising URLs (or every useful URL if fewer), then synthesize. A structured source already containing every requested field needs no item refetch. Snippets are leads, not sources. Start with one broad search, two if it misses an angle. For named sets, batch gaps, follow up misses, and reconcile coverage; never repeat a successful URL/query. Send a kickoff only for genuinely substantial/long-running work, not a small finite set. If sources support the memo, final next with linked evidence; keep chat deep memos under about 5,000 chars unless asked otherwise.\n\n"
 
         "## Configuration Discipline (CRITICAL)\n\n"
         "Finished answers/briefings/charts/lookups/one-off research are not charter changes; never store transient facts, results, or guesses in __agent_config. "
         "Do not set a schedule merely to continue or remember a single research question; schedule only user-requested recurrence. "
         "Keep cadence unless changed. Set future recurring work once and stop; do not run it unless asked. "
-        "If a future job will email/text and the user says not to send now, do not request contact permission during setup; record recipient/permission needs in charter and request permission only when a send is due. "
-        "Keep explicitly one-off preferences like 'stand by' in the current conversation; otherwise treat corrections as durable.\n\n"
+        "If a future job will email/text and the user says not to send now, do not request contact permission during setup; record recipient/permission needs in charter and request permission only when a send is due.\n\n"
 
         "## Plan Discipline (CRITICAL)\n\n"
         "Use `update_plan` only for substantial multi-step work where a visible plan helps. "
@@ -4441,7 +4422,8 @@ def _get_unified_history_prompt(
     config_authority: _ConfigAuthorityResolver,
     *,
     run_cache: PromptRunCache | None = None,
-) -> Tuple[Set[str], bool]:
+    named_model_tables: Set[str] | None = None,
+) -> Tuple[Set[str], bool, Tuple[str, ...]]:
     """Add summaries + interleaved recent steps & messages to the provided promptree group."""
     epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
     unified_limit, unified_hysteresis = _get_unified_history_limits(agent)
@@ -4524,8 +4506,6 @@ def _get_unified_history_prompt(
         .prefetch_related("attachments__filespace_node")
         .order_by("-timestamp")[:unified_fetch_span]
     )
-
-    # Collect structured events with their components grouped together
     structured_events: List[Tuple[datetime, str, dict]] = []  # (timestamp, event_type, components)
 
     step_candidates: List[PersistentAgentStep] = []
@@ -4555,6 +4535,8 @@ def _get_unified_history_prompt(
                 "step_id",
                 "result",
                 "tool_name",
+                "tool_params",
+                "status",
                 "step__completion_id",
                 "parent_tool_call_id",
                 "parent_tool_call__tool_name",
@@ -4562,6 +4544,7 @@ def _get_unified_history_prompt(
         )
         tool_call_parent_ids: Dict[str, str] = {}
         tool_call_parent_names: Dict[str, str] = {}
+        source_reconciliations = []
         for row in tool_call_results:
             step_id = str(row["step_id"])
             step = step_lookup.get(step_id)
@@ -4584,6 +4567,10 @@ def _get_unified_history_prompt(
                 parent_tool_name = row.get("parent_tool_call__tool_name") or ""
                 if parent_tool_name:
                     tool_call_parent_names[step_id] = str(parent_tool_name)
+            if row.get("tool_name") == "sqlite_batch" and str(row.get("status") or "").casefold() == "complete" and _tool_result_status_is_ok(result_text):
+                sql_values = _sql_values_from_params(row.get("tool_params") or {})
+                if set(source_derived_model_reconciled_tables(sql_values)).intersection(named_model_tables or ()):
+                    source_reconciliations.append((step.created_at, "\n".join(sql_values)))
             tool_call_records.append(
                 ToolCallResultRecord(
                     step_id=step_id,
@@ -4625,6 +4612,36 @@ def _get_unified_history_prompt(
                 }
             else:
                 fresh_tool_call_step_ids = {newest_record.step_id}
+            if named_model_tables:
+                short_ids = build_short_result_id_map([record.step_id for record in tool_call_records])
+                model_entities = {entity_name_stem(table) for table in named_model_tables}
+
+                def source_is_reconciled(record):
+                    result_id = short_ids.get(record.step_id, record.step_id)
+                    all_entities, keyed_entities = source_array_entity_groups(record.result_text, record.tool_name)
+                    matching_entities = all_entities.intersection(model_entities)
+                    if not matching_entities:
+                        return True
+                    required_entities = matching_entities | keyed_entities
+                    reconciled_entities = set()
+                    for reconciled_at, sql in source_reconciliations:
+                        if reconciled_at <= record.created_at:
+                            continue
+                        id_filter = re.search(r"\bresult_id\b\s*(?:=|\bIN\b)", sql, re.IGNORECASE)
+                        tool_filter = re.search(r"\btool_name\b\s*(?:=|\bIN\b)", sql, re.IGNORECASE)
+                        id_match = not id_filter or any(value in sql for value in (result_id, record.step_id))
+                        tool_match = not tool_filter or record.tool_name in sql
+                        if id_match and tool_match:
+                            reconciled_entities.update(
+                                entity_name_stem(table)
+                                for table in source_derived_model_reconciled_tables([sql])
+                            )
+                    return bool(required_entities) and required_entities.issubset(reconciled_entities)
+
+                fresh_tool_call_step_ids.update(
+                    record.step_id for record in tool_call_records
+                    if is_source_bearing_tool(record.tool_name) and not source_is_reconciled(record)
+                )
 
             # Build recency position map: most recent = 0, then 1, 2, etc.
             ordered_records = sorted(tool_call_records, key=lambda r: r.created_at, reverse=True)
@@ -4659,9 +4676,9 @@ def _get_unified_history_prompt(
             create=is_source_bearing_tool(record.tool_name),
         ),
         paired_url_step_ids=paired_url_step_ids,
+        named_model_tables=named_model_tables,
     )
 
-    # format steps (group meta/params/result components together)
     for s in steps:
         try:
             system_step = getattr(s, "system_step", None)
@@ -4692,8 +4709,6 @@ def _get_unified_history_prompt(
                 if result_info.preview_text:
                     key = "result" if result_info.is_inline else "result_preview"
                     components[key] = result_info.preview_text
-                if result_info.schema_text:
-                    components["result_schema"] = result_info.schema_text
 
             structured_events.append((s.created_at, "tool_call", components))
         except ObjectDoesNotExist:
@@ -4741,7 +4756,6 @@ def _get_unified_history_prompt(
                 return f"{address} - {display_name}"
         return address
 
-    # format messages
     for m in messages:
         if not m.from_endpoint:
             # Skip malformed records defensively
@@ -4979,7 +4993,6 @@ def _get_unified_history_prompt(
             "prompt": 1,      # Browser task/user prompt context; useful but repeatable
             "result": 1,      # Payload body; can be shrunk to protect model limits.
             "result_meta": 2, # Medium priority - supports tool result lookup
-            "result_schema": 1, # Query/shape hint from tool_results.py; keep intact.
             "result_preview": 1, # Payload preview; can be shrunk to protect model limits.
             "result_summary": 1, # Low priority - browser task prose summary
             "files": 3,       # High priority - direct filespace paths for follow-up actions
@@ -5038,7 +5051,12 @@ def _get_unified_history_prompt(
                     non_shrinkable=non_shrinkable,
                 )
 
-    return fresh_tool_call_step_ids, has_link_references
+    source_reconciliation_directives = tuple(
+        info.source_reconciliation_directive
+        for info in tool_result_prompt_info.values()
+        if info.source_reconciliation_directive
+    )
+    return fresh_tool_call_step_ids, has_link_references, source_reconciliation_directives
 
 
 def get_agent_tools(agent: PersistentAgent = None) -> List[dict]:

--- a/api/agent/core/tests/test_link_references.py
+++ b/api/agent/core/tests/test_link_references.py
@@ -335,8 +335,8 @@ class LinkReferenceTests(TestCase):
                     self.assertIn(path, result["message"])
                     self.assertIn("Query not executed", result["message"])
                     if tool_name == "sqlite_batch":
-                        self.assertIn("Select raw values/URLs from __tool_results", result["message"])
-                        self.assertIn("never replace tokens with literals", result["message"])
+                        self.assertIn("Derive raw values/URLs inside INSERT ... SELECT", result["message"])
+                        self.assertIn("replace tokens with literals", result["message"])
 
         enabled.assert_not_called()
         apply_patch_mock.assert_not_called()
@@ -691,7 +691,8 @@ class LinkReferenceTests(TestCase):
     def test_source_result_marks_sparse_item_link_field_as_not_provided(self):
         raw_result = (
             "name=Linked | console_url=https://console.example.test/linked\n"
-            "name=Unlinked | console_host=console.example.test | console_route=/unlinked"
+            "name=Unlinked | console_host=console.example.test | console_route=/unlinked | "
+            "profile_id=p_7f2c | directory_slug=unlinked"
         )
         record = ToolCallResultRecord(
             step_id="00000000-0000-4000-8000-000000000012",
@@ -718,10 +719,13 @@ class LinkReferenceTests(TestCase):
         )[record.step_id]
 
         self.assertIn(
-            "name=Unlinked | console_host=[omitted: no item link] | console_route=[omitted: no item link] | console_url= [not provided]",
+            "name=Unlinked | console_host=[omitted: no item link] | console_route=[omitted: no item link] | "
+            "profile_id=p_7f2c | directory_slug=unlinked | console_url= [not provided]",
             prompt_info.preview_text,
         )
         self.assertNotIn("console_host=console.example.test", prompt_info.meta)
+        self.assertIn("profile_id=p_7f2c", prompt_info.preview_text)
+        self.assertIn("directory_slug=unlinked", prompt_info.preview_text)
         self.assertEqual(record.result_text, raw_result)
 
     def test_large_source_focus_replaces_misleading_prefix_and_query_hint(self):
@@ -895,18 +899,15 @@ class LinkReferenceTests(TestCase):
         self.assertIn(f"Compare Acme: {url} [link_ref: {token}]", user_prompt)
         self.assertEqual(system_prompt.count("## Link References (CRITICAL)"), 1)
         self.assertNotIn("## Link References (CRITICAL)", user_prompt)
-        self.assertIn("the raw URL identifies that exact item", system_prompt)
-        self.assertIn("adjacent token is the only user-visible link or URL-tool destination", system_prompt)
+        self.assertIn("the raw URL is evidence", system_prompt)
+        self.assertIn("adjacent token is only a display/fetch handle", system_prompt)
         self.assertIn("Keep pairs attached", system_prompt)
-        self.assertIn("delivery resolves it only after call", system_prompt)
-        self.assertIn("Copy it character-for-character", system_prompt)
-        self.assertIn("`[Atlas launch]($[link:LEXACT])`", system_prompt)
-        self.assertIn("Wrong: `[Atlas launch](https://host/a)`", system_prompt)
-        self.assertIn("If missing, omit the link", system_prompt)
-        self.assertIn("Never reassign a token, derive a sibling URL", system_prompt)
-        self.assertIn("An item lacking its token stays unlinked", system_prompt)
-        self.assertIn("Never put tokens in SQL or search text", system_prompt)
-        self.assertIn("A bare source name or `(source)`", system_prompt)
+        self.assertIn("Final Markdown is exactly `[item]($[link:LEXACT])`", system_prompt)
+        self.assertIn("replace it with a raw URL", system_prompt)
+        self.assertIn("Never encode, edit, reassign, combine, or guess it", system_prompt)
+        self.assertIn("Items without a token stay plain", system_prompt)
+        self.assertIn("SQL/state/search", system_prompt)
+        self.assertIn("A report is unfinished while a token-backed entity name is plain", system_prompt)
         self.assertIn("body must contain the exact tokens", system_prompt)
         message.refresh_from_db()
         self.assertEqual(message.body, f"Compare Acme: {url}")

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -9,7 +9,8 @@ from ..tools.context_hints import URL_FIELD_PRIORITY, extract_context_hint, hint
 from ..tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
 from ..tools.sqlite_state import TOOL_RESULTS_TABLE, get_sqlite_db_path
 from ..tools.tool_manager import SQLITE_TOOL_NAME
-from .result_analysis import ResultAnalysis, analyze_result, analysis_to_dict, _safe_json_path
+from .link_references import is_source_bearing_tool
+from .result_analysis import ResultAnalysis, analyze_result, analysis_to_dict, _get_json_type, _safe_json_path
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ _LINK_FIELD_RE = re.compile(
     re.IGNORECASE,
 )
 _URL_PART_FIELD_RE = re.compile(
-    r"(\b[\w-]*(?:host|path|route|slug|public_identifier|profile_id)\s*[:=]\s*)([^|\n]*?\S)(?=\s*(?:\||\\n|$))",
+    r"(\b[\w-]*(?:host|path|route)\s*[:=]\s*)([^|\n]*?\S)(?=[^\S\r\n]*(?:\||\\n|\r?\n|$))",
     re.IGNORECASE,
 )
 
@@ -110,10 +111,42 @@ class ToolResultPromptInfo:
     meta: str
     preview_text: Optional[str]
     is_inline: bool
-    schema_text: Optional[str]
+    source_reconciliation_directive: Optional[str]
 
 
-def _build_short_result_id_map(result_ids: Sequence[str]) -> Dict[str, str]:
+def entity_name_stem(value: str) -> str:
+    words = re.sub(r"(?<!^)(?=[A-Z])", "_", value).casefold().replace("-", "_").split("_")
+    leaf = next((word for word in reversed(words) if word), "")
+    return f"{leaf[:-3]}y" if leaf.endswith("ies") else leaf[:-1] if leaf.endswith("s") else leaf
+
+
+def _entity_arrays(analysis: ResultAnalysis | None) -> tuple:
+    json_analysis = analysis.json_analysis if analysis else None
+    if not json_analysis:
+        return ()
+    return tuple(sorted(
+        (item for item in (json_analysis.primary_array, *json_analysis.secondary_arrays) if item and item.item_fields),
+        key=lambda item: (sum(_is_entity_key(field) for field in item.item_fields), item.path),
+    ))
+
+
+def _is_entity_key(field: str) -> bool:
+    return field == "id" or field.endswith("_id")
+
+
+def source_array_entity_groups(result_text: str, tool_name: str) -> tuple[set[str], set[str]]:
+    _meta, _stored_json, _stored_text, analysis = _summarize_result(result_text, "source", tool_name)
+    arrays = _entity_arrays(analysis)
+    return (
+        {entity_name_stem(item.path.rsplit(".", 1)[-1]) for item in arrays},
+        {
+            entity_name_stem(item.path.rsplit(".", 1)[-1]) for item in arrays
+            if any(_is_entity_key(field) for field in item.item_fields)
+        },
+    )
+
+
+def build_short_result_id_map(result_ids: Sequence[str]) -> Dict[str, str]:
     normalized: Dict[str, str] = {str(rid): str(rid) for rid in result_ids}
     uuid_ids = [str(rid) for rid in result_ids if _UUID_RESULT_ID_RE.match(str(rid))]
     if not uuid_ids:
@@ -155,6 +188,7 @@ def prepare_tool_results_for_prompt(
     url_rewriter: Optional[Callable[[str, ToolCallResultRecord], str]] = None,
     paired_url_rewriter: Optional[Callable[[str, ToolCallResultRecord], str]] = None,
     paired_url_step_ids: Optional[Set[str]] = None,
+    named_model_tables: Optional[Set[str]] = None,
 ) -> Dict[str, ToolResultPromptInfo]:
     prompt_info: Dict[str, ToolResultPromptInfo] = {}
     rows: List[Tuple] = []
@@ -163,7 +197,8 @@ def prepare_tool_results_for_prompt(
     if fresh_tool_call_step_id:
         fresh_step_ids.add(fresh_tool_call_step_id)
     paired_step_ids = set(paired_url_step_ids or ())
-    short_id_map = _build_short_result_id_map(
+    model_tables = {table.casefold() for table in (named_model_tables or ())}
+    short_id_map = build_short_result_id_map(
         [
             record.step_id
             for record in records
@@ -196,9 +231,7 @@ def prepare_tool_results_for_prompt(
         if is_analysis_eligible and (stored_json or (is_fresh_tool_call and meta.get("is_json"))):
             payload = _load_json_payload(stored_json, analysis)
             if payload is not None:
-                json_digest = None
-                if analysis and analysis.json_analysis:
-                    json_digest = analysis.json_analysis.json_digest
+                json_digest = analysis.json_analysis.json_digest if analysis and analysis.json_analysis else None
                 if json_digest and json_digest.action in {"skip", "inspect_manually"}:
                     payload = None
             if payload is not None:
@@ -217,7 +250,9 @@ def prepare_tool_results_for_prompt(
             context_hint = hint_from_unstructured_text(analysis_text)
 
         preview_source = (
-            stored_text
+            stored_json
+            if is_fresh_tool_call and stored_json is not None and meta.get("result_json_path")
+            else stored_text
             if stored_text is not None
             else analysis.prepared_text if analysis and analysis.prepared_text is not None
             else result_text
@@ -229,6 +264,31 @@ def prepare_tool_results_for_prompt(
             tool_name=record.tool_name,
             is_fresh_tool_call=is_fresh_tool_call,
         )
+        source_import_prefix = ""
+        keep_source_import_hint = is_source_bearing_tool(record.tool_name) and is_fresh_tool_call
+        if keep_source_import_hint:
+            arrays = _entity_arrays(analysis)
+            model_entities = {entity_name_stem(table) for table in model_tables}
+            relevant_arrays = tuple(
+                item for item in arrays
+                if any(_is_entity_key(field) for field in item.item_fields)
+                or entity_name_stem(item.path.rsplit(".", 1)[-1]) in model_entities
+            )
+            schemas = [f"{item.path}({','.join(item.item_fields[:10])})" for item in relevant_arrays]
+            matching_arrays = tuple(
+                item for item in relevant_arrays
+                if entity_name_stem(item.path.rsplit(".", 1)[-1]) in model_entities
+            )
+            if schemas and matching_arrays:
+                source_import_prefix = (
+                    f"[SOURCE ARRAYS result_id={result_id}; stored paths: {'; '.join(schemas)}. "
+                    "NEXT: output one sqlite_batch only. In that single batch, create/evolve keyed model tables for "
+                    "every listed entity array, import each exact path with INSERT ... SELECT/json_each, then SELECT "
+                    "bounded task-relevant rows from every updated table using stable-ID filters/joins—not counts or "
+                    "whole-table dumps. Derive all facts, URLs, and write keys from j.value. This ordinary evidence "
+                    "task never changes __agent_config/__agent_skills. No pre-read, refetch, blob inspection, copied "
+                    "literals, or splitting arrays across calls.]\n"
+                )
         has_focus = "\nFOCUS:\n" in (context_hint or "")
         if has_focus and not is_inline:
             preview_text = None
@@ -240,11 +300,27 @@ def prepare_tool_results_for_prompt(
         if active_url_rewriter:
             if context_hint:
                 context_hint = active_url_rewriter(context_hint, record)
-            if preview_text:
+            if preview_text and not source_import_prefix:
                 preview_text = active_url_rewriter(preview_text, record)
-        if "$[link:" in f"{context_hint or ''}{preview_text or ''}":
+        has_link_tokens = "$[link:" in f"{context_hint or ''}{preview_text or ''}"
+        if has_link_tokens:
             context_hint = _mark_missing_item_links(context_hint or "") or None
             preview_text = _mark_missing_item_links(preview_text or "")
+        if preview_text and has_link_tokens and keep_source_import_hint and not source_import_prefix:
+            preview_text = (
+                "[VERIFIED LINK PRESENTATION: when presenting these sourced items, anchor each token on its exact "
+                "entity name using the active "
+                "surface syntax ([entity](token) or <a href='token'>entity</a>), never a host, URL, generic "
+                "'link/page', or related entity. No separate URL/link column unless requested. "
+                "For an owner report with 4+ items, say "
+                "Covered N/N and use one channel-appropriate table for every item/requested field. Say Not returned "
+                "where a requested URL is absent. Without a preceding SOURCE ARRAYS directive, use this visible "
+                "source directly rather than creating or querying SQLite. This link guidance does not change the "
+                "requested audience or action.]\n"
+                f"{preview_text}"
+            )
+        if source_import_prefix:
+            preview_text = f"{source_import_prefix}{preview_text or ''}"
 
         is_scrape_markdown = _is_scrape_as_markdown_tool(record.tool_name)
         meta_text = _format_meta_text(
@@ -269,7 +345,7 @@ def prepare_tool_results_for_prompt(
             meta=meta_text,
             preview_text=preview_text,
             is_inline=is_inline,
-            schema_text=None,  # Replaced by analysis in meta_text
+            source_reconciliation_directive=source_import_prefix or None,
         )
 
         if stored_in_db:
@@ -611,7 +687,7 @@ def _summarize_result(
     elif is_json:
         try:
             parsed = json.loads(result_text)
-            json_type = _json_type(parsed)
+            json_type = _get_json_type(parsed)
             if isinstance(parsed, dict):
                 top_keys = list(parsed.keys())[:MAX_TOP_KEYS]
         except Exception:
@@ -669,16 +745,6 @@ def _summarize_result(
     return meta, result_json, result_text_store, analysis
 
 
-def _wrap_as_sqlite_result(result_text: str, full_bytes: int) -> str:
-    return (
-        f"[FULL RESULT ({full_bytes} chars) - ONE-TIME VIEW. "
-        f"Use this visible result now. Reply directly for a simple answer unless it updates an established named domain model. "
-        f"Use SQL to reconcile that model or for exact filtering/ranking across sizable or multiple results, joins, aggregation, chart input, or truncated data; do not query merely to reread or parse. "
-        f"Next turn shows only preview]\n"
-        f"{result_text}"
-    )
-
-
 def _build_prompt_preview(
     result_text: str,
     full_bytes: int,
@@ -687,15 +753,15 @@ def _build_prompt_preview(
     tool_name: str,
     is_fresh_tool_call: bool = False,
 ) -> Tuple[Optional[str], bool]:
+    is_sqlite = tool_name in EXCLUDED_TOOL_NAMES or tool_name.startswith("sqlite")
     if full_bytes <= SMALL_RESULT_ALWAYS_INLINE:
         return result_text, True
 
-    is_sqlite = tool_name in EXCLUDED_TOOL_NAMES or tool_name.startswith("sqlite")
     tiers = PREVIEW_TIERS_SQLITE if is_sqlite else PREVIEW_TIERS_EXTERNAL
     tier_count = len(tiers)
 
     if is_fresh_tool_call and full_bytes <= FRESH_RESULT_INLINE_THRESHOLD:
-        return _wrap_as_sqlite_result(result_text, full_bytes), True
+        return f"[FULL RESULT ({full_bytes} chars) - ONE-TIME VIEW; later turns show a preview]\n{result_text}", True
 
     if recency_position is None or recency_position >= tier_count:
         return None, False
@@ -790,7 +856,7 @@ def _format_meta_text(
             )
 
     if context_hint:
-        meta_line += f"\nUse visible FOCUS directly when it covers the request; query only missing facts.\n{context_hint}"
+        meta_line += f"\nFor an unrelated one-off, use visible FOCUS directly when it covers the request; query only missing facts.\n{context_hint}"
 
     return meta_line
 
@@ -801,22 +867,6 @@ def _truncate_to_bytes(text: str, max_bytes: int) -> Tuple[str, int]:
         return text, 0
     truncated = encoded[:max_bytes].decode("utf-8", errors="ignore")
     return truncated, len(encoded) - max_bytes
-
-
-def _json_type(value: object) -> str:
-    if isinstance(value, dict):
-        return "object"
-    if isinstance(value, list):
-        return "array"
-    if isinstance(value, str):
-        return "string"
-    if isinstance(value, bool):
-        return "boolean"
-    if isinstance(value, (int, float)):
-        return "number"
-    if value is None:
-        return "null"
-    return "unknown"
 
 
 def _is_probably_binary(text: str) -> bool:

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -566,6 +566,141 @@ def _fix_json_key_vs_alias(sql: str, error_msg: str) -> tuple[str, str | None]:
     return sql, None
 
 
+def _fix_insert_select_upsert_ambiguity(sql: str) -> tuple[str, str | None]:
+    """Disambiguate SQLite UPSERTs whose SELECT has a FROM but no WHERE.
+
+    SQLite can parse the ``ON`` in ``INSERT ... SELECT ... FROM ... ON CONFLICT``
+    as a join clause. A no-op top-level WHERE makes the intended UPSERT grammar
+    unambiguous. Nested WHERE clauses do not resolve that ambiguity.
+    """
+    words: list[tuple[str, int, int, int]] = []
+    depth = 0
+    index = 0
+    length = len(sql)
+
+    while index < length:
+        char = sql[index]
+        next_char = sql[index + 1] if index + 1 < length else ""
+
+        if char == "-" and next_char == "-":
+            newline = sql.find("\n", index + 2)
+            index = length if newline == -1 else newline + 1
+            continue
+        if char == "/" and next_char == "*":
+            closing = sql.find("*/", index + 2)
+            index = length if closing == -1 else closing + 2
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            index += 1
+            while index < length:
+                if sql[index] == quote:
+                    if index + 1 < length and sql[index + 1] == quote:
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            continue
+        if char == "[":
+            closing = sql.find("]", index + 1)
+            index = length if closing == -1 else closing + 1
+            continue
+        if char == "(":
+            depth += 1
+            index += 1
+            continue
+        if char == ")":
+            depth = max(0, depth - 1)
+            index += 1
+            continue
+        if char.isalpha() or char == "_":
+            end = index + 1
+            while end < length and (sql[end].isalnum() or sql[end] in {"_", "$"}):
+                end += 1
+            words.append((sql[index:end].upper(), index, end, depth))
+            index = end
+            continue
+        index += 1
+
+    insert_index = next(
+        (position for position, (word, _start, _end, level) in enumerate(words)
+         if word == "INSERT" and level == 0),
+        None,
+    )
+    if insert_index is None:
+        return sql, None
+
+    action_index = next(
+        (
+            position
+            for position in range(insert_index + 1, len(words) - 1)
+            if words[position][0] == "DO"
+            and words[position][3] == 0
+            and words[position + 1][0] in {"NOTHING", "UPDATE"}
+            and words[position + 1][3] == 0
+        ),
+        None,
+    )
+    if action_index is None:
+        return sql, None
+
+    conflict_index = next(
+        (
+            position
+            for position in range(action_index - 1, insert_index, -1)
+            if words[position][0] == "ON"
+            and words[position][3] == 0
+            and words[position + 1][0] == "CONFLICT"
+            and words[position + 1][3] == 0
+        ),
+        None,
+    )
+    if conflict_index is None:
+        return sql, None
+
+    select_index = next(
+        (
+            position
+            for position in range(conflict_index - 1, insert_index, -1)
+            if words[position][0] == "SELECT" and words[position][3] == 0
+        ),
+        None,
+    )
+    if select_index is None:
+        return sql, None
+
+    from_index = next(
+        (
+            position
+            for position in range(select_index + 1, conflict_index)
+            if words[position][0] == "FROM" and words[position][3] == 0
+        ),
+        None,
+    )
+    if from_index is None:
+        return sql, None
+
+    if any(
+        word == "WHERE" and level == 0
+        for word, _start, _end, level in words[from_index + 1:conflict_index]
+    ):
+        return sql, None
+
+    clause_words = {"GROUP", "HAVING", "WINDOW", "ORDER", "LIMIT", "UNION", "EXCEPT", "INTERSECT"}
+    insertion_index = next(
+        (
+            words[position][1]
+            for position in range(from_index + 1, conflict_index)
+            if words[position][0] in clause_words and words[position][3] == 0
+        ),
+        words[conflict_index][1],
+    )
+    separator = "" if sql[:insertion_index].endswith((" ", "\t", "\r", "\n")) else " "
+    fixed = sql[:insertion_index] + separator + "WHERE 1=1 " + sql[insertion_index:]
+    return fixed, "added WHERE 1=1 to disambiguate INSERT ... SELECT ... ON CONFLICT"
+
+
 def _apply_all_sql_fixes(sql: str, error_msg: str = "") -> tuple[str, list[str]]:
     """Apply all SQL fixes and return (fixed_sql, list_of_corrections)."""
     corrections = []
@@ -595,6 +730,10 @@ def _apply_all_sql_fixes(sql: str, error_msg: str = "") -> tuple[str, list[str]]
         corrections.append(fix)
 
     sql, fix = _fix_dialect_syntax(sql)
+    if fix:
+        corrections.append(fix)
+
+    sql, fix = _fix_insert_select_upsert_ambiguity(sql)
     if fix:
         corrections.append(fix)
 
@@ -1365,6 +1504,7 @@ def _execute_with_autocorrections(
         try:
             consume_patch_text_error()
             start_query_timer(conn)
+            changes_before = conn.total_changes
             cur.execute(current_query)
             if cur.description is not None:
                 columns = [col[0] for col in cur.description]
@@ -1379,7 +1519,7 @@ def _execute_with_autocorrections(
                 if reporting_note:
                     result_entry["reporting_note"] = reporting_note.strip()
             else:
-                affected = cur.rowcount if cur.rowcount is not None else 0
+                affected = max(cur.rowcount or 0, conn.total_changes - changes_before)
                 msg = f"Query {idx} affected {max(0, affected)} rows."
                 zero_rows_warning = False
                 query_upper = current_query.upper()
@@ -1753,11 +1893,12 @@ def _execute_sqlite_batch_inner(
 
         blocking_advisories = [advisory for advisory in advisories if advisory.blocking]
         if blocking_advisories:
+            primary = [item for item in blocking_advisories if item.code == "source_facts_copied_into_model"]
             return {
                 "status": "error",
                 "results": [],
                 "db_size_mb": round(_get_db_size_mb(db_path), 2),
-                "message": " ".join(advisory.message for advisory in blocking_advisories),
+                "message": " ".join(advisory.message for advisory in (primary or blocking_advisories)),
                 "retryable": True,
                 "advisories": [
                     {"code": advisory.code, "message": advisory.message}
@@ -1892,9 +2033,13 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
         "function": {
             "name": "sqlite_batch",
             "description": (
-                "SQLite world model + hard logic. Current complete rows are truth: answer without refetching sources. Read before memory. Tool output isn't state: keyed rows/children belong in the model. Reconcile relations, evolve schema, then query; only unrelated one-offs bypass it. Reusable: "
-                "PRIMARY KEY/UNIQUE + provenance; CTAS is disposable. Normalize children; use joins/set logic/counts/ranking; return needed rows. Import tool output via INSERT ... SELECT/json_each from __tool_results, never copied rows; batch siblings by IN/tool_name. Prefer custom tools writing keyed models for imports/API fan-out. "
-                "http_request JSON: result_json $.content. No ATTACH. `sql` uses semicolons; apostrophe: 'O''Brien'. grep_context_all/split_sections arrays: json_each + ctx.value, not json_extract."
+                "SQLite world model + exact logic. Fetch alone; next completion reconcile and SELECT. SOURCE ARRAYS "
+                "lists paths. Every sourced SET/VALUES and write WHERE/ON key must derive inside INSERT ... SELECT / "
+                "UPDATE ... FROM __tool_results/json_each; only paths/current result_id/tool_name may be literals, "
+                "never facts/URLs/keys. Reconcile entities/relations, evolve schema, then SELECT the model before deciding/reporting. Use "
+                "UNIQUE keys + provenance; normalize children; joins/sets/counts/ranking; CTAS is one-off. http_request "
+                "JSON: result_json $.content. INSERT SELECT needs WHERE before ON CONFLICT. No ATTACH. SQL uses "
+                "semicolons; apostrophe: 'O''Brien'. grep_context_all/split_sections arrays: json_each + ctx.value."
             ),
             "parameters": {
                 "type": "object",

--- a/api/agent/tools/sqlite_query_quality.py
+++ b/api/agent/tools/sqlite_query_quality.py
@@ -11,6 +11,10 @@ from sqlparse.sql import Function, Parenthesis, Values, Where
 
 TOOL_RESULTS_RE = re.compile(r'\b(?:from|join)\s+"?__tool_results"?\b', re.I)
 RESULT_ID_EQ_RE = re.compile(r"\b(?:[a-z_]\w*\.)?result_id\s*=\s*(['\"])(?P<id>[^'\"]+)\1", re.I)
+RESULT_ID_SINGLE_LITERAL_RE = re.compile(
+    r"\b(?:[a-z_]\w*\.)?result_id\s*(?:=\s*(['\"])(?P<eq>[^'\"]+)\1|in\s*\(\s*(['\"])(?P<in>[^'\"]+)\3\s*\))",
+    re.I,
+)
 RESULT_ID_IN_RE = re.compile(r"\b(?:[a-z_]\w*\.)?result_id\s+in\s*\((?P<values>[^)]*)\)", re.I | re.S)
 RESULT_ID_IN_VALUE_RE = re.compile(r"(?:'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|\?|[:@$][a-z_]\w*)", re.I)
 CREATE_TABLE_RE = re.compile(r'\bcreate\s+(?:temp(?:orary)?\s+)?table\s+(?:if\s+not\s+exists\s+)?"?(?P<name>[a-z_]\w*)"?', re.I)
@@ -60,10 +64,10 @@ SINGLE_IMPORT_MESSAGE = (
     "with one shaped query over tool_name or result_id IN (...)."
 )
 SOURCE_LITERAL_COPY_MESSAGE = (
-    "Query not executed: this model write copies source facts into SQL literals. Derive complete rows from "
-    "__tool_results in the same INSERT/UPDATE, keyed by stable ID; refresh every mutable/provenance field. Use "
-    "tool_name or visible result_id; don't fetch/copy the blob. For http_request JSON, nested arrays are under "
-    "$.content; use the actual array key. Then query the model."
+    "Query not executed: a source-derived model write used visible facts or URLs as SQL literals. Derive every "
+    "sourced field in the INSERT/UPDATE SELECT/json_each over all relevant __tool_results; only payload paths and "
+    "current result_id/tool_name may be literals. Use stable keys, refresh provenance, omit unavailable URLs, then "
+    "query the model."
 )
 COUNT_FIELDS = (
     "statement_count", "tool_result_statement_count", "single_result_id_filters", "single_derived_result_filters", "single_tool_result_imports",
@@ -188,11 +192,7 @@ def build_tool_result_query_advisories(
         advisories.append(_advisory("tool_result_ctas", "CTAS has no stable identity. Use it only for a disposable extract; reusable models need explicit CREATE TABLE with PRIMARY KEY/UNIQUE, then aggregate INSERT."))
     if available_tool_result_rows < 2:
         if copied_model_tables:
-            advisories.append(_advisory(
-                "source_facts_copied_into_model",
-                SOURCE_LITERAL_COPY_MESSAGE,
-                blocking=True,
-            ))
+            advisories.append(_advisory("source_facts_copied_into_model", SOURCE_LITERAL_COPY_MESSAGE, blocking=True))
         return advisories
     model_advisories, advisories = advisories, []
     literal_select_rows, copied_provenance_urls = _manual_import_evidence(sql_values, tool_result_payloads)
@@ -204,16 +204,18 @@ def build_tool_result_query_advisories(
         advisories.append(_advisory("tool_result_blob_fetch_loop", BLOB_LOOP_MESSAGE, blocking=True))
     elif summary.direct_result_text_fetches:
         advisories.append(_advisory("single_tool_result_blob_fetch", "This fetched one full result_text blob while multiple tool results are available. For multi-source synthesis, query the needed rows together; use substr(result_text,1,N) only for previews."))
-    if summary.single_result_id_filters >= 2 and summary.direct_result_text_fetches < 2:
+    relation_import_tables = source_derived_model_mutation_tables(sql_values)
+    relation_import_ids = tuple(match.group("eq") or match.group("in") for sql in sql_values for match in RESULT_ID_SINGLE_LITERAL_RE.finditer(sql))
+    relation_import_batch = (
+        len(relation_import_tables) == len(relation_import_ids) == summary.single_result_id_filters > 1
+        and len(set(relation_import_ids)) == 1
+    )
+    if summary.single_result_id_filters >= 2 and summary.direct_result_text_fetches < 2 and not relation_import_batch:
         advisories.append(_advisory("tool_result_row_loop", ROW_LOOP_MESSAGE, blocking=True))
-    elif summary.single_tool_result_imports:
+    elif summary.single_tool_result_imports and not relation_import_batch:
         advisories.append(_advisory("single_tool_result_import", SINGLE_IMPORT_MESSAGE))
     if copied_model_tables:
-        advisories.append(_advisory(
-            "source_facts_copied_into_model",
-            SOURCE_LITERAL_COPY_MESSAGE,
-            blocking=True,
-        ))
+        advisories.append(_advisory("source_facts_copied_into_model", SOURCE_LITERAL_COPY_MESSAGE, blocking=True))
     return advisories + model_advisories
 
 
@@ -385,16 +387,22 @@ def _source_literal_copy_tables(
                 continue
             matched_literals = set()
             copied_url = False
-            previous_token = None
-            for token in _mutation_value_tokens(statement, match.group("operation")):
-                if token.is_whitespace or token.ttype in sql_tokens.Comment:
-                    continue
+            value_tokens = [
+                token for token in _mutation_value_tokens(statement, match.group("operation"))
+                if not token.is_whitespace and token.ttype not in sql_tokens.Comment
+            ]
+            for index, token in enumerate(value_tokens):
+                previous_token = value_tokens[index - 1] if index else None
+                next_token = value_tokens[index + 1] if index + 1 < len(value_tokens) else None
                 is_json_selector = previous_token is not None and previous_token.value in {"->", "->>"}
-                previous_token = token
-                if token.ttype != sql_tokens.Literal.String.Single or is_json_selector:
+                is_case_match = (
+                    previous_token is not None and previous_token.normalized in {"WHEN", "THEN", "ELSE"}
+                    or next_token is not None and next_token.normalized in {"THEN", "ELSE", "END"}
+                )
+                if token.ttype != sql_tokens.Literal.String.Single or is_json_selector or is_case_match:
                     continue
                 value = token.value[1:-1].replace("''", "'")
-                if len(value) < 6 or value not in payload_text:
+                if len(value) < 6 or value not in payload_text or re.fullmatch(r"[A-Za-z_]\w*=", value):
                     continue
                 matched_literals.add(value)
                 copied_url = copied_url or bool(URL_RE.fullmatch(value))

--- a/api/agent/tools/tests/test_attachment_guidance.py
+++ b/api/agent/tools/tests/test_attachment_guidance.py
@@ -10,10 +10,7 @@ from api.agent.tools.peer_dm import get_send_agent_message_tool
 from api.agent.tools.send_discord_message import get_send_discord_message_tool
 from api.agent.tools.sms_sender import get_send_sms_tool
 from api.agent.tools.web_chat_sender import get_send_chat_tool
-from api.agent.core.prompt_context import (
-    _get_email_formatting_guidance,
-    _get_web_chat_formatting_guidance,
-)
+from api.agent.core.prompt_context import _get_formatting_guidance
 
 
 @tag("batch_attachment_guidance")
@@ -78,21 +75,23 @@ class AttachmentGuidanceTests(SimpleTestCase):
         discord_tool = get_send_discord_message_tool()
         peer_tool = get_send_agent_message_tool()
         sms_tool = get_send_sms_tool()
-        email_guidance = _get_email_formatting_guidance()
-        chat_guidance = _get_web_chat_formatting_guidance()
+        surface_guidance = _get_formatting_guidance()
 
-        self.assertIn("reports/dashboards", email_guidance)
+        self.assertIn("reports/dashboards", surface_guidance)
         self.assertIn("Never leave metrics in plain lists", email_tool["function"]["description"])
         self.assertIn("styled tables or metric blocks", email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"])
         self.assertIn("false when this email is the requested final delivery", email_tool["function"]["parameters"]["properties"]["will_continue_work"]["description"])
         self.assertIn("Do not use this to simulate or confirm an email/SMS delivery", chat_tool["function"]["description"])
-        self.assertIn("Start with the answer/main finding", chat_guidance)
-        self.assertIn("Address known recipients once", chat_guidance)
-        self.assertIn("agent-name self-intros", chat_guidance)
+        self.assertIn("Start with the answer/main finding", surface_guidance)
+        self.assertIn("Address known recipients once", surface_guidance)
+        self.assertIn("agent-name self-intros", surface_guidance)
         body_guidance = chat_tool["function"]["parameters"]["properties"]["body"]["description"]
-        self.assertIn("Keep chat/outreach light", body_guidance)
-        self.assertIn("Reports comparing 4+ peers", body_guidance)
-        self.assertIn("use one table", body_guidance)
+        self.assertIn("Owner report with 4+ items", body_guidance)
+        self.assertIn("Covered N/N", body_guidance)
+        self.assertIn("one requested-field Markdown table", body_guidance)
+        self.assertIn("exact entity name", body_guidance)
+        self.assertIn("other chat/outreach light", body_guidance)
+        self.assertNotIn("$[link:id]", body_guidance)
         delivery_fields = (
             email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"],
             body_guidance,

--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -294,8 +294,9 @@ def get_send_chat_tool() -> Dict[str, Any]:
                     "body": {
                         "type": "string",
                         "description": (
-                            "Natural recipient text; no dash punctuation between phrases. Keep chat/outreach light. Reports comparing 4+ peers use one table. "
-                            "Do not pass tool-call/XML syntax; it is sent literally."
+                            "No dash punctuation or pre-work status for short/finite work. Owner report with 4+ items: "
+                            "include `Covered N/N` and one requested-field "
+                            "Markdown table; link exact entity names only with provided tokens. Keep other chat/outreach light. "
                         ),
                     },
                     "to_address": {

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import json
+import re
 from copy import deepcopy
 from dataclasses import dataclass, field
 
@@ -9,6 +10,7 @@ from api.agent.core.processing_flags import get_human_inbound_generation
 from api.agent.files.filespace_service import write_bytes_to_dir
 from api.agent.tools.eval_synthetic_tools import EVAL_SYNTHETIC_TOOL_DEFINITIONS, EVAL_SYNTHETIC_TOOL_SERVER, is_eval_synthetic_tool_name
 from api.agent.tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
+from api.agent.tools.sqlite_query_quality import _structural_sql
 from api.agent.tools.sqlite_state import agent_sqlite_db
 from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
 from api.evals.base import EvalScenario, ScenarioTask
@@ -16,6 +18,7 @@ from api.evals.execution import ScenarioExecutionTools
 from api.evals.registry import ScenarioRegistry, register_scenario
 from api.evals.tool_params import resolved_tool_param
 from api.evals.stop_policy import (
+    split_sql_statements,
     sqlite_batch_is_only_eval_bookkeeping_read,
     sqlite_batch_is_only_planning_state_read,
     sqlite_batch_is_only_planning_state_mutation,
@@ -57,9 +60,12 @@ CHARTER_ADDS_INFERRED_PREFERENCE_PRESERVING_EXISTING = "charter_adds_inferred_pr
 CHARTER_EXPANDS_SPARSE_CHARTER_WITH_DETAIL = "charter_expands_sparse_charter_with_detail"
 CHARTER_NARROWS_SCOPE_PRESERVING_UNRELATED_GUIDANCE = "charter_narrows_scope_preserving_unrelated_guidance"
 CHARTER_IGNORES_ONE_OFF_PREFERENCE = "charter_ignores_one_off_preference"
+CHARTER_IGNORES_BATCH_SCOPED_PREFERENCE = "charter_ignores_batch_scoped_preference"
 CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION = "charter_adds_feedback_rule_from_correction"
 CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD = "charter_adds_plain_preference_without_save_word"
 CHARTER_PATCHES_DIRECT_STYLE_CORRECTION = "charter_patches_direct_style_correction"
+CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK = "charter_patches_evaluative_output_feedback"
+CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK = "charter_interprets_ambiguous_operating_feedback"
 CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION = "charter_records_cli_github_secrets_correction"
 CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW = "charter_judge_preserves_cli_github_secret_workflow"
 
@@ -373,9 +379,12 @@ CHARTER_MEMORY_MICRO_SCENARIO_SLUGS = [
     CHARTER_EXPANDS_SPARSE_CHARTER_WITH_DETAIL,
     CHARTER_NARROWS_SCOPE_PRESERVING_UNRELATED_GUIDANCE,
     CHARTER_IGNORES_ONE_OFF_PREFERENCE,
+    CHARTER_IGNORES_BATCH_SCOPED_PREFERENCE,
     CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION,
     CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD,
     CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
+    CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK,
+    CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK,
     CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION,
     CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
 ]
@@ -1888,18 +1897,19 @@ class CharterMemoryScenario(BehaviorMicroScenario):
     success_summary = ""
     failure_summary = ""
     expect_charter_mutation = True
+    verify_feedback_reply = False
+    feedback_reply_options = {}
 
     def _eval_stop_policy(self):
         if self.expect_charter_mutation:
+            required_calls = [
+                {"tool_name": "sqlite_batch", "agent_config_field": "charter", "after_execution": True}
+            ]
+            if self.verify_feedback_reply:
+                required_calls.append({"tool_name": "send_chat_message", "after_execution": True})
             return {
                 "ignore_sqlite_agent_config_mutations": False,
-                "stop_when_all_seen": [
-                    {
-                        "tool_name": "sqlite_batch",
-                        "agent_config_field": "charter",
-                        "after_execution": True,
-                    }
-                ],
+                "stop_when_all_seen": required_calls,
             }
         return {
             "ignore_sqlite_agent_config_mutations": False,
@@ -1980,10 +1990,20 @@ class CharterMemoryScenario(BehaviorMicroScenario):
         return get_agent_config_mutation_calls_for_run(run_id, after=inbound.timestamp)
 
     def _charter_check(self, agent, mutation_calls):
+        if not self.expect_charter_mutation:
+            passed = not mutation_calls and agent.charter == self.existing_charter
+            return passed, f"mutation_count={len(mutation_calls)}, charter={agent.charter!r}."
         raise NotImplementedError
 
     def _additional_charter_check(self, agent, run_id, inbound):
-        return True, ""
+        if not self.verify_feedback_reply:
+            return True, ""
+        return _one_shot_charter_feedback_check(
+            run_id,
+            inbound,
+            existing_charter=self.existing_charter,
+            **self.feedback_reply_options,
+        )
 
     def run(self, run_id, agent_id):
         self._seed_charter_agent(agent_id)
@@ -1998,6 +2018,21 @@ class CharterMemoryScenario(BehaviorMicroScenario):
         mutation_calls = self._mutation_calls_for_verification(run_id, inbound)
         agent = PersistentAgent.objects.get(id=agent_id)
         passed, failure_detail = self._charter_check(agent, mutation_calls)
+        rescue_steps = PersistentAgentStep.objects.filter(
+            agent=agent, created_at__gt=inbound.timestamp,
+            description__startswith="Skipped unrelated __agent_config",
+        ).count() if not self.expect_charter_mutation else 0
+        passed = passed and not rescue_steps
+        if rescue_steps:
+            failure_detail = f"{failure_detail}; runtime_config_rescues={rescue_steps}"
+        schedule_mutations = [
+            call
+            for call in get_tool_calls_for_run(run_id, after=inbound.timestamp, tool_names={"sqlite_batch"})
+            if sqlite_batch_mutates_agent_config_field(call, "schedule")
+        ]
+        passed = passed and not schedule_mutations
+        if schedule_mutations:
+            failure_detail = f"{failure_detail}; unexpected_schedule_mutations={len(schedule_mutations)}"
         additional_passed, additional_detail = self._additional_charter_check(agent, run_id, inbound)
         passed = passed and additional_passed
         if additional_detail:
@@ -2173,9 +2208,228 @@ class CharterIgnoresOneOffPreferenceScenario(CharterMemoryScenario):
     failure_summary = "Expected no config mutation for one-off preference"
     expect_charter_mutation = False
 
-    def _charter_check(self, agent, mutation_calls):
-        passed = not mutation_calls and agent.charter == self.existing_charter
-        return passed, f"mutation_count={len(mutation_calls)}, charter={agent.charter!r}."
+@register_scenario
+class CharterIgnoresBatchScopedPreferenceScenario(CharterMemoryScenario):
+    slug = CHARTER_IGNORES_BATCH_SCOPED_PREFERENCE
+    description = "A preference scoped to today's batch should not mutate the charter."
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_no_charter_mutation", assertion_type="manual"),
+    ]
+    existing_charter = (
+        "Review vendor renewals monthly. Prioritize by renewal date. Include the owner and renewal risk."
+    )
+    prior_outbound_body = (
+        "Renewal update: Acme is due in 90 days. The security review is open and procurement is waiting."
+    )
+    prompt = "only this batch, those long updates aren't useful. put security reviews first and keep each note super short"
+    verification_task_name = "verify_no_charter_mutation"
+    success_summary = "Agent kept the batch-scoped preference in the current task only."
+    failure_summary = "Expected no config mutation for a preference scoped to today's batch"
+    expect_charter_mutation = False
+
+    def _additional_charter_check(self, agent, run_id, inbound):
+        calls = [
+            call for call in get_tool_calls_for_run(run_id, after=inbound.timestamp)
+            if call.tool_name != "sleep_until_next_trigger"
+        ]
+        if len(calls) != 1 or calls[0].tool_name != "send_chat_message" or str(calls[0].status).lower() != "complete":
+            return False, f"expected one same-channel first action, found {[(call.tool_name, call.status) for call in calls]}"
+
+        call = calls[0]
+        body = str(resolved_tool_param(call, "body") or "")
+        normalized = body.casefold()
+        acknowledges_scope = "security" in normalized and any(
+            term in normalized for term in ("short", "brief", "concise")
+        )
+        claims_permanence = any(term in normalized for term in ("going forward", "from now on", "always"))
+        terminal = resolved_tool_param(call, "will_continue_work") is False
+        clean = not any(term in normalized for term in ("charter", "config", "saved", "updated my instructions"))
+        one_shot, completion_detail = _completion_actions_match(
+            run_id, inbound, calls, ("send_chat_message",)
+        )
+        passed = (
+            one_shot and acknowledges_scope and not claims_permanence
+            and terminal and clean and "?" not in body and len(body) <= 300
+        )
+        return passed, (
+            f"call_count={len(calls)}, acknowledges_scope={acknowledges_scope}, "
+            f"claims_permanence={claims_permanence}, "
+            f"terminal={terminal}, clean={clean}, {completion_detail}, body={body!r}"
+        )
+
+
+def _charter_clauses(value):
+    return [
+        re.sub(r"\s+", " ", clause).strip(" -\t")
+        for clause in re.split(r"[.;\n]+", (value or "").casefold())
+        if clause.strip(" -\t")
+    ]
+
+
+def _keeps_clauses(value, *clauses):
+    charter = re.sub(r"\s+", " ", (value or "").casefold())
+    return all(re.sub(r"\s+", " ", clause.casefold()) in charter for clause in clauses)
+
+
+def _has_clause_rule(value, *pattern_groups, reject=()):
+    return any(
+        all(any(re.search(pattern, clause) for pattern in group) for group in pattern_groups)
+        and not any(re.search(pattern, clause) for pattern in reject)
+        for clause in _charter_clauses(value)
+    )
+
+
+def _requires_candidate_links(value):
+    return _has_clause_rule(
+        value,
+        (r"\b(?:candidate|applicant|prospect|lead|recruit|report|update)\w*\b",),
+        (r"\b(?:links?|urls?|profiles?|citations?)\b",),
+        (r"\b(?:include|add|provide|attach|cite|link|must|should|required)\w*\b", r"\bnever\b.+\bwithout\b"),
+        (r"\b(?:verified|confirmed|known|available|sourced|source[ -]backed|evidence[ -]backed|retrieved)\b",),
+        reject=(
+            r"\b(?:do not|don't|never|omit|skip|avoid)\b.{0,35}\b(?:include|add|provide|attach|link|cite)\w*\b",
+            r"\b(?:even if|whether or not|regardless of)\b.{0,35}\b(?:unavailable|unverified|unknown|missing)\b",
+        ),
+    )
+
+
+def _requires_natural_dashless_style(value):
+    natural = _has_clause_rule(
+        value,
+        (r"\b(?:message|note|outreach|writing|style|tone|voice|copy)\w*\b",),
+        (r"\b(?:natural|human|conversational|authentic|plainspoken)\b", r"\bavoid\b.{0,25}\b(?:template|canned|robotic|automated)\w*\b"),
+        reject=(r"\b(?:use|prefer)\b.{0,25}\b(?:template|canned|robotic|automated)\w*\b",),
+    )
+    dashless = _has_clause_rule(
+        value,
+        (r"\b(?:dashes?|hyphens?)\b",),
+        (r"\b(?:avoid|never|without|omit|skip|stop|no|do not|don't)\b",),
+    )
+    return natural and dashless
+
+
+def _requires_comparison_table_takeaways(value):
+    positive = (
+        r"\b(?:use|prefer|include|add|provide|present|show|format|structure|organi[sz]e|summari[sz]e|"
+        r"keep|make|default|requir)\w*\b",
+    )
+    return all(
+        _has_clause_rule(
+            value,
+            (item,),
+            positive,
+            reject=(
+                rf"\b(?:do not|don't|never|avoid|omit|skip)\b.{{0,40}}{item}",
+                rf"{item}.{{0,40}}\b(?:should|must|are|is)\s+(?:not|never|avoided|omitted)\b",
+            ),
+        )
+        for item in (
+            r"\b(?:comparison\s+)?tables?\b",
+            r"\b(?:bullets?|bullet[ -]points?|takeaways?)\b",
+        )
+    )
+
+
+def _requires_low_recipient_effort(value):
+    return _has_clause_rule(
+        value,
+        (r"\b(?:prospect|outreach|lead)s?\b",),
+        (r"\b(?:question|ask|answer|reply|respond)\w*\b",),
+        (
+            r"\b(?:easy|simple|quick|specific|concrete|low[ -]effort|low[ -]friction)\b",
+            r"\b(?:context|observation|insight)s?\b",
+            r"\b(?:reduce|minimi[sz]e|avoid)\w*\b.{0,35}\b(?:effort|work|burden|friction)\b",
+        ),
+        reject=(
+            r"\b(?:increase|maximi[sz]e|raise)\w*\b.{0,45}\b(?:effort|work|burden|friction)\b",
+            r"\b(?:hard|difficult|demanding)\b.{0,25}\b(?:answer|reply|respond)\w*\b",
+            r"\b(?:make|have|let)\b.{0,20}\b(?:them|recipient|prospect)\b.{0,25}\b(?:do|carry)\b.{0,15}\bwork\b",
+        ),
+    )
+
+
+def _requires_outcome_report(value):
+    return _has_clause_rule(
+        value,
+        (
+            r"\b(?:report|update|summary|recap|brief|message|tell|share|send|notify)\w*\b",
+            r"\b(?:come|report)\s+back\b",
+            r"\breturn\s+with\b",
+            r"\bpull\s+(?:the owner|them)\s+in\b",
+        ),
+        (r"\b(?:what changed|changed|changes?|outcomes?|results?|decisions?)\b",),
+        (r"\b(?:blockers?|impediments?|material risks?)\b",),
+        (r"\bnext (?:move|step|action)s?\b",),
+        reject=(
+            r"\b(?:do not|don't|never|omit|skip|exclude|without)\b.{0,60}"
+            r"\b(?:what changed|changes?|outcomes?|blockers?|impediments?|next (?:move|step|action)s?)\b",
+        ),
+    )
+
+
+def _requires_morgan_routing_boundary(value):
+    owner = r"\b(?:owner|user|me|andrew)\b"
+    routine_to_morgan = _has_clause_rule(
+        value,
+        (r"\b(?:routine|ordinary|standard|normal|day-to-day)\b",),
+        (r"\bmorgan\b",),
+        (r"\b(?:route|send|direct|forward|delegate|assign|handle|own|go|for)\w*\b",),
+    )
+    blockers_to_owner = _has_clause_rule(
+        value,
+        (r"\b(?:real|material|serious|major|significant|genuine)\s+blockers?\b",),
+        (owner,),
+        (r"\b(?:only|send|escalate|surface|flag|notify|involve|contact|pull|loop)\w*\b",),
+    )
+    clauses = _charter_clauses(value)
+    routine = r"(?:routine|ordinary|standard|normal|day-to-day)"
+    blocker = r"(?:real|material|serious|major|significant|genuine)\s+blockers?"
+    route = r"(?:route|send|direct|forward|delegate|assign)\w*"
+    reversed_boundary = any(
+        re.search(rf"\b{route}\b.{{0,45}}\b{routine}\b.{{0,45}}{owner}", clause)
+        or re.search(rf"\b{routine}\b.{{0,35}}\b(?:to|for)\s+(?:the\s+)?(?:owner|user|andrew)\b", clause)
+        or re.search(rf"\b{route}\b.{{0,45}}\b{blocker}\b.{{0,45}}\bmorgan\b", clause)
+        or re.search(rf"\b{blocker}\b.{{0,18}}\b(?:to|for)\s+morgan\b", clause)
+        for clause in clauses
+    )
+    return routine_to_morgan and blockers_to_owner and not reversed_boundary
+
+
+def _charter_patch_pairs(patch_sql):
+    return [
+        (old.replace("''", "'"), new.replace("''", "'"))
+        for old, new in re.findall(
+            r"patch_text\s*\(\s*charter\s*,\s*'((?:''|[^'])*)'\s*,\s*'((?:''|[^'])*)'\s*\)",
+            patch_sql,
+            re.IGNORECASE | re.DOTALL,
+        )
+    ]
+
+
+def _contains_existing_charter(fragment, existing_charter):
+    normalized_fragment = " ".join(re.findall(r"[a-z0-9]+", (fragment or "").casefold()))
+    normalized_existing = " ".join(re.findall(r"[a-z0-9]+", (existing_charter or "").casefold()))
+    return bool(normalized_fragment and normalized_existing and normalized_existing in normalized_fragment)
+
+
+def _uses_one_focused_charter_patch(mutation_calls, existing_charter):
+    if len(mutation_calls) != 1:
+        return False
+    sql = str(resolved_tool_param(mutation_calls[0], "sql") or "")
+    pairs = _charter_patch_pairs(sql)
+    structural_sql = _structural_sql(sql)
+    old, new = pairs[0] if len(pairs) == 1 else (None, None)
+    return (
+        len(pairs) == 1
+        and len(split_sql_statements(sql)) == 1
+        and re.search(r"\bupdate\s+__agent_config\b", structural_sql, re.IGNORECASE)
+        and not re.search(r"\bselect\b", structural_sql, re.IGNORECASE)
+        and old != new
+        and (not old or old in existing_charter)
+        and bool(new.strip())
+        and not _contains_existing_charter(new, existing_charter)
+    )
 
 
 @register_scenario
@@ -2201,17 +2455,15 @@ class CharterAddsFeedbackRuleFromCorrectionScenario(CharterMemoryScenario):
     verification_task_name = "verify_feedback_rule_saved"
     success_summary = "Agent saved the user's correction as an ongoing report-link rule while preserving sourcing guidance."
     failure_summary = "Expected charter to preserve sourcing role and add durable lead/source link guidance"
+    verify_feedback_reply = True
+    feedback_reply_options = {"required_reply_concepts": (("link", "url", "source"),)}
 
     def _charter_check(self, agent, mutation_calls):
-        charter = (agent.charter or "").lower()
-        preserved_job = "candidate" in charter or "lead" in charter or "recruit" in charter
-        includes_link_rule = (
-            ("link" in charter or "url" in charter or "source" in charter or "profile" in charter)
-            and ("report" in charter or "update" in charter or "lead" in charter or "candidate" in charter)
-        )
-        passed = bool(mutation_calls and preserved_job and includes_link_rule)
+        preserved_job = _keeps_clauses(agent.charter, self.existing_charter)
+        includes_link_rule = _requires_candidate_links(agent.charter)
+        focused_patch = _uses_one_focused_charter_patch(mutation_calls, self.existing_charter)
+        passed = bool(focused_patch and preserved_job and includes_link_rule)
         return passed, f"mutation_count={len(mutation_calls)}, charter={agent.charter!r}."
-
 
 @register_scenario
 class CharterAddsPlainPreferenceWithoutSaveWordScenario(CharterMemoryScenario):
@@ -2229,14 +2481,14 @@ class CharterAddsPlainPreferenceWithoutSaveWordScenario(CharterMemoryScenario):
     verification_task_name = "verify_plain_preference_saved"
     success_summary = "Agent saved the user's table-and-bullets preference while preserving market brief guidance."
     failure_summary = "Expected charter to preserve market brief role and add durable table/bullet format preference"
+    verify_feedback_reply = True
+    feedback_reply_options = {"required_reply_concepts": (("table",), ("bullet", "takeaway"))}
 
     def _charter_check(self, agent, mutation_calls):
-        charter = (agent.charter or "").lower()
-        preserved_job = "market" in charter and ("brief" in charter or "finding" in charter)
-        added_format_preference = "table" in charter and ("bullet" in charter or "takeaway" in charter)
-        passed = bool(mutation_calls and preserved_job and added_format_preference)
+        preserved_job = _keeps_clauses(agent.charter, self.existing_charter)
+        added_format_preference = _requires_comparison_table_takeaways(agent.charter)
+        passed = _uses_one_focused_charter_patch(mutation_calls, self.existing_charter) and preserved_job and added_format_preference
         return passed, f"mutation_count={len(mutation_calls)}, charter={agent.charter!r}."
-
 
 @register_scenario
 class CharterPatchesDirectStyleCorrectionScenario(CharterMemoryScenario):
@@ -2250,7 +2502,7 @@ class CharterPatchesDirectStyleCorrectionScenario(CharterMemoryScenario):
         "Research qualified prospects and send concise, personalized outreach. "
         "Keep daily outreach below 20 messages."
     )
-    prior_outbound_body = "Thanks for the context—I'd be delighted to explore how we can unlock value together."
+    prior_outbound_body = "Thanks for sharing that your team is expanding apprenticeships—I'd be delighted to explore how we can unlock value together."
     prompt = (
         "That sounded automated. Stop writing like a template, and don't use em dashes or double hyphens "
         "in my messages. Rewrite it more naturally."
@@ -2258,16 +2510,212 @@ class CharterPatchesDirectStyleCorrectionScenario(CharterMemoryScenario):
     verification_task_name = "verify_partial_style_correction_saved"
     success_summary = "Agent used one partial SQLite patch to save the correction while preserving outreach limits."
     failure_summary = "Expected one patch_text charter mutation preserving the prospecting job and daily limit"
+    verify_feedback_reply = True
+    feedback_reply_options = {"require_result": True, "required_reply_terms": ("apprenticeship",)}
 
     def _charter_check(self, agent, mutation_calls):
-        charter = (agent.charter or "").lower()
-        sql = "\n".join(json.dumps(call.tool_params or {}) for call in mutation_calls).lower()
-        preserved = "qualified prospect" in charter and "below 20" in charter
-        added_style = ("natural" in charter or "human" in charter) and ("dash" in charter or "template" in charter)
-        used_one_patch = len(mutation_calls) == 1 and "patch_text" in sql
+        preserved = _keeps_clauses(agent.charter, self.existing_charter)
+        added_style = _requires_natural_dashless_style(agent.charter)
+        used_one_patch = _uses_one_focused_charter_patch(mutation_calls, self.existing_charter)
         passed = preserved and added_style and used_one_patch
         return passed, f"mutation_count={len(mutation_calls)}, used_patch={used_one_patch}, charter={agent.charter!r}."
 
+def _completion_actions_match(run_id, inbound, calls, expected_tools):
+    completion_ids = list(
+        PersistentAgentCompletion.objects.filter(
+            eval_run_id=run_id,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+            created_at__gte=inbound.timestamp,
+        )
+        .order_by("created_at", "id")
+        .values_list("id", flat=True)
+    )
+    action_completion_ids = [call.step.completion_id for call in calls]
+    matched = (
+        [call.tool_name for call in calls] == list(expected_tools)
+        and action_completion_ids == completion_ids
+        and None not in action_completion_ids
+        and len(set(action_completion_ids)) == len(action_completion_ids)
+    )
+    return matched, (
+        f"completion_ids={[str(value) for value in completion_ids]}, "
+        f"action_completion_ids={[str(value) for value in action_completion_ids]}"
+    )
+
+
+def _successful_without_repair(call):
+    try:
+        result = call.result if isinstance(call.result, dict) else json.loads(call.result or "{}")
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return (
+        str(call.status).lower() == "complete"
+        and result.get("status") == "ok"
+        and "auto_correction" not in json.dumps(result).casefold()
+    )
+
+
+def _one_shot_charter_feedback_check(
+    run_id,
+    inbound,
+    *,
+    existing_charter,
+    require_result=False,
+    required_reply_terms=(),
+    required_reply_concepts=(),
+):
+    calls = [
+        call for call in get_tool_calls_for_run(run_id, after=inbound.timestamp)
+        if call.tool_name != "sleep_until_next_trigger"
+    ]
+    sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch"]
+    replies = [call for call in calls if call.tool_name == "send_chat_message"]
+    one_shot, completion_detail = _completion_actions_match(
+        run_id, inbound, calls, ("sqlite_batch", "send_chat_message")
+    )
+    reply_body = str(resolved_tool_param(replies[0], "body") or "") if len(replies) == 1 else ""
+    reply_folded = reply_body.casefold()
+    terminal_reply = (
+        len(replies) == 1
+        and str(replies[0].status).lower() == "complete"
+        and resolved_tool_param(replies[0], "will_continue_work") is False
+    )
+    natural_reply = (
+        len(reply_body.strip()) >= 12
+        and not any(
+            term in reply_folded
+            for term in ("charter", "sqlite", "config", "saved", "stored", "tools", "i'll research", "i will research")
+        )
+        and all(term.casefold() in reply_folded for term in required_reply_terms)
+        and all(
+            any(term.casefold() in reply_folded for term in alternatives)
+            for alternatives in required_reply_concepts
+        )
+    )
+    if require_result:
+        natural_reply = natural_reply and len(reply_body) >= 50 and not any(
+            term in reply_folded
+            for term in (
+                "going forward", "from now on", "i'll ", "i will ", "template", "automated",
+                "thanks for sharing", "explore how we can", "value together", "work together on",
+                "i'd love to", "i'd be delighted", "—", "--",
+            )
+        )
+    clean_sqlite = (
+        len(sqlite_calls) == 1
+        and _successful_without_repair(sqlite_calls[0])
+        and _uses_one_focused_charter_patch(sqlite_calls, existing_charter)
+    )
+    runtime_corrections = PersistentAgentStep.objects.filter(
+        eval_run_id=run_id,
+        created_at__gt=inbound.timestamp,
+        description__startswith="Tool policy: persist this direct user correction",
+    ).count()
+    passed = one_shot and clean_sqlite and terminal_reply and natural_reply and not runtime_corrections
+    return passed, (
+        f"actions={[call.tool_name for call in calls]}, terminal_reply={terminal_reply}, "
+        f"natural_reply={natural_reply}, clean_sqlite={clean_sqlite}, {completion_detail}, "
+        f"runtime_correction_count={runtime_corrections}."
+    )
+
+
+@register_scenario
+class CharterPatchesEvaluativeOutputFeedbackScenario(CharterMemoryScenario):
+    slug = CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK
+    description = "Evaluative feedback on a prior output should become a concise charter correction."
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_evaluative_feedback_saved", assertion_type="manual"),
+    ]
+    existing_charter = (
+        "Research qualified prospects and send concise, personalized outreach. "
+        "For prospect outreach, end each note with an open question asking for the recipient's opinion. "
+        "For customer interviews, end each note with an open question asking for the recipient's opinion. "
+        "Keep daily outreach below 20 messages. "
+        "Do not change these instructions unless the owner explicitly asks."
+    )
+    prior_outbound_body = "Prospect outreach draft: Curious what you think the biggest gap is right now."
+    prompt = (
+        '"Curious what you think the biggest gap is right now." this is not so good. '
+        "it makes the other person do the work"
+    )
+    verification_task_name = "verify_evaluative_feedback_saved"
+    success_summary = "Agent interpreted the critique and patched the related outreach rule without adding a feedback block."
+    failure_summary = "Expected one focused patch that removes the high-effort opinion prompt and preserves unrelated limits"
+    verify_feedback_reply = True
+    feedback_reply_options = {"required_reply_concepts": (("question", "ask", "answer", "recipient"),)}
+
+    def _charter_check(self, agent, mutation_calls):
+        charter = (agent.charter or "").lower()
+        old_rule = "For prospect outreach, end each note with an open question asking for the recipient's opinion."
+        preserved = _keeps_clauses(
+            agent.charter,
+            "Research qualified prospects and send concise, personalized outreach.",
+            "For customer interviews, end each note with an open question asking for the recipient's opinion.",
+            "Keep daily outreach below 20 messages.",
+            "Do not change these instructions unless the owner explicitly asks.",
+        )
+        replaced_old_rule = not _keeps_clauses(agent.charter, old_rule)
+        learned_feedback = _requires_low_recipient_effort(agent.charter)
+        used_one_patch = _uses_one_focused_charter_patch(mutation_calls, self.existing_charter)
+        focused = len(agent.charter or "") <= len(self.existing_charter) + 240 and "feedback:" not in charter
+        passed = preserved and replaced_old_rule and learned_feedback and used_one_patch and focused
+        return passed, f"mutation_count={len(mutation_calls)}, used_patch={used_one_patch}, charter={agent.charter!r}."
+
+@register_scenario
+class CharterInterpretsAmbiguousOperatingFeedbackScenario(CharterMemoryScenario):
+    slug = CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK
+    description = "Messy but durable operating feedback should be interpreted and saved without blocking for clarification."
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_ambiguous_operating_feedback_saved", assertion_type="manual"),
+    ]
+    existing_charter = (
+        "Coordinate vendor renewal work with the team. "
+        "Send the owner a short kickoff and a progress note for each work session. "
+        "Route routine follow-ups and blockers to the owner. "
+        "Never include customer secrets in team messages."
+    )
+    prior_outbound_body = (
+        "I'm starting the renewal review now and will keep you posted as I work through it."
+    )
+    prompt = (
+        "for this renewal only, put legal review first. going forward, these play by play updates arent useful. "
+        "just come back with what changed + blockers + next move. "
+        "routine followups are for Morgan, only pull me in on a real blocker"
+    )
+    verification_task_name = "verify_ambiguous_operating_feedback_saved"
+    success_summary = "Agent inferred and saved the new update and routing boundaries without asking a blocking question."
+    failure_summary = "Expected one focused patch preserving the role and privacy rule while updating reporting and routing"
+    verify_feedback_reply = True
+    feedback_reply_options = {"required_reply_concepts": (("morgan",), ("blocker",))}
+
+    def _charter_check(self, agent, mutation_calls):
+        charter = (agent.charter or "").lower()
+        preserved = _keeps_clauses(
+            agent.charter,
+            "Coordinate vendor renewal work with the team.",
+            "Never include customer secrets in team messages.",
+        )
+        temporary_scope_omitted = "legal review first" not in charter and "put legal" not in charter
+        replaced_old_rule = (
+            "short kickoff and a progress note" not in charter
+            and "route routine follow-ups and blockers to the owner" not in charter
+        )
+        learned_reporting = _requires_outcome_report(agent.charter)
+        learned_routing = _requires_morgan_routing_boundary(agent.charter)
+        used_one_patch = _uses_one_focused_charter_patch(mutation_calls, self.existing_charter)
+        focused = len(agent.charter or "") <= len(self.existing_charter) + 300 and "feedback:" not in charter
+        passed = (
+            preserved
+            and temporary_scope_omitted
+            and replaced_old_rule
+            and learned_reporting
+            and learned_routing
+            and used_one_patch
+            and focused
+        )
+        return passed, f"mutation_count={len(mutation_calls)}, used_patch={used_one_patch}, charter={agent.charter!r}."
 
 @register_scenario
 class ToolChoiceExactJsonUrlUsesHttpRequestScenario(BehaviorMicroScenario):

--- a/api/evals/scenarios/hallucinated_links.py
+++ b/api/evals/scenarios/hallucinated_links.py
@@ -1,4 +1,5 @@
 import html
+import json
 import re
 from dataclasses import dataclass
 from typing import Iterable
@@ -10,6 +11,8 @@ from api.evals.registry import ScenarioRegistry
 from api.models import (
     EvalRunTask,
     PersistentAgent,
+    PersistentAgentCompletion,
+    PersistentAgentLinkReference,
     PersistentAgentMessage,
     PersistentAgentStep,
     PersistentAgentSystemStep,
@@ -29,6 +32,7 @@ _BARE_DOMAIN_PATH_RE = re.compile(
     re.IGNORECASE,
 )
 _TRAILING_PUNCTUATION = ".,;:!?"
+_LINK_TOKEN_RE = re.compile(r"\$\[link:[^\]]+\]", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -41,6 +45,7 @@ class LinkGroundingPattern:
     prompt: str
     entity_urls: tuple[tuple[str, str], ...]
     unlinked_entities: tuple[str, ...] = ()
+    table_row_requirements: tuple[tuple[str, tuple[str, ...]], ...] = ()
     context_only_urls: tuple[str, ...] = ()
     history_messages: tuple[str, ...] = ()
     long_history_messages: tuple[str, ...] = ()
@@ -624,6 +629,41 @@ LINK_GROUNDING_PATTERNS = (
         relevant_position="early",
     ),
     LinkGroundingPattern(
+        slug_root="association_owner_report_tool",
+        failure_type="association",
+        domain="owner_research_report",
+        context_source="tool",
+        fixture_url="https://api.example.test/evals/current-cohort.json",
+        source_text=(
+            "Current cohort company API response:\n"
+            "company=Atlas Forge | founders=Mina Shah, Leon Wu | builds=hardware compliance automation | "
+            "company_url=https://atlasforge.example.test/company?view=team\n"
+            "company=Atlas Foundry | founder=Elena Ruiz | builds=materials procurement software | "
+            "company_url=https://atlasfoundry.example.test/about#founders\n"
+            "company=Meridian Care | founders=Imani Brooks, Sol Park | builds=clinic scheduling software | "
+            "company_url=https://meridiancare.example.test/team\n"
+            "company=Threadline Robotics | founders=Jon Bell, Sara Okoye | builds=warehouse inspection robots | "
+            "directory_slug=threadline-robotics | company_url_status=not_returned"
+        ),
+        prompt=(
+            "Fetch https://api.example.test/evals/current-cohort.json and send me a concise owner report on all four "
+            "companies, their founders, and what each team is building."
+        ),
+        entity_urls=(
+            ("Atlas Forge", "https://atlasforge.example.test/company?view=team"),
+            ("Atlas Foundry", "https://atlasfoundry.example.test/about#founders"),
+            ("Meridian Care", "https://meridiancare.example.test/team"),
+        ),
+        unlinked_entities=("Threadline Robotics",),
+        table_row_requirements=(
+            ("Atlas Forge", ("Mina Shah", "Leon Wu", "hardware compliance")),
+            ("Atlas Foundry", ("Elena Ruiz", "materials procurement")),
+            ("Meridian Care", ("Imani Brooks", "Sol Park", "clinic scheduling")),
+            ("Threadline Robotics", ("Jon Bell", "Sara Okoye", "warehouse inspection")),
+        ),
+        relevant_position="middle",
+    ),
+    LinkGroundingPattern(
         slug_root="construction_contact_tool",
         failure_type="construction",
         domain="contact_directory",
@@ -761,6 +801,136 @@ def provenance_failures(
     return failures, unexpected, missing
 
 
+def owner_report_table_failures(
+    body: str,
+    *,
+    row_requirements: Iterable[tuple[str, Iterable[str]]],
+    entity_urls: Iterable[tuple[str, str]],
+    unlinked_entities: Iterable[str],
+) -> list[str]:
+    body = body or ""
+    row_requirements = tuple(row_requirements)
+    entity_urls = tuple(entity_urls)
+    unlinked_entities = tuple(unlinked_entities)
+    tables = []
+    current = []
+    for line in body.splitlines():
+        if line.count("|") >= 3:
+            current.append(line)
+        elif current:
+            tables.append(tuple(current))
+            current = []
+    if current:
+        tables.append(tuple(current))
+    if len(tables) != 1:
+        return ["Owner report must contain exactly one comparison table."]
+
+    table = tables[0]
+    if not any(
+        re.fullmatch(r"\s*\|?\s*:?-{3,}:?(?:\s*\|\s*:?-{3,}:?){2,}\s*\|?\s*", line)
+        for line in table
+    ):
+        return ["Owner report comparison table lacked a Markdown separator row."]
+
+    failures = []
+    entity_rows = {}
+    for entity, required in row_requirements:
+        rows = tuple(line for line in table if entity.casefold() in line.casefold())
+        entity_rows[entity] = rows
+        if len(rows) != 1:
+            failures.append(f"{entity} did not have exactly one result row.")
+        elif missing := tuple(term for term in required if term.casefold() not in rows[0].casefold()):
+            failures.append(f"{entity} row omitted requested field(s): {list(missing)}.")
+
+    for entity, url in entity_urls:
+        rows = entity_rows.get(entity, ())
+        entity_link = re.compile(
+            rf"\[\s*(?:\*\*)?{re.escape(entity)}(?:\*\*)?\s*\]\(\s*{re.escape(url)}\s*\)",
+            re.IGNORECASE,
+        )
+        if len(rows) == 1 and not entity_link.search(rows[0]):
+            failures.append(f"{entity} was not linked to its exact supplied destination in its row.")
+        if body.count(url) != 1:
+            failures.append(f"{entity}'s supplied destination did not appear exactly once.")
+
+    for entity in unlinked_entities:
+        rows = entity_rows.get(entity, ())
+        if len(rows) == 1 and _link_destinations(rows[0]):
+            failures.append(f"{entity} was linked despite having no returned item URL.")
+
+    expected = {url for _entity, url in entity_urls}
+    dangling = tuple(destination for destination in _link_destinations(body) if destination not in expected)
+    if dangling:
+        failures.append(f"Owner report contained generic or dangling destination(s): {list(dangling)}.")
+    return failures
+
+
+def _link_destinations(text: str) -> tuple[str, ...]:
+    return tuple(dict.fromkeys((
+        *extract_http_urls(text),
+        *extract_bare_link_like_destinations(text),
+        *_LINK_TOKEN_RE.findall(text),
+    )))
+
+
+def owner_report_has_resolved_summary(body: str, *, resolved: int, total: int) -> bool:
+    lines = (body or "").splitlines()
+    if not any(line.count("|") >= 3 for line in lines):
+        return False
+    summary = " ".join(line for line in lines if line.count("|") < 3)
+    count = re.compile(rf"(?<!\d){resolved}\s*/\s*{total}(?!\d)")
+    state = r"(?:resolved|covered|included|accounted\s+for|complete|coverage|found)"
+    company = r"compan(?:y|ies)"
+    exact_count = count.search(summary) and re.search(rf"\b{state}\b", summary, re.I)
+    number_words = {4: "four", 8: "eight"}
+    total_value = rf"(?:{total}|{number_words.get(total, str(total))})"
+    all_count = resolved == total and (
+        re.search(rf"\ball\s+{total_value}\s+{company}\b[^.\n]{{0,45}}\b{state}\b", summary, re.I)
+        or re.search(rf"\b{state}\b[^.\n]{{0,45}}\ball\s+{total_value}\s+{company}\b", summary, re.I)
+    )
+    return bool(exact_count or all_count)
+
+
+def _tool_result_status(call) -> str:
+    try:
+        result = call.result if isinstance(call.result, dict) else json.loads(call.result or "{}")
+    except (AttributeError, TypeError, ValueError):
+        return ""
+    return str(result.get("status") or "").casefold() if isinstance(result, dict) else ""
+
+
+def owner_report_execution_failures(action_calls, orchestrator_completion_ids: Iterable[object]) -> list[str]:
+    action_calls = tuple(action_calls)
+    action_names = [call.tool_name for call in action_calls]
+    failures = []
+    if action_names != ["http_request", "send_chat_message"]:
+        failures.append(f"Owner report used extra or repeated actions: {action_names}.")
+
+    bad_statuses = [
+        (call.tool_name, str(call.status or "").casefold(), _tool_result_status(call))
+        for call in action_calls
+        if str(call.status or "").casefold() != "complete" or _tool_result_status(call) != "ok"
+    ]
+    if bad_statuses:
+        failures.append(f"Owner report actions were not all successful: {bad_statuses}.")
+
+    action_completion_ids = [
+        str(call.step.completion_id) if getattr(call.step, "completion_id", None) else None
+        for call in action_calls
+    ]
+    completion_ids = [str(completion_id) for completion_id in orchestrator_completion_ids]
+    if len(set(action_completion_ids)) != len(action_completion_ids) or action_completion_ids != completion_ids:
+        failures.append(
+            "Owner report actions did not map one-to-one, in order, to every post-inbound orchestrator completion: "
+            f"actions={action_completion_ids}, completions={completion_ids}."
+        )
+
+    sends = [call for call in action_calls if call.tool_name == "send_chat_message"]
+    if len(sends) != 1 or (sends[0].tool_params or {}).get("will_continue_work") is not False:
+        failures.append("Owner report required exactly one successful terminal web-chat send.")
+    return failures
+
+
 class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
     tier = "extended"
     category = "link_grounding"
@@ -790,6 +960,7 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
         if case.context_messages():
             self._seed_history(agent_id, case)
 
+        owner_report = bool(case.pattern.table_row_requirements)
         with self.wait_for_agent_idle(agent_id, timeout=180) as processing:
             inbound = self.inject_message(
                 agent_id,
@@ -800,7 +971,11 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
                 eval_stop_policy={
                     "stop_on_tool_names_after_execution": ["send_chat_message"],
                     "stop_on_unexpected_relevant_tool": True,
-                    "allowed_tool_names": [
+                    "allowed_tool_names": ([
+                        "http_request",
+                        "sqlite_batch",
+                        "send_chat_message",
+                    ] if owner_report else [
                         "http_request",
                         "mcp_brightdata_scrape_as_markdown",
                         "mcp_brightdata_search_engine",
@@ -809,9 +984,10 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
                         "send_chat_message",
                         "sqlite_batch",
                         "update_plan",
-                    ],
+                    ]),
                     "ignored_tool_names": ["sleep_until_next_trigger"],
-                    "max_relevant_tool_calls": 32 if case.is_long else 16,
+                    # Let a bad pre-work send finish so the strict action-shape check can diagnose it.
+                    "max_relevant_tool_calls": 4 if owner_report else 32 if case.is_long else 16,
                 },
             )
 
@@ -836,7 +1012,7 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
             self._record_missing_answer_tasks(run_id)
             return
 
-        self._record_provenance(run_id, case, message)
+        self._record_provenance(run_id, case, message, after=inbound.timestamp)
         self._record_semantic_judgment(run_id, case, message)
 
     def _case(self) -> LinkGroundingCase:
@@ -1005,6 +1181,8 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
         run_id: str,
         case: LinkGroundingCase,
         message: PersistentAgentMessage,
+        *,
+        after,
     ) -> None:
         self.record_task_result(
             run_id,
@@ -1017,8 +1195,76 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
             allowed_urls=case.allowed_urls,
             required_urls=case.required_urls,
         )
+        missing_tokens = []
+        raw_body = ""
+        token_association_failures = []
+        if case.pattern.table_row_requirements:
+            references = {
+                reference.url: f"$[link:{reference.public_id}]"
+                for reference in PersistentAgentLinkReference.objects.filter(
+                    agent_id=message.owner_agent_id,
+                    url__in=case.required_urls,
+                )
+            }
+            action_calls = list(PersistentAgentToolCall.objects.filter(
+                step__eval_run_id=run_id,
+                step__agent_id=message.owner_agent_id,
+                step__created_at__gt=after,
+            ).exclude(
+                tool_name="sleep_until_next_trigger",
+            ).order_by("step__created_at", "step_id"))
+            orchestrator_completion_ids = PersistentAgentCompletion.objects.filter(
+                eval_run_id=run_id,
+                agent_id=message.owner_agent_id,
+                completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+                created_at__gt=after,
+            ).order_by("created_at", "id").values_list("id", flat=True)
+            failures.extend(owner_report_execution_failures(action_calls, orchestrator_completion_ids))
+            send_attempts = [call for call in action_calls if call.tool_name == "send_chat_message"]
+            if len(send_attempts) == 1:
+                raw_body = str((send_attempts[0].tool_params or {}).get("body") or "")
+                missing_tokens = [
+                    url for url in case.required_urls
+                    if not references.get(url) or references[url] not in raw_body
+                ]
+                if missing_tokens:
+                    failures.append(f"Final send omitted supplied link token(s) for: {missing_tokens}.")
+            token_associations = tuple(
+                (entity, references[url])
+                for entity, url in case.pattern.entity_urls
+                if references.get(url)
+            )
+            token_association_failures = owner_report_table_failures(
+                raw_body,
+                row_requirements=case.pattern.table_row_requirements,
+                entity_urls=token_associations,
+                unlinked_entities=case.pattern.unlinked_entities,
+            )
+            failures.extend(token_association_failures)
+        owner_report_failures = (
+            owner_report_table_failures(
+                message.body or "",
+                row_requirements=case.pattern.table_row_requirements,
+                entity_urls=case.pattern.entity_urls,
+                unlinked_entities=case.pattern.unlinked_entities,
+            )
+            if case.pattern.table_row_requirements else []
+        )
+        failures.extend(owner_report_failures)
+        owner_report_table = not owner_report_failures
+        owner_report_summary = not case.pattern.table_row_requirements or owner_report_has_resolved_summary(
+            message.body or "",
+            resolved=len(case.pattern.table_row_requirements),
+            total=len(case.pattern.table_row_requirements),
+        )
+        if not owner_report_summary:
+            failures.append("Four-item owner report lacked a clear resolved/total 4/4 summary.")
         status = EvalRunTask.Status.FAILED if failures else EvalRunTask.Status.PASSED
-        summary = "; ".join(failures) if failures else "Every delivered URL came from context and all required URLs were preserved."
+        summary = (
+            "; ".join(failures)
+            if failures
+            else "Every delivered URL came from context and all required URLs were preserved."
+        )
         self.record_task_result(
             run_id,
             None,
@@ -1033,6 +1279,11 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
                 ),
                 "unexpected_urls": list(unexpected),
                 "missing_urls": list(missing),
+                "missing_reference_tokens": missing_tokens,
+                "association_failures": owner_report_failures,
+                "token_association_failures": token_association_failures,
+                "owner_report_comparison_table": owner_report_table,
+                "owner_report_resolved_summary": owner_report_summary,
             },
         )
 

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -1,3 +1,4 @@
+import json
 import re
 from typing import Iterable
 
@@ -13,7 +14,6 @@ from api.agent.tools.sqlite_query_quality import (
     _reads_table,
     _structural_sql,
     source_derived_model_mutation_tables,
-    source_derived_model_reconciled_tables,
     summarize_sqlite_tool_result_calls,
 )
 from api.agent.tools.sqlite_state import agent_sqlite_db
@@ -24,7 +24,14 @@ from api.evals.execution import ScenarioExecutionTools
 from api.evals.registry import register_scenario
 from api.evals.tool_params import resolved_tool_param
 from api.evals.scenarios.effort_calibration import MESSAGE_TOOL_NAMES, STOP_TOOL_NAMES, _outbound_messages_after, _tool_calls_for_run
-from api.models import EvalRunTask, PersistentAgent, PersistentAgentEnabledTool, PersistentAgentStep, PersistentAgentSystemStep
+from api.models import (
+    EvalRunTask,
+    PersistentAgent,
+    PersistentAgentCompletion,
+    PersistentAgentEnabledTool,
+    PersistentAgentStep,
+    PersistentAgentSystemStep,
+)
 
 
 SQLITE_TOOL_RESULT_SUITE_SLUG = "sqlite_tool_results"
@@ -96,6 +103,181 @@ DOMAIN_WORKSTREAMS = (
     ("ws-security-17", "Security packet", "complete", "Maya Chen", "2026-07-22"),
     ("ws-legal-04", "Contract redlines", "open", "Noah Reed", "2026-07-24"),
 )
+
+
+_MUTATION_TARGET_RE = re.compile(
+    r'\b(?:insert\s+(?:or\s+\w+\s+)?into|replace\s+into|update|delete\s+from)\s+["`\[]?'
+    r'(?P<table>[a-z_]\w*)',
+    re.I,
+)
+
+
+def _result_payload(call) -> dict | None:
+    result = getattr(call, "result", None)
+    try:
+        payload = result if isinstance(result, dict) else json.loads(str(result or ""))
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _contains_auto_correction(value) -> bool:
+    if isinstance(value, dict):
+        return "auto_correction" in value or any(_contains_auto_correction(item) for item in value.values())
+    return isinstance(value, list) and any(_contains_auto_correction(item) for item in value)
+
+
+def _tool_attempt_failures(calls, label: str, *, reject_auto_correction: bool = False) -> list[str]:
+    failures = []
+    for index, call in enumerate(calls, start=1):
+        call_status = str(getattr(call, "status", "") or "").casefold()
+        payload = _result_payload(call)
+        if call_status != "complete":
+            failures.append(f"{label} attempt {index} had execution status {call_status or 'missing'}")
+        elif not isinstance(payload, dict):
+            failures.append(f"{label} attempt {index} returned an unreadable result")
+        elif str(payload.get("status") or "").casefold() != "ok":
+            failures.append(f"{label} attempt {index} returned result status {payload.get('status') or 'missing'}")
+        elif reject_auto_correction and _contains_auto_correction(payload):
+            failures.append(f"{label} attempt {index} depended on auto-correction")
+    return failures
+
+
+def _sqlite_attempt_failures(calls) -> list[str]:
+    return _tool_attempt_failures(calls, "SQLite", reject_auto_correction=True)
+
+
+def _first_shot_source_phase_failures(calls) -> list[str]:
+    calls = tuple(calls)
+    fetches = [call for call in calls if call.tool_name == "http_request"]
+    sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch"]
+    sends = [call for call in calls if call.tool_name == "send_chat_message"]
+    failures = _tool_attempt_failures(fetches, "Source fetch")
+    failures.extend(_tool_attempt_failures(sends, "Final send"))
+    failures.extend(message for failed, message in (
+        (
+            [call.tool_name for call in calls] != ["http_request", "sqlite_batch", "send_chat_message"],
+            f"expected fetch, one SQLite batch, then one send; found {[call.tool_name for call in calls]}",
+        ),
+        (
+            len(fetches) != 1
+            or str(resolved_tool_param(fetches[0], "url") or "").rstrip("/")
+            != DOMAIN_REFRESH_URL.rstrip("/"),
+            "expected one exact CRM snapshot fetch",
+        ),
+        (len(sqlite_calls) != 1, f"expected one SQLite batch, found {len(sqlite_calls)}"),
+        (
+            len(sends) != 1 or resolved_tool_param(sends[0], "will_continue_work") is not False,
+            f"expected one successful terminal send, found {len(sends)} send attempt(s)",
+        ),
+    ) if failed)
+
+    completion_ids = [getattr(getattr(call, "step", None), "completion_id", None) for call in calls]
+    if any(completion_id is None for completion_id in completion_ids):
+        failures.append("every source, SQLite, and send phase must link to an orchestrator completion")
+    elif len(set(completion_ids)) != len(completion_ids):
+        failures.append("fetch, SQLite, and send phases need separate completions")
+    return failures
+
+
+def _source_write_effect_failures(calls, expected_tables: Iterable[str]) -> list[str]:
+    expected = {table.casefold() for table in expected_tables}
+    if len(calls) != 1:
+        return ["source-derived model write was not a single clean batch"]
+
+    raw_sql = (calls[0].tool_params or {}).get("queries", (calls[0].tool_params or {}).get("sql") or "")
+    statements = [
+        statement
+        for query in (raw_sql if isinstance(raw_sql, list) else [raw_sql])
+        for statement in sqlparse.split(str(query))
+        if statement.strip()
+    ]
+    derived = []
+    for index, statement in enumerate(statements):
+        tables = set(source_derived_model_mutation_tables([statement]))
+        mutation = _MUTATION_TARGET_RE.search(statement)
+        if mutation and mutation.group("table").casefold() in {"__agent_config", "__agent_skills"}:
+            return ["ordinary source reconciliation changed durable agent configuration"]
+        if mutation and mutation.group("table").casefold() in expected and not tables:
+            return ["source-derived model write began with literal or non-source facts"]
+        if tables:
+            derived.append((index, tables))
+
+    payload = _result_payload(calls[0]) or {}
+    results = payload.get("results", [])
+    derived_tables = set().union(*(tables for _index, tables in derived)) if derived else set()
+    effective = expected.issubset(derived_tables) and all(
+        index < len(results)
+        and not _contains_auto_correction(results[index])
+        and re.search(r"\baffected\s+[1-9]\d*\s+rows?\b", json.dumps(results[index]), re.I)
+        for index, _tables in derived
+    )
+    return [] if effective else [
+        "source-derived model write was wrong, recovered within the batch, or affected no rows"
+    ]
+
+
+_DECISION_FIELD_RE = re.compile(r"\b(?:stage|status|owner|next_action|due_on)\b", re.I)
+_AGGREGATE_CALL_RE = re.compile(
+    r"\b(?:avg|count|group_concat|json_group_array|json_group_object|max|min|sum|total)\s*\([^)]*\)",
+    re.I,
+)
+
+
+def _source_relationship_read_failures(
+    sql_values: Iterable[str], parent_table: str, child_table: str,
+) -> list[str]:
+    expected = {parent_table.casefold(), child_table.casefold()}
+    mutated = set()
+    row_reads = {table: [] for table in expected}
+    for sql in sql_values:
+        for statement in sqlparse.split(str(sql or "")):
+            derived = set(source_derived_model_mutation_tables((statement,)))
+            if derived:
+                mutated.update(derived)
+                continue
+            structural = _structural_sql(statement)
+            select_matches = tuple(re.finditer(r"\bselect\b(?P<projection>.*?)\bfrom\b", structural, re.I | re.S))
+            if not select_matches:
+                continue
+            projection = _AGGREGATE_CALL_RE.sub("", select_matches[-1].group("projection"))
+            if "*" not in projection and not _DECISION_FIELD_RE.search(projection):
+                continue
+            for table in expected.intersection(mutated):
+                if _reads_table(structural, table):
+                    row_reads[table].append((structural, projection))
+
+    missing = sorted(table for table, reads in row_reads.items() if not reads)
+    if missing:
+        return [f"updated model did not return decision rows from: {missing}"]
+    if not all(
+        any("*" in projection or re.search(r"\baccount_id\b", statement, re.I) for statement, projection in reads)
+        for reads in row_reads.values()
+    ):
+        return ["model reads did not expose or filter the stable account relationship"]
+    return []
+
+
+def _orphan_completion_failures(run_id, after) -> list[str]:
+    if after is None:
+        return []
+    completions = PersistentAgentCompletion.objects.filter(
+        eval_run_id=run_id,
+        completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+        created_at__gte=after,
+    )
+    completion_ids = set(completions.values_list("id", flat=True))
+    linked_ids = set(
+        PersistentAgentStep.objects.filter(
+            eval_run_id=run_id,
+            created_at__gte=after,
+            completion_id__in=completion_ids,
+            tool_call__isnull=False,
+        ).values_list("completion_id", flat=True)
+    )
+    count = len(completion_ids - linked_ids)
+    return [f"found {count} orphan reasoning completion(s) without an action"] if count else []
+
 
 UNIQUE_MODEL_INDEX_RE = re.compile(r'\bcreate\s+unique\s+index\b[^;]*?\bon\s+"?(?P<table>[a-z_]\w*)"?', re.I | re.S)
 STABLE_IDENTITY_RE = re.compile(r'\bprimary\s+key\b|(?<!["\'`\[])\bunique\b(?!["\'`\]])', re.I)
@@ -707,20 +889,25 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
     def _record_result_access(self, run_id: str, *, after, task_name: str, source_urls: Iterable[str], reject_duplicate_fetches: bool = False) -> bool:
         self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name=task_name)
         calls = _tool_calls_for_run(run_id, after=after)
+        fetch_calls = [call for call in calls if call.tool_name in self.result_access_fetch_tools]
+        sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch"]
         fetch_counts = _source_fetch_counts(calls, tool_names=self.result_access_fetch_tools, source_urls=source_urls)
-        successful_sqlite, strategy_calls = _sqlite_calls_with_persisted_effects([call for call in calls if call.tool_name == "sqlite_batch"])
+        attempt_urls = [str(resolved_tool_param(call, "url") or "").rstrip("/") for call in fetch_calls]
+        duplicate_attempts = [url for url in fetch_counts if attempt_urls.count(url) > 1]
+        successful_sqlite, strategy_calls = _sqlite_calls_with_persisted_effects(sqlite_calls)
         summary = summarize_sqlite_tool_result_calls(strategy_calls)
         missing = [url for url, count in fetch_counts.items() if count == 0]
-        duplicates = [url for url, count in fetch_counts.items() if count > 1]
         read_file_calls = [call for call in calls if call.tool_name == "read_file"]
         oversized_sqlite = [
             len(str(call.result or "").encode("utf-8"))
             for call in successful_sqlite
             if len(str(call.result or "").encode("utf-8")) > self.max_result_access_response_bytes
         ]
-        failures = [message for failed, message in (
+        failures = _tool_attempt_failures(fetch_calls, "Source fetch")
+        failures.extend(_sqlite_attempt_failures(sqlite_calls))
+        failures.extend(message for failed, message in (
             (bool(missing), f"missing source fetches={missing}"),
-            (reject_duplicate_fetches and bool(duplicates), f"duplicate source fetches={duplicates}"),
+            (reject_duplicate_fetches and bool(duplicate_attempts), f"duplicate source fetches={duplicate_attempts}"),
             (bool(read_file_calls), f"read_file used for web results {len(read_file_calls)} time(s)"),
             (self.require_result_access_sqlite and not successful_sqlite, "no successful sqlite_batch call observed"),
             (bool(successful_sqlite) and summary.aggregate_tool_result_queries < 1, "no aggregate __tool_results query observed"),
@@ -729,7 +916,7 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
                 f"sqlite result-access probes {len(successful_sqlite)} > {self.max_result_access_sqlite_calls}",
             ),
             (bool(oversized_sqlite), f"oversized SQLite result bytes={oversized_sqlite}"),
-        ) if failed]
+        ) if failed)
         evidence = read_file_calls or successful_sqlite[-1:] or strategy_calls or calls
         self.record_task_result(
             run_id,
@@ -1047,34 +1234,30 @@ class SqliteDomainModelRefreshesAndEvolvesScenario(SqliteDomainModelScenario):
             allowed_tool_names={"http_request", "sqlite_batch", "send_chat_message"}, max_relevant_tool_calls=8,
         )
         calls = _tool_calls_for_run(run_id, after=inbound.timestamp)
-        fetches = [
-            call for call in calls
-            if call.tool_name == "http_request" and str(call.status).lower() == "complete"
-            and str(resolved_tool_param(call, "url") or "").rstrip("/") == DOMAIN_REFRESH_URL.rstrip("/")
-        ]
+        sqlite_attempts = [call for call in calls if call.tool_name == "sqlite_batch"]
         sqlite_calls = [
-            call for call in calls if call.tool_name == "sqlite_batch" and str(call.status).lower() == "complete"
+            call for call in sqlite_attempts if str(call.status).lower() == "complete"
         ]
         sql_values = [str((call.tool_params or {}).get("sql") or "") for call in sqlite_calls]
         source_mutations = set(source_derived_model_mutation_tables(sql_values))
-        reconciled_tables = set(source_derived_model_reconciled_tables(sql_values))
         state_failures, child_table = _inspect_domain_refresh_state(agent_id)
+        if PersistentAgent.objects.values_list("charter", flat=True).get(id=agent_id) != self.domain_charter:
+            state_failures.append("ordinary CRM review changed the agent charter")
         expected_tables = {"accounts"}
         if child_table:
             expected_tables.add(child_table.casefold())
-        failures = [message for failed, message in (
-            (len(fetches) != 1, f"expected one source fetch, found {len(fetches)}"),
-            (not sqlite_calls, "new source evidence was not written to the model"),
+        failures = _first_shot_source_phase_failures(calls)
+        failures.extend(_sqlite_attempt_failures(sqlite_attempts))
+        failures.extend(_source_write_effect_failures(sqlite_attempts, expected_tables))
+        if child_table:
+            failures.extend(_source_relationship_read_failures(sql_values, "accounts", child_table))
+        failures.extend(_orphan_completion_failures(run_id, inbound.timestamp))
+        failures.extend(message for failed, message in (
             (
                 not expected_tables.issubset(source_mutations),
                 f"expected source-derived writes to {sorted(expected_tables)}, found {sorted(source_mutations)}",
             ),
-            (
-                not expected_tables.issubset(reconciled_tables),
-                f"updated model was not queried after reconciliation: {sorted(reconciled_tables)}",
-            ),
-            (len(sqlite_calls) > 4, f"SQLite refresh calls were not bounded: {len(sqlite_calls)}"),
-        ) if failed]
+        ) if failed)
         self._record_check(
             run_id, "verify_source_to_model_refresh", failures,
             "Fetched the newer snapshot once, ingested it, and then replied.",
@@ -1152,6 +1335,7 @@ class SqliteBoundedPortfolioReportScenario(SqliteToolResultScenario):
         task_name = "verify_complete_terminal_report"
         self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name=task_name)
         calls = _tool_calls_for_run(run_id, after=after)
+        send_calls = [call for call in calls if call.tool_name == "send_chat_message"]
         terminal_calls = [
             (index, call)
             for index, call in enumerate(calls)
@@ -1181,10 +1365,11 @@ class SqliteBoundedPortfolioReportScenario(SqliteToolResultScenario):
             and str(getattr(call, "status", "complete")).lower() == "complete"
         }
         fetched_before_final = all(detail_positions.get(url, final_position + 1) < final_position for url in PORTFOLIO_FETCH_URLS)
-        failures = [message for failed, message in (
+        failures = _tool_attempt_failures(send_calls, "Final send")
+        failures.extend(message for failed, message in (
             (bool(missing_associations), f"final report missing/mismatched={missing_associations}"),
             (not fetched_before_final, "terminal report was sent before all available item evidence was fetched"),
-        ) if failed]
+        ) if failed)
         self.record_task_result(
             run_id,
             None,
@@ -1287,7 +1472,7 @@ class SqliteBoundedPortfolioReportScenario(SqliteToolResultScenario):
 
     @classmethod
     def _has_complete_structured_report(cls, body: str) -> bool:
-        return not cls._missing_portfolio_associations(body) and cls._has_coverage_summary(body)
+        return not cls._missing_portfolio_associations(body) and cls._has_complete_comparison_table(body)
 
     @staticmethod
     def _has_complete_comparison_table(body: str) -> bool:
@@ -1303,41 +1488,64 @@ class SqliteBoundedPortfolioReportScenario(SqliteToolResultScenario):
                 if not stripped.startswith("|") or not stripped.endswith("|"):
                     break
                 data_rows.append(stripped)
-            has_full_comparison = all(
-                any(
-                    company.casefold() in row.casefold()
-                    and founder.casefold() in row.casefold()
-                    and background_term.casefold() in row.casefold()
-                    for row in data_rows
+            entity_rows = tuple(
+                tuple(
+                    (index, row)
+                    for index, row in enumerate(data_rows)
+                    if company.casefold() in row.casefold()
                 )
-                for _slug, company, founder, background_term, _background in PORTFOLIO_COMPANIES
+                for _slug, company, _founder, _background_term, _background in PORTFOLIO_COMPANIES
             )
-            if has_full_comparison and SqliteBoundedPortfolioReportScenario._has_coverage_summary(body):
+            complete_rows = all(
+                len(rows) == 1
+                and all(term.casefold() in rows[0][1].casefold() for term in (company, founder, background_term))
+                for rows, (_slug, company, founder, background_term, _background) in zip(
+                    entity_rows,
+                    PORTFOLIO_COMPANIES,
+                )
+            )
+            distinct_rows = len({rows[0][0] for rows in entity_rows if rows}) == len(PORTFOLIO_COMPANIES)
+            summary = "\n".join((
+                *lines[:separator_index - 1],
+                *lines[separator_index + 1 + len(data_rows):],
+            ))
+            if complete_rows and distinct_rows and SqliteBoundedPortfolioReportScenario._has_coverage_summary(summary):
                 return True
         return False
 
     @staticmethod
     def _has_coverage_summary(body: str) -> bool:
-        mentions_founders = re.search(r"\bfounders?\b", body, re.I)
-        partial_coverage = (
-            re.search(r"\b(?:7\s*/\s*8|(?:7|seven)\s+of\s+(?:the\s+)?(?:8|eight))\b", body, re.I)
-            or (
-                re.search(r"\b(?:7|seven)\b", body, re.I)
-                and re.search(
-                    r"\b(?:1|one)\b.*\b(?:nondisclos|undisclos|unavailable|unresolved|block)",
-                    body,
-                    re.I | re.S,
-                )
+        seven = r"(?:7|seven)"
+        eight = r"(?:8|eight)"
+        company = r"compan(?:y|ies)"
+        state = r"(?:resolved|accounted\s+for|covered)"
+        explicit_total = (
+            re.search(
+                rf"\b{state}\b[^\n]{{0,40}}\b(?:8\s*/\s*8|all\s+{eight})\b[^\n]{{0,30}}\b{company}\b",
+                body,
+                re.I,
+            )
+            or re.search(
+                rf"\b(?:8\s*/\s*8|all\s+{eight})\b[^\n]{{0,30}}\b{company}\b[^\n]{{0,40}}\b{state}\b",
+                body,
+                re.I,
             )
         )
-        incorrect_coverage = re.search(
-            r"\b(?:[0-6]|8|zero|one|two|three|four|five|six|eight)\s+founders?\s+(?:were\s+)?identified\b",
+        founder_coverage = any(re.search(pattern, body, re.I) for pattern in (
+            rf"\b{seven}\s+(?:named\s+)?founders?\s+(?:were\s+)?(?:identified|known|named)\b",
+            rf"\b{seven}\s+of\s+(?:the\s+)?{eight}\s+{company}\b[^\n]{{0,50}}"
+            r"\b(?:named\s+founders?|founders?\s+(?:identified|known|named))\b",
+            rf"\b{seven}\s*(?:of\s+(?:the\s+)?{eight}|/\s*8)\s+(?:named\s+)?founders?\b"
+            r"[^\n]{0,35}\b(?:identified|known|named|found|confirmed|sourced)\b",
+            rf"\b(?:identified|named|found|confirmed|sourced)\b[^\n]{{0,25}}\bfounders?\b"
+            rf"[^\n]{{0,25}}\b(?:for|at)\s+{seven}\s+of\s+(?:the\s+)?{eight}\s+(?:portfolio\s+)?{company}\b",
+            rf"\bfounders?\b[^\n]{{0,20}}\b(?:identified|named|known|confirmed|sourced)\b"
+            rf"[^\n]{{0,25}}\b(?:for|at)\s+{seven}\s+of\s+(?:the\s+)?{eight}\s+(?:portfolio\s+)?{company}\b",
+        ))
+        blocker = re.search(
+            r"\b(?:1|one)\b[^\n]{0,80}\b(?:nondisclos|undisclos|not\s+publicly\s+disclosed|unavailable|unresolved|block)",
             body,
             re.I,
         )
-        complete_listing_with_blocker = (
-            all(company.casefold() in body.casefold() for _slug, company, *_rest in PORTFOLIO_COMPANIES)
-            and re.search(r"\b(?:not publicly disclosed|undisclosed|nondisclos)", body, re.I)
-            and not incorrect_coverage
-        )
-        return bool(mentions_founders and (partial_coverage or complete_listing_with_blocker))
+        nondisclosure = re.search(r"\b(?:nondisclos|undisclos|not\s+publicly\s+disclosed)\b", body, re.I)
+        return bool(explicit_total or (founder_coverage and (blocker or nondisclosure)))

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -8,12 +8,13 @@ from unittest.mock import patch
 from allauth.account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase, tag
+from django.utils import timezone
 
 import api.evals.loader  # noqa: F401 - registers scenarios and suites
 from api.evals.scenarios import sqlite_tool_results as sqlite_evals
 from api.agent.core.event_processing import _get_completed_process_run_count, _resolve_eval_mock_result
 from api.agent.core.prompt_context import _get_system_instruction, build_prompt_context_preview
-from api.agent.core.tool_results import _wrap_as_sqlite_result
+from api.agent.core.tool_results import _build_prompt_preview
 from api.agent.tools.create_chart import get_create_chart_tool
 from api.agent.tools.eval_synthetic_tools import EVAL_SYNTHETIC_TOOL_DEFINITIONS
 from api.agent.tools.plan import get_update_plan_tool
@@ -66,7 +67,10 @@ from api.evals.scenarios.sqlite_tool_results import (
     SqliteNaturalResultAccessScenario,
     SqliteToolResultScenario,
     _decision_model_tables,
+    _first_shot_source_phase_failures,
     _portfolio_mock,
+    _source_write_effect_failures,
+    _sqlite_attempt_failures,
 )
 from api.evals.stop_policy import should_stop_for_eval_policy
 from api.evals.suites import SuiteRegistry
@@ -76,6 +80,7 @@ from api.models import (
     EvalRun,
     EvalRunTask,
     PersistentAgent,
+    PersistentAgentCompletion,
     PersistentAgentCommsEndpoint,
     PersistentAgentMessage,
     PersistentAgentStep,
@@ -170,25 +175,27 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
                 source_urls=SOURCE_URLS,
             ))
 
-        calls.append(_eval_tool_call("read_file", {"path": "$[tool_results/abc/result_text]"}))
-        with patch("api.evals.scenarios.sqlite_tool_results._tool_calls_for_run", return_value=calls):
-            self.assertFalse(scenario._record_result_access(
-                "run", after=None,
-                task_name="verify_natural_result_access",
-                source_urls=SOURCE_URLS,
-            ))
-        self.assertIn("read_file used for web results", recorded[-1][1]["observed_summary"])
-
-        oversized_calls = calls[:-2] + [_eval_tool_call(
-            "sqlite_batch",
-            {"sql": "SELECT result_id, result_text FROM __tool_results ORDER BY result_id"},
-            result="x" * 40_000,
-        )]
-        with patch("api.evals.scenarios.sqlite_tool_results._tool_calls_for_run", return_value=oversized_calls):
-            self.assertFalse(scenario._record_result_access(
-                "run", after=None, task_name="verify_natural_result_access", source_urls=SOURCE_URLS,
-            ))
-        self.assertIn("oversized SQLite result", recorded[-1][1]["observed_summary"])
+        failed_fetch = _eval_tool_call(
+            "mcp_brightdata_scrape_as_markdown", {"url": SOURCE_URLS[0]}, status="error",
+        )
+        failed_sqlite = _eval_tool_call("sqlite_batch", result='{"status":"error"}')
+        oversized = _eval_tool_call(
+            "sqlite_batch", {"sql": "SELECT result_text FROM __tool_results"}, result="x" * 40_000,
+        )
+        regressions = (
+            ("Source fetch attempt 1", [failed_fetch, *calls]),
+            ("SQLite attempt 1", [*calls[:-1], failed_sqlite, calls[-1]]),
+            ("read_file used for web results", [*calls, _eval_tool_call("read_file", {"path": "result_text"})]),
+            ("oversized SQLite result", [*calls[:-1], oversized]),
+        )
+        for expected, attempts in regressions:
+            with self.subTest(expected=expected), patch(
+                "api.evals.scenarios.sqlite_tool_results._tool_calls_for_run", return_value=attempts,
+            ):
+                self.assertFalse(scenario._record_result_access(
+                    "run", after=None, task_name="verify_natural_result_access", source_urls=SOURCE_URLS,
+                ))
+            self.assertIn(expected, recorded[-1][1]["observed_summary"])
 
     def test_portfolio_requires_complete_unique_research_and_terminal_report(self):
         scenario, recorded = SqliteBoundedPortfolioReportScenario(), []
@@ -218,6 +225,35 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             ))
             self.assertEqual(scenario._record_complete_terminal_report("run", after=None), body)
         self.assertEqual(recorded[-1][0][2], EvalRunTask.Status.PASSED)
+
+        failed_fetch = _eval_tool_call(
+            "mcp_brightdata_scrape_as_markdown",
+            {"url": PORTFOLIO_FETCH_URLS[0]},
+            status="error",
+        )
+        with patch(
+            "api.evals.scenarios.sqlite_tool_results._tool_calls_for_run",
+            return_value=[failed_fetch, *calls],
+        ):
+            self.assertFalse(scenario._record_result_access(
+                "run", after=None, task_name="verify_result_access",
+                source_urls=PORTFOLIO_FETCH_URLS,
+                reject_duplicate_fetches=True,
+            ))
+        self.assertIn("Source fetch attempt 1", recorded[-1][1]["observed_summary"])
+
+        failed_send = _eval_tool_call(
+            "send_chat_message",
+            {"body": body, "will_continue_work": False},
+            status="error",
+        )
+        with patch(
+            "api.evals.scenarios.sqlite_tool_results._tool_calls_for_run",
+            return_value=[*fetches, sqlite, failed_send, final],
+        ):
+            scenario._record_complete_terminal_report("run", after=None)
+        self.assertEqual(recorded[-1][0][2], EvalRunTask.Status.FAILED)
+        self.assertIn("Final send attempt 1", recorded[-1][1]["observed_summary"])
 
         bad_calls = [*fetches[:-1], fetches[1], sqlite, _eval_tool_call(
             "send_chat_message",
@@ -280,47 +316,50 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
 
         self.assertEqual(recorded[-1][0][2], EvalRunTask.Status.PASSED)
         self.assertIn("complete structured comparison", recorded[-1][1]["observed_summary"])
-        self.assertTrue(
-            scenario._has_complete_comparison_table(
-                body.replace(
-                    "7 founders identified; 1 evidence-backed nondisclosure.",
-                    "7 of the 8 companies have named founders; Umbra is not publicly disclosed.",
+        summary = "7 founders identified; 1 evidence-backed nondisclosure."
+        cases = (
+            (True, "7 of the 8 companies have named founders; Umbra is not publicly disclosed."),
+            (True, "Seven founders identified.\nOne company has an evidence-backed nondisclosure."),
+            (True, "Seven of eight founders were identified; the remaining founder is not publicly disclosed."),
+            (True, "I found founders for seven of the eight portfolio companies; Umbra's is not publicly disclosed."),
+            (False, "Here you go."),
+            (False, "1 founder identified."),
+            (False, "All 8 founders identified."),
+            (False, "8 founders identified."),
+            (False, "Eight founders were identified."),
+        )
+        for expected, replacement in cases:
+            with self.subTest(summary=replacement):
+                self.assertEqual(
+                    scenario._has_complete_comparison_table(body.replace(summary, replacement)), expected,
                 )
-            )
+
+    def test_portfolio_hierarchy_rejects_coverage_and_row_gaming(self):
+        scenario = SqliteBoundedPortfolioReportScenario()
+        rows = [
+            f"| {company} | {founder} | {background} |"
+            for _slug, company, founder, _term, background in PORTFOLIO_COMPANIES
+        ]
+        table = "| Company | Founder | Background |\n|---|---|---|\n" + "\n".join(rows)
+        valid_summary = "Resolved 8/8 companies: 7 founders identified; 1 evidence-backed nondisclosure."
+
+        giant_row = "| " + " | ".join(
+            term
+            for _slug, company, founder, _background_term, background in PORTFOLIO_COMPANIES
+            for term in (company, founder, background)
+        ) + " |"
+        duplicate = "\n".join((rows[0], rows[0], *rows[1:]))
+        cases = (
+            (True, f"{valid_summary}\n\n{table}"),
+            (True, f"{table}\n\n{valid_summary}"),
+            (False, f"Coverage complete.\n\n{table}"),
+            (False, f"7 days reviewed; 1 blocker remains.\n\n{table}"),
+            (False, f"{valid_summary}\n\n| Company | Founder | Background |\n|---|---|---|\n{giant_row}"),
+            (False, f"{valid_summary}\n\n| Company | Founder | Background |\n|---|---|---|\n{duplicate}"),
         )
-        self.assertTrue(
-            scenario._has_complete_comparison_table(
-                body.replace(
-                    "7 founders identified; 1 evidence-backed nondisclosure.",
-                    "Seven founders identified.\nOne company has an evidence-backed nondisclosure.",
-                )
-            )
-        )
-        self.assertTrue(
-            scenario._has_complete_comparison_table(
-                body.replace("7 founders identified; 1 evidence-backed nondisclosure.", "Here you go.")
-            )
-        )
-        self.assertFalse(
-            scenario._has_complete_comparison_table(
-                body.replace("7 founders identified; 1 evidence-backed nondisclosure.", "1 founder identified.")
-            )
-        )
-        self.assertFalse(
-            scenario._has_complete_comparison_table(
-                body.replace("7 founders identified; 1 evidence-backed nondisclosure.", "All 8 founders identified.")
-            )
-        )
-        self.assertFalse(
-            scenario._has_complete_comparison_table(
-                body.replace("7 founders identified; 1 evidence-backed nondisclosure.", "8 founders identified.")
-            )
-        )
-        self.assertFalse(
-            scenario._has_complete_comparison_table(
-                body.replace("7 founders identified; 1 evidence-backed nondisclosure.", "Eight founders were identified.")
-            )
-        )
+        for expected, report in cases:
+            with self.subTest(expected=expected, report=report[:80]):
+                self.assertEqual(scenario._has_complete_comparison_table(report), expected)
 
     def test_portfolio_hierarchy_rejects_dummy_table(self):
         scenario, recorded = SqliteBoundedPortfolioReportScenario(), []
@@ -387,9 +426,9 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertEqual(scenario._missing_portfolio_associations(body), [])
         self.assertTrue(scenario._has_complete_comparison_table(body))
 
-    def test_portfolio_accepts_entity_blocks_with_nested_field_bullets(self):
+    def test_portfolio_rejects_complete_non_table_formats(self):
         scenario = SqliteBoundedPortfolioReportScenario()
-        body = "Seven of eight companies have named founders; one has a sourced nondisclosure.\n\n" + "\n\n".join(
+        entity_blocks = "Seven of eight companies have named founders; one has a sourced nondisclosure.\n\n" + "\n\n".join(
             "\n".join((
                 f"- {company}",
                 f"  - Founder: {founder}",
@@ -401,23 +440,18 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
                 PORTFOLIO_SOURCE_URLS,
             )
         )
-
-        self.assertEqual(scenario._missing_portfolio_associations(body), [])
-        self.assertFalse(scenario._has_complete_comparison_table(body))
-        self.assertTrue(scenario._has_complete_structured_report(body))
-
-    def test_portfolio_accepts_complete_prose_listing_with_disclosure_blocker(self):
-        scenario = SqliteBoundedPortfolioReportScenario()
-        body = "Founders of the current portfolio companies:\n\n" + "\n\n".join(
+        prose = "Founders of the current portfolio companies:\n\n" + "\n\n".join(
             f"**{company}**, {founder}. {background} [{url}]"
             for (_slug, company, founder, _term, background), url in zip(
                 PORTFOLIO_COMPANIES,
                 PORTFOLIO_SOURCE_URLS,
             )
         )
-
-        self.assertEqual(scenario._missing_portfolio_associations(body), [])
-        self.assertTrue(scenario._has_complete_structured_report(body))
+        for body in (entity_blocks, prose):
+            with self.subTest(format=body[:20]):
+                self.assertEqual(scenario._missing_portfolio_associations(body), [])
+                self.assertFalse(scenario._has_complete_comparison_table(body))
+                self.assertFalse(scenario._has_complete_structured_report(body))
 
     def test_portfolio_fixture_exposes_direct_evidence_and_search_fallback(self):
         mocks = _portfolio_mock()
@@ -714,6 +748,99 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             ):
                 self.assertNotIn(implementation_term, prompt.lower())
 
+    def test_source_ingest_rejects_every_non_clean_sqlite_attempt(self):
+        clean = _eval_tool_call(
+            "sqlite_batch",
+            result='{"status":"ok","results":[{"message":"Query 0 affected 1 rows."}]}',
+        )
+        cases = (
+            _eval_tool_call("sqlite_batch", result=clean.result, status="error"),
+            _eval_tool_call("sqlite_batch", result='{"status":"warning","results":[]}'),
+            _eval_tool_call("sqlite_batch", result='{"status":"error","results":[]}'),
+            _eval_tool_call(
+                "sqlite_batch",
+                result='{"status":"ok","results":[{"auto_correction":{"applied":true}}]}',
+            ),
+            _eval_tool_call("sqlite_batch", result="not-json"),
+        )
+
+        self.assertEqual(_sqlite_attempt_failures([clean]), [])
+        for call in cases:
+            with self.subTest(result=call.result, status=call.status):
+                self.assertTrue(_sqlite_attempt_failures([call]))
+
+        failures = _sqlite_attempt_failures([cases[1], clean])
+        self.assertTrue(failures)
+        self.assertIn("attempt 1", failures[0])
+
+    def test_domain_refresh_phase_order_rejects_recovery(self):
+        def call(tool_name, completion, params=None, **kwargs):
+            return _eval_tool_call(
+                tool_name,
+                params,
+                step=SimpleNamespace(completion_id=completion),
+                **kwargs,
+            )
+
+        fetch = call("http_request", "fetch", {"url": sqlite_evals.DOMAIN_REFRESH_URL})
+        sqlite = call("sqlite_batch", "sqlite", {"sql": "SELECT 1"})
+        send = call(
+            "send_chat_message",
+            "send",
+            {"body": "Done", "will_continue_work": False},
+        )
+        clean = [fetch, sqlite, send]
+        failed_fetch = call(
+            "http_request", "failed", {"url": sqlite_evals.DOMAIN_REFRESH_URL}, status="error",
+        )
+
+        self.assertEqual(_first_shot_source_phase_failures(clean), [])
+        cases = (
+            ([sqlite, fetch, send], "expected fetch"),
+            ([fetch, fetch, sqlite, send], "expected one exact CRM snapshot fetch"),
+            ([failed_fetch, sqlite, send], "execution status error"),
+            ([fetch, sqlite, send, send], "terminal send"),
+        )
+        for calls, expected_failure in cases:
+            with self.subTest(expected_failure=expected_failure):
+                failures = _first_shot_source_phase_failures(calls)
+                self.assertTrue(any(expected_failure in failure for failure in failures), failures)
+
+        sqlite.step.completion_id = "fetch"
+        failures = _first_shot_source_phase_failures(clean)
+        self.assertTrue(any("separate completions" in failure for failure in failures), failures)
+
+    def test_source_model_write_effect_rejects_zero_row_and_literal_recovery(self):
+        source_insert = (
+            "INSERT INTO accounts SELECT json_extract(value, '$.id') "
+            "FROM __tool_results, json_each(result_json, '$.content.accounts')"
+        )
+
+        def call(sql, *results):
+            return _eval_tool_call(
+                "sqlite_batch",
+                {"sql": sql},
+                result={"status": "ok", "results": list(results)},
+            )
+
+        affected = {"message": "Query affected 1 rows."}
+        clean = call(source_insert, affected)
+        regressions = (
+            call(
+                source_insert.replace("$.content.accounts", "$.accounts") + ";" + source_insert,
+                {"message": "Query affected 0 rows."},
+                affected,
+            ),
+            call("INSERT INTO accounts(id) VALUES ('acct-1');" + source_insert, affected, affected),
+            call(source_insert, {**affected, "auto_correction": {"applied": True}}),
+            call("UPDATE __agent_config SET charter='special case';" + source_insert, affected, affected),
+        )
+
+        self.assertEqual(_source_write_effect_failures([clean], {"accounts"}), [])
+        for attempted_recovery in regressions:
+            self.assertTrue(_source_write_effect_failures([attempted_recovery], {"accounts"}))
+        self.assertTrue(_source_write_effect_failures([clean], {"accounts", "workstreams"}))
+
     def test_domain_refresh_verifier_checks_persisted_rows(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             db_path = Path(temp_dir) / "state.db"
@@ -993,18 +1120,9 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         scenario.record_task_result = lambda *args, **kwargs: recorded.append((args, kwargs))
         calls = [
             SimpleNamespace(
-                step="rejected",
-                status="error",
-                result='{"status":"error","message":"Query not executed: link references are unsupported","retryable":true}',
-                tool_name="sqlite_batch",
-                tool_params={
-                    "sql": "CREATE TABLE plans(vendor TEXT, plan TEXT); "
-                    "INSERT INTO plans VALUES ('CareMesh', 'Clinic');"
-                },
-            ),
-            SimpleNamespace(
                 step="step",
                 status="complete",
+                result='{"status":"ok"}',
                 tool_name="sqlite_batch",
                 tool_params={
                     "sql": """
@@ -1036,8 +1154,8 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         initial_calls = [
             SimpleNamespace(
                 step="initial",
-                status="error",
-                result='{"status":"error","message":"Query 4 failed: no such column"}',
+                status="complete",
+                result='{"status":"ok"}',
                 tool_name="sqlite_batch",
                 tool_params={"sql": """
                     CREATE TABLE raw_plans AS
@@ -1051,15 +1169,6 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
                     SELECT vendor, json_extract(plan_json, '$.plan'),
                            json_extract(plan_json, '$.monthly_price_usd'), source_url
                     FROM raw_plans;
-                    SELECT missing_column FROM plans;
-                """},
-            ),
-            SimpleNamespace(
-                step="recovery",
-                status="complete",
-                result='{"status":"ok"}',
-                tool_name="sqlite_batch",
-                tool_params={"sql": """
                     SELECT vendor, plan FROM plans WHERE price <= 900 ORDER BY price;
                 """},
             )
@@ -1074,6 +1183,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             SimpleNamespace(
                 step="followup",
                 status="complete",
+                result='{"status":"ok"}',
                 tool_name="sqlite_batch",
                 tool_params={"sql": "SELECT vendor, plan FROM plans WHERE price <= 1600 ORDER BY price;"},
             )
@@ -1090,6 +1200,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             SimpleNamespace(
                 step="step",
                 status="complete",
+                result='{"status":"ok"}',
                 tool_name="sqlite_batch",
                 tool_params={
                     "sql": """
@@ -1114,6 +1225,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             SimpleNamespace(
                 step="step",
                 status="complete",
+                result='{"status":"ok"}',
                 tool_name="sqlite_batch",
                 tool_params={
                     "sql": """
@@ -1252,6 +1364,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             SimpleNamespace(
                 step="step",
                 status="complete",
+                result='{"status":"ok"}',
                 tool_name="sqlite_batch",
                 tool_params={
                     "sql": """
@@ -1283,6 +1396,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             SimpleNamespace(
                 step="step",
                 status="complete",
+                result='{"status":"ok"}',
                 tool_name="sqlite_batch",
                 tool_params={
                     "sql": "SELECT v.vendor, p.plan, p.price FROM vendors v JOIN plans p ON p.vendor=v.vendor "
@@ -1469,14 +1583,20 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertIn("set a resume schedule", outreach_description)
         self.assertIn("only makes sense when a schedule exists", schedule_description)
 
-    def test_fresh_full_tool_result_wrapper_discourages_redundant_sqlite_rereads(self):
-        wrapped = _wrap_as_sqlite_result('{"answer": "ready"}', 19)
+    def test_fresh_full_tool_result_wrapper_only_describes_visibility(self):
+        wrapped, is_inline = _build_prompt_preview(
+            '{"answer": "ready"}' * 200,
+            3800,
+            recency_position=0,
+            tool_name="http_request",
+            is_fresh_tool_call=True,
+        )
 
-        self.assertIn("Reply directly for a simple answer", wrapped)
-        self.assertIn("unless it updates an established named domain model", wrapped)
-        self.assertIn("Use SQL to reconcile that model", wrapped)
-        self.assertIn("exact filtering/ranking across sizable or multiple results", wrapped)
-        self.assertIn("do not query merely to reread or parse", wrapped)
+        self.assertTrue(is_inline)
+        self.assertIn("FULL RESULT (3800 chars) - ONE-TIME VIEW", wrapped)
+        self.assertIn("later turns show a preview", wrapped)
+        self.assertIn('{"answer": "ready"}', wrapped)
+        self.assertNotIn("SOURCE ARRAYS", wrapped)
 
 
 @tag("eval_sim")
@@ -2150,13 +2270,18 @@ class FirstRunPromptCalibrationTests(TestCase):
         )
         self.assertIn("A skipped web send never permits switching", system_prompt)
         self.assertIn("one compact tracked request; use options for a decision and free text", system_prompt)
-        self.assertIn("smallest exact charter phrase; preserve every unrelated word/setting verbatim", system_prompt)
+        self.assertIn("Replace conflicts/softened absolutes", system_prompt)
+        self.assertIn("append only if no related clause", system_prompt)
+        self.assertIn("finite task/batch/day/run/project/renewal/deal/case feedback is temporary", system_prompt)
         self.assertIn("Set false after delivery/config and no active work", system_prompt)
         self.assertIn("Do not set a schedule merely to continue or remember a single research question", system_prompt)
         self.assertIn("explicit SQLite/database request and sqlite_batch is callable", system_prompt)
         self.assertIn("do not search for a SQLite/database tool", system_prompt)
         self.assertIn("enabled tool fits -> use directly", system_prompt)
-        self.assertIn("public exact URL + http/scrape tool callable", system_prompt)
+        self.assertIn("named model + explicit fresh source/URL -> http_request only, no text/send/plan; WAIT", system_prompt)
+        self.assertIn("Use queried rows, not memory, for decisions", system_prompt)
+        self.assertIn("data/api/feed/file URL -> http_request", system_prompt)
+        self.assertIn("reconcile+SELECT there before use", system_prompt)
         self.assertIn("spawn_web_task only after access/render/login blockage", system_prompt)
         self.assertIn("exact docs/blog/changelog/release-notes URL", system_prompt)
         self.assertIn("opaque identifiers", system_prompt)

--- a/api/evals/tests/test_hallucinated_links.py
+++ b/api/evals/tests/test_hallucinated_links.py
@@ -17,6 +17,9 @@ from api.evals.scenarios.hallucinated_links import (
     LONG_CONTEXT_MIN_CHARS,
     extract_bare_link_like_destinations,
     extract_http_urls,
+    owner_report_execution_failures,
+    owner_report_has_resolved_summary,
+    owner_report_table_failures,
     provenance_failures,
 )
 from api.evals.execution import WaitForIdleContext
@@ -27,12 +30,12 @@ from api.evals.suites import SuiteRegistry
 
 @tag("eval_sim")
 class HallucinatedLinkScenarioTests(SimpleTestCase):
-    def test_suite_registers_twelve_generated_real_harness_scenarios(self):
+    def test_suite_registers_fourteen_generated_real_harness_scenarios(self):
         suite = SuiteRegistry.get(HALLUCINATED_LINKS_SUITE_SLUG)
 
         self.assertIsNotNone(suite)
         self.assertEqual(tuple(suite.scenario_slugs), HALLUCINATED_LINK_SCENARIO_SLUGS)
-        self.assertEqual(len(suite.scenario_slugs), 12)
+        self.assertEqual(len(suite.scenario_slugs), 14)
 
         registered = ScenarioRegistry.list_all()
         for slug in HALLUCINATED_LINK_SCENARIO_SLUGS:
@@ -43,26 +46,26 @@ class HallucinatedLinkScenarioTests(SimpleTestCase):
             self.assertIn("url_provenance", metadata.tags)
             self.assertIn("llm_judge", metadata.tags)
 
-    def test_cases_form_six_matched_short_and_long_pairs(self):
+    def test_cases_form_seven_matched_short_and_long_pairs(self):
         variants_by_pattern = defaultdict(set)
         for case in HALLUCINATED_LINK_CASES:
             variants_by_pattern[case.pattern.slug_root].add(case.context_size)
 
-        self.assertEqual(len(variants_by_pattern), 6)
+        self.assertEqual(len(variants_by_pattern), 7)
         self.assertTrue(
             all(variants == set(CONTEXT_VARIANTS) for variants in variants_by_pattern.values())
         )
 
-    def test_cases_split_evenly_between_failure_types(self):
+    def test_cases_cover_both_failure_types(self):
         counts = Counter(case.pattern.failure_type for case in HALLUCINATED_LINK_CASES)
 
         self.assertEqual(set(counts), set(FAILURE_TYPES))
-        self.assertEqual(counts, Counter({"association": 6, "construction": 6}))
+        self.assertEqual(counts, Counter({"association": 8, "construction": 6}))
 
     def test_cases_cover_history_and_tool_contexts(self):
         sources = Counter(case.pattern.context_source for case in HALLUCINATED_LINK_CASES)
 
-        self.assertEqual(sources, Counter({"tool": 8, "history": 4}))
+        self.assertEqual(sources, Counter({"tool": 10, "history": 4}))
         self.assertEqual(
             {pattern.relevant_position for pattern in LINK_GROUNDING_PATTERNS},
             {"early", "middle", "late"},
@@ -99,6 +102,152 @@ class HallucinatedLinkScenarioTests(SimpleTestCase):
             prompt = pattern.prompt.casefold()
             for term in forbidden_terms:
                 self.assertNotIn(term, prompt)
+
+    def test_owner_report_requires_known_links_without_requesting_them(self):
+        case = next(
+            case for case in HALLUCINATED_LINK_CASES
+            if case.pattern.slug_root == "association_owner_report_tool" and not case.is_long
+        )
+        pattern = case.pattern
+        required_mentions = {
+            item for entity, fields in pattern.table_row_requirements for item in (entity, *fields)
+        }
+
+        self.assertNotIn("link", pattern.prompt.casefold())
+        self.assertNotIn("source", pattern.prompt.casefold())
+        self.assertEqual(len(pattern.table_row_requirements), 4)
+        self.assertEqual(len(case.required_urls), 3)
+        self.assertEqual(pattern.unlinked_entities, ("Threadline Robotics",))
+        self.assertEqual(len(required_mentions), 15)
+        self.assertTrue({
+            "Mina Shah", "Elena Ruiz", "Imani Brooks", "Jon Bell",
+            "hardware compliance", "warehouse inspection",
+        }.issubset(required_mentions))
+        self.assertEqual(set(extract_http_urls(pattern.source_text)), set(case.required_urls))
+
+    def test_owner_report_requires_one_complete_table_with_exact_entity_links(self):
+        requirements = (
+            ("Atlas Forge", ("Mina Shah", "automation")),
+            ("Meridian Care", ("Imani Brooks", "scheduling")),
+            ("Threadline Robotics", ("Sara Okoye", "robotics")),
+        )
+        links = (
+            ("Atlas Forge", "https://atlas.example.test/team"),
+            ("Meridian Care", "https://meridian.example.test/team"),
+        )
+        table = (
+            "Covered 3/3 companies\n\n"
+            "| Company | Founder | Building |\n|---|---|---|\n"
+            f"| [Atlas Forge]({links[0][1]}) | Mina Shah | automation |\n"
+            f"| [Meridian Care]({links[1][1]}) | Imani Brooks | scheduling |\n"
+            "| Threadline Robotics | Sara Okoye | robotics |"
+        )
+
+        self.assertEqual(owner_report_table_failures(
+            table,
+            row_requirements=requirements,
+            entity_urls=links,
+            unlinked_entities=("Threadline Robotics",),
+        ), [])
+
+        regressions = {
+            "prose instead of table": "\n\n".join(
+                f"**{entity}** {', '.join(required)}" for entity, required in requirements
+            ),
+            "missing requested field": table.replace(" | scheduling |", " | not returned |"),
+            "misassociated link": table.replace(links[0][1], links[1][1]),
+            "generic duplicate": table + f"\n\nSource: [company page]({links[0][1]})",
+            "unlinked entity linked": table.replace(
+                "Threadline Robotics", f"[Threadline Robotics]({links[0][1]})"
+            ),
+            "split tables": table + "\n\n" + table.partition("\n\n")[2],
+        }
+        for label, body in regressions.items():
+            with self.subTest(label=label):
+                self.assertTrue(owner_report_table_failures(
+                    body,
+                    row_requirements=requirements,
+                    entity_urls=links,
+                    unlinked_entities=("Threadline Robotics",),
+                ))
+
+    def test_owner_report_table_accepts_reference_tokens_only_on_owning_entities(self):
+        requirements = (("Atlas", ("Mina", "automation")), ("Threadline", ("Sara", "robotics")))
+        body = (
+            "| Company | Founder | Building |\n|---|---|---|\n"
+            "| [Atlas]($[link:atlas]) | Mina | automation |\n"
+            "| Threadline | Sara | robotics |"
+        )
+
+        self.assertEqual(owner_report_table_failures(
+            body,
+            row_requirements=requirements,
+            entity_urls=(("Atlas", "$[link:atlas]"),),
+            unlinked_entities=("Threadline",),
+        ), [])
+
+    def test_owner_report_requires_resolved_total_summary(self):
+        table = "| Company | Founder | Building |\n|---|---|---|\n| Atlas | Mina | automation |"
+        cases = (
+            (True, f"## Cohort\nResolved: 4/4 companies\n\n{table}", 4),
+            (True, f"Covered 4/4\n\n{table}", 4),
+            (True, f"## Cohort\nAll four companies are included below.\n\n{table}", 4),
+            (False, f"## Cohort\nAll four companies are included below.\n\n{table}", 3),
+            (False, f"## Cohort\n4/4 companies\n\n{table}", 4),
+            (True, f"{table}\n\nResolved: 4/4 companies", 4),
+        )
+        for expected, body, resolved in cases:
+            with self.subTest(expected=expected, body=body[:30]):
+                self.assertEqual(
+                    owner_report_has_resolved_summary(body, resolved=resolved, total=4), expected,
+                )
+
+    @staticmethod
+    def _owner_report_call(name, completion_id, *, result_status="ok", call_status="complete", terminal=None):
+        params = {} if terminal is None else {"will_continue_work": terminal}
+        return SimpleNamespace(
+            tool_name=name,
+            status=call_status,
+            result={"status": result_status},
+            tool_params=params,
+            step=SimpleNamespace(completion_id=completion_id),
+        )
+
+    def test_owner_report_execution_contract(self):
+        calls = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("send_chat_message", "completion-2", terminal=False),
+        )
+
+        self.assertEqual(owner_report_execution_failures(calls, ("completion-1", "completion-2")), [])
+        parallel = (
+            calls[0],
+            self._owner_report_call("send_chat_message", "completion-1", terminal=False),
+        )
+        with_intermediate_read = (
+            calls[0],
+            self._owner_report_call("sqlite_batch", "completion-2"),
+            self._owner_report_call("send_chat_message", "completion-3", terminal=False),
+        )
+        warning = (
+            self._owner_report_call("http_request", "completion-1", result_status="warning"),
+            self._owner_report_call("send_chat_message", "completion-2", terminal=False),
+        )
+        continuing = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("send_chat_message", "completion-2", terminal=True),
+        )
+        cases = (
+            (calls, ("completion-1", "orphan", "completion-2"), "one-to-one"),
+            (parallel, ("completion-1",), "one-to-one"),
+            (with_intermediate_read, ("completion-1", "completion-2", "completion-3"), "extra or repeated"),
+            (warning, ("completion-1", "completion-2"), "not all successful"),
+            (continuing, ("completion-1", "completion-2"), "terminal web-chat"),
+        )
+        for attempts, completion_ids, expected in cases:
+            with self.subTest(expected=expected):
+                failures = owner_report_execution_failures(attempts, completion_ids)
+                self.assertTrue(any(expected in failure for failure in failures), failures)
 
     def test_url_extraction_handles_plain_markdown_and_html_urls(self):
         body = (

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,29 +1,29 @@
 {
-  "baseline_sha": "6a7b8913a88158e23e5af2fc3c1f5adc3b9d5a71",
+  "baseline_sha": "e523c3e0d2ab6e5e062013fec2d41265ee0db60c",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7309,
-        "system_bytes": 23611,
-        "tools_bytes": 20987,
-        "total_bytes": 55326,
-        "user_bytes": 10728
+        "fitted_tokens": 7256,
+        "system_bytes": 23573,
+        "tools_bytes": 20968,
+        "total_bytes": 55091,
+        "user_bytes": 10550
       },
       "planning_first_run": {
-        "fitted_tokens": 8620,
-        "system_bytes": 30578,
-        "tools_bytes": 11981,
-        "total_bytes": 53040,
-        "user_bytes": 10481
+        "fitted_tokens": 8591,
+        "system_bytes": 30519,
+        "tools_bytes": 11962,
+        "total_bytes": 52953,
+        "user_bytes": 10472
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 7449,
-        "system_bytes": 24111,
-        "tools_bytes": 20987,
-        "total_bytes": 55829,
-        "user_bytes": 10731
+        "fitted_tokens": 7404,
+        "system_bytes": 24073,
+        "tools_bytes": 20968,
+        "total_bytes": 55594,
+        "user_bytes": 10553
       }
     },
     "scenarios": {
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 865,
+    "file_count": 874,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 246939
+    "limit": 247320
   }
 }

--- a/tests/unit/test_agent_event_processing_credits.py
+++ b/tests/unit/test_agent_event_processing_credits.py
@@ -89,6 +89,7 @@ class CreditMessageOnlyModeTests(TestCase):
     def test_restricted_tool_filter_keeps_only_message_and_sleep_tools(self):
         tools = [
             {"type": "function", "function": {"name": "send_email"}},
+            {"type": "function", "function": {"name": "send_discord_message"}},
             {"type": "function", "function": {"name": "sleep_until_next_trigger"}},
             {"type": "function", "function": {"name": "sqlite_query"}},
         ]
@@ -97,7 +98,7 @@ class CreditMessageOnlyModeTests(TestCase):
 
         self.assertEqual(
             [tool["function"]["name"] for tool in filtered],
-            ["send_email", "sleep_until_next_trigger"],
+            ["send_email", "send_discord_message", "sleep_until_next_trigger"],
         )
 
 

--- a/tests/unit/test_eval_behavior_micro_scenarios.py
+++ b/tests/unit/test_eval_behavior_micro_scenarios.py
@@ -27,9 +27,12 @@ from api.evals.scenarios.behavior_micro import (
     CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION,
     CHARTER_ADDS_INFERRED_PREFERENCE_PRESERVING_EXISTING,
     CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD,
-    CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
     CHARTER_EXPANDS_SPARSE_CHARTER_WITH_DETAIL,
     CHARTER_IGNORES_ONE_OFF_PREFERENCE,
+    CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK,
+    CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
+    CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK,
+    CHARTER_IGNORES_BATCH_SCOPED_PREFERENCE,
     CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
     CHARTER_MEMORY_MICRO_SCENARIO_SLUGS,
     CHARTER_NARROWS_SCOPE_PRESERVING_UNRELATED_GUIDANCE,
@@ -76,6 +79,7 @@ from api.evals.scenarios.monitor_pollution import (
     _schedule_is_reasonable_pollution_monitoring,
 )
 from api.evals.scenarios.permit_followup_single_reply import PermitFollowupSingleReplyScenario
+from api.evals.scenarios.sqlite_tool_results import _source_relationship_read_failures
 from api.evals.scenarios.weather_lookup import _is_free_weather_request, _weather_lookup_http_mock
 from api.evals.stop_policy import (
     should_stop_for_eval_policy,
@@ -93,6 +97,7 @@ from api.models import (
     EvalRunTask,
     PersistentAgent,
     PersistentAgentCommsEndpoint,
+    PersistentAgentCompletion,
     PersistentAgentConversation,
     PersistentAgentEnabledTool,
     PersistentAgentHumanInputRequest,
@@ -124,16 +129,29 @@ class BehaviorMicroScenarioRegistrationTests(TestCase):
         self.assertEqual(tool_choice_suite.scenario_slugs, TOOL_CHOICE_MICRO_SCENARIO_SLUGS)
         self.assertFalse(set(CHARTER_MEMORY_MICRO_SCENARIO_SLUGS) & set(BEHAVIOR_MICRO_SCENARIO_SLUGS))
         self.assertFalse(set(CHARTER_MEMORY_MICRO_SCENARIO_SLUGS) & set(TOOL_CHOICE_MICRO_SCENARIO_SLUGS))
-        self.assertIn(CHARTER_ADDS_DURABLE_PREFERENCE_PRESERVING_EXISTING, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_ADDS_INFERRED_PREFERENCE_PRESERVING_EXISTING, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_EXPANDS_SPARSE_CHARTER_WITH_DETAIL, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_NARROWS_SCOPE_PRESERVING_UNRELATED_GUIDANCE, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_IGNORES_ONE_OFF_PREFERENCE, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_PATCHES_DIRECT_STYLE_CORRECTION, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION, charter_memory_suite.scenario_slugs)
-        self.assertIn(CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW, charter_memory_suite.scenario_slugs)
+        for slug in (
+            CHARTER_ADDS_DURABLE_PREFERENCE_PRESERVING_EXISTING,
+            CHARTER_ADDS_INFERRED_PREFERENCE_PRESERVING_EXISTING,
+            CHARTER_EXPANDS_SPARSE_CHARTER_WITH_DETAIL,
+            CHARTER_NARROWS_SCOPE_PRESERVING_UNRELATED_GUIDANCE,
+            CHARTER_IGNORES_ONE_OFF_PREFERENCE,
+            CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION,
+            CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD,
+            CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
+            CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION,
+            CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
+        ):
+            self.assertIn(slug, charter_memory_suite.scenario_slugs)
+
+    def test_new_charter_feedback_prompts_do_not_prescribe_persistence(self):
+        for slug in (
+            CHARTER_IGNORES_BATCH_SCOPED_PREFERENCE,
+            CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK,
+            CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK,
+        ):
+            prompt = ScenarioRegistry.get(slug).prompt.casefold()
+            for forbidden in ("charter", "sqlite", "patch_text", "save this", "update your instructions"):
+                self.assertNotIn(forbidden, prompt)
 
     def test_github_credential_retention_scenarios_expose_diagnostic_tasks(self):
         charter_scenario = ScenarioRegistry.get(CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION)
@@ -740,10 +758,11 @@ class BehaviorMicroHelperTests(TestCase):
                 for definition in get_enabled_tool_definitions(agent)
             }
 
-    def _add_tool_call(self, tool_name, params=None, status="complete"):
+    def _add_tool_call(self, tool_name, params=None, status="complete", completion=None):
         step = PersistentAgentStep.objects.create(
             agent=self.agent,
             eval_run=self.run,
+            completion=completion,
             description=f"{tool_name} call",
         )
         return PersistentAgentToolCall.objects.create(
@@ -753,6 +772,35 @@ class BehaviorMicroHelperTests(TestCase):
             result="{}",
             status=status,
         )
+
+    @staticmethod
+    def _charter_patch_sql(old, new):
+        old = old.replace("'", "''")
+        new = new.replace("'", "''")
+        return f"UPDATE __agent_config SET charter=patch_text(charter,'{old}','{new}')"
+
+    def _add_clean_charter_patch(self, completion, *, old="", new="Keep prospect questions easy to answer."):
+        call = self._add_tool_call(
+            "sqlite_batch",
+            {"sql": self._charter_patch_sql(old, new)},
+            completion=completion,
+        )
+        call.result = '{"status":"ok","results":[{"message":"Query 0 affected 1 rows."}]}'
+        call.save(update_fields=["result"])
+        return call
+
+    def _add_orchestrator_completion(self):
+        return PersistentAgentCompletion.objects.create(agent=self.agent, eval_run=self.run)
+
+    def _assert_charter_cases(self, slug, *, old, new, passing, failing):
+        scenario = ScenarioRegistry.get(slug)
+        calls = [SimpleNamespace(tool_params={"sql": self._charter_patch_sql(old, new)})]
+        for charter in passing:
+            passed, detail = scenario._charter_check(SimpleNamespace(charter=charter), calls)
+            self.assertTrue(passed, detail)
+        for charter in failing:
+            passed, detail = scenario._charter_check(SimpleNamespace(charter=charter), calls)
+            self.assertFalse(passed, detail)
 
     def _add_human_input_request(self, run, question):
         conversation = PersistentAgentConversation.objects.create(
@@ -868,6 +916,150 @@ class BehaviorMicroHelperTests(TestCase):
         self.assertTrue(passed, detail)
         self.assertFalse(no_patch_passed, no_patch_detail)
         self.assertFalse(harmful_passed, harmful_detail)
+
+    def test_charter_feedback_checks_preserve_scope_and_semantic_direction(self):
+        link = ScenarioRegistry.get(CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION)
+        link_rule = "Include a verified profile URL for every candidate."
+        self._assert_charter_cases(
+            link.slug,
+            old="",
+            new=link_rule,
+            passing=[link.existing_charter + " " + link_rule,
+                     link.existing_charter + " Never send candidate reports without verified source links."],
+            failing=[
+                link.existing_charter + " Never include profile URLs in candidate reports.",
+                link.existing_charter + " Always include candidate URLs, even if unavailable or unverified.",
+                link.existing_charter + " Always include a profile URL for every candidate.",
+                link_rule,
+            ],
+        )
+
+        style = ScenarioRegistry.get(CHARTER_PATCHES_DIRECT_STYLE_CORRECTION)
+        style_rule = "Keep messages conversational and avoid automated templates. Do not use dashes or hyphens."
+        self._assert_charter_cases(
+            style.slug,
+            old="",
+            new=style_rule,
+            passing=[style.existing_charter + " " + style_rule],
+            failing=[
+                style.existing_charter + " Keep messages natural, use automated templates, and include dashes.",
+                style_rule,
+            ],
+        )
+
+    def test_evaluative_and_messy_feedback_checks_keep_unrelated_clauses(self):
+        evaluative = ScenarioRegistry.get(CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK)
+        old_question = "For prospect outreach, end each note with an open question asking for the recipient's opinion."
+        easy_question = "For prospect outreach, use observations and ask a specific question that is easy to answer."
+        good_evaluative = evaluative.existing_charter.replace(old_question, easy_question)
+        self._assert_charter_cases(
+            evaluative.slug,
+            old=old_question,
+            new=easy_question,
+            passing=[good_evaluative],
+            failing=[
+                evaluative.existing_charter.replace(old_question, "Make every question easy to answer."),
+                evaluative.existing_charter.replace(
+                    old_question,
+                    "Prospect outreach should increase recipient effort and make them do the work.",
+                ),
+                good_evaluative.replace("Do not change these instructions unless the owner explicitly asks.", ""),
+            ],
+        )
+
+        operating = ScenarioRegistry.get(CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK)
+        old_operating = (
+            "Send the owner a short kickoff and a progress note for each work session. "
+            "Route routine follow-ups and blockers to the owner."
+        )
+        new_operating = (
+            "Send outcome reports with what changed, material blockers, and the next action. "
+            "Route routine follow-ups to Morgan. Only notify the owner for real blockers."
+        )
+        good_operating = operating.existing_charter.replace(old_operating, new_operating)
+        natural_operating = operating.existing_charter.replace(
+            old_operating,
+            "After kickoff, only message the owner with what changed, blockers, and next move. "
+            "Route routine follow-ups to Morgan. Only pull the owner in on a real blocker.",
+        )
+        compact_operating = operating.existing_charter.replace(
+            old_operating,
+            "After kickoff, only pull the owner in on a real blocker — routine follow-ups are for Morgan. "
+            "Come back with what changed, blockers, and next move; play-by-play updates are not useful.",
+        )
+        changed_operating = operating.existing_charter.replace(
+            old_operating,
+            "After kickoff, only message the owner when something has changed, there's a real blocker, "
+            "or a next move is needed. Route routine follow-ups to Morgan.",
+        )
+        self._assert_charter_cases(
+            operating.slug,
+            old=old_operating,
+            new=new_operating,
+            passing=[good_operating, natural_operating, compact_operating, changed_operating],
+            failing=[
+                good_operating.replace("Send outcome reports", "Never send outcome reports"),
+                good_operating.replace(
+                    "Route routine follow-ups to Morgan. Only notify the owner for real blockers.",
+                    "Route routine follow-ups to the owner. Send serious blockers to Morgan.",
+                ),
+                good_operating + " Put legal review first.",
+                good_operating.replace("Never include customer secrets in team messages.", ""),
+            ],
+        )
+
+    def test_focused_charter_patch_rejects_wrong_old_and_full_charter_append(self):
+        scenario = ScenarioRegistry.get(CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD)
+        rule = "Use comparison tables and bullet takeaways."
+        agent = SimpleNamespace(charter=scenario.existing_charter + " " + rule)
+        good_call = SimpleNamespace(tool_params={"sql": self._charter_patch_sql("", rule)})
+        wrong_old = SimpleNamespace(tool_params={"sql": self._charter_patch_sql(scenario.prior_outbound_body, rule)})
+        full_append = SimpleNamespace(
+            tool_params={"sql": self._charter_patch_sql("", scenario.existing_charter + " " + rule)}
+        )
+        opposite_rule = "Never use comparison tables or bullet takeaways."
+        opposite_agent = SimpleNamespace(charter=scenario.existing_charter + " " + opposite_rule)
+        opposite_call = SimpleNamespace(tool_params={"sql": self._charter_patch_sql("", opposite_rule)})
+
+        self.assertTrue(scenario._charter_check(agent, [good_call])[0])
+        self.assertFalse(scenario._charter_check(agent, [wrong_old])[0])
+        self.assertFalse(scenario._charter_check(agent, [full_append])[0])
+        self.assertFalse(scenario._charter_check(agent, [good_call, good_call])[0])
+        self.assertFalse(scenario._charter_check(opposite_agent, [opposite_call])[0])
+
+    def test_domain_refresh_checker_requires_relationship_decision_rows(self):
+        imports = (
+            "INSERT INTO accounts(account_id,stage) SELECT json_extract(j.value,'$.account_id'),"
+            "json_extract(j.value,'$.stage') FROM __tool_results r,"
+            "json_each(r.result_json,'$.content.accounts') j;"
+            "INSERT INTO workstreams(workstream_id,account_id,status) SELECT "
+            "json_extract(j.value,'$.workstream_id'),json_extract(j.value,'$.account_id'),"
+            "json_extract(j.value,'$.status') FROM __tool_results r,"
+            "json_each(r.result_json,'$.content.workstreams') j;"
+        )
+        row_reads = imports + "SELECT * FROM accounts; SELECT * FROM workstreams;"
+        joined_read = imports + (
+            "SELECT a.stage,w.status,w.owner FROM accounts a JOIN workstreams w "
+            "ON w.account_id=a.account_id;"
+        )
+        bounded_reads = imports + (
+            "SELECT stage,owner,next_action FROM accounts WHERE account_id='acct-aster-042';"
+            "SELECT status,owner,due_on FROM workstreams WHERE account_id='acct-aster-042';"
+        )
+        count_only = imports + "SELECT count(*) FROM accounts; SELECT count(*) FROM workstreams;"
+        unlinked_reads = imports + "SELECT stage FROM accounts; SELECT status FROM workstreams;"
+
+        self.assertEqual(_source_relationship_read_failures([row_reads], "accounts", "workstreams"), [])
+        self.assertEqual(_source_relationship_read_failures([joined_read], "accounts", "workstreams"), [])
+        self.assertEqual(_source_relationship_read_failures([bounded_reads], "accounts", "workstreams"), [])
+        self.assertIn(
+            "did not return decision rows",
+            _source_relationship_read_failures([count_only], "accounts", "workstreams")[0],
+        )
+        self.assertIn(
+            "stable account relationship",
+            _source_relationship_read_failures([unlinked_reads], "accounts", "workstreams")[0],
+        )
 
     def test_eval_synthetic_tools_are_catalog_backed_for_eval_agents(self):
         self.agent.execution_environment = "eval"
@@ -1503,6 +1695,130 @@ class BehaviorMicroHelperTests(TestCase):
             [expected, unrelated],
         )
         self.assertNotIn(config_update, get_common_use_case_tool_calls_for_run(self.run.id))
+
+    def test_batch_scoped_charter_eval_requires_one_useful_terminal_web_reply(self):
+        scenario = ScenarioRegistry.get(CHARTER_IGNORES_BATCH_SCOPED_PREFERENCE)
+        inbound = SimpleNamespace(timestamp=timezone.now() - timedelta(seconds=1))
+        completion = self._add_orchestrator_completion()
+        reply = self._add_tool_call(
+            "send_chat_message",
+            {
+                "body": "Got it. For this batch, security reviews come first and every note stays short.",
+                "will_continue_work": False,
+            },
+            completion=completion,
+        )
+
+        self.assertTrue(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+        reply.tool_params = {
+            "body": "Going forward, security reviews always come first and every note stays short.",
+            "will_continue_work": False,
+        }
+        reply.save(update_fields=["tool_params"])
+        self.assertFalse(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+
+        self._add_orchestrator_completion()
+        self.assertFalse(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+
+    def test_transient_preferences_leave_the_charter_untouched(self):
+        mutation = SimpleNamespace(tool_params={"sql": "UPDATE __agent_config SET charter='changed'"})
+        for slug in (CHARTER_IGNORES_ONE_OFF_PREFERENCE, CHARTER_IGNORES_BATCH_SCOPED_PREFERENCE):
+            scenario = ScenarioRegistry.get(slug)
+            unchanged = SimpleNamespace(charter=scenario.existing_charter)
+            changed = SimpleNamespace(charter=scenario.existing_charter + " New rule.")
+            self.assertTrue(scenario._charter_check(unchanged, [])[0])
+            self.assertFalse(scenario._charter_check(unchanged, [mutation])[0])
+            self.assertFalse(scenario._charter_check(changed, [])[0])
+
+    def test_durable_charter_eval_requires_a_clean_two_completion_first_shot(self):
+        scenario = ScenarioRegistry.get(CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK)
+        inbound = SimpleNamespace(timestamp=timezone.now() - timedelta(seconds=1))
+        old = "For prospect outreach, end each note with an open question asking for the recipient's opinion."
+        new = "For prospect outreach, ask a specific question that is easy to answer."
+        sqlite_completion = self._add_orchestrator_completion()
+        sqlite_call = self._add_clean_charter_patch(sqlite_completion, old=old, new=new)
+        reply_completion = self._add_orchestrator_completion()
+        reply = self._add_tool_call(
+            "send_chat_message",
+            {
+                "body": "Got it. I’ll make each prospect question specific and easy to answer. Sound right?",
+                "will_continue_work": False,
+            },
+            completion=reply_completion,
+        )
+
+        self.assertTrue(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+        good_sql = sqlite_call.tool_params
+        sqlite_call.tool_params = {"sql": self._charter_patch_sql(scenario.prior_outbound_body, new)}
+        sqlite_call.save(update_fields=["tool_params"])
+        self.assertFalse(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+        sqlite_call.tool_params = good_sql
+        sqlite_call.save(update_fields=["tool_params"])
+
+        good_result = sqlite_call.result
+        sqlite_call.result = '{"status":"ok","results":[{"auto_correction":{"fixes":["retry"]}}]}'
+        sqlite_call.save(update_fields=["result"])
+        self.assertFalse(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+        sqlite_call.result = good_result
+        sqlite_call.save(update_fields=["result"])
+
+        reply.status = "error"
+        reply.save(update_fields=["status"])
+        self.assertFalse(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+        reply.status = "complete"
+        reply.save(update_fields=["status"])
+
+        reply.step.completion = sqlite_completion
+        reply.step.save(update_fields=["completion"])
+        self.assertFalse(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+        reply.step.completion = reply_completion
+        reply.step.save(update_fields=["completion"])
+
+        extra_completion = self._add_orchestrator_completion()
+        self.assertFalse(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+        extra_completion.delete()
+        correction = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            eval_run=self.run,
+            description="Tool policy: persist this direct user correction before replying.",
+        )
+        self.assertFalse(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+        correction.delete()
+        self.assertTrue(scenario._additional_charter_check(self.agent, self.run.id, inbound)[0])
+
+    def test_direct_rewrite_eval_accepts_a_natural_question_inside_the_rewrite(self):
+        scenario = ScenarioRegistry.get(CHARTER_PATCHES_DIRECT_STYLE_CORRECTION)
+        inbound = SimpleNamespace(timestamp=timezone.now() - timedelta(seconds=1))
+        sqlite_completion = self._add_orchestrator_completion()
+        self._add_clean_charter_patch(
+            sqlite_completion,
+            new="Keep messages conversational and avoid templates. Do not use dashes or hyphens.",
+        )
+        reply_completion = self._add_orchestrator_completion()
+        self._add_tool_call(
+            "send_chat_message",
+            {
+                "body": "The apprenticeship work caught my eye. What are you hoping to build next?",
+                "will_continue_work": False,
+            },
+            completion=reply_completion,
+        )
+
+        passed, detail = scenario._additional_charter_check(self.agent, self.run.id, inbound)
+
+        self.assertTrue(passed, detail)
+
+        reply = PersistentAgentToolCall.objects.filter(
+            step__eval_run=self.run,
+            tool_name="send_chat_message",
+        ).get()
+        reply.tool_params = {
+            "body": "Your team is expanding apprenticeships. Let's work together on that.",
+            "will_continue_work": False,
+        }
+        reply.save(update_fields=["tool_params"])
+        passed, _detail = scenario._additional_charter_check(self.agent, self.run.id, inbound)
+        self.assertFalse(passed)
 
     def test_common_use_case_tool_calls_keep_mixed_sqlite_config_and_domain_work(self):
         mixed_batch = self._add_tool_call(

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2206,6 +2206,119 @@ class PromptContextBuilderTests(TestCase):
             content,
         )
 
+    def test_fresh_related_source_requires_sqlite_only_while_directive_is_visible(self):
+        sqlite_tmp = tempfile.TemporaryDirectory()
+        token = set_sqlite_db_path(f"{sqlite_tmp.name}/state.db")
+        try:
+            with sqlite3.connect(f"{sqlite_tmp.name}/state.db") as conn:
+                conn.execute("CREATE TABLE accounts(account_id TEXT PRIMARY KEY, name TEXT)")
+            scalar_step = PersistentAgentStep.objects.create(agent=self.agent, description="unrelated weather")
+            PersistentAgentToolCall.objects.create(
+                step=scalar_step,
+                tool_name="http_request",
+                tool_params={"url": "https://weather.example.test/current"},
+                result=json.dumps({"status": "ok", "content": {"temperature": 72}}),
+                status="complete",
+            )
+            source_step = PersistentAgentStep.objects.create(agent=self.agent, description="fresh CRM source")
+            PersistentAgentToolCall.objects.create(
+                step=source_step,
+                tool_name="http_request",
+                tool_params={"url": "https://crm.example.test/accounts"},
+                result=json.dumps({"status": "ok", "content": {
+                    "accounts": [{"account_id": "acct-1", "name": "Acme"}],
+                    "workstreams": [{"workstream_id": "work-1", "account_id": "acct-1", "name": "Legal"}],
+                }}),
+                status="complete",
+            )
+            source_step_2 = PersistentAgentStep.objects.create(agent=self.agent, description="second CRM source")
+            PersistentAgentToolCall.objects.create(
+                step=source_step_2,
+                tool_name="http_request",
+                tool_params={"url": "https://crm.example.test/accounts?page=2"},
+                result=json.dumps({"status": "ok", "content": {
+                    "accounts": [{"account_id": "acct-2", "name": "Beta"}],
+                    "workstreams": [{"workstream_id": "work-2", "account_id": "acct-2", "name": "Security"}],
+                }}),
+                status="complete",
+            )
+            with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
+                 patch('api.agent.core.prompt_context.ensure_comms_compacted'):
+                context, _, _, metadata = build_prompt_context(self.agent, include_metadata=True)
+
+            self.assertIn("[SOURCE ARRAYS result_id=", metadata["source_reconciliation_directive"])
+            self.assertIn("[SOURCE ARRAYS result_id=", context[-1]["content"])
+            source_result_ids = re.findall(
+                r"SOURCE ARRAYS result_id=([^;]+)", metadata["source_reconciliation_directive"]
+            )
+            self.assertEqual(len(source_result_ids), 2)
+            source_result_id_sql = "','".join(source_result_ids)
+
+            sqlite_step = PersistentAgentStep.objects.create(agent=self.agent, description="reconciled CRM source")
+            PersistentAgentToolCall.objects.create(
+                step=sqlite_step,
+                tool_name="sqlite_batch",
+                tool_params={"sql": "SELECT * FROM accounts"},
+                result=json.dumps({"status": "ok", "results": []}),
+                status="complete",
+            )
+            with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
+                 patch('api.agent.core.prompt_context.ensure_comms_compacted'):
+                context, _, _, metadata = build_prompt_context(self.agent, include_metadata=True)
+
+            self.assertIn("[SOURCE ARRAYS result_id=", metadata["source_reconciliation_directive"])
+            self.assertIn("[SOURCE ARRAYS result_id=", context[-1]["content"])
+
+            reconciled_step = PersistentAgentStep.objects.create(agent=self.agent, description="modeled CRM source")
+            PersistentAgentToolCall.objects.create(
+                step=reconciled_step,
+                tool_name="sqlite_batch",
+                tool_params={"sql": (
+                    "INSERT INTO accounts(account_id,name) "
+                    "SELECT json_extract(j.value,'$.account_id'),json_extract(j.value,'$.name') "
+                    "FROM __tool_results r,json_each(r.result_json,'$.content.accounts') j "
+                    f"WHERE r.result_id IN ('{source_result_id_sql}') "
+                    "ON CONFLICT(account_id) DO UPDATE SET name=excluded.name; "
+                    "SELECT * FROM accounts;"
+                )},
+                result=json.dumps({"status": "ok", "results": []}),
+                status="complete",
+            )
+            with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
+                 patch('api.agent.core.prompt_context.ensure_comms_compacted'):
+                context, _, _, metadata = build_prompt_context(self.agent, include_metadata=True)
+
+            self.assertIn("[SOURCE ARRAYS result_id=", metadata["source_reconciliation_directive"])
+
+            with sqlite3.connect(f"{sqlite_tmp.name}/state.db") as conn:
+                conn.execute("CREATE TABLE workstreams(workstream_id TEXT PRIMARY KEY, account_id TEXT, name TEXT)")
+            workstream_step = PersistentAgentStep.objects.create(agent=self.agent, description="modeled CRM children")
+            PersistentAgentToolCall.objects.create(
+                step=workstream_step,
+                tool_name="sqlite_batch",
+                tool_params={"sql": (
+                    "INSERT INTO workstreams(workstream_id,account_id,name) "
+                    "SELECT json_extract(j.value,'$.workstream_id'),json_extract(j.value,'$.account_id'),"
+                    "json_extract(j.value,'$.name') FROM __tool_results r,"
+                    "json_each(r.result_json,'$.content.workstreams') j "
+                    f"WHERE r.result_id IN ('{source_result_id_sql}') "
+                    "ON CONFLICT(workstream_id) DO UPDATE SET name=excluded.name; "
+                    "SELECT * FROM accounts; SELECT * FROM workstreams;"
+                )},
+                result=json.dumps({"status": "ok", "results": []}),
+                status="complete",
+            )
+            with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
+                 patch('api.agent.core.prompt_context.ensure_comms_compacted'):
+                context, _, _, metadata = build_prompt_context(self.agent, include_metadata=True)
+
+            self.assertIsNone(metadata["source_reconciliation_directive"])
+            self.assertNotIn("[SOURCE ARRAYS result_id=", context[-1]["content"])
+            self.assertNotIn(str(scalar_step.id), metadata["fresh_tool_call_step_ids"])
+        finally:
+            reset_sqlite_db_path(token)
+            sqlite_tmp.cleanup()
+
     def test_tool_call_history_includes_cost_component(self):
         """Tool-call unified history should include a dedicated <cost> component."""
         with patch(
@@ -3191,6 +3304,27 @@ class PromptContextBuilderTests(TestCase):
         self.assertIn(".json", response["Content-Disposition"])
         downloaded_bytes = b"".join(response.streaming_content)
         self.assertEqual(downloaded_bytes, decompressed)
+
+    def test_prompt_transform_is_routed_and_archived_as_the_actual_request(self):
+        def focus(messages):
+            return [messages[0], {"role": "user", "content": "focused charter patch request"}]
+
+        with patch('api.agent.core.prompt_context.ensure_steps_compacted'), \
+             patch('api.agent.core.prompt_context.ensure_comms_compacted'):
+            context, fitted_tokens, prompt_archive_id, metadata = build_prompt_context(
+                self.agent,
+                include_metadata=True,
+                prompt_message_transform=focus,
+            )
+
+        archive = PersistentAgentPromptArchive.objects.get(id=prompt_archive_id)
+        with self._storage.open(archive.storage_key, "rb") as fh:
+            payload = json.loads(zstd.ZstdDecompressor().decompress(fh.read()).decode("utf-8"))
+
+        self.assertEqual(context[1]["content"], "focused charter patch request")
+        self.assertEqual(payload["user_prompt"], context[1]["content"])
+        self.assertEqual(payload["tokens_after"], fitted_tokens)
+        self.assertTrue(metadata["prompt_message_transform_applied"])
 
     def test_prompt_archive_links_to_step(self):
         """Running the agent loop should attach the prompt archive to the first generated step."""

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import json
 from unittest.mock import MagicMock, patch
 
+import sqlparse
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 from django.utils import timezone
@@ -104,6 +105,21 @@ class ImpliedSendTests(TestCase):
             },
         )
 
+    def test_discord_uses_the_same_delivery_and_reply_semantics(self):
+        inbound = MagicMock()
+        inbound.conversation.is_peer_dm = False
+        inbound.conversation.channel = CommsChannel.DISCORD
+
+        self.assertIn("send_discord_message", ep.MESSAGE_TOOL_NAMES)
+        self.assertEqual(ep.MESSAGE_TOOL_BODY_KEYS["send_discord_message"], "message")
+        self.assertEqual(ep._same_channel_reply_tool_name(inbound), "send_discord_message")
+        self.assertTrue(
+            ep._message_tool_is_terminal(
+                "send_discord_message",
+                {"message": "The report is ready.", "will_continue_work": False},
+            )
+        )
+
     def test_run_setup_resets_inbound_scope_when_prompt_cache_setup_fails(self):
         with patch.object(ep, "PromptRunCache", side_effect=RuntimeError("cache setup failed")), \
              self.assertRaisesRegex(RuntimeError, "cache setup failed"):
@@ -114,83 +130,290 @@ class ImpliedSendTests(TestCase):
     def test_search_tools_is_a_discovery_barrier_for_same_batch_work(self):
         search_call = {"function": {"name": "search_tools", "arguments": '{"query":"meta gobii"}'}}
         research_call = {"function": {"name": "mcp_brightdata_search_engine", "arguments": "{}"}}
+        http_call = {
+            "function": {
+                "name": "http_request",
+                "arguments": '{"method":"GET","url":"https://example.test/data"}',
+            }
+        }
+        sqlite_call = {"function": {"name": "sqlite_batch", "arguments": '{"sql":"SELECT * FROM accounts"}'}}
+        write_call = {"function": {"name": "mcp_slack_send_message", "arguments": "{}"}}
 
         self.assertEqual(
-            ep._defer_tool_calls_behind_discovery([search_call, research_call]),
+            ep._defer_tool_calls_behind_dependencies([search_call, research_call]),
             [search_call],
         )
-        self.assertEqual(ep._defer_tool_calls_behind_discovery([research_call]), [research_call])
+        self.assertEqual(ep._defer_tool_calls_behind_dependencies([research_call]), [research_call])
+        self.assertEqual(
+            ep._defer_tool_calls_behind_dependencies([http_call, sqlite_call]),
+            [http_call],
+        )
+        self.assertEqual(ep._defer_tool_calls_behind_dependencies([research_call, sqlite_call]), [research_call])
+        self.assertEqual(ep._defer_tool_calls_behind_dependencies([write_call, sqlite_call]), [sqlite_call])
 
-    def test_direct_corrections_require_durable_patch_except_when_one_off(self):
-        self.assertTrue(ep._user_text_is_direct_correction("That sounded automated. Stop writing like a template."))
-        self.assertTrue(ep._user_text_is_direct_correction("You sound robotic."))
-        self.assertTrue(ep._user_text_is_direct_correction("Lowercase is too informal."))
-        self.assertTrue(ep._user_text_is_direct_correction("No more em dashes."))
-        self.assertTrue(ep._user_text_is_direct_correction("Don't use em dashes."))
-        self.assertTrue(
-            ep._user_text_is_direct_correction(
-                "you should have github secrets that allow you to use github."
-            )
-        )
-        self.assertTrue(
-            ep._user_text_is_direct_correction(
-                "You already have credentials for that command-line workflow."
-            )
-        )
-        self.assertTrue(
-            ep._user_text_is_direct_correction(
-                "The agent should be able to use the configured environment variables."
-            )
-        )
-        self.assertTrue(ep._user_text_is_direct_correction("Please stop - writing like a template."))
-        self.assertTrue(ep._user_text_is_direct_correction("Please stop always writing like a template."))
-        self.assertTrue(ep._user_text_is_direct_correction("Stop repeatedly sending generic replies."))
-        self.assertFalse(ep._user_text_is_direct_correction("For this response, don't use headings."))
-        self.assertFalse(ep._user_text_is_direct_correction("Don't browse. Just answer the question."))
-        self.assertFalse(ep._user_text_is_direct_correction("You should have a nice day."))
-        self.assertFalse(
-            ep._user_text_is_direct_correction(
-                "You should have access to the CRM tools; export the leads."
-            )
-        )
-        self.assertFalse(
-            ep._user_text_is_direct_correction(
-                "Continue daily sourcing until the recruiter instructs you to pause, stop, "
-                "change search criteria, change format, or close the role."
-            )
-        )
-        self.assertFalse(
-            ep._user_text_is_direct_correction(
-                "Constraint: do not imply a prior relationship or make unsupported claims. Send the email now."
-            )
-        )
-
-    def test_correction_patch_must_use_patch_text_before_reply(self):
-        def call(name, params):
-            return {
-                "id": name,
-                "type": "function",
-                "function": {"name": name, "arguments": json.dumps(params)},
+    def test_sqlite_approval_read_precedes_http_write(self):
+        approval_read = {
+            "function": {
+                "name": "sqlite_batch",
+                "arguments": '{"sql":"SELECT approved FROM outreach_approvals WHERE prospect_id = 42"}',
             }
+        }
+        http_write = {
+            "function": {
+                "name": "http_request",
+                "arguments": '{"method":"POST","url":"https://api.example.test/messages"}',
+            }
+        }
 
-        patch_call = call(
-            "sqlite_batch",
-            {
-                "sql": (
-                    "UPDATE __agent_config SET charter = "
-                    "patch_text(charter, '', 'Keep messages natural.') WHERE id = 1"
-                )
+        self.assertEqual(
+            ep._defer_tool_calls_behind_dependencies([http_write, approval_read]),
+            [approval_read],
+        )
+
+    def test_sqlite_approval_read_precedes_unrecognized_mcp_write(self):
+        approval_read = {
+            "function": {
+                "name": "sqlite_batch",
+                "arguments": '{"sql":"SELECT approved FROM release_approvals WHERE pr_number = 1341"}',
+            }
+        }
+        merge_call = {
+            "function": {
+                "name": "mcp_github_merge_pull_request",
+                "arguments": '{"pull_number":1341}',
+            }
+        }
+
+        self.assertEqual(
+            ep._defer_tool_calls_behind_dependencies([merge_call, approval_read]),
+            [approval_read],
+        )
+
+    def test_feedback_classifier_preserves_real_world_intent(self):
+        durable_feedback = (
+            "That sounded automated. Stop writing like a template.",
+            "You sound robotic.",
+            "Lowercase is too informal.",
+            "No more em dashes.",
+            "Don't use em dashes.",
+            "you should have github secrets that allow you to use github.",
+            "You already have credentials for that command-line workflow.",
+            "The agent should be able to use the configured environment variables.",
+            "Please stop - writing like a template.",
+            "Please stop always writing like a template.",
+            "Stop repeatedly sending generic replies.",
+            "I prefer comparison tables and bullet takeaways. The narrative format is hard to scan.",
+            "Going forward, show source links in reports.",
+            "Going forward, keep responses short.",
+            "From now on, make every response concise.",
+            "Going forward, keep replies short.",
+            "I prefer short responses.",
+            "Do I have to request links each time? Make that a rule.",
+            "yeah these play by play updates arent useful. just come back with what changed + blockers + next move",
+            "That felt kind of stiff.",
+            "this is great actually. a genuine observation can be the whole opener sometimes, no pitch needed",
+            "These updates aren't useful. Never store this customer secret.",
+            "For this batch, put security first. Going forward, never use em dashes.",
+            "Don't save this temporary point; going forward, these updates aren't useful.",
+        )
+        for text in durable_feedback:
+            with self.subTest(durable=text):
+                self.assertTrue(ep._user_text_is_direct_correction(text))
+        quote = "Curious what you think the biggest gap is right now."
+        self.assertTrue(ep._user_text_is_direct_correction(
+            f'"{quote}" this is not so good. it makes the other person do the work',
+            prior_outbound_text=quote,
+        ))
+
+        one_off_or_content = (
+            "Remember, the deadline is Friday.",
+            "I prefer Tuesday for this meeting.",
+            "Always use the Q3 figures in this report.",
+            "Stop sending this email.",
+            "Stop using this source for the report.",
+            "Send a reply that sounds robotic for a demo.",
+            "This is great news about Acme's strategy.",
+            "Those customer messages are not helpful; categorize the complaints.",
+            "This report is bad. Find a better source.",
+            "Your answer was wrong: the renewal date is June 2.",
+            "Explain why customers never share passwords by email.",
+            "Don't browse. Just answer the question.",
+            "Never send this confidential email.",
+            "You should have a nice day.",
+            "That is a better strategy for Acme.",
+            "You should have access to the CRM tools; export the leads.",
+            "Continue daily sourcing until the recruiter instructs you to pause, stop, change search criteria, change format, or close the role.",
+            "Constraint: do not imply a prior relationship or make unsupported claims. Send the email now.",
+        )
+        for text in one_off_or_content:
+            with self.subTest(not_durable=text):
+                self.assertFalse(ep._user_text_is_direct_correction(text))
+
+    def test_feedback_classifier_extracts_scoped_rules_and_tasks(self):
+        lasting_cases = (
+            ("For this renewal only put legal first, going forward send outcomes only.", ("going forward send outcomes only.",)),
+            ("That sounded automated. Stop using templates. Rewrite it naturally.", ("That sounded automated.", "Stop using templates.")),
+            ("That sounded automated. Edit the spreadsheet to add source links.", ("That sounded automated.",)),
+            (
+                "Your reports are too generic. Compare the four companies now. Going forward, use a compact table for portfolio comparisons.",
+                ("Your reports are too generic.", "Going forward, use a compact table for portfolio comparisons."),
+            ),
+            ("For this batch, put security first. Always include source links.", ("Always include source links.",)),
+            ("Do not save this feedback. Going forward, these updates are not useful.", ("Going forward, these updates are not useful.",)),
+            ("Never send this confidential email. Going forward, never share customer secrets.", ("Going forward, never share customer secrets.",)),
+        )
+        for text, expected in lasting_cases:
+            with self.subTest(lasting=text):
+                self.assertEqual(ep._analyze_feedback_turn(text).lasting, expected)
+
+        separate_tasks = (
+            ("Your reports are too generic. Open the portfolio now.", "Your reports are too generic."),
+            ("That sounded robotic and find three prospects.", "That sounded robotic"),
+            ("These updates are not useful and pause the schedule.", "These updates are not useful"),
+            ("Your reports are too generic and research the four companies now.", "Your reports are too generic"),
+            ("That email was too formal and email the rewrite to Sarah.", "That email was too formal"),
+            ("Your report was too generic and export it as CSV.", "Your report was too generic"),
+        )
+        for text, expected_feedback in separate_tasks:
+            with self.subTest(separate_task=text):
+                analysis = ep._analyze_feedback_turn(text, "Here is the prior report.")
+                self.assertEqual(analysis.lasting, (expected_feedback,))
+                self.assertTrue(analysis.separate_task)
+                self.assertFalse(analysis.feedback_only)
+
+        direct_rewrites = (
+            "That sounded robotic and rewrite it naturally.",
+            "That sounded robotic and shorten it.",
+        )
+        for text in direct_rewrites:
+            with self.subTest(direct_rewrite=text):
+                analysis = ep._analyze_feedback_turn(text)
+                self.assertEqual(analysis.lasting, ("That sounded robotic",))
+                self.assertTrue(analysis.direct_reply_task)
+                self.assertFalse(analysis.separate_task)
+
+        mixed_rewrite_tasks = (
+            "That sounded robotic. Rewrite it, then find three prospects.",
+            "That sounded robotic. Rewrite it. Email it to Sarah.",
+        )
+        for text in mixed_rewrite_tasks:
+            with self.subTest(rewrite_then_task=text):
+                analysis = ep._analyze_feedback_turn(text)
+                self.assertTrue(analysis.direct_reply_task)
+                self.assertTrue(analysis.separate_task)
+
+    def test_feedback_classifier_distinguishes_feedback_from_temporary_and_domain_text(self):
+        feedback_only = (
+            ("going forward, these play by play updates arent useful. just come back with what changed + blockers + next move. routine followups are for Morgan, only pull me in on a real blocker", ""),
+            ('"Curious what you think the biggest gap is right now." this is not so good. it makes the other person do the work', "Curious what you think the biggest gap is right now."),
+            ("Great that you found leads, but you did not include links. Do I have to ask each time? Can we make that a rule?", ""),
+            ("Going forward, keep the updates short and include source links.", ""),
+        )
+        for text, prior in feedback_only:
+            with self.subTest(feedback_only=text):
+                analysis = ep._analyze_feedback_turn(text, prior)
+                self.assertTrue(analysis.feedback_only)
+                self.assertFalse(analysis.separate_task)
+
+        transient_feedback = (
+            "That felt stiff; don't update your instructions.",
+            "That sounded robotic. Don't save this.",
+            "For this email only, do not use em dashes.",
+            "For this response, don't use headings.",
+            "For this message, that tone is too formal.",
+            "For this batch, never use headings.",
+            "Never store this customer secret.",
+            "Never persist this API key.",
+            "Never send this confidential email.",
+            "Going forward, do not save this feedback. That sounded stiff.",
+        )
+        for text in transient_feedback:
+            with self.subTest(transient=text):
+                analysis = ep._analyze_feedback_turn(text)
+                self.assertTrue(analysis.transient_only)
+                self.assertFalse(ep._user_text_is_direct_correction(text))
+                if text.startswith("Never"):
+                    self.assertEqual(analysis.lasting, ())
+
+        for text in (
+            "For this customer only, that tone is too formal.",
+            "For this channel only, those updates aren't useful.",
+        ):
+            with self.subTest(durable_context_scope=text):
+                analysis = ep._analyze_feedback_turn(text)
+                self.assertFalse(analysis.transient_only)
+                self.assertEqual(analysis.lasting, (text,))
+
+        task_turns = (
+            "Only this batch, these long updates aren't useful. Pause your schedule until Friday.",
+            "These updates aren't useful. Going forward send only blockers. Pause your schedule until Friday.",
+            "You sound robotic, please find three prospects.",
+        )
+        for text in task_turns:
+            with self.subTest(feedback_plus_task=text):
+                self.assertFalse(ep._analyze_feedback_turn(text).feedback_only)
+
+    def test_structured_charter_patch_compiles_to_one_safe_sqlite_update(self):
+        old = "Owner's rule;\nDROP TABLE notes;"
+        new = "Owner's clearer rule;\nSELECT * FROM notes;"
+        call = {
+            "id": "patch",
+            "type": "function",
+            "function": {
+                "name": "sqlite_batch",
+                "arguments": json.dumps({
+                    "target_charter_text": old,
+                    "replacement_charter_text": new,
+                }),
             },
-        )
-        reply_call = call("send_chat_message", {"body": "Got it.", "will_continue_work": False})
-        concatenation_call = call(
-            "sqlite_batch",
-            {"sql": "UPDATE __agent_config SET charter = charter || 'Keep messages natural.' WHERE id = 1"},
+        }
+
+        compiled = ep._compile_charter_patch_tool_call(call)
+        params = json.loads(compiled["function"]["arguments"])
+
+        self.assertEqual(len(sqlparse.split(params["sql"])), 1)
+        self.assertIn("Owner''s rule", params["sql"])
+        self.assertIn("Owner''s clearer rule", params["sql"])
+        self.assertIs(params["will_continue_work"], True)
+
+        call["function"]["arguments"] = json.dumps({
+            "target_charter_text": "Research prospects.",
+            "replacement_charter_text": "Research prospects. Include verified source links.",
+        })
+        compiled = ep._compile_charter_patch_tool_call(call, "Research prospects.")
+        self.assertIn(
+            "patch_text(charter, '', 'Include verified source links.')",
+            json.loads(compiled["function"]["arguments"])["sql"],
         )
 
-        self.assertTrue(ep._tool_calls_patch_correction_before_reply([patch_call, reply_call]))
-        self.assertFalse(ep._tool_calls_patch_correction_before_reply([reply_call, patch_call]))
-        self.assertFalse(ep._tool_calls_patch_correction_before_reply([concatenation_call]))
+        call["function"]["arguments"] = json.dumps({
+            "target_charter_text": "",
+            "replacement_charter_text": "Research prospects. Include verified source links.",
+        })
+        compiled = ep._compile_charter_patch_tool_call(call, "Research prospects.")
+        self.assertIn(
+            "patch_text(charter, '', 'Include verified source links.')",
+            json.loads(compiled["function"]["arguments"])["sql"],
+        )
+
+    def test_structured_charter_patch_rejects_invalid_values(self):
+        def compile_params(params):
+            return ep._compile_charter_patch_tool_call({
+                "function": {"name": "sqlite_batch", "arguments": json.dumps(params)},
+            })
+
+        for params in (
+            {},
+            [],
+            "old/new",
+            {"target_charter_text": "Rule", "replacement_charter_text": ""},
+            {"target_charter_text": "Rule", "replacement_charter_text": "Rule"},
+            {"target_charter_text": "Rule\x00", "replacement_charter_text": "Better rule"},
+            {"target_charter_text": 1, "replacement_charter_text": "Better rule"},
+            {"preserve": "", "old": "Rule", "new": "Better rule"},
+        ):
+            with self.subTest(params=params):
+                self.assertIsNone(compile_params(params))
 
     def _add_inbound_web_message(self, body):
         user_endpoint = PersistentAgentCommsEndpoint.objects.create(
@@ -227,49 +450,127 @@ class ImpliedSendTests(TestCase):
             body=body,
         )
 
-    def test_direct_correction_patch_requires_prior_outbound_message(self):
-        self._add_inbound_web_message("You sound robotic.")
-
-        self.assertFalse(ep._should_require_direct_correction_patch(self.agent))
-
-    def test_direct_correction_patch_is_disabled_in_planning_mode(self):
-        initial = self._add_inbound_web_message("Initial request")
-        self._add_outbound_web_message(initial.conversation)
-        PersistentAgentMessage.objects.create(
-            owner_agent=self.agent,
-            is_outbound=False,
-            from_endpoint=initial.from_endpoint,
-            conversation=initial.conversation,
-            body="You sound robotic.",
-        )
-        self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
-        self.agent.save(update_fields=["planning_state", "updated_at"])
-
-        self.assertFalse(ep._should_require_direct_correction_patch(self.agent))
-
-    def test_direct_correction_patch_is_required_for_followup_feedback(self):
-        initial = self._add_inbound_web_message("Initial request")
-        self._add_outbound_web_message(initial.conversation)
-        PersistentAgentMessage.objects.create(
-            owner_agent=self.agent,
-            is_outbound=False,
-            from_endpoint=initial.from_endpoint,
-            conversation=initial.conversation,
-            body="You sound robotic.",
-        )
-
-        self.assertTrue(ep._should_require_direct_correction_patch(self.agent))
-
-    def test_direct_correction_patch_uses_seq_to_break_timestamp_ties(self):
-        initial = self._add_inbound_web_message("Initial request")
-        outbound = self._add_outbound_web_message(initial.conversation)
+    def _add_feedback_followup(
+        self,
+        feedback="You sound robotic.",
+        *,
+        initial_body="Initial request",
+        prior_body="Previous agent reply",
+    ):
+        initial = self._add_inbound_web_message(initial_body)
+        outbound = self._add_outbound_web_message(initial.conversation, prior_body)
         correction = PersistentAgentMessage.objects.create(
             owner_agent=self.agent,
             is_outbound=False,
             from_endpoint=initial.from_endpoint,
             conversation=initial.conversation,
+            body=feedback,
+        )
+        return initial, outbound, correction
+
+    def test_direct_correction_patch_requires_prior_outbound_message(self):
+        self._add_inbound_web_message("You sound robotic.")
+
+        self.assertIsNone(ep._direct_correction_context(self.agent))
+
+    def test_direct_correction_patch_is_disabled_in_planning_mode(self):
+        self._add_feedback_followup()
+        self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
+        self.agent.save(update_fields=["planning_state", "updated_at"])
+
+        self.assertIsNone(ep._direct_correction_context(self.agent))
+
+    def test_direct_correction_patch_is_required_for_followup_feedback(self):
+        self._add_feedback_followup()
+
+        self.assertIsNotNone(ep._direct_correction_context(self.agent))
+
+    def test_quoted_feedback_across_a_newline_requires_a_patch(self):
+        prior = "Curious what you think the biggest gap is right now."
+        self._add_feedback_followup(f'"{prior}"\nthis is not so good.', prior_body=prior)
+
+        self.assertIsNotNone(ep._direct_correction_context(self.agent))
+
+    def test_batch_scoped_feedback_requires_only_a_transient_acknowledgement(self):
+        self._add_feedback_followup("Only this batch, those long updates aren't useful.")
+
+        self.assertTrue(ep._analyze_feedback_turn("Only this batch, those long updates aren't useful.").behavior)
+        self.assertIsNone(ep._direct_correction_context(self.agent))
+
+    def test_direct_correction_patch_requires_prior_outbound_in_same_conversation(self):
+        initial = self._add_inbound_web_message("Initial request")
+        self._add_outbound_web_message(initial.conversation)
+        other_conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.WEB,
+            address=initial.from_endpoint.address,
+        )
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=initial.from_endpoint,
+            conversation=other_conversation,
             body="You sound robotic.",
         )
+
+        self.assertIsNone(ep._direct_correction_context(self.agent))
+
+    def test_direct_correction_patch_requires_configure_authority(self):
+        external_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            channel=CommsChannel.EMAIL,
+            address="external@example.com",
+        )
+        agent_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="agent@example.com",
+        )
+        conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address=external_endpoint.address,
+        )
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=True,
+            from_endpoint=agent_endpoint,
+            to_endpoint=external_endpoint,
+            conversation=conversation,
+            body="Previous agent reply",
+        )
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=external_endpoint,
+            conversation=conversation,
+            body="You sound robotic.",
+        )
+
+        self.assertIsNone(ep._direct_correction_context(self.agent))
+
+    def test_direct_correction_patch_uses_bound_inbound_scope(self):
+        initial, _outbound, correction = self._add_feedback_followup()
+        scope = capture_inbound_routing_scope(self.agent)
+        token = bind_inbound_routing_scope(scope)
+        self.addCleanup(reset_inbound_routing_scope, token)
+        newer_conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.WEB,
+            address=initial.from_endpoint.address,
+        )
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=initial.from_endpoint,
+            conversation=newer_conversation,
+            body="What is the latest status?",
+        )
+
+        self.assertEqual(scope.message_id, correction.id)
+        self.assertIsNotNone(ep._direct_correction_context(self.agent))
+
+    def test_direct_correction_patch_uses_seq_to_break_timestamp_ties(self):
+        _initial, outbound, correction = self._add_feedback_followup()
         shared_timestamp = timezone.now()
         PersistentAgentMessage.objects.filter(id=outbound.id).update(
             timestamp=shared_timestamp,
@@ -280,7 +581,7 @@ class ImpliedSendTests(TestCase):
             seq="01BBBBBBBBBBBBBBBBBBBBBBBB",
         )
 
-        self.assertTrue(ep._should_require_direct_correction_patch(self.agent))
+        self.assertIsNotNone(ep._direct_correction_context(self.agent))
 
     def test_eval_mock_result_supports_url_rules(self):
         mock_config = {
@@ -1206,58 +1507,47 @@ class ImpliedSendTests(TestCase):
         self.agent.refresh_from_db()
         self.assertEqual(self.agent.planning_state, PersistentAgent.PlanningState.PLANNING)
 
-    def test_prepare_tool_batch_skips_one_off_config_churn_before_terminal_message(self):
-        self._add_inbound_web_message("What's the latest Bitcoin price right now?")
-
+    def _prepare_tool_batch_for_test(self, tool_calls, *, has_user_facing_message=False):
         with (
             patch.object(ep, "_enforce_tool_rate_limit", return_value=True),
             patch.object(ep, "_ensure_credit_for_tool", return_value={"cost": None, "credit": None}),
         ):
-            prepared = ep._prepare_tool_batch(
+            return ep._prepare_tool_batch(
                 self.agent,
-                tool_calls=[
-                    {
-                        "id": "call_config",
-                        "function": {
-                            "name": "sqlite_batch",
-                            "arguments": json.dumps(
-                                {
-                                    "sql": (
-                                        "UPDATE __agent_config SET charter='Track Bitcoin price after every answer' "
-                                        "WHERE id=1;"
-                                    ),
-                                    "will_continue_work": True,
-                                }
-                            ),
-                        },
-                    },
-                    {
-                        "id": "call_chat",
-                        "function": {
-                            "name": "send_chat_message",
-                            "arguments": json.dumps(
-                                {
-                                    "body": (
-                                        "Bitcoin is trading at $68,500.\n\n"
-                                        "Sources:\n- https://example.test/price"
-                                    ),
-                                    "will_continue_work": False,
-                                }
-                            ),
-                        },
-                    },
-                ],
+                tool_calls=tool_calls,
                 budget_ctx=None,
                 eval_run_id=None,
                 heartbeat=None,
                 lock_extender=None,
                 credit_snapshot={},
-                allow_inferred_message_continue=True,
-                has_non_sleep_calls=True,
-                has_user_facing_message=True,
+                allow_inferred_message_continue=True, has_non_sleep_calls=True,
+                has_user_facing_message=has_user_facing_message,
                 attach_completion=lambda step_kwargs: None,
                 attach_prompt_archive=lambda step: None,
             )
+
+    @staticmethod
+    def _raw_tool_call(tool_name, params, call_id=None):
+        return {
+            "id": call_id or f"call_{tool_name}",
+            "function": {"name": tool_name, "arguments": json.dumps(params)},
+        }
+
+    def test_prepare_tool_batch_skips_one_off_config_churn_before_terminal_message(self):
+        self._add_inbound_web_message("What's the latest Bitcoin price right now?")
+        prepared = self._prepare_tool_batch_for_test(
+            [
+                self._raw_tool_call("sqlite_batch", {
+                    "sql": "UPDATE __agent_config SET charter='Track Bitcoin price after every answer' WHERE id=1;",
+                    "will_continue_work": True,
+                }, "call_config"),
+                self._raw_tool_call("send_chat_message", {
+                    "body": "Bitcoin is trading at $68,500.\n\nSources:\n- https://example.test/price",
+                    "will_continue_work": False,
+                }, "call_chat"),
+            ],
+            has_user_facing_message=True,
+        )
 
         self.assertEqual([call.tool_name for call in prepared.prepared_calls], ["send_chat_message"])
         self.assertFalse(prepared.followup_required)
@@ -1268,61 +1558,80 @@ class ImpliedSendTests(TestCase):
             ).exists()
         )
 
+    def test_prepare_tool_batch_skips_batch_scoped_charter_mutation_without_reply(self):
+        self._add_inbound_web_message("Only this batch, these long updates aren't useful.")
+
+        prepared = self._prepare_tool_batch_for_test(
+            [self._raw_tool_call("sqlite_batch", {
+                "sql": "UPDATE __agent_config SET charter='Keep every update short' WHERE id=1;",
+                "will_continue_work": False,
+            }, "call_config")]
+        )
+
+        self.assertEqual(prepared.prepared_calls, [])
+        self.assertTrue(prepared.followup_required)
+
+    def test_temporary_charter_mutation_blocks_mixed_domain_sql(self):
+        self._add_inbound_web_message("For this batch, keep the notes short, then analyze the CRM rows.")
+
+        self.assertTrue(
+            ep._should_skip_irrelevant_agent_config_mutation(
+                self.agent,
+                tool_name="sqlite_batch",
+                tool_params={
+                    "sql": (
+                        "UPDATE __agent_config SET charter='Keep notes short' WHERE id=1;"
+                        "CREATE TABLE crm_rows(id TEXT PRIMARY KEY);"
+                    ),
+                },
+                batch_has_terminal_message=False,
+            )
+        )
+
+    def test_transient_wording_does_not_block_explicit_schedule_pause(self):
+        self._add_inbound_web_message("For now, pause your schedule.")
+
+        self.assertFalse(ep._should_skip_irrelevant_agent_config_mutation(
+            self.agent,
+            tool_name="sqlite_batch",
+            tool_params={"sql": "UPDATE __agent_config SET schedule=NULL WHERE id=1"},
+            batch_has_terminal_message=False,
+        ))
+
+    def test_temporary_report_preference_does_not_block_recurring_setup(self):
+        self._add_inbound_web_message("For this report, keep it brief. Set up a daily customer digest.")
+
+        self.assertFalse(ep._should_skip_irrelevant_agent_config_mutation(
+            self.agent,
+            tool_name="sqlite_batch",
+            tool_params={
+                "sql": (
+                    "UPDATE __agent_config SET "
+                    "charter='Send a daily customer digest', schedule='0 9 * * *' WHERE id=1"
+                ),
+            },
+            batch_has_terminal_message=False,
+        ))
+
     def test_prepare_tool_batch_keeps_durable_charter_update_with_terminal_message(self):
         self._add_inbound_web_message(
             "Going forward, always include source links in price reports. "
             "Now tell me the latest Bitcoin price."
         )
 
-        with (
-            patch.object(ep, "_enforce_tool_rate_limit", return_value=True),
-            patch.object(ep, "_ensure_credit_for_tool", return_value={"cost": None, "credit": None}),
-        ):
-            prepared = ep._prepare_tool_batch(
-                self.agent,
-                tool_calls=[
-                    {
-                        "id": "call_config",
-                        "function": {
-                            "name": "sqlite_batch",
-                            "arguments": json.dumps(
-                                {
-                                    "sql": (
-                                        "UPDATE __agent_config SET charter='Answer price reports with source links' "
-                                        "WHERE id=1;"
-                                    ),
-                                    "will_continue_work": True,
-                                }
-                            ),
-                        },
-                    },
-                    {
-                        "id": "call_chat",
-                        "function": {
-                            "name": "send_chat_message",
-                            "arguments": json.dumps(
-                                {
-                                    "body": (
-                                        "Bitcoin is trading at $68,500.\n\n"
-                                        "Sources:\n- https://example.test/price"
-                                    ),
-                                    "will_continue_work": False,
-                                }
-                            ),
-                        },
-                    },
-                ],
-                budget_ctx=None,
-                eval_run_id=None,
-                heartbeat=None,
-                lock_extender=None,
-                credit_snapshot={},
-                allow_inferred_message_continue=True,
-                has_non_sleep_calls=True,
-                has_user_facing_message=True,
-                attach_completion=lambda step_kwargs: None,
-                attach_prompt_archive=lambda step: None,
-            )
+        prepared = self._prepare_tool_batch_for_test(
+            [
+                self._raw_tool_call("sqlite_batch", {
+                    "sql": "UPDATE __agent_config SET charter='Answer price reports with source links' WHERE id=1;",
+                    "will_continue_work": True,
+                }, "call_config"),
+                self._raw_tool_call("send_chat_message", {
+                    "body": "Bitcoin is trading at $68,500.\n\nSources:\n- https://example.test/price",
+                    "will_continue_work": False,
+                }, "call_chat"),
+            ],
+            has_user_facing_message=True,
+        )
 
         self.assertEqual(
             [call.tool_name for call in prepared.prepared_calls],
@@ -2389,6 +2698,346 @@ class ImpliedSendTests(TestCase):
         params = mock_send_chat.call_args[0][1]
         self.assertTrue(params.get("will_continue_work"))
 
+    def _run_loop_for_feedback_tool_choice(self, feedback):
+        self._add_feedback_followup(
+            feedback,
+            initial_body="Draft outreach",
+            prior_body="Here is the draft.",
+        )
+        start_web_session(self.agent, self.user)
+
+        tools = [
+            {"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {"will_continue_work": {"type": "boolean"}}}}},
+            {"type": "function", "function": {"name": "send_chat_message", "parameters": {"type": "object", "properties": {"will_continue_work": {"type": "boolean"}}}}},
+        ]
+        failover_configs = [("provider-a", "model-a", {"supports_tool_choice": True, "temperature": 0.1})]
+        prompt_result = (
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": feedback}],
+            1000, None,
+            {"prompt_failover_configs": failover_configs},
+        )
+        response = self._mock_completion(None, reasoning_content="Apply the feedback.")
+        response.choices[0].message.tool_calls = []
+        token_usage = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "model": "model-a", "provider": "provider-a"}
+
+        with patch.object(ep, "get_agent_tools", return_value=tools), \
+             patch.object(ep, "get_agent_daily_credit_state", return_value=None), \
+             patch.object(ep, "build_prompt_context", return_value=prompt_result), \
+             patch.object(ep, "get_llm_config_with_failover", side_effect=AssertionError("use prompt configs")), \
+             patch.object(ep, "_completion_with_failover", return_value=(response, token_usage)) as completion, \
+             patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
+            ep._run_agent_loop(self.agent, is_first_run=False)
+
+        return completion.call_args.kwargs
+
+    def _tool_completion(self, name, arguments):
+        response = self._mock_completion(None)
+        response.choices[0].message.tool_calls = [
+            {
+                "id": f"call_{name}",
+                "type": "function",
+                "function": {"name": name, "arguments": json.dumps(arguments)},
+            }
+        ]
+        return response
+
+    def _run_feedback_flow(self, feedback, responses, tools, *, prompt_metadata=None, config_apply=None):
+        self._add_feedback_followup(
+            feedback,
+            initial_body="Draft outreach",
+            prior_body="Here is the draft.",
+        )
+        start_web_session(self.agent, self.user)
+        failover_configs = [("provider-a", "model-a", {"supports_tool_choice": True})]
+        prompt_result = (
+            [{"role": "system", "content": "sys"}, {"role": "user", "content": feedback}],
+            1000,
+            None,
+            {"prompt_failover_configs": failover_configs, **(prompt_metadata or {})},
+        )
+        usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "model": "model-a",
+            "provider": "provider-a",
+        }
+        executed_tools = []
+
+        def execute_tool(_agent, *, tool_name, **_kwargs):
+            executed_tools.append(tool_name)
+            return {
+                "status": "ok",
+                "auto_sleep_ok": tool_name in ep.MESSAGE_TOOL_NAMES,
+            }, None
+
+        skill_apply = MagicMock(changed=False, errors=())
+        with patch.object(ep, "get_agent_tools", return_value=tools), \
+             patch.object(ep, "get_agent_daily_credit_state", return_value=None), \
+             patch.object(ep, "build_prompt_context", return_value=prompt_result) as build_prompt, \
+             patch.object(ep, "get_llm_config_with_failover", side_effect=AssertionError("use prompt configs")), \
+             patch.object(ep, "_completion_with_failover", side_effect=[(response, usage) for response in responses]) as completion, \
+             patch.object(ep, "_execute_tool_call_runtime", side_effect=execute_tool), \
+             patch.object(ep, "_capture_tool_display_metadata", return_value={}), \
+             patch.object(ep, "_ensure_credit_for_tool", return_value={"cost": None, "credit": None}), \
+             patch.object(ep, "get_sqlite_db_path", return_value="/tmp/test-agent.sqlite3"), \
+             patch.object(ep, "seed_sqlite_agent_config", return_value=MagicMock()), \
+             patch.object(ep, "seed_sqlite_skills", return_value=MagicMock()), \
+             patch.object(
+                 ep,
+                 "apply_sqlite_agent_config_updates",
+                 return_value=config_apply or ep.AgentConfigApplyResult(updated_fields=("charter",), errors={}),
+             ), \
+             patch.object(ep, "apply_sqlite_skill_updates", return_value=skill_apply), \
+             patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", len(responses)):
+            ep._run_agent_loop(self.agent, is_first_run=False)
+
+        return completion, build_prompt, executed_tools
+
+    def test_successful_noop_charter_patch_confirms_without_retrying(self):
+        tools = [
+            {"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "send_chat_message", "parameters": {"type": "object", "properties": {"body": {"type": "string"}, "will_continue_work": {"type": "boolean"}}}}},
+        ]
+        responses = [
+            self._tool_completion("sqlite_batch", {
+                "target_charter_text": "",
+                "replacement_charter_text": "Write naturally.",
+            }),
+            self._tool_completion("send_chat_message", {
+                "body": "Got it. I'll keep the writing natural.",
+                "will_continue_work": False,
+            }),
+        ]
+
+        completion, _build_prompt, executed_tools = self._run_feedback_flow(
+            "You sound robotic.",
+            responses,
+            tools,
+            config_apply=ep.AgentConfigApplyResult(updated_fields=(), errors={}),
+        )
+
+        self.assertEqual(executed_tools, ["sqlite_batch", "send_chat_message"])
+        self.assertEqual(completion.call_count, 2)
+
+    def test_run_loop_forces_only_sqlite_for_durable_feedback(self):
+        completion_kwargs = self._run_loop_for_feedback_tool_choice("You sound robotic.")
+
+        self.assertEqual(len(completion_kwargs["tools"]), 1)
+        sqlite_tool = completion_kwargs["tools"][0]["function"]
+        self.assertEqual(sqlite_tool["name"], "sqlite_batch")
+        self.assertIn('CURRENT CHARTER (<charter>), the only source for a nonempty target: "Test charter"', sqlite_tool["description"])
+        self.assertIn("Patch ONLY the lasting clauses", sqlite_tool["description"])
+        self.assertIn("smallest exact contiguous span", sqlite_tool["description"])
+        self.assertIn("not copied feedback or prior output", sqlite_tool["description"])
+        self.assertEqual(
+            set(sqlite_tool["parameters"]["properties"]),
+            {"target_charter_text", "replacement_charter_text"},
+        )
+        self.assertEqual(
+            sqlite_tool["parameters"]["required"],
+            ["target_charter_text", "replacement_charter_text"],
+        )
+        self.assertIs(sqlite_tool["parameters"]["additionalProperties"], False)
+        self.assertNotIn("sql", sqlite_tool["parameters"]["properties"])
+        self.assertEqual(completion_kwargs["messages"][0], {"role": "system", "content": "sys"})
+        focused_feedback = completion_kwargs["messages"][1]["content"]
+        self.assertIn("<charter>Test charter</charter>", focused_feedback)
+        self.assertIn("You sound robotic.", focused_feedback)
+        self.assertIn("<prior_output_context>Here is the draft.</prior_output_context>", focused_feedback)
+        self.assertIsNone(completion_kwargs["stream_broadcaster"])
+        self.assertEqual(completion_kwargs["failover_configs"][0][2]["tool_choice"], {"type": "function", "function": {"name": "sqlite_batch"}})
+        self.assertIs(completion_kwargs["failover_configs"][0][2]["use_parallel_tool_calls"], False)
+
+    def test_focused_charter_history_excludes_temporary_clauses(self):
+        history = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "For this renewal only, put legal review first. Going forward, send outcomes."},
+        ]
+
+        focused = ep._focused_charter_patch_history(
+            history,
+            "Coordinate renewals.",
+            ("Going forward, send outcomes.",),
+            "I will keep you posted.",
+        )
+
+        self.assertEqual(focused[0], history[0])
+        self.assertIn("Going forward, send outcomes.", focused[1]["content"])
+        self.assertNotIn("legal review first", focused[1]["content"])
+
+    def test_source_reconciliation_contract_is_promoted_without_hiding_context(self):
+        history = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": (
+                "Review Aster Labs. [SOURCE ARRAYS result_id=abc123; stored paths: "
+                "$.content.accounts(account_id,name).]"
+            )},
+        ]
+
+        promoted = ep._promote_source_reconciliation_history(history)
+
+        self.assertIn("Current Fresh Source Contract", promoted[0]["content"])
+        self.assertIn("result_id=abc123", promoted[0]["content"])
+        self.assertEqual(promoted[1], history[1])
+        self.assertEqual(ep._promote_source_reconciliation_history([
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "ordinary task"},
+        ])[0]["content"], "system")
+
+    def test_run_loop_forces_source_focused_sqlite_without_streamed_or_implied_prose(self):
+        tools = [
+            {"type": "function", "function": {"name": "sqlite_batch", "description": "Original SQLite contract", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "http_request", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "send_chat_message", "parameters": {"type": "object", "properties": {}}}},
+        ]
+        response = self._tool_completion("sqlite_batch", {"sql": (
+            "INSERT INTO accounts(account_id,name) SELECT json_extract(j.value,'$.account_id'),"
+            "json_extract(j.value,'$.name') FROM __tool_results r,"
+            "json_each(r.result_json,'$.content.accounts') j WHERE r.result_id='abc123' "
+            "ON CONFLICT(account_id) DO UPDATE SET name=excluded.name; SELECT * FROM accounts"
+        )})
+        response.choices[0].message.content = "I found the fresh accounts."
+
+        completion, _, executed_tools = self._run_feedback_flow(
+            "Review the fresh CRM snapshot.",
+            [response],
+            tools,
+            prompt_metadata={
+                "source_reconciliation_directive": "[SOURCE ARRAYS result_id=abc123; stored paths: $.content.accounts(account_id,name).]",
+                "prompt_allows_implied_send": True,
+            },
+        )
+
+        kwargs = completion.call_args.kwargs
+        self.assertEqual(executed_tools, ["sqlite_batch"])
+        self.assertEqual([tool["function"]["name"] for tool in kwargs["tools"]], ["sqlite_batch"])
+        description = kwargs["tools"][0]["function"]["description"]
+        self.assertNotIn("Original SQLite contract", description)
+        self.assertIn("$.content.accounts(account_id,name)", description)
+        self.assertEqual(
+            kwargs["tools"][0]["function"]["parameters"]["properties"]["will_continue_work"]["const"],
+            True,
+        )
+        sqlite_parameters = kwargs["tools"][0]["function"]["parameters"]
+        self.assertEqual(sqlite_parameters["required"], ["sql", "will_continue_work"])
+        self.assertIn("result_id=abc123", sqlite_parameters["properties"]["sql"]["description"])
+        self.assertNotIn("queries", sqlite_parameters["properties"])
+        self.assertEqual(
+            kwargs["failover_configs"][0][2]["tool_choice"],
+            {"type": "function", "function": {"name": "sqlite_batch"}},
+        )
+        self.assertIs(kwargs["failover_configs"][0][2]["use_parallel_tool_calls"], False)
+        self.assertIsNone(kwargs["stream_broadcaster"])
+        self.assertIs(kwargs["allow_streamed_content"], False)
+
+    def test_direct_rewrite_continues_to_distinct_research_task(self):
+        feedback = "That sounded robotic. Rewrite it, then find three prospects."
+        analysis = ep._analyze_feedback_turn(feedback, "Here is the draft.")
+        self.assertTrue(analysis.direct_reply_task)
+        self.assertTrue(analysis.separate_task)
+
+        tools = [
+            {"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "send_chat_message", "parameters": {"type": "object", "properties": {"body": {"type": "string"}, "will_continue_work": {"type": "boolean"}}}}},
+            {"type": "function", "function": {"name": "search_tools", "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}}},
+        ]
+        responses = [
+            self._tool_completion(
+                "sqlite_batch",
+                {
+                    "target_charter_text": "Test charter",
+                    "replacement_charter_text": "Test charter. Write naturally.",
+                },
+            ),
+            self._tool_completion(
+                "send_chat_message",
+                {"body": "Here is the rewritten draft.", "will_continue_work": True},
+            ),
+            self._tool_completion("search_tools", {"query": "prospect research"}),
+        ]
+
+        completion, build_prompt, executed_tools = self._run_feedback_flow(feedback, responses, tools)
+
+        self.assertEqual(executed_tools, ["sqlite_batch", "send_chat_message", "search_tools"])
+        reply_tool = completion.call_args_list[1].kwargs["tools"][0]["function"]
+        self.assertEqual(reply_tool["name"], "send_chat_message")
+        self.assertIs(reply_tool["parameters"]["properties"]["will_continue_work"]["const"], True)
+        self.assertIn(
+            "Execute the remaining explicit request now",
+            build_prompt.call_args_list[2].kwargs["continuation_notice"],
+        )
+
+    def test_direct_rewrite_with_email_task_does_not_send_rewrite_to_web_chat(self):
+        feedback = "That sounded robotic. Rewrite it. Email it to Sarah."
+        analysis = ep._analyze_feedback_turn(feedback, "Here is the draft.")
+        self.assertTrue(analysis.direct_reply_task)
+        self.assertTrue(analysis.separate_task)
+
+        tools = [
+            {"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "send_chat_message", "parameters": {"type": "object", "properties": {"body": {"type": "string"}, "will_continue_work": {"type": "boolean"}}}}},
+            {"type": "function", "function": {"name": "send_email", "parameters": {"type": "object", "properties": {"to_address": {"type": "string"}, "subject": {"type": "string"}, "mobile_first_html": {"type": "string"}, "will_continue_work": {"type": "boolean"}}}}},
+        ]
+        responses = [
+            self._tool_completion(
+                "sqlite_batch",
+                {
+                    "target_charter_text": "Test charter",
+                    "replacement_charter_text": "Test charter. Write naturally.",
+                },
+            ),
+            self._tool_completion(
+                "send_email",
+                {
+                    "to_address": "sarah@example.com",
+                    "subject": "Rewritten note",
+                    "mobile_first_html": "<p>Here is the rewritten draft.</p>",
+                    "will_continue_work": False,
+                },
+            ),
+        ]
+
+        completion, build_prompt, executed_tools = self._run_feedback_flow(feedback, responses, tools)
+
+        self.assertEqual(executed_tools, ["sqlite_batch", "send_email"])
+        second_tool_names = {
+            tool["function"]["name"] for tool in completion.call_args_list[1].kwargs["tools"]
+        }
+        self.assertEqual(second_tool_names, {"sqlite_batch", "send_chat_message", "send_email"})
+        self.assertIn(
+            "Execute the remaining explicit request now",
+            build_prompt.call_args_list[1].kwargs["continuation_notice"],
+        )
+
+    def test_run_loop_forces_terminal_same_channel_reply_for_temporary_feedback(self):
+        completion_kwargs = self._run_loop_for_feedback_tool_choice(
+            "Only this batch, these long updates aren't useful."
+        )
+
+        self.assertEqual(len(completion_kwargs["tools"]), 1)
+        reply_tool = completion_kwargs["tools"][0]["function"]
+        self.assertEqual(reply_tool["name"], "send_chat_message")
+        self.assertIn("feedback acknowledgement only", reply_tool["description"])
+        self.assertIn("exactly one sentence", reply_tool["description"])
+        self.assertIn("will_continue_work=false", reply_tool["description"])
+        self.assertIs(reply_tool["parameters"]["properties"]["will_continue_work"]["const"], False)
+        self.assertIsNone(completion_kwargs["stream_broadcaster"])
+        self.assertEqual(
+            completion_kwargs["failover_configs"][0][2]["tool_choice"],
+            {"type": "function", "function": {"name": "send_chat_message"}},
+        )
+
+    def test_temporary_feedback_with_rewrite_request_is_not_reduced_to_acknowledgement(self):
+        completion_kwargs = self._run_loop_for_feedback_tool_choice(
+            "For this message, that tone is too formal. Rewrite it."
+        )
+
+        self.assertEqual(
+            {tool["function"]["name"] for tool in completion_kwargs["tools"]},
+            {"sqlite_batch", "send_chat_message"},
+        )
+        self.assertNotIn("tool_choice", completion_kwargs["failover_configs"][0][2])
 
 @tag("batch_event_processing_credits")
 class DailyLimitMessageOnlyModeTests(TestCase):

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -296,6 +296,20 @@ class RunCompletionReasoningTests(TestCase):
 
     @tag("batch_event_llm")
     @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_tool_boolean_const_survives_provider_sanitization(self, mock_completion):
+        mock_completion.return_value = make_completion_response(content="ok")
+        run_completion(model="mock-model", messages=[], params={}, tools=[{
+            "type": "function", "function": {"name": "finish", "description": "Finish", "parameters": {
+                "type": "object", "properties": {"will_continue_work": {"type": "boolean", "const": False, "enum": [False]}},
+            }},
+        }])
+
+        schema = mock_completion.call_args.kwargs["tools"][0]["function"]["parameters"]["properties"]["will_continue_work"]
+        self.assertIs(schema["const"], False)
+        self.assertNotIn("enum", schema)
+
+    @tag("batch_event_llm")
+    @patch("api.agent.core.llm_utils.litellm.completion")
     def test_parallel_tool_calls_omitted_when_tools_absent(self, mock_completion):
         mock_completion.return_value = make_completion_response(content="ok")
 

--- a/tests/unit/test_prompt_context_message_placement.py
+++ b/tests/unit/test_prompt_context_message_placement.py
@@ -49,18 +49,15 @@ class PromptContextSqlitePlacementTests(TestCase):
         self.assertIn("<sqlite_guidance>", system_message["content"])
         self.assertIn("</sqlite_guidance>", system_message["content"])
         self.assertIn("Named tables are the world model", sqlite_guidance)
-        self.assertIn("before external refreshes/decisions", sqlite_guidance)
+        self.assertIn("Use queried rows, not memory, for decisions", sqlite_guidance)
         self.assertIn("use SQLite for exact set logic/counts/ranking", sqlite_guidance)
-        self.assertIn("Keep chat/outreach light. Owner reports on 4+ peers", system_message["content"])
-        self.assertIn(
-            "need resolved/total and one table with requested fields",
-            system_message["content"],
-        )
+        self.assertIn("Keep chat/outreach light. For finite sets", system_message["content"])
         self.assertIn("## Link References (CRITICAL)", system_message["content"])
-        self.assertIn("the raw URL identifies that exact item", system_message["content"])
-        self.assertIn("adjacent token is the only user-visible link", system_message["content"])
-        self.assertIn("An item lacking its token stays unlinked", system_message["content"])
-        self.assertIn("a source/feed token links only itself", system_message["content"])
+        self.assertIn("the raw URL is evidence", system_message["content"])
+        self.assertIn("adjacent token is only a display/fetch handle", system_message["content"])
+        self.assertIn("Items without a token stay plain", system_message["content"])
+        self.assertIn("source/feed tokens link only themselves", system_message["content"])
+        self.assertIn("A report is unfinished while a token-backed entity name is plain", system_message["content"])
         self.assertIn("resolve/source each requested field", system_message["content"])
         self.assertIn("grouped discovery isn't coverage", system_message["content"])
         self.assertIn("separate sourced unavailability from research gaps", system_message["content"])
@@ -108,7 +105,7 @@ class PromptContextSqlitePlacementTests(TestCase):
         )
 
         self.assertIn(
-            "not yet reconciled",
+            "not reconciled",
             prompt_context._get_unreconciled_source_model_warning(self.agent),
         )
 
@@ -124,7 +121,7 @@ class PromptContextSqlitePlacementTests(TestCase):
         )
 
         self.assertIn(
-            "post-update query",
+            "query the model in that batch",
             prompt_context._get_unreconciled_source_model_warning(self.agent),
         )
         post_update_read = PersistentAgentStep.objects.create(agent=self.agent, description="fresh model read")

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -23,7 +23,9 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
 
         self.assertIn("Named tables are the world model", guidance)
         self.assertIn("digest is partial", guidance)
-        self.assertIn("Read them before external refreshes/decisions, not memory", guidance)
+        self.assertIn("Use queried rows, not memory, for decisions", guidance)
+        self.assertIn("Explicit fresh source: fetch once", guidance)
+        self.assertIn("Otherwise read the model first", guidance)
         self.assertIn("Current complete rows are truth; don't refetch them", guidance)
         self.assertIn("Tool output doesn't update it", guidance)
         self.assertIn("sharing a stable ID or its children", guidance)
@@ -37,6 +39,9 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
         self.assertIn("query gaps before reporting", guidance)
         self.assertIn("Only sourced blockers are unresolved", guidance)
         self.assertIn("use SQLite for exact set logic/counts/ranking", guidance)
+        self.assertIn("No sibling-by-sibling result/table/blob loops", guidance)
+        self.assertIn("Inspect unknown structure once", guidance)
+        self.assertNotIn("Copy names/paths/values/URLs", guidance)
 
     def test_low_iteration_warning_keeps_unfinished_work_active(self):
         collector = _NestedPromptSectionCollector()
@@ -120,6 +125,24 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
         self.assertIn("SQLite efficiency warning", warning)
         self.assertIn("one result_id at a time", warning)
 
+    def test_sqlite_retry_warning_allows_multi_entity_import_in_one_batch(self):
+        warning = prompt_context._build_sqlite_retry_warning(
+            [
+                (
+                    {
+                        "sql": "INSERT INTO accounts SELECT value FROM __tool_results, "
+                        "json_each(result_json, '$.content.accounts') WHERE result_id='a1'; "
+                        "INSERT INTO workstreams SELECT value FROM __tool_results, "
+                        "json_each(result_json, '$.content.workstreams') WHERE result_id='a1'; "
+                        "SELECT * FROM accounts; SELECT * FROM workstreams"
+                    },
+                    '{"status":"ok"}',
+                ),
+            ]
+        )
+
+        self.assertEqual(warning, "")
+
     def test_sqlite_retry_warning_recovers_from_rejected_singleton_queries(self):
         rejection = (
             "Query not executed: do not read __tool_results or a staging table derived from it one result_id at a "
@@ -150,10 +173,11 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
 
         warning = prompt_context._build_unreconciled_source_model_warning([source, stale_read])
 
-        self.assertIn("Fresh source evidence from this work cycle", warning)
-        self.assertIn("upsert all changed/provenance fields by stable key from __tool_results", warning)
-        self.assertIn("If it is unrelated or no relevant model exists", warning)
-        self.assertIn("Do not refetch", warning)
+        self.assertIn("Fresh source evidence is not reconciled", warning)
+        self.assertIn("must use INSERT ... SELECT or UPDATE ... FROM __tool_results/json_each", warning)
+        self.assertIn("Every sourced field, including IDs", warning)
+        self.assertIn("only JSON paths and current result_id/tool_name may be literals", warning)
+        self.assertIn("Otherwise answer it directly", warning)
         self.assertEqual(
             prompt_context._build_unreconciled_source_model_warning([
                 ("http_request", {}, "error"), stale_read,
@@ -225,6 +249,20 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
             ])
         )
 
+        child_update = (
+            "sqlite_batch",
+            {"sql": "INSERT INTO workstreams(workstream_id) SELECT json_extract(value,'$.id') "
+                    "FROM __tool_results,json_each(result_json,'$.workstreams')"},
+            "complete",
+        )
+        child_read = ("sqlite_batch", {"sql": "SELECT * FROM workstreams"}, "complete")
+        self.assertTrue(prompt_context._build_unreconciled_source_model_warning([
+            source, stale_read, derived_update, child_update, post_update_read,
+        ]))
+        self.assertEqual(prompt_context._build_unreconciled_source_model_warning([
+            source, stale_read, derived_update, child_update, post_update_read, child_read,
+        ]), "")
+
     def test_source_model_warning_handles_model_first_and_unrelated_mutations(self):
         model_read = ("sqlite_batch", {"sql": "SELECT * FROM accounts"}, "complete")
         source = ("http_request", {}, "complete")
@@ -286,6 +324,30 @@ class PromptContextContactsGuidanceTests(TestCase):
             charter="Test contacts guidance.",
             browser_use_agent=self.browser_agent,
         )
+
+    def test_runtime_config_note_does_not_direct_one_off_feedback_into_config(self):
+        with patch("api.agent.core.prompt_context.ensure_steps_compacted"), patch(
+            "api.agent.core.prompt_context.ensure_comms_compacted"
+        ):
+            context, _, _ = prompt_context.build_prompt_context(self.agent, is_first_run=False)
+
+        content = "\n".join(message["content"] for message in context)
+        self.assertIn("patch_text for lasting owner behavior feedback only", content)
+        self.assertIn("temporary feedback/ordinary tasks never config", content)
+        self.assertIn("No schedule is set. Leave it NULL unless the user requests recurrence", content)
+        self.assertNotIn("Without a schedule, you die", content)
+
+    def test_runtime_schedule_note_keeps_temporary_scope_from_changing_cadence(self):
+        self.agent.schedule = "0 9 * * *"
+        self.agent.save(update_fields=["schedule", "updated_at"])
+        with patch("api.agent.core.prompt_context.ensure_steps_compacted"), patch(
+            "api.agent.core.prompt_context.ensure_comms_compacted"
+        ):
+            context, _, _ = prompt_context.build_prompt_context(self.agent, is_first_run=False)
+
+        content = "\n".join(message["content"] for message in context)
+        self.assertIn("temporary task scope never changes it", content)
+        self.assertNotIn("Task scope changed? Adjust timing", content)
 
     def test_large_allowed_contacts_are_compacted_in_prompt(self):
         CommsAllowlistEntry.objects.bulk_create(

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -25,6 +25,7 @@ from api.agent.tools.sqlite_batch import (
     _get_error_hint,
     _fix_unescaped_single_quote_runs,
     _fix_json_key_vs_alias,
+    _fix_insert_select_upsert_ambiguity,
     _fix_python_operators,
     _fix_singular_plural_columns,
     _fix_singular_plural_tables,
@@ -97,6 +98,16 @@ class SqliteBatchToolTests(TestCase):
             self.assertEqual(results[-1]["result"], [{"a": 1}, {"a": 2}])
             self.assertIsInstance(out.get("db_size_mb"), (int, float))
             self.assertIn("Executed 3 queries", out.get("message", ""))
+
+    def test_cte_insert_reports_actual_changed_rows(self):
+        with self._with_temp_db():
+            out = execute_sqlite_batch(self.agent, {"sql": (
+                "CREATE TABLE t(a INTEGER); "
+                "WITH rows(a) AS (VALUES (1),(2)) INSERT INTO t SELECT a FROM rows;"
+            )})
+
+        self.assertEqual(out.get("status"), "ok", out.get("message"))
+        self.assertEqual(out["results"][1]["message"], "Query 1 affected 2 rows.")
 
     def test_stops_on_error_and_reports_index(self):
         with self._with_temp_db() as (db_path, token, tmp):
@@ -264,15 +275,14 @@ class SqliteBatchToolTests(TestCase):
         definition = get_sqlite_batch_tool()
         description = definition["function"]["description"]
 
-        self.assertIn("SQLite world model + hard logic", description)
-        self.assertIn("Current complete rows are truth: answer without refetching sources", description)
-        self.assertIn("keyed rows/children belong in the model", description)
-        self.assertIn("Reconcile relations, evolve schema, then query", description)
-        self.assertIn("only unrelated one-offs bypass it", description)
-        self.assertIn("joins/set logic/counts/ranking", description)
-        self.assertIn("PRIMARY KEY/UNIQUE + provenance", description)
-        self.assertIn("Import tool output via INSERT ... SELECT/json_each", description)
-        self.assertIn("from __tool_results, never copied rows", description)
+        for expected in (
+            "SQLite world model + exact logic", "Fetch alone; next completion reconcile and SELECT",
+            "SOURCE ARRAYS lists paths", "Every sourced SET/VALUES and write WHERE/ON key",
+            "SELECT the model before deciding/reporting", "INSERT ... SELECT / UPDATE ... FROM __tool_results/json_each",
+            "WHERE before ON CONFLICT", "never facts/URLs/keys",
+        ):
+            self.assertIn(expected, description)
+        self.assertNotIn("before one terminal send", description)
 
     def test_tool_result_ctas_warns_that_identity_is_disposable(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
@@ -485,6 +495,8 @@ class SqliteBatchToolTests(TestCase):
                 out.get("advisories", [{}])[0].get("code"),
                 "bulk_manual_working_table_from_visible_results",
             )
+            self.assertIn("used visible facts or URLs", out.get("message", ""))
+            self.assertNotIn("literal-row import", out.get("message", ""))
             conn = sqlite3.connect(db_path)
             try:
                 table = conn.execute(
@@ -493,6 +505,72 @@ class SqliteBatchToolTests(TestCase):
             finally:
                 conn.close()
             self.assertIsNone(table)
+
+    def test_nested_http_rows_must_be_derived_and_can_reconcile_in_one_batch(self):
+        with self._with_temp_db() as (db_path, _token, _tmp):
+            payload = json.dumps({
+                "status": "ok",
+                "content": {
+                    "accounts": [{
+                        "account_id": "acct-1", "name": "Aster Labs", "stage": "contracting",
+                        "source_url": "https://crm.example.test/aster",
+                    }],
+                    "workstreams": [{
+                        "workstream_id": "ws-1", "account_id": "acct-1", "name": "Redlines",
+                        "status": "open", "source_url": "https://crm.example.test/aster",
+                    }],
+                },
+            })
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    "CREATE TABLE __tool_results(result_id TEXT PRIMARY KEY, tool_name TEXT, "
+                    "result_json TEXT, result_text TEXT)"
+                )
+                conn.execute("INSERT INTO __tool_results VALUES ('r1','http_request',?,?)", (payload, payload))
+                conn.execute(
+                    "CREATE TABLE accounts(account_id TEXT PRIMARY KEY, name TEXT, stage TEXT, source_url TEXT)"
+                )
+
+            copied = execute_sqlite_batch(self.agent, {
+                "sql": (
+                    "INSERT INTO accounts(account_id,name,stage,source_url) VALUES "
+                    "('acct-1','Aster Labs','contracting','https://crm.example.test/aster')"
+                ),
+                "will_continue_work": True,
+            })
+            self.assertEqual(copied.get("status"), "error")
+            self.assertEqual(copied.get("advisories", [{}])[0].get("code"), "source_facts_copied_into_model")
+
+            reconciled = execute_sqlite_batch(self.agent, {
+                "sql": (
+                    "CREATE TABLE workstreams(workstream_id TEXT PRIMARY KEY, account_id TEXT, name TEXT, "
+                    "status TEXT, source_url TEXT);"
+                    "INSERT INTO accounts(account_id,name,stage,source_url) "
+                    "SELECT json_extract(j.value,'$.account_id'),json_extract(j.value,'$.name'),"
+                    "json_extract(j.value,'$.stage'),json_extract(j.value,'$.source_url') "
+                    "FROM __tool_results r,json_each(r.result_json,'$.content.accounts') j "
+                    "WHERE r.result_id='r1' ON CONFLICT(account_id) DO UPDATE SET name=excluded.name,"
+                    "stage=excluded.stage,source_url=excluded.source_url;"
+                    "INSERT INTO workstreams(workstream_id,account_id,name,status,source_url) "
+                    "SELECT json_extract(j.value,'$.workstream_id'),json_extract(j.value,'$.account_id'),"
+                    "json_extract(j.value,'$.name'),json_extract(j.value,'$.status'),"
+                    "json_extract(j.value,'$.source_url') "
+                    "FROM __tool_results r,json_each(r.result_json,'$.content.workstreams') j "
+                    "WHERE r.result_id='r1' ON CONFLICT(workstream_id) DO UPDATE SET "
+                    "account_id=excluded.account_id,name=excluded.name,status=excluded.status,"
+                    "source_url=excluded.source_url;"
+                    "SELECT a.name AS account_name,w.name AS workstream_name,w.status FROM accounts a JOIN workstreams w "
+                    "ON w.account_id=a.account_id WHERE a.account_id='acct-1';"
+                ),
+                "will_continue_work": True,
+            })
+
+            self.assertEqual(reconciled.get("status"), "ok", reconciled)
+            self.assertNotIn("advisories", reconciled)
+            self.assertEqual(
+                reconciled["results"][-1]["result"],
+                [{"account_name": "Aster Labs", "workstream_name": "Redlines", "status": "open"}],
+            )
 
     def test_bulk_manual_tool_result_select_copy_is_rejected_before_execution(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
@@ -845,6 +923,74 @@ class SqliteBatchToolTests(TestCase):
         self.assertEqual(commented, [])
         self.assertEqual(double_quoted_text, [])
 
+    def test_related_model_imports_from_one_source_are_not_a_row_loop(self):
+        sql = (
+            "INSERT INTO accounts(account_id) SELECT json_extract(result_json,'$.account_id') "
+            "FROM __tool_results WHERE result_id='r1';"
+            "INSERT INTO workstreams(workstream_id) SELECT json_extract(value,'$.id') "
+            "FROM __tool_results,json_each(result_json,'$.workstreams') WHERE result_id='r1';"
+        )
+
+        advisories = build_tool_result_query_advisories([sql], available_tool_result_rows=4)
+        split_sources = build_tool_result_query_advisories(
+            [sql.replace("result_id='r1';", "result_id='r2';", 1)],
+            available_tool_result_rows=4,
+        )
+
+        self.assertEqual(advisories, [])
+        self.assertIn("tool_result_row_loop", {advisory.code for advisory in split_sources})
+
+    def test_related_model_imports_from_one_source_execute_without_warning(self):
+        payload = json.dumps({
+            "content": {
+                "accounts": [{"account_id": "acct-1", "name": "Acme"}],
+                "workstreams": [{"workstream_id": "ws-1", "account_id": "acct-1", "status": "open"}],
+            }
+        })
+        with self._with_temp_db() as (db_path, _token, _tmp):
+            conn = sqlite3.connect(db_path)
+            try:
+                conn.execute(
+                    "CREATE TABLE __tool_results "
+                    "(result_id TEXT PRIMARY KEY, tool_name TEXT, result_json TEXT, result_text TEXT)"
+                )
+                conn.executemany(
+                    "INSERT INTO __tool_results VALUES (?, ?, ?, ?)",
+                    [("abc123", "http_request", payload, "")] + [
+                        (f"old-{index}", "http_request", "{}", "") for index in range(4)
+                    ],
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+            out = execute_sqlite_batch(self.agent, {"sql": """
+                CREATE TABLE accounts(account_id TEXT PRIMARY KEY, name TEXT);
+                CREATE TABLE workstreams(
+                    workstream_id TEXT PRIMARY KEY,
+                    account_id TEXT,
+                    status TEXT
+                );
+                INSERT INTO accounts(account_id, name)
+                SELECT json_extract(j.value, '$.account_id'), json_extract(j.value, '$.name')
+                FROM __tool_results r, json_each(r.result_json, '$.content.accounts') j
+                WHERE r.result_id='abc123';
+                INSERT INTO workstreams(workstream_id, account_id, status)
+                SELECT json_extract(j.value, '$.workstream_id'),
+                       json_extract(j.value, '$.account_id'), json_extract(j.value, '$.status')
+                FROM __tool_results r, json_each(r.result_json, '$.content.workstreams') j
+                WHERE r.result_id='abc123';
+                SELECT * FROM accounts;
+                SELECT * FROM workstreams;
+            """})
+
+        self.assertEqual(out.get("status"), "ok", out.get("message"))
+        self.assertNotIn("advisories", out)
+        self.assertEqual(out["results"][-2]["result"], [{"account_id": "acct-1", "name": "Acme"}])
+        self.assertEqual(out["results"][-1]["result"], [{
+            "workstream_id": "ws-1", "account_id": "acct-1", "status": "open",
+        }])
+
     def test_tool_result_quality_detects_smart_queries_and_advisories(self):
         sql = """
         CREATE TABLE candidate_sources(url TEXT);
@@ -1064,17 +1210,38 @@ class SqliteBatchToolTests(TestCase):
             available_tool_result_rows=1,
             tool_result_payloads=(payload,),
         )
+        parsed_text = build_tool_result_query_advisories(
+            [
+                "INSERT INTO accounts(account_id, stage) "
+                "SELECT substr(result_text, instr(result_text, 'account_id=') + 11), "
+                "substr(result_text, instr(result_text, 'stage=') + 6) FROM __tool_results"
+            ],
+            available_tool_result_rows=1,
+            tool_result_payloads=("account_id=acct-1 | stage=contracting",),
+        )
+        case_logic = build_tool_result_query_advisories(
+            [
+                "INSERT INTO accounts(account_id, stage, priority) SELECT "
+                "json_extract(j.value,'$.account_id'), "
+                "CASE json_extract(j.value,'$.stage') WHEN 'in progress' THEN 'active' ELSE 'inactive' END, "
+                "CASE json_extract(j.value,'$.priority') WHEN 'enterprise' THEN 1 ELSE 0 END "
+                "FROM __tool_results r, json_each(r.result_json,'$.content.accounts') j"
+            ],
+            available_tool_result_rows=1,
+            tool_result_payloads=(
+                '{"content":{"accounts":[{"account_id":"acct-1","stage":"in progress",'
+                '"priority":"enterprise","normalized":"active","fallback":"inactive"}]}}',
+            ),
+        )
         self.assertEqual(copied[0].code, "source_facts_copied_into_model")
         self.assertTrue(copied[0].blocking)
-        self.assertIn("copies source facts into SQL literals", copied[0].message)
-        self.assertIn("refresh every mutable/provenance field", copied[0].message)
-        self.assertIn("don't fetch/copy the blob", copied[0].message)
-        self.assertIn("nested arrays are under $.content", copied[0].message)
-        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in derived))
-        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in unrelated))
-        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in identity_predicate))
-        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in single_normalization))
-        self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in arrow_derived))
+        self.assertIn("used visible facts or URLs as SQL literals", copied[0].message)
+        self.assertIn("Derive every sourced field", copied[0].message)
+        self.assertIn("omit unavailable URLs", copied[0].message)
+        for allowed in (
+            derived, unrelated, identity_predicate, single_normalization, arrow_derived, parsed_text, case_logic,
+        ):
+            self.assertFalse(any(item.code == "source_facts_copied_into_model" for item in allowed))
         self.assertTrue(any(item.code == "source_facts_copied_into_model" for item in partially_derived))
 
     def test_model_read_classification_excludes_raw_results_and_staging(self):
@@ -2222,6 +2389,98 @@ class SqliteBatchToolTests(TestCase):
         self.assertIn("AND", fixed)
         self.assertIn("LIKE", fixed)
         self.assertTrue(len(fixes) >= 3)
+
+    def test_fix_insert_select_upsert_adds_top_level_where(self):
+        sql = (
+            "INSERT INTO accounts(account_id,name) "
+            "SELECT json_extract(j.value,'$.account_id'),json_extract(j.value,'$.name') "
+            "FROM json_each((SELECT result_json ->> '$.content.accounts' "
+            "FROM __tool_results WHERE result_id='4c134c')) AS j "
+            "ON CONFLICT(account_id) DO UPDATE SET name=excluded.name"
+        )
+
+        fixed, correction = _fix_insert_select_upsert_ambiguity(sql)
+
+        self.assertIn(")) AS j WHERE 1=1 ON CONFLICT", fixed)
+        self.assertIn("disambiguate", correction)
+
+    def test_fix_insert_select_upsert_preserves_existing_top_level_where(self):
+        sql = (
+            "INSERT INTO accounts(account_id) SELECT account_id FROM incoming "
+            "WHERE account_id IS NOT NULL ON CONFLICT(account_id) DO NOTHING"
+        )
+
+        fixed, correction = _fix_insert_select_upsert_ambiguity(sql)
+
+        self.assertEqual(fixed, sql)
+        self.assertIsNone(correction)
+
+    def test_fix_insert_select_upsert_preserves_values_form(self):
+        sql = "INSERT INTO accounts(account_id) VALUES ('acct-1') ON CONFLICT(account_id) DO NOTHING"
+
+        fixed, correction = _fix_insert_select_upsert_ambiguity(sql)
+
+        self.assertEqual(fixed, sql)
+        self.assertIsNone(correction)
+
+    def test_fix_insert_select_upsert_checks_final_compound_select(self):
+        sql = (
+            "INSERT INTO accounts(account_id) "
+            "SELECT account_id FROM primary_accounts WHERE active=1 "
+            "UNION ALL SELECT account_id FROM secondary_accounts "
+            "ON CONFLICT(account_id) DO NOTHING"
+        )
+
+        fixed, correction = _fix_insert_select_upsert_ambiguity(sql)
+
+        self.assertIn("FROM secondary_accounts WHERE 1=1 ON CONFLICT", fixed)
+        self.assertIn("disambiguate", correction)
+
+    def test_fix_insert_select_upsert_ignores_where_in_literals_and_comments(self):
+        sql = (
+            "INSERT INTO notes(note_id,note) SELECT note_id,'WHERE ON CONFLICT' "
+            "FROM incoming /* WHERE */ ON CONFLICT(note_id) DO NOTHING"
+        )
+
+        fixed, correction = _fix_insert_select_upsert_ambiguity(sql)
+
+        self.assertIn("/* WHERE */ WHERE 1=1 ON CONFLICT", fixed)
+        self.assertIn("disambiguate", correction)
+
+    def test_fix_insert_select_upsert_preserves_join_to_conflict_table(self):
+        sql = "INSERT INTO target SELECT a.id FROM a JOIN conflict ON conflict.id=a.id"
+
+        fixed, correction = _fix_insert_select_upsert_ambiguity(sql)
+
+        self.assertEqual(fixed, sql)
+        self.assertIsNone(correction)
+
+    def test_insert_select_upsert_ambiguity_is_corrected_before_execution(self):
+        payload = json.dumps({"content": {"accounts": [{"account_id": "acct-1", "name": "Aster Labs"}]}})
+        with self._with_temp_db() as (db_path, _token, _tmp):
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    "CREATE TABLE __tool_results(result_id TEXT PRIMARY KEY, tool_name TEXT, "
+                    "result_json TEXT, result_text TEXT)"
+                )
+                conn.execute("INSERT INTO __tool_results VALUES ('4c134c','http_request',?,?)", (payload, payload))
+
+            out = execute_sqlite_batch(self.agent, {"sql": (
+                "CREATE TABLE accounts(account_id TEXT PRIMARY KEY,name TEXT);"
+                "INSERT INTO accounts(account_id,name) "
+                "SELECT json_extract(j.value,'$.account_id'),json_extract(j.value,'$.name') "
+                "FROM json_each((SELECT result_json ->> '$.content.accounts' "
+                "FROM __tool_results WHERE result_id='4c134c')) AS j "
+                "ON CONFLICT(account_id) DO UPDATE SET name=excluded.name;"
+                "SELECT account_id,name FROM accounts"
+            )})
+
+        self.assertEqual(out.get("status"), "ok", out.get("message"))
+        self.assertEqual(out["results"][-1]["result"], [{"account_id": "acct-1", "name": "Aster Labs"}])
+        auto_fix = out["results"][1].get("auto_correction")
+        self.assertIsNotNone(auto_fix)
+        self.assertIn("WHERE 1=1 ON CONFLICT", auto_fix["after"])
+        self.assertIn("disambiguate", " ".join(auto_fix["fixes"]))
 
     def test_integration_trailing_tool_params(self):
         """Full integration: trailing tool params are stripped and query runs."""

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -615,6 +615,19 @@ class MetaTextFormattingTests(SimpleTestCase):
 class PreviewByteLimitTests(SimpleTestCase):
     """Tests for preview byte limits with large external results."""
 
+    @staticmethod
+    def _prepare_http_result(step_id, payload, *, recency=0, fresh=True, **kwargs):
+        record = tool_results.ToolCallResultRecord(
+            step_id=step_id,
+            tool_name="http_request",
+            created_at=datetime.now(timezone.utc),
+            result_text=json.dumps(payload),
+        )
+        params = {"recency_positions": {step_id: recency}, **kwargs}
+        if fresh:
+            params["fresh_tool_call_step_id"] = step_id
+        return tool_results.prepare_tool_results_for_prompt([record], **params)[step_id], record
+
     def test_large_result_preview_capped(self):
         """Results >= 5KB should have preview capped to 200 bytes."""
         from api.agent.core.tool_results import (
@@ -683,18 +696,13 @@ class PreviewByteLimitTests(SimpleTestCase):
             small_text,
             len(small_text),
             recency_position=0,
-            tool_name="mcp_brightdata_scrape_as_markdown",
+            tool_name="send_chat_message",
         )
 
         self.assertTrue(is_inline)
         self.assertEqual(preview, small_text)
 
-    def test_small_inline_http_result_does_not_include_sql_affordances(self):
-        from api.agent.core.tool_results import (
-            ToolCallResultRecord,
-            prepare_tool_results_for_prompt,
-        )
-
+    def test_fresh_small_inline_http_result_includes_source_model_choice(self):
         payload = {
             "status": "ok",
             "status_code": 206,
@@ -715,28 +723,127 @@ class PreviewByteLimitTests(SimpleTestCase):
                 ],
             },
         }
-        record = ToolCallResultRecord(
-            step_id="step-http",
-            tool_name="http_request",
-            created_at=datetime.now(timezone.utc),
-            result_text=json.dumps(payload),
+        info, record = self._prepare_http_result(
+            "step-http", payload,
+            named_model_tables={"items"},
         )
-
-        info = prepare_tool_results_for_prompt(
-            [record],
-            recency_positions={"step-http": 0},
-            fresh_tool_call_step_id="step-http",
-        )["step-http"]
 
         self.assertTrue(info.is_inline)
         self.assertIn("result_id=step-http", info.meta)
         self.assertIn("parsed_with=json", info.meta)
         self.assertIn("Central bank signals rate hold", info.preview_text)
-        self.assertNotIn("QUERY:", info.meta)
-        self.assertNotIn("PATH:", info.meta)
-        self.assertNotIn("SAMPLE:", info.meta)
-        self.assertNotIn("JSON_DIGEST:", info.meta)
-        self.assertNotIn("__tool_results", info.meta)
+        self.assertIn("SOURCE ARRAYS result_id=step-http; stored paths", info.preview_text)
+        self.assertLess(
+            info.preview_text.index("SOURCE ARRAYS result_id=step-http"),
+            info.preview_text.index("Central bank signals rate hold"),
+        )
+        for expected in (
+            "$.content.items", '"content":{', "one sqlite_batch only", "every listed entity array",
+            "INSERT ... SELECT/json_each", "Derive all facts, URLs, and write keys from j.value",
+            "never changes __agent_config/__agent_skills", "No pre-read, refetch, blob inspection, copied literals",
+        ):
+            self.assertIn(expected, info.preview_text)
+        self.assertEqual(info.preview_text.count("[SOURCE ARRAYS"), 1)
+        self.assertTrue(info.source_reconciliation_directive)
+        self.assertIn(info.source_reconciliation_directive, info.preview_text)
+        aliased = tool_results.prepare_tool_results_for_prompt(
+            [record], recency_positions={"step-http": 0}, fresh_tool_call_step_id="step-http",
+            named_model_tables={"news_items"},
+        )["step-http"]
+        self.assertTrue(aliased.source_reconciliation_directive)
+        compact_payload = json.dumps(payload, separators=(",", ":"))
+        self.assertLess(len(info.preview_text) - len(compact_payload), 1_000)
+        for absent in ("QUERY:", "PATH:", "SAMPLE:", "JSON_DIGEST:", "__tool_results"):
+            self.assertNotIn(absent, info.meta)
+
+        linked = tool_results.prepare_tool_results_for_prompt(
+            [record],
+            recency_positions={"step-http": 0},
+            fresh_tool_call_step_id="step-http",
+            paired_url_rewriter=lambda text, _record: text.replace(
+                "https://news.example.test/rate-hold",
+                "https://news.example.test/rate-hold [link_ref: $[link:LEXACT]]",
+            ),
+            paired_url_step_ids={"step-http"},
+        )["step-http"]
+        for expected in (
+            "VERIFIED LINK PRESENTATION", "anchor each token on its exact entity name",
+            "<a href='token'>entity</a>", "No separate URL/link column unless requested", "owner report with 4+ items",
+            "Say Not returned where a requested URL is absent", "Without a preceding SOURCE ARRAYS directive",
+            "does not change the requested audience or action",
+        ):
+            self.assertIn(expected, linked.preview_text)
+        self.assertNotIn("NEVER OUTREACH", linked.preview_text)
+        self.assertNotIn("[SOURCE ARRAYS result_id=", linked.preview_text)
+
+        linked_model = tool_results.prepare_tool_results_for_prompt(
+            [record],
+            recency_positions={"step-http": 0},
+            fresh_tool_call_step_id="step-http",
+            paired_url_rewriter=lambda text, _record: text.replace(
+                "https://news.example.test/rate-hold",
+                "https://news.example.test/rate-hold [link_ref: $[link:LEXACT]]",
+            ),
+            paired_url_step_ids={"step-http"},
+            named_model_tables={"items"},
+        )["step-http"]
+        self.assertTrue(linked_model.source_reconciliation_directive)
+        self.assertIn("https://news.example.test/rate-hold", linked_model.preview_text)
+        self.assertNotIn("$[link:LEXACT]", linked_model.preview_text)
+
+        recent = tool_results.prepare_tool_results_for_prompt(
+            [record], recency_positions={"step-http": 1}
+        )["step-http"]
+        self.assertNotIn("SOURCE ARRAYS result_id=step-http", recent.preview_text)
+        self.assertIsNone(recent.source_reconciliation_directive)
+        self.assertIn("Central bank signals rate hold", recent.preview_text)
+
+    def test_fresh_relational_http_result_requires_one_source_derived_model_batch(self):
+        payload = {
+            "status": "ok",
+            "content": {
+                "alerts": [{"message": "Account data refreshed"}],
+                "accounts": [{"account_id": "acct-1", "name": "Acme"}],
+                "workstreams": [{"workstream_id": "ws-1", "account_id": "acct-1", "status": "open"}],
+            },
+        }
+        info, _record = self._prepare_http_result(
+            "step-relational", payload,
+            named_model_tables={"accounts"},
+        )
+        preview = info.preview_text
+
+        self.assertIn("$.content.accounts(account_id,name)", preview)
+        self.assertIn("$.content.workstreams(workstream_id,account_id,status)", preview)
+        self.assertNotIn("$.content.alerts", preview)
+        self.assertIn("every listed entity array", preview)
+        self.assertIn("INSERT ... SELECT/json_each", preview)
+        self.assertEqual(preview.count("[SOURCE ARRAYS"), 1)
+        self.assertLess(preview.index("SOURCE ARRAYS"), preview.index('"workstreams"'))
+
+        payload["content"]["notes"] = "context " * 10_000
+        large, _record = self._prepare_http_result(
+            "step-large-relational", payload,
+            named_model_tables={"accounts"},
+        )
+        self.assertFalse(large.is_inline)
+        self.assertIn("SOURCE ARRAYS", large.preview_text)
+        self.assertTrue(large.source_reconciliation_directive)
+
+    def test_fresh_source_without_matching_entity_array_does_not_force_import(self):
+        cases = (
+            ("object", {"answer": "ready"}, set(), '"answer":"ready"'),
+            ("weather", {"forecasts": [{"temperature": 72}]}, {"accounts"}, '"temperature":72'),
+        )
+        for step, content, model_tables, expected in cases:
+            with self.subTest(step=step):
+                info, _record = self._prepare_http_result(
+                    f"step-{step}", {"status": "ok", "content": content},
+                    named_model_tables=model_tables,
+                )
+                self.assertIn(expected, info.preview_text)
+                self.assertNotIn("SOURCE ARRAY", info.preview_text)
+                self.assertIsNone(info.source_reconciliation_directive)
 
     def test_fresh_tool_call_under_threshold_shown_inline(self):
         """Fresh tool calls under 40KB should be shown fully inline with SQLite wrapper."""
@@ -758,8 +865,8 @@ class PreviewByteLimitTests(SimpleTestCase):
         self.assertTrue(is_inline)
         # Should be wrapped with one-time view warning
         self.assertIn("[FULL RESULT (30000 chars) - ONE-TIME VIEW", preview)
-        self.assertIn("Use this visible result now", preview)
-        self.assertIn("exact filtering/ranking across sizable or multiple results", preview)
+        self.assertIn("later turns show a preview", preview)
+        self.assertNotIn("SOURCE ARRAYS", preview)
         self.assertIn(medium_text, preview)
 
     def test_fresh_tool_call_over_threshold_truncated(self):


### PR DESCRIPTION
## Summary

- Interpret durable owner feedback into one focused charter patch, preserve unrelated instructions, exclude one-off directions, and confirm naturally on the active channel.
- Reconcile fresh structured evidence into keyed SQLite domain tables directly from __tool_results, then query the modeled rows before deciding or reporting. Includes a narrow SQLite INSERT SELECT UPSERT parser correction that prevents valid-intent retry loops.
- Preserve sourced URLs for useful visual owner reports without inventing links or overriding requested outreach, and keep Discord available for same-channel replies in credit-limited mode.
- Archive the actual focused prompt and tighten dependency ordering so reads precede dependent writes without reordering mutating calls.

## Evidence

DeepSeek V4 Flash real-harness evals:

- SQLite domain refresh: 12/12, suite 31da5134-6ffd-44d5-acff-8f10a45dc1e6
- Sourced owner report links and structure: 12/12, suite aaa644a6-3bfe-47df-8227-5e2d729c590f
- Ambiguous durable feedback: 6/6, suite efc3cb7b-1e55-4946-8f2f-7dd9f9c5c336
- Plain and evaluative feedback variants also passed their focused three-run suites.

Focused tests:

- SQLite batch module: 130/130
- Behavior eval helpers: 84/84
- Tool-result and credit-mode coverage: 52/52
- Earlier affected serial gate: 407/407

Complexity budgets pass. Core product source increases by 381 nonblank lines; representative prompt totals decrease from 55,326 to 55,091 bytes, 53,040 to 52,953 bytes, and 55,829 to 55,594 bytes.

## Review notes

The eval checker still requires one successful focused mutation, preserved privacy and role clauses, correct routing direction, a natural terminal reply, and no runtime correction loop. Its only relaxation is accepting semantically equivalent human verbs such as message, tell, or share instead of requiring the literal word report.