### PR TITLE
Make chat UI preferences persistent and explicit

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -839,6 +839,7 @@ class UserPreference(models.Model):
     KEY_AGENT_CHAT_ROSTER_FAVORITE_AGENT_IDS = "agent.chat.roster.favorite_agent_ids"
     KEY_AGENT_CHAT_MUTED_AGENT_IDS = "agent.chat.muted_agent_ids"
     KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED = "agent.chat.insights_panel.expanded"
+    KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT = "agent.chat.insights_panel.expanded_by_agent"
     KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED = "agent.chat.notifications.enabled"
     KEY_AGENT_CHAT_SUGGESTIONS_ENABLED = "agent.chat.suggestions.enabled"
     KEY_USER_TIMEZONE = "user.timezone"
@@ -859,6 +860,11 @@ class UserPreference(models.Model):
         KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED: {
             "default": None,
             "type": "nullable_boolean",
+        },
+        KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: {
+            "default": {},
+            "type": "uuid_boolean_map",
+            "merge_updates": True,
         },
         KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED: {
             "default": True,
@@ -949,6 +955,29 @@ class UserPreference(models.Model):
         return cls._normalize_boolean_preference_value(key, value)
 
     @classmethod
+    def _normalize_uuid_boolean_map_preference_value(cls, key: str, value: object) -> dict[str, bool]:
+        if not isinstance(value, dict):
+            raise ValueError(f"Invalid value for '{key}'. Expected an object keyed by agent UUID.")
+
+        normalized: dict[str, bool] = {}
+        for raw_agent_id, expanded in value.items():
+            if not isinstance(raw_agent_id, str) or not isinstance(expanded, bool):
+                raise ValueError(
+                    f"Invalid value for '{key}'. Expected boolean values keyed by agent UUID."
+                )
+            try:
+                canonical_agent_id = str(uuid.UUID(raw_agent_id.strip()))
+            except (TypeError, ValueError, AttributeError) as exc:
+                raise ValueError(
+                    f"Invalid value for '{key}'. Expected boolean values keyed by agent UUID."
+                ) from exc
+            if canonical_agent_id in normalized:
+                raise ValueError(f"Invalid value for '{key}'. Duplicate agent UUIDs are not allowed.")
+            normalized[canonical_agent_id] = expanded
+
+        return normalized
+
+    @classmethod
     def _normalize_preference_value(
         cls,
         key: str,
@@ -971,6 +1000,9 @@ class UserPreference(models.Model):
 
         if preference_type == "nullable_boolean":
             return cls._normalize_nullable_boolean_preference_value(key, value)
+
+        if preference_type == "uuid_boolean_map":
+            return cls._normalize_uuid_boolean_map_preference_value(key, value)
 
         if preference_type == "timezone":
             return cls._normalize_timezone_preference_value(key, value)
@@ -1071,7 +1103,21 @@ class UserPreference(models.Model):
                     known_stored[key] = cls._normalize_preference_value(key, stored.get(key), definition)
                 except ValueError:
                     continue
-            next_stored = {**known_stored, **normalized_updates}
+            # Preserve preferences written by a newer rolling-deploy version while
+            # still replacing malformed values for keys this version understands.
+            next_stored = {
+                key: value
+                for key, value in stored.items()
+                if key not in cls.PREFERENCE_DEFINITIONS
+            }
+            next_stored.update(known_stored)
+            for key, value in normalized_updates.items():
+                definition = cls.PREFERENCE_DEFINITIONS[key]
+                if definition.get("merge_updates"):
+                    current_value = next_stored.get(key, {})
+                    next_stored[key] = {**current_value, **value}
+                else:
+                    next_stored[key] = value
             if next_stored != stored:
                 preference.preferences = next_stored
                 preference.save(update_fields=["preferences", "updated_at"])

--- a/api/models.py
+++ b/api/models.py
@@ -840,6 +840,7 @@ class UserPreference(models.Model):
     KEY_AGENT_CHAT_MUTED_AGENT_IDS = "agent.chat.muted_agent_ids"
     KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED = "agent.chat.insights_panel.expanded"
     KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED = "agent.chat.notifications.enabled"
+    KEY_AGENT_CHAT_SUGGESTIONS_ENABLED = "agent.chat.suggestions.enabled"
     KEY_USER_TIMEZONE = "user.timezone"
     PREFERENCE_DEFINITIONS = {
         KEY_AGENT_CHAT_ROSTER_SORT_MODE: {
@@ -860,6 +861,10 @@ class UserPreference(models.Model):
             "type": "nullable_boolean",
         },
         KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED: {
+            "default": True,
+            "type": "boolean",
+        },
+        KEY_AGENT_CHAT_SUGGESTIONS_ENABLED: {
             "default": True,
             "type": "boolean",
         },
@@ -1039,31 +1044,39 @@ class UserPreference(models.Model):
                 cls.PREFERENCE_DEFINITIONS[key],
             )
 
-        try:
-            preference, _ = cls.objects.get_or_create(user=user)
-        except IntegrityError:
-            # Concurrent first-write requests can both race to create the one-to-one
-            # row. If another request won, load that row and continue applying the
-            # validated updates instead of surfacing a duplicate-key failure.
+        with transaction.atomic():
             try:
-                preference = cls.objects.get(user=user)
-            except cls.DoesNotExist:
-                preference, _ = cls.objects.get_or_create(user=user)
-        stored = preference.preferences if isinstance(preference.preferences, dict) else {}
-        known_stored: dict[str, object] = {}
-        for key, definition in cls.PREFERENCE_DEFINITIONS.items():
-            if key not in stored:
-                continue
-            try:
-                known_stored[key] = cls._normalize_preference_value(key, stored.get(key), definition)
-            except ValueError:
-                continue
-        next_stored = {**known_stored, **normalized_updates}
-        if next_stored != stored:
-            preference.preferences = next_stored
-            preference.save(update_fields=["preferences", "updated_at"])
+                preference, created = cls.objects.get_or_create(user=user)
+            except IntegrityError:
+                # Concurrent first writes may race on the one-to-one constraint.
+                # Lock the winning row before merging this request's updates.
+                try:
+                    preference = cls.objects.select_for_update().get(user=user)
+                except cls.DoesNotExist:
+                    preference, created = cls.objects.get_or_create(user=user)
+                    if not created:
+                        preference = cls.objects.select_for_update().get(pk=preference.pk)
+            else:
+                if not created:
+                    # get_or_create() does not lock an existing row. Re-read it under
+                    # the lock so concurrent PATCHes merge instead of overwriting.
+                    preference = cls.objects.select_for_update().get(pk=preference.pk)
 
-        return cls.resolve_known_preferences(user)
+            stored = preference.preferences if isinstance(preference.preferences, dict) else {}
+            known_stored: dict[str, object] = {}
+            for key, definition in cls.PREFERENCE_DEFINITIONS.items():
+                if key not in stored:
+                    continue
+                try:
+                    known_stored[key] = cls._normalize_preference_value(key, stored.get(key), definition)
+                except ValueError:
+                    continue
+            next_stored = {**known_stored, **normalized_updates}
+            if next_stored != stored:
+                preference.preferences = next_stored
+                preference.save(update_fields=["preferences", "updated_at"])
+
+            return cls.resolve_known_preferences(user)
 
 
 def validate_product_announcement_action_url(value: str) -> None:

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -3066,6 +3066,9 @@ class AgentChatRosterAPIView(LoginRequiredMixin, View):
         agent_chat_notifications_enabled = resolved_preferences.get(
             UserPreference.KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED
         )
+        agent_chat_suggestions_enabled = resolved_preferences.get(
+            UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED
+        )
         if for_agent_id and not staff_override:
             override_for_agent, error_response, requested_agent_status = self._resolve_override_for_agent(
                 request,
@@ -3265,6 +3268,7 @@ class AgentChatRosterAPIView(LoginRequiredMixin, View):
                 "muted_agent_ids": muted_agent_ids,
                 "insights_panel_expanded": insights_panel_expanded,
                 "agent_chat_notifications_enabled": agent_chat_notifications_enabled,
+                "agent_chat_suggestions_enabled": agent_chat_suggestions_enabled,
                 "billingStatus": billing_status,
                 "accountPause": account_pause,
                 "agents": payload,
@@ -7028,6 +7032,10 @@ class AgentSuggestionsAPIView(LoginRequiredMixin, View):
             allow_shared=True,
             allow_delinquent_personal_chat=True,
         )
+        preferences = UserPreference.resolve_known_preferences(request.user)
+        if not preferences[UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED]:
+            return JsonResponse({"suggestions": [], "source": "none"})
+
         try:
             prompt_count = int(request.GET.get("prompt_count", DEFAULT_PROMPT_COUNT))
         except (TypeError, ValueError):

--- a/console/api_views.py
+++ b/console/api_views.py
@@ -3063,6 +3063,10 @@ class AgentChatRosterAPIView(LoginRequiredMixin, View):
         insights_panel_expanded = resolved_preferences.get(
             UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED
         )
+        insights_panel_expanded_by_agent = resolved_preferences.get(
+            UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT,
+            {},
+        )
         agent_chat_notifications_enabled = resolved_preferences.get(
             UserPreference.KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED
         )
@@ -3267,6 +3271,7 @@ class AgentChatRosterAPIView(LoginRequiredMixin, View):
                 "favorite_agent_ids": favorite_agent_ids,
                 "muted_agent_ids": muted_agent_ids,
                 "insights_panel_expanded": insights_panel_expanded,
+                "insights_panel_expanded_by_agent": insights_panel_expanded_by_agent,
                 "agent_chat_notifications_enabled": agent_chat_notifications_enabled,
                 "agent_chat_suggestions_enabled": agent_chat_suggestions_enabled,
                 "billingStatus": billing_status,

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -77,6 +77,7 @@ type AgentRosterPayload = {
   favorite_agent_ids?: string[]
   muted_agent_ids?: string[]
   insights_panel_expanded?: boolean | null
+  agent_chat_suggestions_enabled?: boolean
   agent_chat_notifications_enabled?: boolean
   billingStatus?: BillingStatusInfo | null
   accountPause?: AccountPauseInfo | null
@@ -136,6 +137,7 @@ export async function fetchAgentRoster(
   favoriteAgentIds: string[]
   mutedAgentIds: string[]
   insightsPanelExpanded: boolean | null
+  suggestionsEnabled: boolean
   agentChatNotificationsEnabled: boolean
   requestedAgentStatus?: 'deleted' | 'missing' | null
   billingStatus?: BillingStatusInfo | null
@@ -164,6 +166,7 @@ export async function fetchAgentRoster(
       ? payload.muted_agent_ids.filter((value): value is string => typeof value === 'string')
       : [],
     insightsPanelExpanded: payload.insights_panel_expanded ?? null,
+    suggestionsEnabled: payload.agent_chat_suggestions_enabled !== false,
     agentChatNotificationsEnabled: payload.agent_chat_notifications_enabled !== false,
     requestedAgentStatus: payload.requested_agent_status ?? null,
     billingStatus: payload.billingStatus ?? null,

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -3,6 +3,10 @@ import { staffViewContextHeaders, type ConsoleContext, type StaffViewContext } f
 import type { AgentRosterEntry, AgentRosterSortMode, AgentSidebarInvite, PlanningState, SignupPreviewState } from '../types/agentRoster'
 import type { AccountPauseInfo, BillingStatusInfo } from '../types/agentAddons'
 import type { LlmIntelligenceConfig } from '../types/llmIntelligence'
+import {
+  parseInsightsPanelExpandedByAgentPreference,
+  type InsightsPanelExpandedByAgent,
+} from './userPreferences'
 
 export type UpdateAgentPayload = {
   preferred_llm_tier?: string
@@ -77,6 +81,7 @@ type AgentRosterPayload = {
   favorite_agent_ids?: string[]
   muted_agent_ids?: string[]
   insights_panel_expanded?: boolean | null
+  insights_panel_expanded_by_agent?: unknown
   agent_chat_suggestions_enabled?: boolean
   agent_chat_notifications_enabled?: boolean
   billingStatus?: BillingStatusInfo | null
@@ -137,6 +142,7 @@ export async function fetchAgentRoster(
   favoriteAgentIds: string[]
   mutedAgentIds: string[]
   insightsPanelExpanded: boolean | null
+  insightsPanelExpandedByAgent: InsightsPanelExpandedByAgent
   suggestionsEnabled: boolean
   agentChatNotificationsEnabled: boolean
   requestedAgentStatus?: 'deleted' | 'missing' | null
@@ -166,6 +172,9 @@ export async function fetchAgentRoster(
       ? payload.muted_agent_ids.filter((value): value is string => typeof value === 'string')
       : [],
     insightsPanelExpanded: payload.insights_panel_expanded ?? null,
+    insightsPanelExpandedByAgent: parseInsightsPanelExpandedByAgentPreference(
+      payload.insights_panel_expanded_by_agent,
+    ),
     suggestionsEnabled: payload.agent_chat_suggestions_enabled !== false,
     agentChatNotificationsEnabled: payload.agent_chat_notifications_enabled !== false,
     requestedAgentStatus: payload.requested_agent_status ?? null,

--- a/frontend/src/api/userPreferences.ts
+++ b/frontend/src/api/userPreferences.ts
@@ -3,10 +3,12 @@ export const USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_SORT_MODE = 'agent.chat.roste
 export const USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_FAVORITE_AGENT_IDS = 'agent.chat.roster.favorite_agent_ids' as const
 export const USER_PREFERENCE_KEY_AGENT_CHAT_MUTED_AGENT_IDS = 'agent.chat.muted_agent_ids' as const
 export const USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED = 'agent.chat.insights_panel.expanded' as const
+export const USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT = 'agent.chat.insights_panel.expanded_by_agent' as const
 export const USER_PREFERENCE_KEY_AGENT_CHAT_SUGGESTIONS_ENABLED = 'agent.chat.suggestions.enabled' as const
 export const USER_PREFERENCE_KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED = 'agent.chat.notifications.enabled' as const
 
 export type UserPreferencesMap = Record<string, unknown>
+export type InsightsPanelExpandedByAgent = Record<string, boolean>
 
 type UserPreferencesPayload = {
   preferences: UserPreferencesMap
@@ -65,4 +67,19 @@ export function parseBooleanPreference(value: unknown): boolean {
 
 export function parseNullableBooleanPreference(value: unknown): boolean | null {
   return typeof value === 'boolean' ? value : null
+}
+
+export function parseInsightsPanelExpandedByAgentPreference(value: unknown): InsightsPanelExpandedByAgent {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  const entries: Array<[string, boolean]> = []
+  for (const [agentId, expanded] of Object.entries(value)) {
+    const normalizedAgentId = agentId.trim()
+    if (normalizedAgentId && typeof expanded === 'boolean') {
+      entries.push([normalizedAgentId, expanded])
+    }
+  }
+  return Object.fromEntries(entries)
 }

--- a/frontend/src/api/userPreferences.ts
+++ b/frontend/src/api/userPreferences.ts
@@ -3,6 +3,7 @@ export const USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_SORT_MODE = 'agent.chat.roste
 export const USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_FAVORITE_AGENT_IDS = 'agent.chat.roster.favorite_agent_ids' as const
 export const USER_PREFERENCE_KEY_AGENT_CHAT_MUTED_AGENT_IDS = 'agent.chat.muted_agent_ids' as const
 export const USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED = 'agent.chat.insights_panel.expanded' as const
+export const USER_PREFERENCE_KEY_AGENT_CHAT_SUGGESTIONS_ENABLED = 'agent.chat.suggestions.enabled' as const
 export const USER_PREFERENCE_KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED = 'agent.chat.notifications.enabled' as const
 
 export type UserPreferencesMap = Record<string, unknown>

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -166,7 +166,9 @@ export type AgentChatLayoutSidebarConfig = Omit<
 > & {
   settings?: AgentChatLayoutSidebarSettings
   insightsPanelExpandedPreference?: boolean | null
+  insightsPanelPreferenceHydrated?: boolean
   onInsightsPanelExpandedPreferenceChange?: (expanded: boolean) => void
+  suggestionsPreferenceHydrated?: boolean
 }
 
 type AgentChatLayoutProps = AgentTimelineProps & {
@@ -428,7 +430,9 @@ export function AgentChatLayout({
   const {
     settings: sidebarSettingsConfig,
     insightsPanelExpandedPreference = null,
+    insightsPanelPreferenceHydrated = true,
     onInsightsPanelExpandedPreferenceChange,
+    suggestionsPreferenceHydrated = true,
     ...chatSidebarProps
   } = sidebarConfig
   const {
@@ -459,6 +463,8 @@ export function AgentChatLayout({
   const sidebarNotificationsEnabled = sidebarSettingsConfig?.notificationsEnabled ?? true
   const sidebarNotificationStatus = sidebarSettingsConfig?.notificationStatus ?? 'off'
   const onSidebarNotificationsEnabledChange = sidebarSettingsConfig?.onNotificationsEnabledChange
+  const sidebarSuggestionsEnabled = sidebarSettingsConfig?.suggestionsEnabled ?? true
+  const onSidebarSuggestionsEnabledChange = sidebarSettingsConfig?.onSuggestionsEnabledChange
   const runtimeSession = useAppSelector(selectActiveChatSession)
   const shellViewer = useAppSelector(selectImmersiveShellViewer)
   const activeAgentId = agentId ?? null
@@ -902,9 +908,11 @@ export function AgentChatLayout({
     starterPrompts,
     starterPromptsLoading,
     starterPromptSubmitting,
+    handleStarterPromptDismiss,
     handleStarterPromptSelect,
   } = useStarterPrompts({
     agentId,
+    enabled: suggestionsPreferenceHydrated && sidebarSuggestionsEnabled,
     events,
     initialLoading,
     spawnIntentLoading,
@@ -1344,6 +1352,8 @@ export function AgentChatLayout({
     notificationsEnabled: sidebarNotificationsEnabled,
     notificationStatus: sidebarNotificationStatus,
     onNotificationsEnabledChange: onSidebarNotificationsEnabledChange,
+    suggestionsEnabled: sidebarSuggestionsEnabled,
+    onSuggestionsEnabledChange: onSidebarSuggestionsEnabledChange,
     onOpenBilling,
     onOpenUsage,
     onOpenApiKeys,
@@ -1364,6 +1374,7 @@ export function AgentChatLayout({
     currentContext,
     isProprietaryMode,
     onSidebarNotificationsEnabledChange,
+    onSidebarSuggestionsEnabledChange,
     onOpenBilling,
     onOpenUsage,
     onOpenApiKeys,
@@ -1382,6 +1393,7 @@ export function AgentChatLayout({
     sidebarCreditsResetOn,
     sidebarNotificationStatus,
     sidebarNotificationsEnabled,
+    sidebarSuggestionsEnabled,
     sidebarTodayCreditsUsed,
     taskQuota,
     viewerEmail,
@@ -1522,6 +1534,7 @@ export function AgentChatLayout({
             onPurchaseSeats={handlePurchaseSeats}
             onReportMessage={handleReportMessage}
             onRetryMessage={onRetryMessage}
+            onStarterPromptDismiss={handleStarterPromptDismiss}
             onStarterPromptSelect={handleStarterPromptSelect}
             onTaskCreditsDismiss={handleTaskCreditsDismiss}
             onTaskCreditsOpenPacks={taskPackCanManageBilling ? () => handleAddonsOpen('tasks') : undefined}
@@ -1618,6 +1631,7 @@ export function AgentChatLayout({
               isProcessing={showProcessingIndicator}
               autoFocus={autoFocusComposer}
               insightsPanelExpandedPreference={insightsPanelExpandedPreference}
+              insightsPanelPreferenceHydrated={insightsPanelPreferenceHydrated}
               onInsightsPanelExpandedPreferenceChange={onInsightsPanelExpandedPreferenceChange}
               insightsLoading={effectiveInsightsLoading}
               onOpenUsage={onOpenUsage}

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -921,6 +921,9 @@ export function AgentChatLayout({
     promptCount: starterPromptCount,
     hasPendingHumanInput: pendingActionRequests.length > 0,
   })
+  const handleStarterPromptsTurnOff = useCallback(() => {
+    onSidebarSuggestionsEnabledChange?.(false)
+  }, [onSidebarSuggestionsEnabledChange])
   const hasTimelineEvents = timelineRenderEvents.length > 0
   const showJumpButton = !initialLoading
     && hasTimelineEvents
@@ -1535,6 +1538,7 @@ export function AgentChatLayout({
             onReportMessage={handleReportMessage}
             onRetryMessage={onRetryMessage}
             onStarterPromptDismiss={handleStarterPromptDismiss}
+            onStarterPromptsTurnOff={onSidebarSuggestionsEnabledChange ? handleStarterPromptsTurnOff : undefined}
             onStarterPromptSelect={handleStarterPromptSelect}
             onTaskCreditsDismiss={handleTaskCreditsDismiss}
             onTaskCreditsOpenPacks={taskPackCanManageBilling ? () => handleAddonsOpen('tasks') : undefined}

--- a/frontend/src/components/agentChat/AgentComposer.test.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.test.tsx
@@ -296,9 +296,11 @@ describe('AgentComposer pending action insights panel', () => {
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
   })
 
-  it('auto-expands when pending requests arrive despite a collapsed insight preference', async () => {
+  it('keeps a saved collapsed preference when pending requests arrive', async () => {
+    const handleExpandedPreferenceChange = vi.fn()
     const { rerender } = renderAgentComposer({
       insightsPanelExpandedPreference: false,
+      onInsightsPanelExpandedPreferenceChange: handleExpandedPreferenceChange,
     })
 
     expect(screen.queryByText('Needs your input')).not.toBeInTheDocument()
@@ -310,12 +312,54 @@ describe('AgentComposer pending action insights panel', () => {
         insightsLoading={false}
         isProcessing={false}
         insightsPanelExpandedPreference={false}
+        onInsightsPanelExpandedPreferenceChange={handleExpandedPreferenceChange}
       />,
     )
 
     await waitFor(() => {
-      expect(screen.getByText('Stripe API key')).toBeInTheDocument()
+      expect(screen.getByText('Needs your input')).toBeInTheDocument()
     })
+    expect(screen.getByText('1 request')).toBeInTheDocument()
+    expect(screen.queryByText('Stripe API key')).not.toBeInTheDocument()
+    expect(handleExpandedPreferenceChange).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('Needs your input').closest('.composer-working-header-row') as HTMLElement)
+
+    expect(handleExpandedPreferenceChange).toHaveBeenCalledWith(true)
+  })
+
+  it('stays collapsed while a saved panel preference hydrates', () => {
+    const handleExpandedPreferenceChange = vi.fn()
+    const { rerender } = renderAgentComposer({
+      pendingActionRequests: [makeRequestedSecretsAction()],
+      insightsPanelPreferenceHydrated: false,
+      onInsightsPanelExpandedPreferenceChange: handleExpandedPreferenceChange,
+    })
+
+    expect(screen.getByText('Needs your input')).toBeInTheDocument()
+    expect(screen.queryByText('Stripe API key')).not.toBeInTheDocument()
+    expect(handleExpandedPreferenceChange).not.toHaveBeenCalled()
+
+    rerender(
+      <AgentComposer
+        onSubmit={vi.fn(async () => undefined)}
+        pendingActionRequests={[makeRequestedSecretsAction()]}
+        insightsLoading={false}
+        isProcessing={false}
+        insightsPanelExpandedPreference={false}
+        insightsPanelPreferenceHydrated={true}
+        onInsightsPanelExpandedPreferenceChange={handleExpandedPreferenceChange}
+      />,
+    )
+
+    expect(screen.getByText('Needs your input')).toBeInTheDocument()
+    expect(screen.getByText('1 request')).toBeInTheDocument()
+    expect(screen.queryByText('Stripe API key')).not.toBeInTheDocument()
+    expect(handleExpandedPreferenceChange).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'View 1 pending credentials request' }))
+
+    expect(handleExpandedPreferenceChange).toHaveBeenCalledWith(true)
   })
 
   it('renders pending request tabs alongside regular insight tabs', () => {

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -530,6 +530,7 @@ type AgentComposerProps = {
   onFocus?: () => void
   onRequestScrollToBottom?: () => void
   insightsPanelExpandedPreference?: boolean | null
+  insightsPanelPreferenceHydrated?: boolean
   onInsightsPanelExpandedPreferenceChange?: (expanded: boolean) => void
   isProcessing?: boolean
   insightsLoading?: boolean
@@ -575,6 +576,7 @@ export const AgentComposer = memo(function AgentComposer({
   onFocus,
   onRequestScrollToBottom,
   insightsPanelExpandedPreference = null,
+  insightsPanelPreferenceHydrated = true,
   onInsightsPanelExpandedPreferenceChange,
   isProcessing = false,
   insightsLoading = false,
@@ -764,9 +766,10 @@ export const AgentComposer = memo(function AgentComposer({
   const wasProcessingRef = useRef(isProcessing)
   const isProcessingRef = useRef(isProcessing)
   const hadPendingActionsRef = useRef(false)
-  const baseWorkingExpanded = insightsPanelExpandedPreference ?? autoWorkingExpanded
   const hasPendingActions = pendingActionRequests.length > 0
-  const resolvedWorkingExpanded = pendingActionsForceExpanded || baseWorkingExpanded
+  const resolvedWorkingExpanded = insightsPanelPreferenceHydrated
+    ? insightsPanelExpandedPreference ?? (pendingActionsForceExpanded || autoWorkingExpanded)
+    : false
 
   useEffect(() => {
     isProcessingRef.current = isProcessing
@@ -919,8 +922,8 @@ export const AgentComposer = memo(function AgentComposer({
     onRequestScrollToBottom?.()
   }, [isTouchDevice, onRequestScrollToBottom])
 
-  const selectWorkingTab = useCallback((tabId: string) => {
-    if (!resolvedWorkingExpanded) {
+  const selectWorkingTab = useCallback((tabId: string, expandPanel = true) => {
+    if (expandPanel && !resolvedWorkingExpanded) {
       if (onInsightsPanelExpandedPreferenceChange) {
         onInsightsPanelExpandedPreferenceChange(true)
       } else {
@@ -981,7 +984,7 @@ export const AgentComposer = memo(function AgentComposer({
 
     const nextPendingTabId = changedPendingTab?.id ?? pendingActionTabs[0]?.id
     if (nextPendingTabId) {
-      selectWorkingTab(nextPendingTabId)
+      selectWorkingTab(nextPendingTabId, false)
     }
   }, [
     activeWorkingTabId,

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -53,6 +53,7 @@ type AgentTimelinePaneProps = {
   onPurchaseSeats?: () => void
   onReportMessage?: (message: AgentMessage) => void
   onRetryMessage?: (message: AgentMessage) => void | Promise<void>
+  onStarterPromptDismiss?: () => void
   onStarterPromptSelect?: (prompt: StarterPrompt, position: number) => Promise<void>
   onTaskCreditsDismiss?: () => void
   onTaskCreditsOpenPacks?: () => void
@@ -109,6 +110,7 @@ export function AgentTimelinePane({
   onPurchaseSeats,
   onReportMessage,
   onRetryMessage,
+  onStarterPromptDismiss,
   onStarterPromptSelect,
   onTaskCreditsDismiss,
   onTaskCreditsOpenPacks,
@@ -256,6 +258,7 @@ export function AgentTimelinePane({
                   loading={starterPromptsLoading}
                   loadingCount={starterPromptCount}
                   disabled={starterPromptSubmitting || starterPromptsDisabled || composerDisabled}
+                  onDismiss={onStarterPromptDismiss}
                   onSelect={onStarterPromptSelect}
                 />
               ) : null}

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -54,6 +54,7 @@ type AgentTimelinePaneProps = {
   onReportMessage?: (message: AgentMessage) => void
   onRetryMessage?: (message: AgentMessage) => void | Promise<void>
   onStarterPromptDismiss?: () => void
+  onStarterPromptsTurnOff?: () => void
   onStarterPromptSelect?: (prompt: StarterPrompt, position: number) => Promise<void>
   onTaskCreditsDismiss?: () => void
   onTaskCreditsOpenPacks?: () => void
@@ -111,6 +112,7 @@ export function AgentTimelinePane({
   onReportMessage,
   onRetryMessage,
   onStarterPromptDismiss,
+  onStarterPromptsTurnOff,
   onStarterPromptSelect,
   onTaskCreditsDismiss,
   onTaskCreditsOpenPacks,
@@ -259,6 +261,7 @@ export function AgentTimelinePane({
                   loadingCount={starterPromptCount}
                   disabled={starterPromptSubmitting || starterPromptsDisabled || composerDisabled}
                   onDismiss={onStarterPromptDismiss}
+                  onTurnOff={onStarterPromptsTurnOff}
                   onSelect={onStarterPromptSelect}
                 />
               ) : null}

--- a/frontend/src/components/agentChat/SidebarSettingsMenu.test.tsx
+++ b/frontend/src/components/agentChat/SidebarSettingsMenu.test.tsx
@@ -126,4 +126,28 @@ describe('SidebarSettingsMenu', () => {
 
     expect(handleNotificationsEnabledChange).toHaveBeenCalledWith(false)
   })
+
+  it('renders a reversible suggested follow-ups preference', async () => {
+    const handleSuggestionsEnabledChange = vi.fn()
+
+    render(
+      <SidebarSettingsMenu
+        context={{ type: 'personal', id: '1', name: 'Personal' }}
+        viewerEmail="person@example.com"
+        isProprietaryMode={true}
+        suggestionsEnabled={false}
+        onSuggestionsEnabledChange={handleSuggestionsEnabledChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open settings' }))
+
+    const toggle = await screen.findByRole('switch', { name: 'Suggested follow-ups' })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByText('Hidden')).toBeInTheDocument()
+
+    fireEvent.click(toggle)
+
+    expect(handleSuggestionsEnabledChange).toHaveBeenCalledWith(true)
+  })
 })

--- a/frontend/src/components/agentChat/SidebarSettingsMenu.tsx
+++ b/frontend/src/components/agentChat/SidebarSettingsMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
-import { Bell, Building2, ChevronDown, CircleHelp, ClipboardList, CreditCard, KeyRound, LockKeyhole, ServerCog, Settings, User, UserRound } from 'lucide-react'
+import { Bell, Building2, ChevronDown, CircleHelp, ClipboardList, CreditCard, KeyRound, LockKeyhole, ServerCog, Settings, Sparkles, User, UserRound, type LucideIcon } from 'lucide-react'
 import { Button, Dialog, Popover } from 'react-aria-components'
 
 import type { ConsoleContext } from '../../api/context'
@@ -34,6 +34,8 @@ export type SidebarSettingsInfo = {
   notificationsEnabled?: boolean
   notificationStatus?: 'off' | 'on' | 'needs_permission' | 'blocked'
   onNotificationsEnabledChange?: (enabled: boolean) => void
+  suggestionsEnabled?: boolean
+  onSuggestionsEnabledChange?: (enabled: boolean) => void
   taskCredits?: SidebarTaskCreditsInfo | null
   onOpenHelp?: (() => void) | null
 }
@@ -88,6 +90,46 @@ function resolveNotificationStatusLabel(
   return 'On'
 }
 
+function SidebarPreferenceToggle({
+  checked,
+  icon: Icon,
+  label,
+  onChange,
+  status,
+}: {
+  checked: boolean
+  icon: LucideIcon
+  label: string
+  onChange?: (checked: boolean) => void
+  status: string
+}) {
+  return (
+    <button
+      type="button"
+      className="sidebar-settings__notification-toggle"
+      role="switch"
+      aria-label={label}
+      aria-checked={checked}
+      onClick={() => onChange?.(!checked)}
+    >
+      <span className="sidebar-settings__notification-copy">
+        <span className="sidebar-settings__notification-title">
+          <Icon className="sidebar-settings__link-icon" aria-hidden="true" />
+          <span>{label}</span>
+        </span>
+        <span className="sidebar-settings__notification-status">{status}</span>
+      </span>
+      <span
+        className="sidebar-settings__switch"
+        data-checked={checked ? 'true' : 'false'}
+        aria-hidden="true"
+      >
+        <span className="sidebar-settings__switch-thumb" />
+      </span>
+    </button>
+  )
+}
+
 export function SidebarSettingsMenu({
   context = null,
   viewerEmail = null,
@@ -111,6 +153,8 @@ export function SidebarSettingsMenu({
   notificationsEnabled = true,
   notificationStatus = 'off',
   onNotificationsEnabledChange,
+  suggestionsEnabled = true,
+  onSuggestionsEnabledChange,
   taskCredits = null,
   onOpenHelp = null,
   variant = 'sidebar',
@@ -173,9 +217,6 @@ export function SidebarSettingsMenu({
     notificationsEnabled,
     notificationStatus,
   )
-  const handleNotificationToggle = useCallback(() => {
-    onNotificationsEnabledChange?.(!notificationsEnabled)
-  }, [notificationsEnabled, onNotificationsEnabledChange])
   const handleTriggerPointerDownCapture = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
     if (!open) {
       return
@@ -241,28 +282,20 @@ export function SidebarSettingsMenu({
           <div className="sidebar-settings__rule" role="separator" aria-hidden="true" />
 
           <div className="sidebar-settings__links">
-            <button
-              type="button"
-              className="sidebar-settings__notification-toggle"
-              role="switch"
-              aria-checked={notificationsEnabled}
-              onClick={handleNotificationToggle}
-            >
-              <span className="sidebar-settings__notification-copy">
-                <span className="sidebar-settings__notification-title">
-                  <Bell className="sidebar-settings__link-icon" aria-hidden="true" />
-                  <span>Notifications &amp; sound</span>
-                </span>
-                <span className="sidebar-settings__notification-status">{notificationStatusLabel}</span>
-              </span>
-              <span
-                className="sidebar-settings__switch"
-                data-checked={notificationsEnabled ? 'true' : 'false'}
-                aria-hidden="true"
-              >
-                <span className="sidebar-settings__switch-thumb" />
-              </span>
-            </button>
+            <SidebarPreferenceToggle
+              checked={notificationsEnabled}
+              icon={Bell}
+              label="Notifications & sound"
+              onChange={onNotificationsEnabledChange}
+              status={notificationStatusLabel}
+            />
+            <SidebarPreferenceToggle
+              checked={suggestionsEnabled}
+              icon={Sparkles}
+              label="Suggested follow-ups"
+              onChange={onSuggestionsEnabledChange}
+              status={suggestionsEnabled ? 'Shown after replies' : 'Hidden'}
+            />
             <div className="sidebar-settings__rule" role="separator" aria-hidden="true" />
             {canShowProfile ? (
               onOpenProfile ? (

--- a/frontend/src/components/agentChat/StarterPromptSuggestions.test.tsx
+++ b/frontend/src/components/agentChat/StarterPromptSuggestions.test.tsx
@@ -4,8 +4,9 @@ import { describe, expect, it, vi } from 'vitest'
 import { StarterPromptSuggestions } from './StarterPromptSuggestions'
 
 describe('StarterPromptSuggestions', () => {
-  it('offers an accessible way to dismiss the current suggestions', () => {
+  it('distinguishes temporary dismissal from turning off future suggestions', () => {
     const onDismiss = vi.fn()
+    const onTurnOff = vi.fn()
 
     render(
       <StarterPromptSuggestions
@@ -15,11 +16,18 @@ describe('StarterPromptSuggestions', () => {
           category: 'deliverables',
         }]}
         onDismiss={onDismiss}
+        onTurnOff={onTurnOff}
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Dismiss suggested follow-ups' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Hide for now' }))
 
     expect(onDismiss).toHaveBeenCalledOnce()
+    expect(onTurnOff).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Turn off suggestions' }))
+
+    expect(onDismiss).toHaveBeenCalledOnce()
+    expect(onTurnOff).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/components/agentChat/StarterPromptSuggestions.test.tsx
+++ b/frontend/src/components/agentChat/StarterPromptSuggestions.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { StarterPromptSuggestions } from './StarterPromptSuggestions'
+
+describe('StarterPromptSuggestions', () => {
+  it('offers an accessible way to dismiss the current suggestions', () => {
+    const onDismiss = vi.fn()
+
+    render(
+      <StarterPromptSuggestions
+        prompts={[{
+          id: 'follow-up-1',
+          text: 'Summarize the next steps',
+          category: 'deliverables',
+        }]}
+        onDismiss={onDismiss}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss suggested follow-ups' }))
+
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/agentChat/StarterPromptSuggestions.tsx
+++ b/frontend/src/components/agentChat/StarterPromptSuggestions.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { ChevronRight, FileText, Lightbulb, Link2, ListChecks } from 'lucide-react'
+import { ChevronRight, FileText, Lightbulb, Link2, ListChecks, X } from 'lucide-react'
 import { AgentChatSectionCard } from './uiPrimitives'
 
 export type StarterPrompt = {
@@ -13,6 +13,7 @@ type StarterPromptSuggestionsProps = {
   loading?: boolean
   loadingCount?: number
   disabled?: boolean
+  onDismiss?: () => void
   onSelect?: (prompt: StarterPrompt, position: number) => void | Promise<void>
 }
 
@@ -34,6 +35,7 @@ export const StarterPromptSuggestions = memo(function StarterPromptSuggestions({
   loading = false,
   loadingCount = 3,
   disabled = false,
+  onDismiss,
   onSelect,
 }: StarterPromptSuggestionsProps) {
   if (!loading && !prompts.length) {
@@ -48,7 +50,20 @@ export const StarterPromptSuggestions = memo(function StarterPromptSuggestions({
       aria-label="Suggested follow-ups"
       aria-busy={loading}
     >
-      <h3 className="starter-prompts-card__title">Suggested follow-ups</h3>
+      <div className="starter-prompts-card__header">
+        <h3 className="starter-prompts-card__title">Suggested follow-ups</h3>
+        {onDismiss ? (
+          <button
+            type="button"
+            className="starter-prompts-card__dismiss"
+            onClick={onDismiss}
+            aria-label="Dismiss suggested follow-ups"
+            title="Dismiss suggested follow-ups"
+          >
+            <X aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
       <div className="starter-prompts-card__rows" role="list">
         {loading
           ? Array.from({ length: Math.max(1, loadingCount) }).map((_, index) => (

--- a/frontend/src/components/agentChat/StarterPromptSuggestions.tsx
+++ b/frontend/src/components/agentChat/StarterPromptSuggestions.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { ChevronRight, FileText, Lightbulb, Link2, ListChecks, X } from 'lucide-react'
+import { ChevronRight, FileText, Lightbulb, Link2, ListChecks } from 'lucide-react'
 import { AgentChatSectionCard } from './uiPrimitives'
 
 export type StarterPrompt = {
@@ -14,6 +14,7 @@ type StarterPromptSuggestionsProps = {
   loadingCount?: number
   disabled?: boolean
   onDismiss?: () => void
+  onTurnOff?: () => void
   onSelect?: (prompt: StarterPrompt, position: number) => void | Promise<void>
 }
 
@@ -36,6 +37,7 @@ export const StarterPromptSuggestions = memo(function StarterPromptSuggestions({
   loadingCount = 3,
   disabled = false,
   onDismiss,
+  onTurnOff,
   onSelect,
 }: StarterPromptSuggestionsProps) {
   if (!loading && !prompts.length) {
@@ -52,17 +54,6 @@ export const StarterPromptSuggestions = memo(function StarterPromptSuggestions({
     >
       <div className="starter-prompts-card__header">
         <h3 className="starter-prompts-card__title">Suggested follow-ups</h3>
-        {onDismiss ? (
-          <button
-            type="button"
-            className="starter-prompts-card__dismiss"
-            onClick={onDismiss}
-            aria-label="Dismiss suggested follow-ups"
-            title="Dismiss suggested follow-ups"
-          >
-            <X aria-hidden="true" />
-          </button>
-        ) : null}
       </div>
       <div className="starter-prompts-card__rows" role="list">
         {loading
@@ -106,6 +97,30 @@ export const StarterPromptSuggestions = memo(function StarterPromptSuggestions({
             )
           })}
       </div>
+      {onDismiss || onTurnOff ? (
+        <div className="starter-prompts-card__actions" role="group" aria-label="Suggestion display options">
+          {onDismiss ? (
+            <button
+              type="button"
+              className="starter-prompts-card__action"
+              onClick={onDismiss}
+              title="Hide this set until the agent replies or finishes new work"
+            >
+              Hide for now
+            </button>
+          ) : null}
+          {onTurnOff ? (
+            <button
+              type="button"
+              className="starter-prompts-card__action"
+              onClick={onTurnOff}
+              title="Hide future suggestions until you turn them back on in Settings"
+            >
+              Turn off suggestions
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       {loading ? <span className="sr-only">Loading suggested follow-ups</span> : null}
     </AgentChatSectionCard>
   )

--- a/frontend/src/components/agentChat/useStarterPrompts.test.tsx
+++ b/frontend/src/components/agentChat/useStarterPrompts.test.tsx
@@ -1,0 +1,125 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { PropsWithChildren, ReactElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { TimelineEvent } from './types'
+import { useStarterPrompts } from './useStarterPrompts'
+
+const { fetchAgentSuggestionsMock } = vi.hoisted(() => ({
+  fetchAgentSuggestionsMock: vi.fn(),
+}))
+
+vi.mock('../../api/agentChat', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../api/agentChat')>()),
+  fetchAgentSuggestions: fetchAgentSuggestionsMock,
+}))
+
+function messageEvent(cursor: string, isOutbound: boolean): TimelineEvent {
+  return {
+    kind: 'message',
+    cursor,
+    message: {
+      id: cursor,
+      bodyText: 'Message',
+      isOutbound,
+    },
+  }
+}
+
+describe('useStarterPrompts', () => {
+  let queryClient: QueryClient
+  let wrapper: ({ children }: PropsWithChildren) => ReactElement
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    fetchAgentSuggestionsMock.mockReset()
+    fetchAgentSuggestionsMock.mockResolvedValue({
+      suggestions: [{
+        id: 'follow-up-1',
+        text: 'Summarize the next steps',
+        category: 'deliverables',
+      }],
+    })
+  })
+
+  it('dismisses only the current set and restores suggestions for new timeline context', async () => {
+    const initialEvents = [
+      messageEvent('message-1', false),
+      messageEvent('message-2', true),
+    ]
+    const { result, rerender } = renderHook(
+      ({ events, promptCount }) => useStarterPrompts({
+        agentId: 'agent-1',
+        events,
+        initialLoading: false,
+        spawnIntentLoading: false,
+        isWorkingNow: false,
+        onSendMessage: vi.fn(),
+        promptCount,
+        hasPendingHumanInput: false,
+      }),
+      { initialProps: { events: initialEvents, promptCount: 3 }, wrapper },
+    )
+
+    await waitFor(() => expect(result.current.starterPrompts).toHaveLength(1))
+
+    act(() => result.current.handleStarterPromptDismiss())
+    expect(result.current.starterPrompts).toEqual([])
+    expect(result.current.starterPromptsLoading).toBe(false)
+
+    rerender({ events: initialEvents, promptCount: 2 })
+    expect(result.current.starterPrompts).toEqual([])
+    expect(fetchAgentSuggestionsMock).toHaveBeenCalledTimes(1)
+
+    rerender({
+      events: [
+        ...initialEvents,
+        { kind: 'thinking', cursor: 'thinking-3', reasoning: 'Finishing background work' },
+      ],
+      promptCount: 2,
+    })
+    expect(result.current.starterPrompts).toEqual([])
+    expect(fetchAgentSuggestionsMock).toHaveBeenCalledTimes(1)
+
+    rerender({ events: [...initialEvents, messageEvent('message-3', true)], promptCount: 2 })
+
+    await waitFor(() => expect(fetchAgentSuggestionsMock).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.starterPrompts).toHaveLength(1))
+  })
+
+  it('does not request suggestions while the preference is disabled', async () => {
+    vi.useFakeTimers()
+    try {
+      const { rerender } = renderHook(
+        ({ enabled }) => useStarterPrompts({
+          agentId: 'agent-1',
+          enabled,
+          events: [messageEvent('message-1', true)],
+          initialLoading: false,
+          spawnIntentLoading: false,
+          isWorkingNow: false,
+          onSendMessage: vi.fn(),
+          hasPendingHumanInput: false,
+        }),
+        { initialProps: { enabled: false }, wrapper },
+      )
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500)
+      })
+      expect(fetchAgentSuggestionsMock).not.toHaveBeenCalled()
+
+      rerender({ enabled: true })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500)
+      })
+      expect(fetchAgentSuggestionsMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/frontend/src/components/agentChat/useStarterPrompts.ts
+++ b/frontend/src/components/agentChat/useStarterPrompts.ts
@@ -13,6 +13,7 @@ const STARTER_PROMPT_STALE_TIME_MS = 60_000
 
 type UseStarterPromptsParams = {
   agentId?: string | null
+  enabled?: boolean
   events: TimelineEvent[]
   initialLoading: boolean
   spawnIntentLoading: boolean
@@ -26,6 +27,7 @@ type UseStarterPromptsResult = {
   starterPrompts: StarterPrompt[]
   starterPromptsLoading: boolean
   starterPromptSubmitting: boolean
+  handleStarterPromptDismiss: () => void
   handleStarterPromptSelect: (prompt: StarterPrompt, position: number) => Promise<void>
 }
 
@@ -49,14 +51,15 @@ function isStarterPrompt(suggestion: unknown): suggestion is StarterPrompt {
 function starterPromptsQueryKey(
   agentId: string | null | undefined,
   promptCount: number,
-  latestEventCursor: string | null,
+  latestAgentReplyCursor: string | null,
   refreshNonce: number,
 ) {
-  return ['agent-starter-prompts', agentId ?? null, promptCount, latestEventCursor, refreshNonce] as const
+  return ['agent-starter-prompts', agentId ?? null, promptCount, latestAgentReplyCursor, refreshNonce] as const
 }
 
 export function useStarterPrompts({
   agentId,
+  enabled = true,
   events,
   initialLoading,
   spawnIntentLoading,
@@ -67,6 +70,7 @@ export function useStarterPrompts({
 }: UseStarterPromptsParams): UseStarterPromptsResult {
   const [starterPromptSubmitting, setStarterPromptSubmitting] = useState(false)
   const [starterPromptFetchReadyKey, setStarterPromptFetchReadyKey] = useState<string | null>(null)
+  const [dismissedStarterPromptRequestKey, setDismissedStarterPromptRequestKey] = useState<string | null>(null)
   const [idleRefreshNonce, setIdleRefreshNonce] = useState(0)
   const starterPromptInFlightRef = useRef(false)
   const wasWorkingRef = useRef(isWorkingNow)
@@ -83,11 +87,14 @@ export function useStarterPrompts({
     () => events.some((event) => event.kind === 'message' && Boolean(event.message.isOutbound)),
     [events],
   )
-  const latestEventCursor = useMemo(() => {
-    if (!events.length) {
-      return null
+  const latestAgentReplyCursor = useMemo(() => {
+    for (let index = events.length - 1; index >= 0; index -= 1) {
+      const event = events[index]
+      if (event.kind === 'message' && event.message.isOutbound) {
+        return event.cursor
+      }
     }
-    return events[events.length - 1]?.cursor ?? null
+    return null
   }, [events])
 
   useEffect(() => {
@@ -98,7 +105,8 @@ export function useStarterPrompts({
   }, [isWorkingNow])
 
   const canRequestSuggestions = Boolean(
-    agentId
+    enabled
+    && agentId
     && onSendMessage
     && hasAgentMessage
     && !initialLoading
@@ -108,13 +116,18 @@ export function useStarterPrompts({
   )
 
   const starterPromptRequestKey = useMemo(
-    () => JSON.stringify([agentId ?? null, promptCount, latestEventCursor, idleRefreshNonce]),
-    [agentId, idleRefreshNonce, latestEventCursor, promptCount],
+    () => JSON.stringify([agentId ?? null, promptCount, latestAgentReplyCursor, idleRefreshNonce]),
+    [agentId, idleRefreshNonce, latestAgentReplyCursor, promptCount],
   )
+  const starterPromptContextKey = useMemo(
+    () => JSON.stringify([agentId ?? null, latestAgentReplyCursor, idleRefreshNonce]),
+    [agentId, idleRefreshNonce, latestAgentReplyCursor],
+  )
+  const starterPromptsDismissed = dismissedStarterPromptRequestKey === starterPromptContextKey
   const starterPromptFetchReady = starterPromptFetchReadyKey === starterPromptRequestKey
 
   const starterPromptsQuery = useQuery({
-    queryKey: starterPromptsQueryKey(agentId, promptCount, latestEventCursor, idleRefreshNonce),
+    queryKey: starterPromptsQueryKey(agentId, promptCount, latestAgentReplyCursor, idleRefreshNonce),
     queryFn: async ({ signal }) => {
       if (!agentId) {
         throw new Error('No agentId')
@@ -125,7 +138,7 @@ export function useStarterPrompts({
       })
       return (payload.suggestions || []).filter(isStarterPrompt).slice(0, promptCount)
     },
-    enabled: canRequestSuggestions && starterPromptFetchReady,
+    enabled: canRequestSuggestions && starterPromptFetchReady && !starterPromptsDismissed,
     staleTime: STARTER_PROMPT_STALE_TIME_MS,
     refetchOnWindowFocus: false,
     retry: false,
@@ -151,10 +164,15 @@ export function useStarterPrompts({
     }
   }, [starterPromptsQuery.error])
 
-  const starterPrompts = useMemo(() => starterPromptsQuery.data ?? EMPTY_PROMPTS, [starterPromptsQuery.data])
+  const starterPrompts = useMemo(
+    () => starterPromptsQuery.data ?? EMPTY_PROMPTS,
+    [starterPromptsQuery.data],
+  )
 
   const canShowStarterPrompts = Boolean(
-    hasAgentMessage
+    enabled
+    && !starterPromptsDismissed
+    && hasAgentMessage
     && !initialLoading
     && !spawnIntentLoading
     && !isWorkingNow
@@ -177,6 +195,10 @@ export function useStarterPrompts({
     setIdleRefreshNonce(0)
     wasWorkingRef.current = false
   }, [agentId])
+
+  const handleStarterPromptDismiss = useCallback(() => {
+    setDismissedStarterPromptRequestKey(starterPromptContextKey)
+  }, [starterPromptContextKey])
 
   const handleStarterPromptSelect = useCallback(
     async (prompt: StarterPrompt, position: number) => {
@@ -208,6 +230,7 @@ export function useStarterPrompts({
     starterPrompts: canShowStarterPrompts ? starterPrompts : EMPTY_PROMPTS,
     starterPromptsLoading: showStarterPromptLoading,
     starterPromptSubmitting,
+    handleStarterPromptDismiss,
     handleStarterPromptSelect,
   }
 }

--- a/frontend/src/hooks/useRosterPreferencesBridge.ts
+++ b/frontend/src/hooks/useRosterPreferencesBridge.ts
@@ -10,6 +10,7 @@ type AgentRosterPreferencesSource = Pick<
   | 'favoriteAgentIds'
   | 'mutedAgentIds'
   | 'insightsPanelExpanded'
+  | 'suggestionsEnabled'
   | 'agentChatNotificationsEnabled'
 >
 
@@ -25,6 +26,7 @@ export function useRosterPreferencesBridge(rosterData: AgentRosterPreferencesSou
       favoriteAgentIds: rosterData.favoriteAgentIds,
       mutedAgentIds: rosterData.mutedAgentIds,
       insightsPanelExpanded: rosterData.insightsPanelExpanded,
+      suggestionsEnabled: rosterData.suggestionsEnabled,
       agentChatNotificationsEnabled: rosterData.agentChatNotificationsEnabled,
     }))
   }, [dispatch, rosterData])

--- a/frontend/src/hooks/useRosterPreferencesBridge.ts
+++ b/frontend/src/hooks/useRosterPreferencesBridge.ts
@@ -9,7 +9,7 @@ type AgentRosterPreferencesSource = Pick<
   | 'agentRosterSortMode'
   | 'favoriteAgentIds'
   | 'mutedAgentIds'
-  | 'insightsPanelExpanded'
+  | 'insightsPanelExpandedByAgent'
   | 'suggestionsEnabled'
   | 'agentChatNotificationsEnabled'
 >
@@ -25,7 +25,7 @@ export function useRosterPreferencesBridge(rosterData: AgentRosterPreferencesSou
       sortMode: rosterData.agentRosterSortMode,
       favoriteAgentIds: rosterData.favoriteAgentIds,
       mutedAgentIds: rosterData.mutedAgentIds,
-      insightsPanelExpanded: rosterData.insightsPanelExpanded,
+      insightsPanelExpandedByAgent: rosterData.insightsPanelExpandedByAgent,
       suggestionsEnabled: rosterData.suggestionsEnabled,
       agentChatNotificationsEnabled: rosterData.agentChatNotificationsEnabled,
     }))

--- a/frontend/src/screens/AgentChatPage.test.tsx
+++ b/frontend/src/screens/AgentChatPage.test.tsx
@@ -59,6 +59,7 @@ const {
   rosterState: {
     agents: [] as unknown[],
     agentChatNotificationsEnabled: true,
+    suggestionsEnabled: true,
     mutedAgentIds: [] as string[],
     personalSignupPreviewCreateAvailable: false,
   },
@@ -152,12 +153,13 @@ vi.mock('../api/agentChat', () => ({
 
 vi.mock('../api/userPreferences', () => ({
   parseBooleanPreference: vi.fn((value: unknown) => value === true),
-  parseNullableBooleanPreference: vi.fn(() => null),
+  parseNullableBooleanPreference: vi.fn((value: unknown) => typeof value === 'boolean' ? value : null),
   updateUserPreferences: updateUserPreferencesMock,
   parseFavoriteAgentIdsPreference: vi.fn(() => []),
   USER_PREFERENCE_KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED: 'agent_chat_notifications_enabled',
   USER_PREFERENCE_KEY_AGENT_CHAT_MUTED_AGENT_IDS: 'agent_chat_muted_agent_ids',
   USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED: 'agent_chat_insights_panel_expanded',
+  USER_PREFERENCE_KEY_AGENT_CHAT_SUGGESTIONS_ENABLED: 'agent_chat_suggestions_enabled',
   USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_FAVORITE_AGENT_IDS: 'agent_chat_roster_favorite_agent_ids',
   USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_SORT_MODE: 'agent_chat_roster_sort_mode',
 }))
@@ -214,6 +216,8 @@ vi.mock('../components/agentChat/AgentChatLayout', async () => {
           notificationsEnabled?: boolean
           notificationStatus?: string
           onNotificationsEnabledChange?: (enabled: boolean) => void
+          suggestionsEnabled?: boolean
+          onSuggestionsEnabledChange?: (enabled: boolean) => void
         }
       }
       onOpenFullSettings?: () => void
@@ -261,6 +265,7 @@ vi.mock('../components/agentChat/AgentChatLayout', async () => {
       ))
       const configureTarget = sidebar?.agents?.find((agent) => agent.id !== agentId) ?? sidebar?.agents?.[0] ?? null
       const sidebarNotificationsEnabled = sidebar?.settings?.notificationsEnabled
+      const sidebarSuggestionsEnabled = sidebar?.settings?.suggestionsEnabled
       const hasAgentReply = events?.some((event) => event.kind === 'message' && event.message?.status !== 'sending') ?? false
       const signupPreviewState = (
         agentChatStoreState.signupPreviewState === 'awaiting_first_reply_pause'
@@ -277,6 +282,7 @@ vi.mock('../components/agentChat/AgentChatLayout', async () => {
           <div data-testid="working-state">{String(runtimeProcessingActive)}</div>
           <div data-testid="embedded-settings-open">{String(Boolean(sidebar?.showEmbeddedSettings))}</div>
           <div data-testid="notifications-enabled">{String(Boolean(sidebarNotificationsEnabled))}</div>
+          <div data-testid="suggestions-enabled">{String(Boolean(sidebarSuggestionsEnabled))}</div>
           <div data-testid="notification-status">{sidebar?.settings?.notificationStatus ?? ''}</div>
           <div data-testid="google-sheets-drive-tab-enabled">{String(Boolean(enabledIntegrationTabs.googleSheetsDrive))}</div>
           <div data-testid="apollo-native-tab-enabled">{String(Boolean(enabledIntegrationTabs.apolloNative))}</div>
@@ -344,6 +350,12 @@ vi.mock('../components/agentChat/AgentChatLayout', async () => {
             onClick={() => sidebar?.settings?.onNotificationsEnabledChange?.(!sidebarNotificationsEnabled)}
           >
             Toggle notifications
+          </button>
+          <button
+            type="button"
+            onClick={() => sidebar?.settings?.onSuggestionsEnabledChange?.(!sidebarSuggestionsEnabled)}
+          >
+            Toggle suggested follow-ups
           </button>
           {isUpgradeModalOpen ? (
             <div
@@ -418,6 +430,7 @@ vi.mock('../hooks/useAgentRoster', () => ({
       favoriteAgentIds: [],
       mutedAgentIds: rosterState.mutedAgentIds,
       insightsPanelExpanded: null,
+      suggestionsEnabled: rosterState.suggestionsEnabled,
       agentChatNotificationsEnabled: rosterState.agentChatNotificationsEnabled,
       requestedAgentStatus: null,
       billingStatus: null,
@@ -675,6 +688,7 @@ describe('AgentChatPage trial onboarding', () => {
     agentChatStoreState.awaitingResponse = false
     rosterState.agents = []
     rosterState.agentChatNotificationsEnabled = true
+    rosterState.suggestionsEnabled = true
     rosterState.mutedAgentIds = []
     rosterState.personalSignupPreviewCreateAvailable = false
     agentChatStoreState.signupPreviewState = 'none'
@@ -1110,6 +1124,34 @@ describe('AgentChatPage trial onboarding', () => {
     })
     await waitFor(() => {
       expect(screen.getByTestId('notifications-enabled')).toHaveTextContent('true')
+    })
+  })
+
+  it('hydrates and persists the suggested follow-ups preference from roster data', async () => {
+    rosterState.suggestionsEnabled = false
+    rosterState.agents = [buildRosterAgent('agent-1', 'Test Agent')]
+    updateUserPreferencesMock.mockResolvedValue({
+      preferences: {
+        agent_chat_suggestions_enabled: true,
+      },
+    })
+
+    window.history.pushState({}, '', '/app/agents/agent-1')
+    renderAgentChatPage({ agentId: 'agent-1' })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestions-enabled')).toHaveTextContent('false')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle suggested follow-ups' }))
+
+    await waitFor(() => {
+      expect(updateUserPreferencesMock).toHaveBeenCalledWith({
+        preferences: {
+          agent_chat_suggestions_enabled: true,
+        },
+      })
+      expect(screen.getByTestId('suggestions-enabled')).toHaveTextContent('true')
     })
   })
 

--- a/frontend/src/screens/AgentChatPage.test.tsx
+++ b/frontend/src/screens/AgentChatPage.test.tsx
@@ -60,6 +60,7 @@ const {
     agents: [] as unknown[],
     agentChatNotificationsEnabled: true,
     suggestionsEnabled: true,
+    insightsPanelExpandedByAgent: {} as Record<string, boolean>,
     mutedAgentIds: [] as string[],
     personalSignupPreviewCreateAvailable: false,
   },
@@ -153,12 +154,16 @@ vi.mock('../api/agentChat', () => ({
 
 vi.mock('../api/userPreferences', () => ({
   parseBooleanPreference: vi.fn((value: unknown) => value === true),
+  parseInsightsPanelExpandedByAgentPreference: vi.fn((value: unknown) => (
+    value && typeof value === 'object' && !Array.isArray(value) ? value : {}
+  )),
   parseNullableBooleanPreference: vi.fn((value: unknown) => typeof value === 'boolean' ? value : null),
   updateUserPreferences: updateUserPreferencesMock,
   parseFavoriteAgentIdsPreference: vi.fn(() => []),
   USER_PREFERENCE_KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED: 'agent_chat_notifications_enabled',
   USER_PREFERENCE_KEY_AGENT_CHAT_MUTED_AGENT_IDS: 'agent_chat_muted_agent_ids',
   USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED: 'agent_chat_insights_panel_expanded',
+  USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: 'agent.chat.insights_panel.expanded_by_agent',
   USER_PREFERENCE_KEY_AGENT_CHAT_SUGGESTIONS_ENABLED: 'agent_chat_suggestions_enabled',
   USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_FAVORITE_AGENT_IDS: 'agent_chat_roster_favorite_agent_ids',
   USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_SORT_MODE: 'agent_chat_roster_sort_mode',
@@ -209,7 +214,10 @@ vi.mock('../components/agentChat/AgentChatLayout', async () => {
       agentId?: string | null
       sidebar?: {
         agents?: Array<{ id: string }>
+        insightsPanelExpandedPreference?: boolean | null
+        onInsightsPanelExpandedPreferenceChange?: (expanded: boolean) => void
         showEmbeddedSettings?: boolean
+        onSelectAgent?: (agent: { id: string }) => void
         onConfigureAgent?: (agent: { id: string }) => void
         onBackFromEmbeddedSettings?: () => void
         settings?: {
@@ -266,6 +274,7 @@ vi.mock('../components/agentChat/AgentChatLayout', async () => {
       const configureTarget = sidebar?.agents?.find((agent) => agent.id !== agentId) ?? sidebar?.agents?.[0] ?? null
       const sidebarNotificationsEnabled = sidebar?.settings?.notificationsEnabled
       const sidebarSuggestionsEnabled = sidebar?.settings?.suggestionsEnabled
+      const insightsPanelExpandedPreference = sidebar?.insightsPanelExpandedPreference
       const hasAgentReply = events?.some((event) => event.kind === 'message' && event.message?.status !== 'sending') ?? false
       const signupPreviewState = (
         agentChatStoreState.signupPreviewState === 'awaiting_first_reply_pause'
@@ -283,6 +292,11 @@ vi.mock('../components/agentChat/AgentChatLayout', async () => {
           <div data-testid="embedded-settings-open">{String(Boolean(sidebar?.showEmbeddedSettings))}</div>
           <div data-testid="notifications-enabled">{String(Boolean(sidebarNotificationsEnabled))}</div>
           <div data-testid="suggestions-enabled">{String(Boolean(sidebarSuggestionsEnabled))}</div>
+          <div data-testid="insights-panel-expanded-preference">
+            {insightsPanelExpandedPreference === null || insightsPanelExpandedPreference === undefined
+              ? 'auto'
+              : String(insightsPanelExpandedPreference)}
+          </div>
           <div data-testid="notification-status">{sidebar?.settings?.notificationStatus ?? ''}</div>
           <div data-testid="google-sheets-drive-tab-enabled">{String(Boolean(enabledIntegrationTabs.googleSheetsDrive))}</div>
           <div data-testid="apollo-native-tab-enabled">{String(Boolean(enabledIntegrationTabs.apolloNative))}</div>
@@ -332,6 +346,26 @@ vi.mock('../components/agentChat/AgentChatLayout', async () => {
             }}
           >
             Configure
+          </button>
+          <button
+            type="button"
+            data-testid="switch-agent"
+            onClick={() => {
+              if (configureTarget) {
+                sidebar?.onSelectAgent?.(configureTarget)
+              }
+            }}
+          >
+            Switch agent
+          </button>
+          <button
+            type="button"
+            data-testid="toggle-insights-panel"
+            onClick={() => sidebar?.onInsightsPanelExpandedPreferenceChange?.(
+              !insightsPanelExpandedPreference,
+            )}
+          >
+            Toggle insights panel
           </button>
           <button type="button" data-testid="back-from-settings" onClick={() => sidebar?.onBackFromEmbeddedSettings?.()}>
             Back
@@ -430,6 +464,7 @@ vi.mock('../hooks/useAgentRoster', () => ({
       favoriteAgentIds: [],
       mutedAgentIds: rosterState.mutedAgentIds,
       insightsPanelExpanded: null,
+      insightsPanelExpandedByAgent: rosterState.insightsPanelExpandedByAgent,
       suggestionsEnabled: rosterState.suggestionsEnabled,
       agentChatNotificationsEnabled: rosterState.agentChatNotificationsEnabled,
       requestedAgentStatus: null,
@@ -689,6 +724,7 @@ describe('AgentChatPage trial onboarding', () => {
     rosterState.agents = []
     rosterState.agentChatNotificationsEnabled = true
     rosterState.suggestionsEnabled = true
+    rosterState.insightsPanelExpandedByAgent = {}
     rosterState.mutedAgentIds = []
     rosterState.personalSignupPreviewCreateAvailable = false
     agentChatStoreState.signupPreviewState = 'none'
@@ -704,6 +740,45 @@ describe('AgentChatPage trial onboarding', () => {
 
   afterEach(() => {
     window.history.pushState({}, '', '/')
+  })
+
+  it('keeps the Insights panel preference scoped to the active agent', async () => {
+    const firstAgentId = '11111111-1111-4111-8111-111111111111'
+    const secondAgentId = '22222222-2222-4222-8222-222222222222'
+    rosterState.agents = [
+      buildRosterAgent(firstAgentId, 'First Agent'),
+      buildRosterAgent(secondAgentId, 'Second Agent'),
+    ]
+    rosterState.insightsPanelExpandedByAgent = {
+      [firstAgentId]: false,
+      [secondAgentId]: true,
+    }
+    window.history.pushState({}, '', `/app/agents/${firstAgentId}`)
+
+    renderAgentChatPage({ agentId: firstAgentId })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('insights-panel-expanded-preference')).toHaveTextContent('false')
+    })
+
+    fireEvent.click(screen.getByTestId('switch-agent'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-agent-id')).toHaveTextContent(secondAgentId)
+      expect(screen.getByTestId('insights-panel-expanded-preference')).toHaveTextContent('true')
+    })
+
+    fireEvent.click(screen.getByTestId('toggle-insights-panel'))
+
+    await waitFor(() => {
+      expect(updateUserPreferencesMock).toHaveBeenCalledWith({
+        preferences: {
+          'agent.chat.insights_panel.expanded_by_agent': {
+            [secondAgentId]: false,
+          },
+        },
+      })
+    })
   })
 
   it('keeps the selected agent working when stale timeline metadata reports idle during a switch', async () => {

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -85,7 +85,10 @@ import {
   selectAgentRosterSortMode,
   selectFavoriteAgentIds,
   selectInsightsPanelExpandedPreference,
+  selectInsightsPanelPreferenceHydrated,
   selectMutedAgentIds,
+  selectSuggestionsEnabled,
+  selectSuggestionsPreferenceHydrated,
   toggleAgentRosterStringPreference,
 } from '../store/agentRosterPreferencesSlice'
 import {
@@ -575,6 +578,7 @@ type AgentRosterQueryData = {
   favoriteAgentIds?: string[]
   mutedAgentIds?: string[]
   insightsPanelExpanded?: boolean | null
+  suggestionsEnabled?: boolean
   agentChatNotificationsEnabled?: boolean
   agents: AgentRosterEntry[]
   agentInvites?: AgentSidebarInvite[]
@@ -1530,6 +1534,9 @@ export function AgentChatPage({
   const favoriteAgentIds = useAppSelector(selectFavoriteAgentIds)
   const mutedAgentIds = useAppSelector(selectMutedAgentIds)
   const insightsPanelExpandedPreference = useAppSelector(selectInsightsPanelExpandedPreference)
+  const insightsPanelPreferenceHydrated = useAppSelector(selectInsightsPanelPreferenceHydrated)
+  const suggestionsEnabled = useAppSelector(selectSuggestionsEnabled)
+  const suggestionsPreferenceHydrated = useAppSelector(selectSuggestionsPreferenceHydrated)
   const agentChatNotificationsEnabled = useAppSelector(selectAgentChatNotificationsEnabled)
   const notificationPermissionPromptAttemptedRef = useRef(false)
   useRosterPreferencesBridge(rosterQuery.data)
@@ -1558,6 +1565,13 @@ export function AgentChatPage({
   const handleInsightsPanelExpandedPreferenceChange = useCallback(
     (nextInsightsPanelExpanded: boolean) => {
       void dispatch(persistAgentRosterPreference('insightsPanelExpanded', nextInsightsPanelExpanded))
+    },
+    [dispatch],
+  )
+
+  const handleSuggestionsEnabledChange = useCallback(
+    (nextSuggestionsEnabled: boolean) => {
+      void dispatch(persistAgentRosterPreference('suggestionsEnabled', nextSuggestionsEnabled))
     },
     [dispatch],
   )
@@ -4049,6 +4063,8 @@ export function AgentChatPage({
     favoriteAgentIds,
     mutedAgentIds,
     insightsPanelExpandedPreference,
+    insightsPanelPreferenceHydrated,
+    suggestionsPreferenceHydrated,
     switchingAgentId,
     loading: rosterLoading,
     errorMessage: rosterErrorMessage,
@@ -4087,6 +4103,8 @@ export function AgentChatPage({
       notificationsEnabled: agentChatNotificationsEnabled,
       notificationStatus,
       onNotificationsEnabledChange: handleAgentChatNotificationsEnabledChange,
+      suggestionsEnabled,
+      onSuggestionsEnabledChange: handleSuggestionsEnabledChange,
     },
     galleryShellPage: selectionPage,
     galleryShellPanel: selectionPage !== 'agents' ? selectionShellPanel : null,
@@ -4120,6 +4138,7 @@ export function AgentChatPage({
     handleCreateAgent,
     handleExitEmbeddedSettings,
     handleInsightsPanelExpandedPreferenceChange,
+    handleSuggestionsEnabledChange,
     handleOpenSupport,
     handleRespondInvite,
     handleSelectAgent,
@@ -4127,6 +4146,7 @@ export function AgentChatPage({
     handleToggleAgentMute,
     immersiveShellOpenHandlers,
     insightsPanelExpandedPreference,
+    insightsPanelPreferenceHydrated,
     mutedAgentIds,
     notificationStatus,
     onScrolledToAgent,
@@ -4138,6 +4158,8 @@ export function AgentChatPage({
     scrollToAgentId,
     selectionPage,
     selectionShellPanel,
+    suggestionsEnabled,
+    suggestionsPreferenceHydrated,
     showEmbeddedSettings,
     sidebarAgents,
     sidebarTaskCredits?.resetOn,

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -80,6 +80,7 @@ import {
 import { immersiveShellActions } from '../store/immersiveShellSlice'
 import {
   agentRosterPreferencesActions,
+  persistInsightsPanelExpandedPreference,
   persistAgentRosterPreference,
   selectAgentChatNotificationsEnabled,
   selectAgentRosterSortMode,
@@ -578,6 +579,7 @@ type AgentRosterQueryData = {
   favoriteAgentIds?: string[]
   mutedAgentIds?: string[]
   insightsPanelExpanded?: boolean | null
+  insightsPanelExpandedByAgent?: Record<string, boolean>
   suggestionsEnabled?: boolean
   agentChatNotificationsEnabled?: boolean
   agents: AgentRosterEntry[]
@@ -1533,7 +1535,9 @@ export function AgentChatPage({
   const agentRosterSortMode = useAppSelector(selectAgentRosterSortMode)
   const favoriteAgentIds = useAppSelector(selectFavoriteAgentIds)
   const mutedAgentIds = useAppSelector(selectMutedAgentIds)
-  const insightsPanelExpandedPreference = useAppSelector(selectInsightsPanelExpandedPreference)
+  const insightsPanelExpandedPreference = useAppSelector((state) => (
+    selectInsightsPanelExpandedPreference(state, activeAgentId)
+  ))
   const insightsPanelPreferenceHydrated = useAppSelector(selectInsightsPanelPreferenceHydrated)
   const suggestionsEnabled = useAppSelector(selectSuggestionsEnabled)
   const suggestionsPreferenceHydrated = useAppSelector(selectSuggestionsPreferenceHydrated)
@@ -1564,9 +1568,12 @@ export function AgentChatPage({
 
   const handleInsightsPanelExpandedPreferenceChange = useCallback(
     (nextInsightsPanelExpanded: boolean) => {
-      void dispatch(persistAgentRosterPreference('insightsPanelExpanded', nextInsightsPanelExpanded))
+      if (!activeAgentId) {
+        return
+      }
+      void dispatch(persistInsightsPanelExpandedPreference(activeAgentId, nextInsightsPanelExpanded))
     },
-    [dispatch],
+    [activeAgentId, dispatch],
   )
 
   const handleSuggestionsEnabledChange = useCallback(

--- a/frontend/src/store/agentRosterPreferencesSlice.test.ts
+++ b/frontend/src/store/agentRosterPreferencesSlice.test.ts
@@ -31,6 +31,7 @@ describe('agentRosterPreferencesSlice', () => {
       favoriteAgentIds: ['agent-1'],
       mutedAgentIds: ['agent-2'],
       insightsPanelExpanded: true,
+      suggestionsEnabled: false,
       agentChatNotificationsEnabled: true,
     }))
 
@@ -39,6 +40,7 @@ describe('agentRosterPreferencesSlice', () => {
       favoriteAgentIds: { value: ['agent-1'], persistedValue: ['agent-1'], hydrated: true },
       mutedAgentIds: { value: ['agent-2'], persistedValue: ['agent-2'], hydrated: true },
       insightsPanelExpanded: { value: true, persistedValue: true, hydrated: true },
+      suggestionsEnabled: { value: false, persistedValue: false, hydrated: true },
       agentChatNotificationsEnabled: { value: true, persistedValue: true, hydrated: true },
     })
   })
@@ -63,6 +65,34 @@ describe('agentRosterPreferencesSlice', () => {
       persistedValue: ['agent-1'],
     })
     expect(queryClient.getQueryData<{ favoriteAgentIds: string[] }>(['agent-roster'])?.favoriteAgentIds).toEqual(['agent-1'])
+  })
+
+  it('optimistically disables suggestions and updates the roster cache', async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(['agent-roster'], {
+      agents: [],
+      suggestionsEnabled: true,
+    })
+    vi.mocked(updateUserPreferences).mockResolvedValue({
+      preferences: {
+        'agent.chat.suggestions.enabled': false,
+      },
+    })
+    const store = createAppStore({ queryClient })
+    store.dispatch(agentRosterPreferencesActions.hydratedFromRoster({ suggestionsEnabled: true }))
+
+    await store.dispatch(persistAgentRosterPreference('suggestionsEnabled', false))
+
+    expect(updateUserPreferences).toHaveBeenCalledWith({
+      preferences: {
+        'agent.chat.suggestions.enabled': false,
+      },
+    })
+    expect(selectAgentRosterPreferencesState(store.getState()).suggestionsEnabled).toMatchObject({
+      value: false,
+      persistedValue: false,
+    })
+    expect(queryClient.getQueryData<{ suggestionsEnabled: boolean }>(['agent-roster'])?.suggestionsEnabled).toBe(false)
   })
 
   it('rolls back Redux and roster cache when persistence fails', async () => {

--- a/frontend/src/store/agentRosterPreferencesSlice.test.ts
+++ b/frontend/src/store/agentRosterPreferencesSlice.test.ts
@@ -6,7 +6,9 @@ import { createAppStore } from './appStore'
 import {
   agentRosterPreferencesActions,
   persistAgentRosterPreference,
+  persistInsightsPanelExpandedPreference,
   selectAgentRosterPreferencesState,
+  selectInsightsPanelExpandedPreference,
   toggleAgentRosterStringPreference,
 } from './agentRosterPreferencesSlice'
 
@@ -17,6 +19,9 @@ vi.mock('../api/userPreferences', async (importOriginal) => {
     updateUserPreferences: vi.fn(),
   }
 })
+
+const FIRST_AGENT_ID = '11111111-1111-4111-8111-111111111111'
+const SECOND_AGENT_ID = '22222222-2222-4222-8222-222222222222'
 
 describe('agentRosterPreferencesSlice', () => {
   beforeEach(() => {
@@ -30,7 +35,10 @@ describe('agentRosterPreferencesSlice', () => {
       sortMode: 'alphabetical',
       favoriteAgentIds: ['agent-1'],
       mutedAgentIds: ['agent-2'],
-      insightsPanelExpanded: true,
+      insightsPanelExpandedByAgent: {
+        'agent-1': false,
+        'agent-2': true,
+      },
       suggestionsEnabled: false,
       agentChatNotificationsEnabled: true,
     }))
@@ -39,10 +47,17 @@ describe('agentRosterPreferencesSlice', () => {
       sortMode: { value: 'alphabetical', persistedValue: 'alphabetical', hydrated: true },
       favoriteAgentIds: { value: ['agent-1'], persistedValue: ['agent-1'], hydrated: true },
       mutedAgentIds: { value: ['agent-2'], persistedValue: ['agent-2'], hydrated: true },
-      insightsPanelExpanded: { value: true, persistedValue: true, hydrated: true },
+      insightsPanelExpandedByAgent: {
+        value: { 'agent-1': false, 'agent-2': true },
+        persistedValue: { 'agent-1': false, 'agent-2': true },
+        hydrated: true,
+      },
       suggestionsEnabled: { value: false, persistedValue: false, hydrated: true },
       agentChatNotificationsEnabled: { value: true, persistedValue: true, hydrated: true },
     })
+    expect(selectInsightsPanelExpandedPreference(store.getState(), 'agent-1')).toBe(false)
+    expect(selectInsightsPanelExpandedPreference(store.getState(), 'agent-2')).toBe(true)
+    expect(selectInsightsPanelExpandedPreference(store.getState(), 'agent-3')).toBeNull()
   })
 
   it('optimistically persists and normalizes roster cache values', async () => {
@@ -65,6 +80,180 @@ describe('agentRosterPreferencesSlice', () => {
       persistedValue: ['agent-1'],
     })
     expect(queryClient.getQueryData<{ favoriteAgentIds: string[] }>(['agent-roster'])?.favoriteAgentIds).toEqual(['agent-1'])
+  })
+
+  it('does not write an agent entry before the whole preference map is hydrated', async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(['agent-roster'], {
+      agents: [],
+      insightsPanelExpandedByAgent: {},
+    })
+    const store = createAppStore({ queryClient })
+
+    await store.dispatch(persistInsightsPanelExpandedPreference(FIRST_AGENT_ID, false))
+
+    expect(updateUserPreferences).not.toHaveBeenCalled()
+    expect(selectAgentRosterPreferencesState(store.getState()).insightsPanelExpandedByAgent).toEqual({
+      value: {},
+      persistedValue: {},
+      hydrated: false,
+    })
+    expect(queryClient.getQueryData<{ insightsPanelExpandedByAgent: Record<string, boolean> }>(
+      ['agent-roster'],
+    )?.insightsPanelExpandedByAgent).toEqual({})
+  })
+
+  it('serializes same-agent writes and rolls a failed newer write back to the last success', async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(['agent-roster'], {
+      agents: [],
+      insightsPanelExpandedByAgent: { [SECOND_AGENT_ID]: false },
+    })
+    let resolveFirst: ((value: { preferences: Record<string, unknown> }) => void) | undefined
+    let rejectSecond: ((reason?: unknown) => void) | undefined
+    vi.mocked(updateUserPreferences)
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve }))
+      .mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectSecond = reject }))
+    const store = createAppStore({ queryClient })
+    store.dispatch(agentRosterPreferencesActions.hydratedFromRoster({
+      insightsPanelExpandedByAgent: { [SECOND_AGENT_ID]: false },
+    }))
+
+    const firstRequest = store.dispatch(persistInsightsPanelExpandedPreference(FIRST_AGENT_ID, false))
+    const secondRequest = store.dispatch(persistInsightsPanelExpandedPreference(FIRST_AGENT_ID, true))
+
+    await vi.waitFor(() => expect(updateUserPreferences).toHaveBeenCalledTimes(1))
+    expect(updateUserPreferences).toHaveBeenCalledWith({
+      preferences: {
+        'agent.chat.insights_panel.expanded_by_agent': { [FIRST_AGENT_ID]: false },
+      },
+    })
+    expect(selectAgentRosterPreferencesState(store.getState()).insightsPanelExpandedByAgent.value).toEqual({
+      [FIRST_AGENT_ID]: true,
+      [SECOND_AGENT_ID]: false,
+    })
+
+    resolveFirst?.({
+      preferences: {
+        'agent.chat.insights_panel.expanded_by_agent': {
+          [FIRST_AGENT_ID]: false,
+          [SECOND_AGENT_ID]: false,
+        },
+      },
+    })
+    await firstRequest
+
+    await vi.waitFor(() => expect(updateUserPreferences).toHaveBeenCalledTimes(2))
+    expect(updateUserPreferences).toHaveBeenNthCalledWith(2, {
+      preferences: {
+        'agent.chat.insights_panel.expanded_by_agent': { [FIRST_AGENT_ID]: true },
+      },
+    })
+    expect(selectAgentRosterPreferencesState(store.getState()).insightsPanelExpandedByAgent).toMatchObject({
+      value: { [FIRST_AGENT_ID]: true, [SECOND_AGENT_ID]: false },
+      persistedValue: { [FIRST_AGENT_ID]: false, [SECOND_AGENT_ID]: false },
+    })
+
+    rejectSecond?.(new Error('nope'))
+    await secondRequest
+
+    expect(selectAgentRosterPreferencesState(store.getState()).insightsPanelExpandedByAgent).toMatchObject({
+      value: { [FIRST_AGENT_ID]: false, [SECOND_AGENT_ID]: false },
+      persistedValue: { [FIRST_AGENT_ID]: false, [SECOND_AGENT_ID]: false },
+    })
+    expect(queryClient.getQueryData<{ insightsPanelExpandedByAgent: Record<string, boolean> }>(
+      ['agent-roster'],
+    )?.insightsPanelExpandedByAgent).toEqual({
+      [FIRST_AGENT_ID]: false,
+      [SECOND_AGENT_ID]: false,
+    })
+  })
+
+  it('does not let an older repeated-value failure roll back the latest write', async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(['agent-roster'], {
+      agents: [],
+      insightsPanelExpandedByAgent: { [FIRST_AGENT_ID]: false },
+    })
+    let rejectFirst: ((reason?: unknown) => void) | undefined
+    vi.mocked(updateUserPreferences)
+      .mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectFirst = reject }))
+      .mockResolvedValueOnce({
+        preferences: {
+          'agent.chat.insights_panel.expanded_by_agent': { [FIRST_AGENT_ID]: false },
+        },
+      })
+      .mockResolvedValueOnce({
+        preferences: {
+          'agent.chat.insights_panel.expanded_by_agent': { [FIRST_AGENT_ID]: true },
+        },
+      })
+    const store = createAppStore({ queryClient })
+    store.dispatch(agentRosterPreferencesActions.hydratedFromRoster({
+      insightsPanelExpandedByAgent: { [FIRST_AGENT_ID]: false },
+    }))
+
+    const firstRequest = store.dispatch(persistInsightsPanelExpandedPreference(FIRST_AGENT_ID, true))
+    const secondRequest = store.dispatch(persistInsightsPanelExpandedPreference(FIRST_AGENT_ID, false))
+    const thirdRequest = store.dispatch(persistInsightsPanelExpandedPreference(FIRST_AGENT_ID, true))
+
+    await vi.waitFor(() => expect(updateUserPreferences).toHaveBeenCalledTimes(1))
+    rejectFirst?.(new Error('nope'))
+    await Promise.all([firstRequest, secondRequest, thirdRequest])
+
+    expect(updateUserPreferences).toHaveBeenCalledTimes(3)
+    expect(selectAgentRosterPreferencesState(store.getState()).insightsPanelExpandedByAgent).toMatchObject({
+      value: { [FIRST_AGENT_ID]: true },
+      persistedValue: { [FIRST_AGENT_ID]: true },
+    })
+    expect(queryClient.getQueryData<{ insightsPanelExpandedByAgent: Record<string, boolean> }>(
+      ['agent-roster'],
+    )?.insightsPanelExpandedByAgent).toEqual({ [FIRST_AGENT_ID]: true })
+  })
+
+  it('rolls back only the failed agent while another agent update remains optimistic', async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(['agent-roster'], {
+      agents: [],
+      insightsPanelExpandedByAgent: { [FIRST_AGENT_ID]: true, [SECOND_AGENT_ID]: false },
+    })
+    let rejectFirst: ((reason?: unknown) => void) | undefined
+    let resolveSecond: ((value: { preferences: Record<string, unknown> }) => void) | undefined
+    vi.mocked(updateUserPreferences)
+      .mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectFirst = reject }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveSecond = resolve }))
+    const store = createAppStore({ queryClient })
+    store.dispatch(agentRosterPreferencesActions.hydratedFromRoster({
+      insightsPanelExpandedByAgent: { [FIRST_AGENT_ID]: true, [SECOND_AGENT_ID]: false },
+    }))
+
+    const failedRequest = store.dispatch(persistInsightsPanelExpandedPreference(FIRST_AGENT_ID, false))
+    const pendingRequest = store.dispatch(persistInsightsPanelExpandedPreference(SECOND_AGENT_ID, true))
+    await vi.waitFor(() => expect(updateUserPreferences).toHaveBeenCalledTimes(2))
+    rejectFirst?.(new Error('nope'))
+    await failedRequest
+
+    expect(selectAgentRosterPreferencesState(store.getState()).insightsPanelExpandedByAgent).toMatchObject({
+      value: { [FIRST_AGENT_ID]: true, [SECOND_AGENT_ID]: true },
+      persistedValue: { [FIRST_AGENT_ID]: true, [SECOND_AGENT_ID]: false },
+    })
+    expect(queryClient.getQueryData<{ insightsPanelExpandedByAgent: Record<string, boolean> }>(
+      ['agent-roster'],
+    )?.insightsPanelExpandedByAgent).toEqual({ [FIRST_AGENT_ID]: true, [SECOND_AGENT_ID]: true })
+
+    resolveSecond?.({
+      preferences: {
+        'agent.chat.insights_panel.expanded_by_agent': {
+          [FIRST_AGENT_ID]: true,
+          [SECOND_AGENT_ID]: true,
+        },
+      },
+    })
+    await pendingRequest
+    expect(selectAgentRosterPreferencesState(store.getState()).insightsPanelExpandedByAgent.persistedValue).toEqual({
+      [FIRST_AGENT_ID]: true,
+      [SECOND_AGENT_ID]: true,
+    })
   })
 
   it('optimistically disables suggestions and updates the roster cache', async () => {

--- a/frontend/src/store/agentRosterPreferencesSlice.ts
+++ b/frontend/src/store/agentRosterPreferencesSlice.ts
@@ -11,6 +11,7 @@ import {
   USER_PREFERENCE_KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED,
   USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_FAVORITE_AGENT_IDS,
   USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_SORT_MODE,
+  USER_PREFERENCE_KEY_AGENT_CHAT_SUGGESTIONS_ENABLED,
 } from '../api/userPreferences'
 import type { AgentRosterSortMode } from '../types/agentRoster'
 import { parseAgentRosterSortMode } from '../util/agentRosterSort'
@@ -27,6 +28,7 @@ export type AgentRosterPreferencesState = {
   favoriteAgentIds: PreferenceFieldState<string[]>
   mutedAgentIds: PreferenceFieldState<string[]>
   insightsPanelExpanded: PreferenceFieldState<boolean | null>
+  suggestionsEnabled: PreferenceFieldState<boolean>
   agentChatNotificationsEnabled: PreferenceFieldState<boolean>
 }
 
@@ -35,6 +37,7 @@ export type AgentRosterPreferencesHydrationPayload = {
   favoriteAgentIds?: unknown
   mutedAgentIds?: unknown
   insightsPanelExpanded?: unknown
+  suggestionsEnabled?: unknown
   agentChatNotificationsEnabled?: unknown
 }
 
@@ -45,6 +48,7 @@ type AgentRosterQueryData = {
   favoriteAgentIds?: string[]
   mutedAgentIds?: string[]
   insightsPanelExpanded?: boolean | null
+  suggestionsEnabled?: boolean
   agentChatNotificationsEnabled?: boolean
 }
 
@@ -82,6 +86,12 @@ const preferenceConfig = {
     hydrateOnce: true,
     normalize: parseNullableBooleanPreference,
   },
+  suggestionsEnabled: {
+    preferenceKey: USER_PREFERENCE_KEY_AGENT_CHAT_SUGGESTIONS_ENABLED,
+    rosterQueryField: 'suggestionsEnabled',
+    hydrateOnce: true,
+    normalize: parseBooleanPreference,
+  },
   agentChatNotificationsEnabled: {
     preferenceKey: USER_PREFERENCE_KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED,
     rosterQueryField: 'agentChatNotificationsEnabled',
@@ -95,6 +105,7 @@ const initialState: AgentRosterPreferencesState = {
   favoriteAgentIds: createPreferenceField<string[]>([]),
   mutedAgentIds: createPreferenceField<string[]>([]),
   insightsPanelExpanded: createPreferenceField<boolean | null>(null),
+  suggestionsEnabled: createPreferenceField(true),
   agentChatNotificationsEnabled: createPreferenceField(false),
 }
 
@@ -259,4 +270,7 @@ export const selectAgentRosterSortMode = (state: RootState): AgentRosterSortMode
 export const selectFavoriteAgentIds = (state: RootState): string[] => state.agentRosterPreferences.favoriteAgentIds.value
 export const selectMutedAgentIds = (state: RootState): string[] => state.agentRosterPreferences.mutedAgentIds.value
 export const selectInsightsPanelExpandedPreference = (state: RootState): boolean | null => state.agentRosterPreferences.insightsPanelExpanded.value
+export const selectInsightsPanelPreferenceHydrated = (state: RootState): boolean => state.agentRosterPreferences.insightsPanelExpanded.hydrated
+export const selectSuggestionsEnabled = (state: RootState): boolean => state.agentRosterPreferences.suggestionsEnabled.value
+export const selectSuggestionsPreferenceHydrated = (state: RootState): boolean => state.agentRosterPreferences.suggestionsEnabled.hydrated
 export const selectAgentChatNotificationsEnabled = (state: RootState): boolean => state.agentRosterPreferences.agentChatNotificationsEnabled.value

--- a/frontend/src/store/agentRosterPreferencesSlice.ts
+++ b/frontend/src/store/agentRosterPreferencesSlice.ts
@@ -4,14 +4,15 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import {
   parseBooleanPreference,
   parseFavoriteAgentIdsPreference,
-  parseNullableBooleanPreference,
+  parseInsightsPanelExpandedByAgentPreference,
   updateUserPreferences,
-  USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED,
+  USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT,
   USER_PREFERENCE_KEY_AGENT_CHAT_MUTED_AGENT_IDS,
   USER_PREFERENCE_KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED,
   USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_FAVORITE_AGENT_IDS,
   USER_PREFERENCE_KEY_AGENT_CHAT_ROSTER_SORT_MODE,
   USER_PREFERENCE_KEY_AGENT_CHAT_SUGGESTIONS_ENABLED,
+  type InsightsPanelExpandedByAgent,
 } from '../api/userPreferences'
 import type { AgentRosterSortMode } from '../types/agentRoster'
 import { parseAgentRosterSortMode } from '../util/agentRosterSort'
@@ -27,7 +28,7 @@ export type AgentRosterPreferencesState = {
   sortMode: PreferenceFieldState<AgentRosterSortMode>
   favoriteAgentIds: PreferenceFieldState<string[]>
   mutedAgentIds: PreferenceFieldState<string[]>
-  insightsPanelExpanded: PreferenceFieldState<boolean | null>
+  insightsPanelExpandedByAgent: PreferenceFieldState<InsightsPanelExpandedByAgent>
   suggestionsEnabled: PreferenceFieldState<boolean>
   agentChatNotificationsEnabled: PreferenceFieldState<boolean>
 }
@@ -36,7 +37,7 @@ export type AgentRosterPreferencesHydrationPayload = {
   sortMode?: unknown
   favoriteAgentIds?: unknown
   mutedAgentIds?: unknown
-  insightsPanelExpanded?: unknown
+  insightsPanelExpandedByAgent?: unknown
   suggestionsEnabled?: unknown
   agentChatNotificationsEnabled?: unknown
 }
@@ -47,7 +48,7 @@ type AgentRosterQueryData = {
   agentRosterSortMode?: AgentRosterSortMode
   favoriteAgentIds?: string[]
   mutedAgentIds?: string[]
-  insightsPanelExpanded?: boolean | null
+  insightsPanelExpandedByAgent?: InsightsPanelExpandedByAgent
   suggestionsEnabled?: boolean
   agentChatNotificationsEnabled?: boolean
 }
@@ -60,6 +61,8 @@ type AgentRosterPreferenceConfig = {
 }
 
 const AGENT_ROSTER_QUERY_KEY = ['agent-roster'] as const
+const insightsPanelWriteQueueByAgent = new Map<string, Promise<void>>()
+const latestInsightsPanelWriteByAgent = new Map<string, symbol>()
 
 const preferenceConfig = {
   sortMode: {
@@ -80,11 +83,11 @@ const preferenceConfig = {
     hydrateOnce: false,
     normalize: parseFavoriteAgentIdsPreference,
   },
-  insightsPanelExpanded: {
-    preferenceKey: USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED,
-    rosterQueryField: 'insightsPanelExpanded',
+  insightsPanelExpandedByAgent: {
+    preferenceKey: USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT,
+    rosterQueryField: 'insightsPanelExpandedByAgent',
     hydrateOnce: true,
-    normalize: parseNullableBooleanPreference,
+    normalize: parseInsightsPanelExpandedByAgentPreference,
   },
   suggestionsEnabled: {
     preferenceKey: USER_PREFERENCE_KEY_AGENT_CHAT_SUGGESTIONS_ENABLED,
@@ -104,7 +107,7 @@ const initialState: AgentRosterPreferencesState = {
   sortMode: createPreferenceField('recent' as AgentRosterSortMode),
   favoriteAgentIds: createPreferenceField<string[]>([]),
   mutedAgentIds: createPreferenceField<string[]>([]),
-  insightsPanelExpanded: createPreferenceField<boolean | null>(null),
+  insightsPanelExpandedByAgent: createPreferenceField<InsightsPanelExpandedByAgent>({}),
   suggestionsEnabled: createPreferenceField(true),
   agentChatNotificationsEnabled: createPreferenceField(false),
 }
@@ -151,10 +154,7 @@ function updateRosterPreferenceInCache<K extends AgentRosterPreferenceField>(
         return current
       }
       const currentValue = current[queryField]
-      if (Array.isArray(currentValue) && Array.isArray(nextValue) && sameStringList(currentValue, nextValue)) {
-        return current
-      }
-      if (Object.is(currentValue, nextValue)) {
+      if (samePreferenceValue(currentValue, nextValue)) {
         return current
       }
       return {
@@ -221,6 +221,42 @@ const agentRosterPreferencesSlice = createSlice({
       const target = state[action.payload.field] as PreferenceFieldState<AgentRosterPreferencesState[K]['value']>
       target.value = target.persistedValue
     },
+    insightsPanelAgentOptimisticallySet(
+      state,
+      action: PayloadAction<{ agentId: string; expanded: boolean }>,
+    ) {
+      const target = state.insightsPanelExpandedByAgent
+      target.value = {
+        ...target.value,
+        [action.payload.agentId]: action.payload.expanded,
+      }
+    },
+    insightsPanelAgentPersisted(
+      state,
+      action: PayloadAction<{ agentId: string; attemptedValue: boolean }>,
+    ) {
+      const target = state.insightsPanelExpandedByAgent
+      target.persistedValue = {
+        ...target.persistedValue,
+        [action.payload.agentId]: action.payload.attemptedValue,
+      }
+    },
+    insightsPanelAgentRolledBack(
+      state,
+      action: PayloadAction<{ agentId: string; attemptedValue: boolean }>,
+    ) {
+      const target = state.insightsPanelExpandedByAgent
+      if (target.value[action.payload.agentId] !== action.payload.attemptedValue) {
+        return
+      }
+      const nextValue = { ...target.value }
+      if (Object.prototype.hasOwnProperty.call(target.persistedValue, action.payload.agentId)) {
+        nextValue[action.payload.agentId] = target.persistedValue[action.payload.agentId]
+      } else {
+        delete nextValue[action.payload.agentId]
+      }
+      target.value = nextValue
+    },
   },
 })
 
@@ -255,6 +291,76 @@ export function persistAgentRosterPreference<K extends AgentRosterPreferenceFiel
   }
 }
 
+export function persistInsightsPanelExpandedPreference(agentId: string, expanded: boolean) {
+  return async (dispatch: AppDispatch, getState: () => RootState, extra?: { queryClient?: QueryClient | null }) => {
+    const normalizedAgentId = agentId.trim()
+    if (!normalizedAgentId) {
+      return
+    }
+
+    const field = 'insightsPanelExpandedByAgent' as const
+    if (!getState().agentRosterPreferences.insightsPanelExpandedByAgent.hydrated) {
+      return
+    }
+
+    const writeToken = Symbol(normalizedAgentId)
+    latestInsightsPanelWriteByAgent.set(normalizedAgentId, writeToken)
+    dispatch(agentRosterPreferencesActions.insightsPanelAgentOptimisticallySet({
+      agentId: normalizedAgentId,
+      expanded,
+    }))
+    updateRosterPreferenceInCache(
+      extra?.queryClient,
+      field,
+      getState().agentRosterPreferences.insightsPanelExpandedByAgent.value,
+    )
+
+    const previousWrite = insightsPanelWriteQueueByAgent.get(normalizedAgentId) ?? Promise.resolve()
+    const currentWrite = previousWrite
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await updateUserPreferences({
+            preferences: {
+              [USER_PREFERENCE_KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT]: {
+                [normalizedAgentId]: expanded,
+              },
+            },
+          })
+          dispatch(agentRosterPreferencesActions.insightsPanelAgentPersisted({
+            agentId: normalizedAgentId,
+            attemptedValue: expanded,
+          }))
+        } catch {
+          if (latestInsightsPanelWriteByAgent.get(normalizedAgentId) === writeToken) {
+            dispatch(agentRosterPreferencesActions.insightsPanelAgentRolledBack({
+              agentId: normalizedAgentId,
+              attemptedValue: expanded,
+            }))
+          }
+        }
+
+        updateRosterPreferenceInCache(
+          extra?.queryClient,
+          field,
+          getState().agentRosterPreferences.insightsPanelExpandedByAgent.value,
+        )
+      })
+    insightsPanelWriteQueueByAgent.set(normalizedAgentId, currentWrite)
+
+    try {
+      await currentWrite
+    } finally {
+      if (insightsPanelWriteQueueByAgent.get(normalizedAgentId) === currentWrite) {
+        insightsPanelWriteQueueByAgent.delete(normalizedAgentId)
+      }
+      if (latestInsightsPanelWriteByAgent.get(normalizedAgentId) === writeToken) {
+        latestInsightsPanelWriteByAgent.delete(normalizedAgentId)
+      }
+    }
+  }
+}
+
 export function toggleAgentRosterStringPreference(field: 'favoriteAgentIds' | 'mutedAgentIds', agentId: string) {
   return (dispatch: AppDispatch, getState: () => RootState) => {
     const currentValue = getState().agentRosterPreferences[field].value
@@ -269,8 +375,20 @@ export const selectAgentRosterPreferencesState = (state: RootState): AgentRoster
 export const selectAgentRosterSortMode = (state: RootState): AgentRosterSortMode => state.agentRosterPreferences.sortMode.value
 export const selectFavoriteAgentIds = (state: RootState): string[] => state.agentRosterPreferences.favoriteAgentIds.value
 export const selectMutedAgentIds = (state: RootState): string[] => state.agentRosterPreferences.mutedAgentIds.value
-export const selectInsightsPanelExpandedPreference = (state: RootState): boolean | null => state.agentRosterPreferences.insightsPanelExpanded.value
-export const selectInsightsPanelPreferenceHydrated = (state: RootState): boolean => state.agentRosterPreferences.insightsPanelExpanded.hydrated
+export const selectInsightsPanelExpandedPreference = (
+  state: RootState,
+  agentId: string | null,
+): boolean | null => {
+  const values = state.agentRosterPreferences.insightsPanelExpandedByAgent.value
+  if (!agentId || !Object.prototype.hasOwnProperty.call(values, agentId)) {
+    return null
+  }
+  const value = values[agentId]
+  return typeof value === 'boolean' ? value : null
+}
+export const selectInsightsPanelPreferenceHydrated = (state: RootState): boolean => (
+  state.agentRosterPreferences.insightsPanelExpandedByAgent.hydrated
+)
 export const selectSuggestionsEnabled = (state: RootState): boolean => state.agentRosterPreferences.suggestionsEnabled.value
 export const selectSuggestionsPreferenceHydrated = (state: RootState): boolean => state.agentRosterPreferences.suggestionsEnabled.hydrated
 export const selectAgentChatNotificationsEnabled = (state: RootState): boolean => state.agentRosterPreferences.agentChatNotificationsEnabled.value

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3123,12 +3123,41 @@
     color: #1e1b4b;
     overflow: hidden;
 }
+.starter-prompts-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.38rem 0.48rem 0.2rem 0.85rem;
+}
 .starter-prompts-card__title {
     margin: 0;
-    padding: 0.6rem 0.85rem 0.42rem;
     color: #3730a3;
     font-size: 0.75rem;
     font-weight: 600;
+}
+.starter-prompts-card__dismiss {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 0;
+    border-radius: 0.5rem;
+    background: transparent;
+    color: #6366f1;
+    cursor: pointer;
+}
+.starter-prompts-card__dismiss:hover {
+    background: rgba(99, 102, 241, 0.1);
+    color: #3730a3;
+}
+.starter-prompts-card__dismiss:focus-visible {
+    outline: 2px solid rgba(99, 102, 241, 0.45);
+    outline-offset: 1px;
+}
+.starter-prompts-card__dismiss svg {
+    width: 0.9rem;
+    height: 0.9rem;
 }
 .starter-prompts-card__rows {
     display: flex;

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3127,37 +3127,13 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.38rem 0.48rem 0.2rem 0.85rem;
+    padding: 0.52rem 0.85rem 0.34rem;
 }
 .starter-prompts-card__title {
     margin: 0;
     color: #3730a3;
     font-size: 0.75rem;
     font-weight: 600;
-}
-.starter-prompts-card__dismiss {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.75rem;
-    height: 1.75rem;
-    border: 0;
-    border-radius: 0.5rem;
-    background: transparent;
-    color: #6366f1;
-    cursor: pointer;
-}
-.starter-prompts-card__dismiss:hover {
-    background: rgba(99, 102, 241, 0.1);
-    color: #3730a3;
-}
-.starter-prompts-card__dismiss:focus-visible {
-    outline: 2px solid rgba(99, 102, 241, 0.45);
-    outline-offset: 1px;
-}
-.starter-prompts-card__dismiss svg {
-    width: 0.9rem;
-    height: 0.9rem;
 }
 .starter-prompts-card__rows {
     display: flex;
@@ -3252,6 +3228,32 @@
     border-radius: 999px;
     background: rgba(99, 102, 241, 0.22);
     color: transparent;
+}
+.starter-prompts-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.15rem;
+    padding: 0.28rem 0.55rem 0.42rem;
+}
+.starter-prompts-card__action {
+    min-height: 2rem;
+    border: 0;
+    border-radius: 0.48rem;
+    background: transparent;
+    padding: 0.28rem 0.48rem;
+    color: #4f46e5;
+    font-size: 0.72rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+.starter-prompts-card__action:hover {
+    background: rgba(99, 102, 241, 0.1);
+    color: #312e81;
+}
+.starter-prompts-card__action:focus-visible {
+    outline: 2px solid rgba(99, 102, 241, 0.45);
+    outline-offset: 1px;
 }
 .agent-chat-section-card.template-recommendations-card {
     gap: 0.72rem;

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "d29be81f13ac837096570879f45bd341ea3367ad",
+  "baseline_sha": "15f325954f5ba1e06ecca65f570b1dd782ac1a21",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 249981
+    "limit": 250171
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "b5322373af94d27ac74ae2bfdd4889dacf373da1",
+  "baseline_sha": "d29be81f13ac837096570879f45bd341ea3367ad",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 249957
+    "limit": 249981
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "3771cb4759e1cd2e1f348dbeddc91750287be74a",
+  "baseline_sha": "b5322373af94d27ac74ae2bfdd4889dacf373da1",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 249779
+    "limit": 249957
   }
 }

--- a/tests/unit/test_agent_chat_access.py
+++ b/tests/unit/test_agent_chat_access.py
@@ -770,6 +770,7 @@ class AgentChatAccessTests(TestCase):
         self.assertEqual(payload.get("agent_roster_sort_mode"), "recent")
         self.assertEqual(payload.get("favorite_agent_ids"), [])
         self.assertTrue(payload.get("agent_chat_notifications_enabled"))
+        self.assertTrue(payload.get("agent_chat_suggestions_enabled"))
         roster_ids = {entry["id"] for entry in payload.get("agents", [])}
         self.assertIn(str(self.org_agent.id), roster_ids)
         self.assertIn(str(self.org_agent_two.id), roster_ids)
@@ -850,6 +851,23 @@ class AgentChatAccessTests(TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertFalse(payload.get("agent_chat_notifications_enabled"))
+
+    def test_roster_includes_agent_chat_suggestions_enabled_preference(self):
+        UserPreference.update_known_preferences(
+            self.user,
+            {
+                UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED: False,
+            },
+        )
+
+        response = self.client.get(
+            reverse("console_agent_roster"),
+            HTTP_X_GOBII_CONTEXT_TYPE="organization",
+            HTTP_X_GOBII_CONTEXT_ID=str(self.org.id),
+        )
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload.get("agent_chat_suggestions_enabled"))
 
     @tag("batch_agent_chat")
     def test_roster_includes_only_enabled_system_skill_keys(self):

--- a/tests/unit/test_agent_chat_access.py
+++ b/tests/unit/test_agent_chat_access.py
@@ -769,6 +769,7 @@ class AgentChatAccessTests(TestCase):
         payload = response.json()
         self.assertEqual(payload.get("agent_roster_sort_mode"), "recent")
         self.assertEqual(payload.get("favorite_agent_ids"), [])
+        self.assertEqual(payload.get("insights_panel_expanded_by_agent"), {})
         self.assertTrue(payload.get("agent_chat_notifications_enabled"))
         self.assertTrue(payload.get("agent_chat_suggestions_enabled"))
         roster_ids = {entry["id"] for entry in payload.get("agents", [])}
@@ -834,6 +835,32 @@ class AgentChatAccessTests(TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertFalse(payload.get("insights_panel_expanded"))
+
+    def test_roster_includes_insights_panel_expanded_preferences_by_agent(self):
+        UserPreference.update_known_preferences(
+            self.user,
+            {
+                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: {
+                    str(self.org_agent.id): False,
+                    str(self.org_agent_two.id): True,
+                },
+            },
+        )
+
+        response = self.client.get(
+            reverse("console_agent_roster"),
+            HTTP_X_GOBII_CONTEXT_TYPE="organization",
+            HTTP_X_GOBII_CONTEXT_ID=str(self.org.id),
+        )
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload.get("insights_panel_expanded_by_agent"),
+            {
+                str(self.org_agent.id): False,
+                str(self.org_agent_two.id): True,
+            },
+        )
 
     def test_roster_includes_agent_chat_notifications_enabled_preference(self):
         UserPreference.update_known_preferences(

--- a/tests/unit/test_agent_chat_suggestions.py
+++ b/tests/unit/test_agent_chat_suggestions.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from api.agent.core.processing_flags import clear_processing_queued_flag, set_processing_queued_flag
 from console.agent_chat.suggestions import _context_from_timeline_events, _generate_dynamic_suggestions
 from api.models import (
+    AgentCollaborator,
     BrowserUseAgent,
     CommsChannel,
     PersistentAgent,
@@ -17,6 +18,7 @@ from api.models import (
     PersistentAgentCompletion,
     PersistentAgentConversation,
     PersistentAgentMessage,
+    UserPreference,
     build_web_agent_address,
     build_web_user_address,
 )
@@ -92,6 +94,44 @@ class AgentChatSuggestionsAPITests(TestCase):
         payload = response.json()
         self.assertEqual(payload.get("source"), "none")
         self.assertEqual(payload.get("suggestions"), [])
+
+    @patch("console.api_views.build_agent_timeline_suggestions")
+    def test_returns_empty_without_building_suggestions_when_viewer_disabled_them(self, mock_build):
+        UserPreference.update_known_preferences(
+            self.user,
+            {UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED: False},
+        )
+
+        response = self.client.get(self._suggestions_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"suggestions": [], "source": "none"})
+        mock_build.assert_not_called()
+
+    @patch("console.api_views.build_agent_timeline_suggestions")
+    def test_shared_agent_uses_collaborator_suggestion_preference(self, mock_build):
+        collaborator = get_user_model().objects.create_user(
+            username="suggestions-collaborator",
+            email="suggestions-collaborator@example.com",
+            password="password123",
+        )
+        with patch("util.subscription_helper.get_user_max_contacts_per_agent", return_value=0):
+            AgentCollaborator.objects.create(
+                agent=self.agent,
+                user=collaborator,
+                invited_by=self.user,
+            )
+        UserPreference.update_known_preferences(
+            collaborator,
+            {UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED: False},
+        )
+        self.client.force_login(collaborator)
+
+        response = self.client.get(self._suggestions_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"suggestions": [], "source": "none"})
+        mock_build.assert_not_called()
 
     def test_returns_static_prompts_for_initial_phase(self):
         self._create_message(body="What can you help with?", is_outbound=False)

--- a/tests/unit/test_console_user_preferences_api.py
+++ b/tests/unit/test_console_user_preferences_api.py
@@ -42,6 +42,10 @@ class ConsoleUserPreferencesApiTests(TestCase):
         self.assertIsNone(
             preferences.get(UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED),
         )
+        self.assertEqual(
+            preferences.get(UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT),
+            {},
+        )
         self.assertTrue(
             preferences.get(UserPreference.KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED),
         )
@@ -221,6 +225,149 @@ class ConsoleUserPreferencesApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         preferences = response.json().get("preferences", {})
         self.assertIsNone(preferences.get(UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED))
+
+    def test_patch_merges_insights_panel_preferences_by_agent(self):
+        first_agent_id = uuid.uuid4()
+        second_agent_id = uuid.uuid4()
+
+        first_response = self.client.patch(
+            self.url,
+            data=json.dumps(
+                {
+                    "preferences": {
+                        UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: {
+                            str(first_agent_id).upper(): False,
+                        },
+                    }
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(first_response.status_code, 200)
+
+        second_response = self.client.patch(
+            self.url,
+            data=json.dumps(
+                {
+                    "preferences": {
+                        UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: {
+                            str(second_agent_id): True,
+                        },
+                    }
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(second_response.status_code, 200)
+        expected = {
+            str(first_agent_id): False,
+            str(second_agent_id): True,
+        }
+        self.assertEqual(
+            second_response.json()["preferences"][
+                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT
+            ],
+            expected,
+        )
+
+        stored = UserPreference.objects.get(user=self.user)
+        self.assertEqual(
+            stored.preferences[UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT],
+            expected,
+        )
+
+    def test_patch_rejects_invalid_insights_panel_preferences_by_agent(self):
+        valid_agent_id = str(uuid.uuid4())
+        invalid_values = (
+            [],
+            {"not-an-agent-uuid": False},
+            {valid_agent_id: "false"},
+            {valid_agent_id: False, valid_agent_id.upper(): True},
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=invalid_value):
+                response = self.client.patch(
+                    self.url,
+                    data=json.dumps(
+                        {
+                            "preferences": {
+                                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: invalid_value,
+                            }
+                        }
+                    ),
+                    content_type="application/json",
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertFalse(UserPreference.objects.filter(user=self.user).exists())
+
+    def test_agent_scoped_preference_merge_preserves_unknown_stored_preferences(self):
+        first_agent_id = str(uuid.uuid4())
+        second_agent_id = str(uuid.uuid4())
+        future_key = "agent.chat.future.preference"
+        preference = UserPreference.objects.create(
+            user=self.user,
+            preferences={
+                future_key: {"enabled": True},
+                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: {
+                    first_agent_id: False,
+                },
+            },
+        )
+
+        UserPreference.update_known_preferences(
+            self.user,
+            {
+                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: {
+                    second_agent_id: True,
+                },
+            },
+        )
+
+        preference.refresh_from_db()
+        self.assertEqual(preference.preferences[future_key], {"enabled": True})
+        self.assertEqual(
+            preference.preferences[UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT],
+            {
+                first_agent_id: False,
+                second_agent_id: True,
+            },
+        )
+
+    def test_insights_panel_preferences_by_agent_are_isolated_per_user(self):
+        agent_id = str(uuid.uuid4())
+        other_user = get_user_model().objects.create_user(
+            username="other-preferences-owner",
+            email="other-preferences-owner@example.com",
+            password="password123",
+        )
+        UserPreference.update_known_preferences(
+            self.user,
+            {
+                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: {
+                    agent_id: False,
+                },
+            },
+        )
+        UserPreference.update_known_preferences(
+            other_user,
+            {
+                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT: {
+                    agent_id: True,
+                },
+            },
+        )
+
+        self.assertFalse(
+            UserPreference.resolve_known_preferences(self.user)[
+                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT
+            ][agent_id]
+        )
+        self.assertTrue(
+            UserPreference.resolve_known_preferences(other_user)[
+                UserPreference.KEY_AGENT_CHAT_INSIGHTS_PANEL_EXPANDED_BY_AGENT
+            ][agent_id]
+        )
 
     def test_patch_updates_agent_chat_notifications_enabled_preference(self):
         response = self.client.patch(

--- a/tests/unit/test_console_user_preferences_api.py
+++ b/tests/unit/test_console_user_preferences_api.py
@@ -1,9 +1,9 @@
 import json
 import uuid
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
-from django.db import IntegrityError
+from django.db import IntegrityError, connection, transaction
 from django.test import TestCase, tag
 from django.urls import reverse
 
@@ -44,6 +44,9 @@ class ConsoleUserPreferencesApiTests(TestCase):
         )
         self.assertTrue(
             preferences.get(UserPreference.KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED),
+        )
+        self.assertTrue(
+            preferences.get(UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED),
         )
         self.assertEqual(
             preferences.get(UserPreference.KEY_USER_TIMEZONE),
@@ -255,6 +258,44 @@ class ConsoleUserPreferencesApiTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertFalse(UserPreference.objects.filter(user=self.user).exists())
 
+    def test_patch_updates_agent_chat_suggestions_enabled_preference(self):
+        response = self.client.patch(
+            self.url,
+            data=json.dumps(
+                {
+                    "preferences": {
+                        UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED: False,
+                    }
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        preferences = response.json().get("preferences", {})
+        self.assertFalse(preferences.get(UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED))
+
+        stored = UserPreference.objects.get(user=self.user)
+        self.assertFalse(
+            (stored.preferences or {}).get(UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED)
+        )
+
+    def test_patch_rejects_invalid_agent_chat_suggestions_enabled_preference(self):
+        response = self.client.patch(
+            self.url,
+            data=json.dumps(
+                {
+                    "preferences": {
+                        UserPreference.KEY_AGENT_CHAT_SUGGESTIONS_ENABLED: "no",
+                    }
+                }
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(UserPreference.objects.filter(user=self.user).exists())
+
     def test_patch_rejects_invalid_favorite_agent_ids(self):
         response = self.client.patch(
             self.url,
@@ -404,14 +445,68 @@ class ConsoleUserPreferencesApiTests(TestCase):
             "America/Los_Angeles",
         )
 
+    def test_update_known_preferences_locks_and_merges_fresh_stored_preferences(self):
+        existing = UserPreference.objects.create(
+            user=self.user,
+            preferences={UserPreference.KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED: False},
+        )
+        stale_preference = UserPreference(
+            pk=existing.pk,
+            user=self.user,
+            preferences={},
+        )
+        select_for_update = UserPreference.objects.select_for_update
+
+        def select_for_update_in_transaction(*args, **kwargs):
+            self.assertTrue(connection.in_atomic_block)
+            return select_for_update(*args, **kwargs)
+
+        with patch.object(
+            UserPreference.objects,
+            "get_or_create",
+            return_value=(stale_preference, False),
+        ), patch.object(
+            UserPreference.objects,
+            "select_for_update",
+            side_effect=select_for_update_in_transaction,
+        ) as locked_query, patch.object(
+            transaction,
+            "atomic",
+            wraps=transaction.atomic,
+        ) as atomic:
+            resolved = UserPreference.update_known_preferences(
+                self.user,
+                {UserPreference.KEY_USER_TIMEZONE: "America/Los_Angeles"},
+            )
+
+        atomic.assert_called_once_with()
+        locked_query.assert_called_once_with()
+        self.assertFalse(resolved[UserPreference.KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED])
+        self.assertEqual(resolved[UserPreference.KEY_USER_TIMEZONE], "America/Los_Angeles")
+        existing.refresh_from_db()
+        self.assertEqual(
+            existing.preferences,
+            {
+                UserPreference.KEY_AGENT_CHAT_NOTIFICATIONS_ENABLED: False,
+                UserPreference.KEY_USER_TIMEZONE: "America/Los_Angeles",
+            },
+        )
+
     def test_update_known_preferences_retries_create_if_row_disappears_after_integrity_error(self):
         replacement = UserPreference.objects.create(user=self.user, preferences={})
+        missing_locked_query = MagicMock()
+        missing_locked_query.get.side_effect = UserPreference.DoesNotExist
+        locked_replacement_query = UserPreference.objects.select_for_update()
 
         with patch.object(
             UserPreference.objects,
             "get_or_create",
             side_effect=[IntegrityError("duplicate key"), (replacement, False)],
-        ), patch.object(UserPreference.objects, "get", side_effect=UserPreference.DoesNotExist):
+        ), patch.object(
+            UserPreference.objects,
+            "select_for_update",
+            side_effect=[missing_locked_query, locked_replacement_query],
+        ):
             resolved = UserPreference.update_known_preferences(
                 self.user,
                 {UserPreference.KEY_USER_TIMEZONE: "America/Los_Angeles"},
@@ -421,6 +516,7 @@ class ConsoleUserPreferencesApiTests(TestCase):
             resolved.get(UserPreference.KEY_USER_TIMEZONE),
             "America/Los_Angeles",
         )
+        replacement.refresh_from_db()
         self.assertEqual(
             replacement.preferences.get(UserPreference.KEY_USER_TIMEZONE),
             "America/Los_Angeles",


### PR DESCRIPTION
## Summary

- Replaces the ambiguous suggestion-card X with two visible inline actions: **Hide for now** dismisses only the current set, while **Turn off suggestions** persists the viewer preference and stops future generation.
- Keeps the reversible Suggested follow-ups toggle in Settings.
- Persists Insights expansion independently for each viewer and agent. Collapsing Agent A no longer changes Agent B, and each viewer of a shared agent has their own setting.
- Merges per-agent preference deltas under the existing user-row lock and serializes same-agent browser writes so rapid toggles cannot overwrite unrelated agents or commit out of click order.

## UX rationale

The compact inline action row follows established guidance to keep related actions contextual, use concise labels that state the consequence, and let narrow layouts wrap. The controls use native visible-text buttons, visible focus states, and 32px targets, above the WCAG 2.2 AA 24px minimum.

- https://carbondesignsystem.com/components/notification/usage/
- https://carbondesignsystem.com/components/button/usage/
- https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum

## Verification

Exact head: `d5206304e683d6e12853b36cd13f585278ead261`.

- [Full GitHub CI](https://github.com/gobii-ai/gobii-platform/actions/runs/29961377520) passed: all 10 backend shards, both combined gates, frontend, sandbox, tag guard, complexity, and preview dispatch.
- Focused local Django preference and roster suites: 74 passed, 3 skipped.
- Full local frontend suite: 42 files, 235 tests passed.
- Production TypeScript/Vite build passed.
- Changed-source ESLint passed with zero errors; the 9 reported AgentChatPage hook warnings predate this change.
- `makemigrations --check --dry-run`: no changes detected.
- Complexity guardrails: 250171/250171 source LoC; all prompt budgets unchanged and green.
- [Preview deploy](https://github.com/gobii-ai/gobii/actions/runs/29961449476) passed; migrations and schedule sync succeeded, and Argo reported Synced/Healthy.
- https://pr-1355.ship.gobii.ai returns HTTP 200 and references exact-head immutable assets; exact-head CSS/JS assets return 200. The deployed bundles contain the new per-agent preference key and both inline action labels.
- Anonymous desktop and 390x844 mobile browser renders completed. Mobile matches the current production homepage baseline; authenticated chat behavior remains the explicit human check below.

## Compatibility and scope

This is deterministic UI/API preference work, so no agent-prompt eval was added. The old global Insights boolean is still accepted and returned for rolling compatibility, but the corrected UI intentionally does not apply it to every agent because there is no truthful way to infer which agent it belonged to. Existing global state therefore returns to automatic behavior until a per-agent choice is saved.

No database migration is required. Unknown namespaced preferences are preserved during row-locked merges so rolling deploys do not discard newer keys.

## Human verification

Do not merge before authenticated preview verification:

- **Hide for now** removes only the current suggestions.
- **Turn off suggestions** persists; Settings can turn suggestions back on.
- Collapse Insights for Agent A, switch to Agent B and verify B remains independent, refresh, then switch back and verify A is still collapsed.

This PR must remain open for explicit human approval.
