### PR TITLE
Make SQLite domain modeling reliable and incremental

### DIFF
--- a/api/agent/core/link_references.py
+++ b/api/agent/core/link_references.py
@@ -201,6 +201,16 @@ def resolve_link_reference_params(value, agent, *, tool_name: str = "", _path=()
         return [resolve_link_reference_params(item, agent, tool_name=tool_name, _path=(*_path, index), _allowed=_allowed) for index, item in enumerate(value)]
     if not isinstance(value, str):
         return value
+    if tool_name == "sqlite_batch" and _path and _path[0] == "bindings":
+        stripped = value.strip()
+        if _REFERENCE_RE.fullmatch(stripped):
+            resolved = resolve_link_references(stripped, agent)
+            return value[: len(value) - len(value.lstrip())] + resolved + value[len(value.rstrip()):]
+    if tool_name == "sqlite_batch" and _contains_reference_syntax(value):
+        # A valid handle is safe opaque data in SQLite. Direct source extraction remains preferable,
+        # but rejecting the whole query loses otherwise useful modeled work.
+        resolve_link_references(value, agent)
+        return value
     if _path and _path[0] in _allowed:
         if tool_name == "http_request":
             return resolve_link_references(value, agent)
@@ -212,9 +222,10 @@ def resolve_link_reference_params(value, agent, *, tool_name: str = "", _path=()
         return value[: len(value) - len(value.lstrip())] + resolved + value[len(value.rstrip()):]
     if tool_name and _contains_reference_syntax(value):
         location = f"{tool_name}.{_param_path(_path)}" if tool_name else _param_path(_path) or "this value"
-        guidance = "Derive raw values/URLs inside INSERT ... SELECT from __tool_results; never copy a blob or replace tokens with literals." if tool_name == "sqlite_batch" else "Use a standalone token only where URL input is supported, move it to supported message/document content, or omit it."
         raise LinkReferenceResolutionError(
-            f"Query not executed: link references are unsupported in {location}. {guidance}")
+            f"Query not executed: link references are unsupported in {location}. "
+            "Use a standalone token only where URL input is supported, move it to supported message/document content, or omit it."
+        )
     return value
 
 

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -98,7 +98,6 @@ from ..tools.spawn_web_task import get_browser_daily_task_limit
 from ..tools.static_tools import get_static_tool_definitions
 from ..tools.sqlite_state import AGENT_CONFIG_TABLE, AGENT_SKILLS_TABLE, CONTACTS_TABLE, FILES_TABLE, get_sqlite_digest_prompt, get_sqlite_schema_prompt
 from ..tools.sqlite_query_quality import (
-    ROW_LOOP_MESSAGE,
     named_model_read_tables,
     source_derived_model_mutation_tables,
     source_derived_model_reconciled_tables,
@@ -143,8 +142,9 @@ LINK_REFERENCE_PROMPT_NOTE = (
     "Sources may pair `raw URL [link_ref: $[link:L…]]`: the raw URL is evidence; its adjacent token is only a "
     "display/fetch handle. Keep pairs attached. Final Markdown is exactly `[item]($[link:LEXACT])`; HTML uses "
     "`<a href=\"$[link:LEXACT]\">item</a>`; URL tools use `{\"url\":\"$[link:LEXACT]\"}`. The token is the whole "
-    "destination. Never encode, edit, reassign, combine, or guess it; never put it inside `[]`, SQL/state/search, or "
-    "replace it with a raw URL. Items without a token stay plain; source/feed tokens link only themselves. A report "
+    "destination. Never encode, edit, reassign, combine, or guess it; never put it inside `[]` or search text. "
+    "SQLite source rows derive raw URLs from __tool_results; for an unavoidable agent-authored URL value, pass the "
+    "exact handle through a named binding, never SQL text. Items without a token stay plain; source/feed tokens link only themselves. A report "
     "is unfinished while a token-backed entity name is plain: `Atlas URL [link_ref: $[link:L1]]` becomes "
     "`[Atlas]($[link:L1])`. Outreach links only if useful/requested. Cite beside the supported "
     "claim; a source name alone is not a citation. Before sending, the "
@@ -683,9 +683,10 @@ def _get_sqlite_guidance() -> str:
         "## SQLite Data\n\n"
         "Named tables are the world model; digest is partial. Use queried rows, not memory, for decisions. Current complete rows are truth; don't refetch them. "
         "Explicit fresh source: fetch once, then reconcile and SELECT the model in one SQLite batch. Otherwise read the model first and fetch only stale/missing facts. "
-        "Tool output doesn't update it. Source rows sharing a stable ID or its children belong there even when small: reconcile entities/relations, evolve schema, then query before acting/reporting. Only unrelated one-offs bypass it. "
+        "Tool output doesn't update it. During long or multi-source work, reconcile each useful source batch so tables become the checklist, intermediate state, and resume point. "
+        "Source rows sharing a stable ID or its children belong there even when small: reconcile entities/relations, evolve schema, then query before acting/reporting. Only unrelated one-offs bypass it. "
         "Use stable keys. Upserts refresh every mutable/provenance field; inspect identity after wrong row counts; query gaps before reporting. Only sourced blockers are unresolved. "
-        "Normalize children with PRIMARY KEY/UNIQUE + indexes; use SQLite for exact set logic/counts/ranking. "
+        "Normalize children with PRIMARY KEY/UNIQUE + indexes; use SQLite for exact set logic/counts/ranking. Bind messy agent-authored values with :name + bindings; source facts still derive from __tool_results. For fuzzy interpretation of unstructured text, bind one JSON array and expand it with json_each(:rows), retaining source result IDs/provenance. "
         "No sibling-by-sibling result/table/blob loops. Custom tools may write keyed models directly. CTAS is one-off; named tables persist, TEMP do not. Inspect unknown structure once. "
         "Locate payloads with analysis_json/top_keys; http_request JSON is result_json $.content. Prefer result_json for known paths, else result_text.\n\n"
         "Snapshots:\n"
@@ -3330,7 +3331,11 @@ def _build_sqlite_retry_warning(
         if not sql:
             continue
         sql_values.append(sql)
-        if ROW_LOOP_MESSAGE.split(" A one-item", 1)[0] in (result_text or ""):
+        if (
+            "Query not executed: do not read __tool_results or a staging table derived from it one "
+            "result_id at a time."
+            in (result_text or "")
+        ):
             row_loop_rejections += 1
         result_ids = set(_SQLITE_RESULT_ID_RE.findall(sql))
         if not result_ids:
@@ -3399,10 +3404,14 @@ def _build_unreconciled_source_model_warning(
         return ""
 
     sqlite_events: list[tuple[int, set[str], set[str], set[str]]] = []
+    inspected_source_batch = False
     for index, (tool_name, params, status) in enumerate(recent_calls):
         if status != "complete" or tool_name != "sqlite_batch":
             continue
         sql_values = _sql_values_from_params(params or {})
+        inspected_source_batch = inspected_source_batch or bool(
+            summarize_sqlite_tool_result_sql(sql_values).tool_result_statement_count
+        )
         sqlite_events.append((
             index,
             set(named_model_read_tables(sql_values)),
@@ -3417,18 +3426,48 @@ def _build_unreconciled_source_model_warning(
         if index > latest_source_index
         for table in targets
     }
-    if latest_mutation_by_table and all(
-        any(
-            (index > latest_mutation_by_table[table] and table in reads)
-            or (index == latest_mutation_by_table[table] and table in reconciled)
+    pending_model_reads = sorted(
+        table
+        for table, mutation_index in latest_mutation_by_table.items()
+        if not any(
+            (index > mutation_index and table in reads)
+            or (index == mutation_index and table in reconciled)
             for index, reads, _mutations, reconciled in sqlite_events
         )
-        for table in latest_mutation_by_table
-    ):
-        return ""
+    )
+    if latest_mutation_by_table:
+        if not pending_model_reads:
+            return ""
+        return (
+            "Fresh source evidence is reconciled. Next, query the updated named model before answering or acting; "
+            f"include the still-unread updated table(s): {', '.join(pending_model_reads)}. Use joins, set logic, "
+            "counts, or ranking there instead of rereading transient results or repeating the write."
+        )
 
     if not read_tables and not latest_mutation_by_table:
-        return ""
+        completed_source_count = sum(
+            status == "complete" and is_source_bearing_tool(tool_name)
+            for tool_name, _params, status in recent_calls
+        )
+        if completed_source_count < 2:
+            return ""
+        if inspected_source_batch:
+            return (
+                "You already inspected this source batch. Do not query raw __tool_results again. The next action must "
+                "create or evolve the durable keyed model, then query it. For fuzzy interpretation of unstructured "
+                "text, bind one JSON array and expand it with json_each(:rows), retaining source result IDs and "
+                "provenance; do not build literal INSERTs. Import same-shaped siblings with one set query over "
+                "tool_name or result_id IN (...), not one statement per result_id."
+            )
+        return (
+            "Multiple source results form a working set and remain transient. The next action must be sqlite_batch: "
+            "create or evolve durable named entity/relationship tables with PRIMARY "
+            "KEY/UNIQUE and provenance (not TEMP/CTAS), reconcile this source batch directly from __tool_results, then "
+            "query coverage gaps and next work. Import same-shaped siblings in one set query over tool_name or "
+            "result_id IN (...), never one INSERT per result_id; use separate statements only for different entity "
+            "shapes. Do not answer or act from transient results. Bind only agent-authored "
+            "notes or classifications; derive source facts and URLs in SQL."
+        )
     return (
         "Fresh source evidence is not reconciled with the named model you read. If it belongs there, the next SQLite "
         "call must use INSERT ... SELECT or UPDATE ... FROM __tool_results/json_each. Every sourced field, including IDs, "

--- a/api/agent/core/tests/test_link_references.py
+++ b/api/agent/core/tests/test_link_references.py
@@ -308,7 +308,6 @@ class LinkReferenceTests(TestCase):
         cases = (
             ("create_image", {"prompt": f"Render {token}", "file_path": "/exports/a.png"}, "create_image.prompt"),
             ("create_video", {"prompt": token, "file_path": "/exports/a.mp4"}, "create_video.prompt"),
-            ("sqlite_batch", {"queries": [{"sql": f"SELECT '{token}'"}]}, "sqlite_batch.queries[0].sql"),
             ("apply_patch", {"patch": f"+ {token}"}, "apply_patch.patch"),
             ("send_email", {"subject": token, "mobile_first_html": "Body"}, "send_email.subject"),
             ("send_webhook_event", {"payload": {"item": {"url": token}}}, "send_webhook_event.payload.item.url"),
@@ -332,13 +331,36 @@ class LinkReferenceTests(TestCase):
                     self.assertTrue(result["retryable"])
                     self.assertIn(path, result["message"])
                     self.assertIn("Query not executed", result["message"])
-                    if tool_name == "sqlite_batch":
-                        self.assertIn("Derive raw values/URLs inside INSERT ... SELECT", result["message"])
-                        self.assertIn("replace tokens with literals", result["message"])
 
         enabled.assert_not_called()
         apply_patch_mock.assert_not_called()
         email_mock.assert_not_called()
+
+    def test_sqlite_allows_a_valid_link_handle_as_opaque_fallback_data(self):
+        token = rewrite_prompt_urls(
+            "https://profiles.example.test/avery?view=full",
+            self.agent,
+            create=True,
+        )
+        params = {
+            "sql": f"INSERT INTO prospects(profile_ref) VALUES ('{token}')",
+            "will_continue_work": True,
+        }
+
+        with patch(
+            "api.agent.core.event_processing.execute_enabled_tool",
+            return_value={"status": "ok"},
+        ) as enabled:
+            result, _ = _execute_tool_call_runtime(
+                self.agent,
+                tool_name="sqlite_batch",
+                exec_params=params,
+                budget_ctx=None,
+                eval_run_id=None,
+            )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(enabled.call_args.args[2], params)
 
     def test_runtime_allows_embedded_references_only_in_supported_content_fields(self):
         token = rewrite_prompt_urls(
@@ -367,6 +389,22 @@ class LinkReferenceTests(TestCase):
                 tool_name="create_file",
             )
         self.assertIn("create_file.content", str(raised.exception))
+
+    def test_sqlite_named_binding_resolves_a_known_link_handle_as_data(self):
+        url = "https://profiles.example.test/avery"
+        token = rewrite_prompt_urls(url, self.agent, create=True)
+
+        resolved = resolve_link_reference_params(
+            {
+                "sql": "INSERT INTO prospects(profile_url) VALUES (:profile_url)",
+                "bindings": {"profile_url": token},
+                "will_continue_work": True,
+            },
+            self.agent,
+            tool_name="sqlite_batch",
+        )
+
+        self.assertEqual(resolved["bindings"]["profile_url"], url)
 
     def test_rejects_references_concatenated_into_urls(self):
         token = rewrite_prompt_urls(
@@ -900,10 +938,10 @@ class LinkReferenceTests(TestCase):
         self.assertIn("adjacent token is only a display/fetch handle", system_prompt)
         self.assertIn("Keep pairs attached", system_prompt)
         self.assertIn("Final Markdown is exactly `[item]($[link:LEXACT])`", system_prompt)
-        self.assertIn("replace it with a raw URL", system_prompt)
         self.assertIn("Never encode, edit, reassign, combine, or guess it", system_prompt)
         self.assertIn("Items without a token stay plain", system_prompt)
-        self.assertIn("SQL/state/search", system_prompt)
+        self.assertIn("SQLite source rows derive raw URLs from __tool_results", system_prompt)
+        self.assertIn("exact handle through a named binding, never SQL text", system_prompt)
         self.assertIn("A report is unfinished while a token-backed entity name is plain", system_prompt)
         self.assertIn("body must contain the exact tokens", system_prompt)
         message.refresh_from_db()

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -1508,6 +1508,7 @@ def _execute_with_autocorrections(
     query: str,
     idx: int,
     base_corrections: list[str],
+    bindings: dict[str, object],
 ) -> tuple[Dict[str, Any] | None, str, list[str], str | None]:
     seen: set[str] = {query}
     queue_items: deque[tuple[str, list[str]]] = deque([(query, base_corrections)])
@@ -1522,7 +1523,7 @@ def _execute_with_autocorrections(
             consume_patch_text_error()
             start_query_timer(conn)
             changes_before = conn.total_changes
-            cur.execute(current_query)
+            cur.execute(current_query, bindings)
             if cur.description is not None:
                 columns = [col[0] for col in cur.description]
                 rows = [dict(zip(columns, row)) for row in cur.fetchall()]
@@ -1808,6 +1809,23 @@ def _normalize_queries(params: Dict[str, Any]) -> Optional[List[str]]:
     return queries if queries else None
 
 
+def _normalize_named_bindings(params: Dict[str, Any]) -> tuple[dict[str, object] | None, str | None]:
+    raw = params.get("bindings")
+    if raw is None:
+        return {}, None
+    if not isinstance(raw, dict):
+        return None, "Provide `bindings` as an object keyed by SQL parameter name."
+
+    bindings: dict[str, object] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not re.fullmatch(r"[A-Za-z_]\w*", key):
+            return None, "Every binding name must be a plain SQL parameter name such as `company_name`."
+        if value is not None and not isinstance(value, (str, int, float, bool)):
+            return None, f"Binding `{key}` must be a JSON scalar (string, number, boolean, or null)."
+        bindings[key] = value
+    return bindings, None
+
+
 def _run_sqlite_batch_in_subprocess(
     *,
     agent_id: str,
@@ -1903,6 +1921,9 @@ def _execute_sqlite_batch_inner(
             "status": "error",
             "message": "Provide `sql` as a SQL string (semicolon-separated for multiple statements).",
         }
+    bindings, bindings_error = _normalize_named_bindings(params)
+    if bindings_error:
+        return {"status": "error", "message": bindings_error}
 
     will_continue_work_raw = params.get("will_continue_work", None)
     if will_continue_work_raw is None:
@@ -1948,21 +1969,6 @@ def _execute_sqlite_batch_inner(
         preview = [q.strip()[:160] for q in queries[:5]]
         logger.info("Agent %s executing sqlite_batch: %s queries (preview=%s)", agent_id, len(queries), preview)
 
-        blocking_advisories = [advisory for advisory in advisories if advisory.blocking]
-        if blocking_advisories:
-            primary = [item for item in blocking_advisories if item.code == "source_facts_copied_into_model"]
-            return {
-                "status": "error",
-                "results": [],
-                "db_size_mb": round(_get_db_size_mb(db_path), 2),
-                "message": " ".join(advisory.message for advisory in (primary or blocking_advisories)),
-                "retryable": True,
-                "advisories": [
-                    {"code": advisory.code, "message": advisory.message}
-                    for advisory in blocking_advisories
-                ],
-            }
-
         for idx, query in enumerate(queries):
             if not isinstance(query, str) or not query.strip():
                 had_error = True
@@ -1990,6 +1996,7 @@ def _execute_sqlite_batch_inner(
                 query,
                 idx,
                 query_corrections,
+                bindings or {},
             )
             if failure_message:
                 had_error = True
@@ -2020,8 +2027,6 @@ def _execute_sqlite_batch_inner(
         if db_size_mb > 50:
             size_warning = " WARNING: DB SIZE EXCEEDS 50MB. YOU MUST EXECUTE MORE QUERIES TO SHRINK THE SIZE, OR THE WHOLE DB WILL BE WIPED!!!"
 
-        if advisories:
-            had_warning = True
         advice = (
             " [!] SQLITE QUERY ADVICE: " + " ".join(advisory.message for advisory in advisories)
             if advisories else ""
@@ -2094,8 +2099,13 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
                 "lists paths. Every sourced SET/VALUES and write WHERE/ON key must derive inside INSERT ... SELECT / "
                 "UPDATE ... FROM __tool_results/json_each; only paths/current result_id/tool_name may be literals, "
                 "never facts/URLs/keys. Reconcile entities/relations, evolve schema, then SELECT the model before deciding/reporting. Use "
-                "UNIQUE keys + provenance; normalize children; joins/sets/counts/ranking; CTAS is one-off. http_request "
-                "JSON: result_json $.content. INSERT SELECT needs WHERE before ON CONFLICT. No ATTACH. SQL uses "
+                "UNIQUE keys + provenance; normalize children; joins/sets/counts/ranking. For agent-authored notes or "
+                "classifications that cannot come from a source row, use named bindings like :note with the bindings object; "
+                "never hand-escape messy values into SQL. For fuzzy extraction from unstructured text, bind one JSON "
+                "array and expand it with json_each(:rows), retaining source result IDs/provenance. Same-shaped sibling "
+                "results use one set import over tool_name or result_id IN (...), never one INSERT per result_id; use "
+                "separate statements only for different entity shapes. CTAS is one-off. "
+                "http_request JSON: result_json $.content. INSERT SELECT needs WHERE before ON CONFLICT. No ATTACH. SQL uses "
                 "semicolons; apostrophe: 'O''Brien'. grep_context_all/split_sections arrays: json_each + ctx.value."
             ),
             "parameters": {
@@ -2104,6 +2114,17 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
                     "sql": {
                         "type": "string",
                         "description": "SQL string; use semicolons between statements.",
+                    },
+                    "bindings": {
+                        "type": "object",
+                        "description": (
+                            "Optional named SQL values. Use :name in SQL and {\"name\": value} here; keys omit the colon. "
+                            "Values must be strings, numbers, booleans, or null. Source facts should still derive directly "
+                            "from __tool_results."
+                        ),
+                        "additionalProperties": {
+                            "type": ["string", "number", "boolean", "null"],
+                        },
                     },
                     "will_continue_work": {
                         "type": "boolean",

--- a/api/agent/tools/sqlite_query_quality.py
+++ b/api/agent/tools/sqlite_query_quality.py
@@ -44,16 +44,16 @@ TOOL_PAYLOAD_RE = re.compile(r"\b(?:result_json|result_text|analysis_json)\b", r
 URL_RE = re.compile(r"https?://[^\s'\",)]+", re.I)
 BULK_MANUAL_VALUES_ROW_LIMIT = 4
 BULK_COPY_MESSAGE = (
-    "Query not executed: a literal-row import copied from tool results is unreliable. Do not copy rows from visible "
-    "output; derive them from all relevant __tool_results rows in one INSERT ... SELECT/json_each query."
+    "This literal-row import copied visible tool output. Next time derive rows from all relevant __tool_results in "
+    "one INSERT ... SELECT/json_each query."
 )
 BLOB_LOOP_MESSAGE = (
-    "Query not executed: full result blobs were fetched one at a time. Combine prior outputs in one shaped query "
+    "Full result blobs were fetched one at a time. Next time combine prior outputs in one shaped query "
     "using tool_name or result_id IN (...), plus CTEs/json_extract/json_each as needed."
 )
 ROW_LOOP_MESSAGE = (
-    "Query not executed: do not read __tool_results or a staging table derived from it one result_id at a time. "
-    "A one-item IN (...) is still one-at-a-time. Do not retry that shape: use one shaped INSERT ... SELECT/json_each or "
+    "This read handled __tool_results or a derived staging table one result_id at a time. A one-item IN (...) is still "
+    "one-at-a-time. Next time use one shaped INSERT ... SELECT/json_each or "
     "query covering every relevant sibling via tool_name or a multi-item result_id IN (...)."
 )
 MANUAL_COPY_MESSAGE = (
@@ -65,9 +65,8 @@ SINGLE_IMPORT_MESSAGE = (
     "with one shaped query over tool_name or result_id IN (...)."
 )
 SOURCE_LITERAL_COPY_MESSAGE = (
-    "Query not executed: a source-derived model write used visible facts or URLs as SQL literals. Derive every "
-    "sourced field in the INSERT/UPDATE SELECT/json_each over all relevant __tool_results; only payload paths and "
-    "current result_id/tool_name may be literals. Use stable keys, refresh provenance, omit unavailable URLs, then "
+    "This model write copied visible source facts or URLs as SQL literals. Next time derive sourced fields in the "
+    "INSERT/UPDATE SELECT/json_each over all relevant __tool_results, use stable keys, refresh provenance, and then "
     "query the model."
 )
 GROUNDED_LITERAL_IMPORT_MESSAGE = (
@@ -215,12 +214,12 @@ def build_tool_result_query_advisories(
     ungrounded_copied_tables = copied_model_tables - grounded_literal_tables
     unkeyed_models = set(summary.unkeyed_explicit_table_names).intersection(summary.row_derived_working_table_names)
     if unkeyed_models:
-        advisories.append(_advisory("reusable_model_missing_identity", f"Query not executed: reusable table(s) {', '.join(sorted(unkeyed_models))} derive repeating tool-result rows without stable identity. Add PRIMARY KEY/UNIQUE to CREATE TABLE; use TEMP CTAS only for a disposable extract.", blocking=True))
+        advisories.append(_advisory("reusable_model_missing_identity", f"Reusable table(s) {', '.join(sorted(unkeyed_models))} derive repeating tool-result rows without stable identity. Add PRIMARY KEY/UNIQUE to CREATE TABLE; use TEMP CTAS only for a disposable extract."))
     if summary.tool_result_ctas:
         advisories.append(_advisory("tool_result_ctas", "CTAS has no stable identity. Use it only for a disposable extract; reusable models need explicit CREATE TABLE with PRIMARY KEY/UNIQUE, then aggregate INSERT."))
     if available_tool_result_rows < 2:
         if ungrounded_copied_tables:
-            advisories.append(_advisory("source_facts_copied_into_model", SOURCE_LITERAL_COPY_MESSAGE, blocking=True))
+            advisories.append(_advisory("source_facts_copied_into_model", SOURCE_LITERAL_COPY_MESSAGE))
         if grounded_literal_tables:
             advisories.append(_advisory("grounded_literal_model_import", GROUNDED_LITERAL_IMPORT_MESSAGE))
         return advisories
@@ -233,25 +232,28 @@ def build_tool_result_query_advisories(
         and len(copied_provenance_urls) >= 2
         and not all_manual_values_grounded
     ):
-        advisories.append(_advisory("bulk_manual_working_table_from_visible_results", BULK_COPY_MESSAGE, blocking=True))
+        advisories.append(_advisory("bulk_manual_working_table_from_visible_results", BULK_COPY_MESSAGE))
     elif summary.manual_values_working_tables:
         advisories.append(_advisory("manual_working_table_from_visible_results", MANUAL_COPY_MESSAGE))
     if summary.direct_result_text_fetches >= 2 or summary.duplicate_direct_fetches:
-        advisories.append(_advisory("tool_result_blob_fetch_loop", BLOB_LOOP_MESSAGE, blocking=True))
+        advisories.append(_advisory("tool_result_blob_fetch_loop", BLOB_LOOP_MESSAGE))
     elif summary.direct_result_text_fetches:
         advisories.append(_advisory("single_tool_result_blob_fetch", "This fetched one full result_text blob while multiple tool results are available. For multi-source synthesis, query the needed rows together; use substr(result_text,1,N) only for previews."))
     relation_import_tables = source_derived_model_mutation_tables(sql_values)
     relation_import_ids = tuple(match.group("eq") or match.group("in") for sql in sql_values for match in RESULT_ID_SINGLE_LITERAL_RE.finditer(sql))
     relation_import_batch = (
         len(relation_import_tables) == len(relation_import_ids) == summary.single_result_id_filters > 1
-        and len(set(relation_import_ids)) == 1
+        and (
+            len(set(relation_import_ids)) == 1
+            or len(set(relation_import_tables)) == len(relation_import_tables)
+        )
     )
     if summary.single_result_id_filters >= 2 and summary.direct_result_text_fetches < 2 and not relation_import_batch:
-        advisories.append(_advisory("tool_result_row_loop", ROW_LOOP_MESSAGE, blocking=True))
+        advisories.append(_advisory("tool_result_row_loop", ROW_LOOP_MESSAGE))
     elif summary.single_tool_result_imports and not relation_import_batch:
         advisories.append(_advisory("single_tool_result_import", SINGLE_IMPORT_MESSAGE))
     if ungrounded_copied_tables:
-        advisories.append(_advisory("source_facts_copied_into_model", SOURCE_LITERAL_COPY_MESSAGE, blocking=True))
+        advisories.append(_advisory("source_facts_copied_into_model", SOURCE_LITERAL_COPY_MESSAGE))
     if grounded_literal_tables:
         advisories.append(_advisory("grounded_literal_model_import", GROUNDED_LITERAL_IMPORT_MESSAGE))
     return advisories + model_advisories
@@ -353,8 +355,8 @@ def _tool_result_cte_names(statement: str) -> tuple[str, ...]:
     return tuple(names)
 
 
-def _advisory(code: str, message: str, *, blocking: bool = False) -> SimpleNamespace:
-    return SimpleNamespace(code=code, message=message, blocking=blocking)
+def _advisory(code: str, message: str) -> SimpleNamespace:
+    return SimpleNamespace(code=code, message=message)
 
 
 def _sql_values_from_params(params: dict) -> list[str]:

--- a/api/evals/scenarios/__init__.py
+++ b/api/evals/scenarios/__init__.py
@@ -63,6 +63,7 @@ from .sqlite_tool_results import (
     SQLITE_TOOL_RESULT_SCENARIO_SLUGS,
     SQLITE_TOOL_RESULT_SUITE_SLUG,
     SqliteDedupeRequeryScenario,
+    SqliteIncrementalDomainModelScenario,
     SqliteIntermediateWorkingTableScenario,
     SqliteItemLinkReportScenario,
     SqliteMultiResultWebSynthesisScenario,

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -44,6 +44,7 @@ SQLITE_BOUNDED_PORTFOLIO_REPORT = "sqlite_tool_results_bounded_portfolio_report"
 SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY = "sqlite_domain_truth_over_stale_history"
 SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES = "sqlite_domain_model_refreshes_and_evolves"
 SQLITE_SOURCE_ARRAY_FIRST_WRITE = "sqlite_source_array_first_write"
+SQLITE_INCREMENTAL_DOMAIN_MODEL = "sqlite_incremental_domain_model"
 SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_MULTI_RESULT_WEB_SYNTHESIS,
     SQLITE_INTERMEDIATE_WORKING_TABLE,
@@ -54,6 +55,7 @@ SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY,
     SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES,
     SQLITE_SOURCE_ARRAY_FIRST_WRITE,
+    SQLITE_INCREMENTAL_DOMAIN_MODEL,
 ]
 
 
@@ -112,6 +114,33 @@ RELEASE_EVENTS = (
     ("rel-search-18", "Search index", "2026-07-23T17:00:43Z", "Mateo Ruiz", "blocked"),
     ("rel-billing-09", "Billing worker", "2026-07-24T13:05:29Z", "Hana Lee", "approved"),
     ("rel-mobile-27", "Mobile client", "2026-07-24T19:45:11Z", "Avery Cole", "canceled"),
+)
+
+INITIATIVE_FEED_URL = "https://ops.example.test/initiatives.json"
+OWNERSHIP_FEED_URL = "https://ops.example.test/ownership.json"
+RISK_FEED_URL = "https://ops.example.test/risks.json"
+OPERATING_FEED_URLS = (INITIATIVE_FEED_URL, OWNERSHIP_FEED_URL, RISK_FEED_URL)
+INITIATIVES = (
+    ("init-checkout", "Checkout Recovery", "active", "revenue"),
+    ("init-search", "Search Relevance", "active", "discovery"),
+    ("init-migration", "Lumen Migration", "active", "platform"),
+    ("init-mobile", "Mobile Refresh", "paused", "engagement"),
+    ("init-billing", "Billing Reliability", "active", "revenue"),
+    ("init-onboarding", "Onboarding Simplification", "active", "activation"),
+)
+OWNERSHIP_ASSIGNMENTS = (
+    ("own-checkout", "init-checkout", "Priya Shah", "primary"),
+    ("own-search", "init-search", "Mateo Ruiz", "primary"),
+    ("own-mobile", "init-mobile", "Avery Cole", "primary"),
+    ("own-billing", "init-billing", "Hana Lee", "primary"),
+    ("own-onboarding", "init-onboarding", "Rowan Kim", "advisor"),
+)
+INITIATIVE_RISKS = (
+    ("risk-checkout", "init-checkout", "critical", "payment data consistency"),
+    ("risk-search", "init-search", "medium", "index freshness"),
+    ("risk-migration", "init-migration", "high", "cutover dependency"),
+    ("risk-billing", "init-billing", "low", "retry backlog"),
+    ("risk-onboarding", "init-onboarding", "high", "incomplete analytics"),
 )
 
 
@@ -623,6 +652,67 @@ def _release_calendar_mock() -> dict:
     }
 
 
+def _operating_feeds_mock() -> dict:
+    payloads = {
+        INITIATIVE_FEED_URL: {
+            "source_url": INITIATIVE_FEED_URL,
+            "initiatives": [
+                {
+                    "initiative_id": initiative_id,
+                    "name": name,
+                    "status": status,
+                    "program": program,
+                    "source_url": INITIATIVE_FEED_URL,
+                }
+                for initiative_id, name, status, program in INITIATIVES
+            ],
+        },
+        OWNERSHIP_FEED_URL: {
+            "source_url": OWNERSHIP_FEED_URL,
+            "assignments": [
+                {
+                    "assignment_id": assignment_id,
+                    "initiative_id": initiative_id,
+                    "person": person,
+                    "role": role,
+                    "source_url": OWNERSHIP_FEED_URL,
+                }
+                for assignment_id, initiative_id, person, role in OWNERSHIP_ASSIGNMENTS
+            ],
+        },
+        RISK_FEED_URL: {
+            "source_url": RISK_FEED_URL,
+            "risks": [
+                {
+                    "risk_id": risk_id,
+                    "initiative_id": initiative_id,
+                    "risk_level": risk_level,
+                    "reason": reason,
+                    "source_url": RISK_FEED_URL,
+                }
+                for risk_id, initiative_id, risk_level, reason in INITIATIVE_RISKS
+            ],
+        },
+    }
+    return {
+        "http_request": {
+            "rules": [
+                {
+                    "url_contains": url,
+                    "result": {
+                        "status": "ok",
+                        "status_code": 200,
+                        "url": url,
+                        "content": payload,
+                    },
+                }
+                for url, payload in payloads.items()
+            ],
+            "default": {"status": "error", "message": "Unknown eval URL."},
+        }
+    }
+
+
 MOCK_BUILDERS = {
     "web": _web_mock,
     "aged_web": lambda: _web_mock(facts_last=True),
@@ -630,6 +720,7 @@ MOCK_BUILDERS = {
     "dedupe": _dedupe_mock,
     "inventory": _inventory_mock,
     "release_calendar": _release_calendar_mock,
+    "operating_feeds": _operating_feeds_mock,
 }
 
 
@@ -942,6 +1033,17 @@ def _source_array_first_write_failures(sqlite_calls, model_table: str | None) ->
     return failures
 
 
+def _uses_queryable_source_model(summary) -> bool:
+    source_models = set(summary.row_derived_working_table_names)
+    return bool(
+        source_models
+        and summary.single_tool_result_imports
+        and summary.creates_working_table
+        and summary.reads_working_table
+        and source_models.isdisjoint(summary.unkeyed_explicit_table_names)
+    )
+
+
 class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
     tier = "core"
     category = "sqlite_tool_results"
@@ -955,6 +1057,7 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
     max_single_result_filters = 1
     max_sqlite_usage_calls: int | None = None
     max_sqlite_attempts: int | None = None
+    accept_queryable_source_model = False
     reject_result_id_case_rows = False
     sourced_answer_task_name = "verify_sourced_answer"
     result_access_source_urls: tuple[str, ...] = ()
@@ -1005,6 +1108,7 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
         calls = _tool_calls_for_run(run_id, after=after, tool_names={"sqlite_batch"})
         successful_calls, strategy_calls = _sqlite_calls_with_persisted_effects(calls)
         summary = summarize_sqlite_tool_result_calls(strategy_calls)
+        modeled_usage = self.accept_queryable_source_model and _uses_queryable_source_model(summary)
         result_id_case_calls = [
             call for call in successful_calls
             if any(
@@ -1020,8 +1124,8 @@ class SqliteToolResultScenario(EvalScenario, ScenarioExecutionTools):
             (not successful_calls, "no successful sqlite_batch call observed"),
             (self.max_sqlite_attempts is not None and len(calls) > self.max_sqlite_attempts, f"sqlite_batch attempts {len(calls)} > {self.max_sqlite_attempts}"),
             (self.max_sqlite_usage_calls is not None and len(successful_calls) > self.max_sqlite_usage_calls, f"sqlite_batch calls {len(successful_calls)} > {self.max_sqlite_usage_calls}"),
-            (summary.aggregate_tool_result_queries < 1, "no aggregate __tool_results query observed"),
-            (summary.smart_tool_result_queries < 1, "no smart __tool_results query observed"),
+            (summary.aggregate_tool_result_queries < 1 and not modeled_usage, "no aggregate __tool_results query observed"),
+            (summary.smart_tool_result_queries < 1 and not modeled_usage, "no smart __tool_results query observed"),
             (summary.direct_result_text_fetches > max_direct_fetches, f"direct result_text fetches {summary.direct_result_text_fetches} > {max_direct_fetches}"),
             (bool(summary.duplicate_direct_fetches), f"duplicate direct result_text fetches={summary.duplicate_direct_fetches}"),
             (bool(summary.manual_values_working_tables), f"manual VALUES working tables={summary.manual_values_working_tables}"),
@@ -1487,6 +1591,164 @@ class SqliteSourceArrayFirstWriteScenario(SqliteDomainModelScenario):
 
 
 @register_scenario
+class SqliteIncrementalDomainModelScenario(SqliteDomainModelScenario):
+    slug = SQLITE_INCREMENTAL_DOMAIN_MODEL
+    description = "Multi-source operating work should build a keyed relational model before research ends."
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_incremental_domain_model", assertion_type="tool_call"),
+        ScenarioTask(name="verify_operating_answer", assertion_type="manual"),
+    ]
+    prompt = (
+        "We're coordinating this work across people and feeds. Build the current ownership and risk picture from "
+        "these sources. Tell me every active initiative without a primary owner, then rank the owned active "
+        "initiatives by risk. Include the source links; I'll have follow-ups.\n\n"
+        + "\n".join(f"- {url}" for url in OPERATING_FEED_URLS)
+    )
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._ready_agent(agent_id)
+        PersistentAgent.objects.filter(id=agent_id).update(
+            charter="Keep current cross-team operating ownership and risk evidence coherent."
+        )
+        self._enable_tools(agent_id, ("http_request",))
+        inbound = self._inject_and_wait(
+            run_id,
+            agent_id,
+            self.prompt,
+            _operating_feeds_mock(),
+            allowed_tool_names={"http_request", "sqlite_batch", "send_chat_message"},
+            max_relevant_tool_calls=12,
+        )
+        self._record_incremental_model(run_id, after=inbound.timestamp)
+        self._record_sourced_answer(
+            run_id,
+            agent_id=agent_id,
+            after=inbound.timestamp,
+            task_name="verify_operating_answer",
+            source_urls=OPERATING_FEED_URLS,
+            required_terms=(
+                "Lumen Migration",
+                "Onboarding Simplification",
+                "Checkout Recovery",
+                "critical",
+                "Priya Shah",
+            ),
+            min_sources=3,
+        )
+
+    def _record_incremental_model(self, run_id: str, *, after) -> None:
+        task_name = "verify_incremental_domain_model"
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name=task_name)
+        calls = _tool_calls_for_run(run_id, after=after)
+        source_calls = [call for call in calls if call.tool_name == "http_request"]
+        sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch"]
+        successful_sqlite = [
+            call for call in sqlite_calls
+            if str(getattr(call, "status", "")).casefold() == "complete"
+            and str((_result_payload(call) or {}).get("status") or "").casefold() == "ok"
+        ]
+        source_positions = [
+            index
+            for index, call in enumerate(calls)
+            if call.tool_name == "http_request"
+            and str(getattr(call, "status", "")).casefold() == "complete"
+        ]
+        last_source_position = max(source_positions) if source_positions else -1
+        after_last_source = [
+            call for index, call in enumerate(calls)
+            if call in successful_sqlite and index > last_source_position
+        ]
+
+        def sql_values(selected_calls) -> list[str]:
+            return [str((call.tool_params or {}).get("sql") or "") for call in selected_calls]
+
+        all_sql_values = sql_values(successful_sqlite)
+        combined_sql = "\n".join(all_sql_values)
+        after_targets = set(source_derived_model_mutation_tables(sql_values(after_last_source)))
+        all_targets = set(source_derived_model_mutation_tables(all_sql_values))
+        summary = summarize_sqlite_tool_result_calls(successful_sqlite)
+        candidates = tuple(dict.fromkeys((*summary.working_table_names, *all_targets)))
+        _modeled, _row_modeled, identity_tables = _domain_model_lineage(
+            combined_sql,
+            direct_tables=all_targets,
+            row_direct_tables=summary.row_derived_working_table_names,
+            candidate_tables=candidates,
+        )
+        statements = [
+            _structural_sql(statement)
+            for statement in sqlparse.split(combined_sql)
+            if statement.strip()
+        ]
+        literal_model_writes = []
+        for statement in statements:
+            mutation = _MUTATION_TARGET_RE.search(statement)
+            if (
+                mutation
+                and mutation.group("table").casefold() in all_targets
+                and mutation.group("table").casefold()
+                not in source_derived_model_mutation_tables((statement,))
+            ):
+                literal_model_writes.append(statement)
+        decision_reads = [
+            statement
+            for statement in statements
+            if re.search(r"\bselect\b", statement, re.I)
+            and any(_reads_table(statement, table) for table in all_targets)
+        ]
+        fetch_counts = _source_fetch_counts(
+            source_calls,
+            tool_names={"http_request"},
+            source_urls=OPERATING_FEED_URLS,
+        )
+        failures = _tool_attempt_failures(source_calls, "Source fetch")
+        failures.extend(_sqlite_attempt_failures(sqlite_calls))
+        failures.extend(message for failed, message in (
+            (
+                any(count != 1 for count in fetch_counts.values()),
+                f"expected each operating feed once, found {fetch_counts}",
+            ),
+            (
+                not after_targets,
+                "the completed source batch was not reconciled before answering",
+            ),
+            (
+                len(all_targets) < 2,
+                f"expected related entity models, found {sorted(all_targets)}",
+            ),
+            (
+                not all_targets.issubset(identity_tables),
+                f"modeled tables lacked stable identity: {sorted(all_targets - identity_tables)}",
+            ),
+            (bool(literal_model_writes), "source facts were copied into model writes as SQL literals"),
+            (
+                not re.search(r"\binitiative_id\b", combined_sql, re.I),
+                "model did not preserve the cross-feed initiative relationship",
+            ),
+            (
+                not re.search(r"\b(?:source_url|source_id|provenance)\b", combined_sql, re.I),
+                "modeled entities lacked source provenance",
+            ),
+            (
+                not any(re.search(r"\b(?:left\s+join|not\s+exists|having)\b", statement, re.I)
+                        for statement in decision_reads),
+                "model was not queried for missing ownership with set logic",
+            ),
+            (
+                not any("risk" in statement.casefold() and re.search(r"\border\s+by\b", statement, re.I)
+                        for statement in decision_reads),
+                "modeled risk was not ranked in SQL",
+            ),
+        ) if failed)
+        self._record_check(
+            run_id,
+            task_name,
+            failures,
+            f"Incrementally modeled and queried related operating tables: {sorted(all_targets)}.",
+        )
+
+
+@register_scenario
 class SqliteDedupeRequeryScenario(SqliteToolResultScenario):
     slug = SQLITE_DEDUPE_REQUERY
     description = "Duplicate source synthesis should use aggregate SQLite/CTE queries, not repeated blob re-fetches."
@@ -1514,6 +1776,8 @@ class SqliteItemLinkReportScenario(SqliteToolResultScenario):
     required_terms = ("Model Y", "Harrisburg", "$27,455")
     min_sources = 2
     max_single_result_filters = 2
+    require_working_table = True
+    accept_queryable_source_model = True
     sourced_answer_task_name = "verify_listing_links_in_report"
 
 

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "15f325954f5ba1e06ecca65f570b1dd782ac1a21",
+  "baseline_sha": "eef05027d4830c0738f76d7873793e3c07fac9fb",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7470,
-        "system_bytes": 23869,
-        "tools_bytes": 20968,
-        "total_bytes": 56091,
+        "fitted_tokens": 7563,
+        "system_bytes": 24386,
+        "tools_bytes": 21784,
+        "total_bytes": 57424,
         "user_bytes": 11254
       },
       "planning_first_run": {
-        "fitted_tokens": 8624,
-        "system_bytes": 30724,
-        "tools_bytes": 11962,
-        "total_bytes": 53113,
+        "fitted_tokens": 8707,
+        "system_bytes": 31241,
+        "tools_bytes": 12778,
+        "total_bytes": 54446,
         "user_bytes": 10427
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 7605,
-        "system_bytes": 24369,
-        "tools_bytes": 20968,
-        "total_bytes": 56594,
+        "fitted_tokens": 7721,
+        "system_bytes": 24886,
+        "tools_bytes": 21784,
+        "total_bytes": 57927,
         "user_bytes": 11257
       }
     },
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 250171
+    "limit": 250242
   }
 }

--- a/tests/unit/test_prompt_context_message_placement.py
+++ b/tests/unit/test_prompt_context_message_placement.py
@@ -120,10 +120,10 @@ class PromptContextSqlitePlacementTests(TestCase):
             status="complete",
         )
 
-        self.assertIn(
-            "query the model in that batch",
-            prompt_context._get_unreconciled_source_model_warning(self.agent),
-        )
+        warning = prompt_context._get_unreconciled_source_model_warning(self.agent)
+        self.assertIn("Fresh source evidence is reconciled", warning)
+        self.assertIn("still-unread updated table(s): accounts", warning)
+        self.assertNotIn("not reconciled", warning)
         post_update_read = PersistentAgentStep.objects.create(agent=self.agent, description="fresh model read")
         PersistentAgentToolCall.objects.create(
             step=post_update_read,

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -28,6 +28,8 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
         self.assertIn("Otherwise read the model first", guidance)
         self.assertIn("Current complete rows are truth; don't refetch them", guidance)
         self.assertIn("Tool output doesn't update it", guidance)
+        self.assertIn("reconcile each useful source batch", guidance)
+        self.assertIn("checklist, intermediate state, and resume point", guidance)
         self.assertIn("sharing a stable ID or its children", guidance)
         self.assertIn("reconcile entities/relations", guidance)
         self.assertIn("before acting/reporting", guidance)
@@ -39,6 +41,7 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
         self.assertIn("query gaps before reporting", guidance)
         self.assertIn("Only sourced blockers are unresolved", guidance)
         self.assertIn("use SQLite for exact set logic/counts/ranking", guidance)
+        self.assertIn("Bind messy agent-authored values with :name + bindings", guidance)
         self.assertIn("No sibling-by-sibling result/table/blob loops", guidance)
         self.assertIn("Inspect unknown structure once", guidance)
         self.assertNotIn("Copy names/paths/values/URLs", guidance)
@@ -279,6 +282,88 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
         )
         self.assertTrue(
             prompt_context._build_unreconciled_source_model_warning([source, model_read, unrelated_write])
+        )
+
+    def test_multi_source_work_gets_an_incremental_model_checkpoint(self):
+        first_source = ("mcp_brightdata_search_engine", {"query": "company roster"}, "complete")
+        second_source = ("mcp_brightdata_search_engine", {"query": "founder roster"}, "complete")
+
+        self.assertEqual(
+            prompt_context._build_unreconciled_source_model_warning([first_source]),
+            "",
+        )
+        warning = prompt_context._build_unreconciled_source_model_warning([
+            first_source,
+            second_source,
+        ])
+
+        self.assertIn("form a working set and remain transient", warning)
+        self.assertIn("next action must be sqlite_batch", warning)
+        self.assertIn("durable named entity/relationship tables", warning)
+        self.assertIn("PRIMARY KEY/UNIQUE and provenance (not TEMP/CTAS)", warning)
+        self.assertIn("reconcile this source batch", warning)
+        self.assertIn("query coverage gaps", warning)
+        self.assertIn("Import same-shaped siblings in one set query", warning)
+        self.assertIn("separate statements only for different entity shapes", warning)
+        self.assertIn("Do not answer or act from transient results", warning)
+
+        inspection = (
+            "sqlite_batch",
+            {"sql": "SELECT result_id, substr(result_text,1,500) FROM __tool_results ORDER BY created_at"},
+            "complete",
+        )
+        post_inspection = prompt_context._build_unreconciled_source_model_warning([
+            first_source,
+            second_source,
+            inspection,
+        ])
+        self.assertIn("already inspected this source batch", post_inspection)
+        self.assertIn("Do not query raw __tool_results again", post_inspection)
+        self.assertIn("bind one JSON array", post_inspection)
+        self.assertIn("json_each(:rows)", post_inspection)
+        self.assertIn("Import same-shaped siblings with one set query", post_inspection)
+
+        modeled_without_read = (
+            "sqlite_batch",
+            {
+                "sql": (
+                    "CREATE TABLE companies(company_id TEXT PRIMARY KEY, name TEXT);"
+                    "INSERT INTO companies(company_id,name) "
+                    "SELECT json_extract(value,'$.company_id'),json_extract(value,'$.name') "
+                    "FROM __tool_results,json_each(result_json,'$.companies')"
+                )
+            },
+            "complete",
+        )
+        read_checkpoint = prompt_context._build_unreconciled_source_model_warning([
+            first_source,
+            second_source,
+            modeled_without_read,
+        ])
+        self.assertIn("Fresh source evidence is reconciled", read_checkpoint)
+        self.assertIn("still-unread updated table(s): companies", read_checkpoint)
+        self.assertIn("instead of rereading transient results or repeating the write", read_checkpoint)
+
+        modeled = (
+            "sqlite_batch",
+            {
+                "sql": (
+                    "CREATE TABLE companies(company_id TEXT PRIMARY KEY, name TEXT);"
+                    "INSERT INTO companies(company_id,name) "
+                    "SELECT json_extract(value,'$.company_id'),json_extract(value,'$.name') "
+                    "FROM __tool_results,json_each(result_json,'$.companies');"
+                    "SELECT * FROM companies"
+                )
+            },
+            "complete",
+        )
+        self.assertEqual(
+            prompt_context._build_unreconciled_source_model_warning([
+                first_source,
+                second_source,
+                modeled,
+            ]),
+            "",
         )
 
 

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -99,6 +99,48 @@ class SqliteBatchToolTests(TestCase):
             self.assertIsInstance(out.get("db_size_mb"), (int, float))
             self.assertIn("Executed 3 queries", out.get("message", ""))
 
+    def test_named_bindings_preserve_messy_values_across_a_batch(self):
+        bindings = {
+            "company_id": "ocv-1",
+            "company_name": "O'Brien & Sons",
+            "notes": "Line one\nLine two with :punctuation, quotes, and {json}.",
+        }
+        with self._with_temp_db():
+            out = execute_sqlite_batch(
+                self.agent,
+                {
+                    "sql": (
+                        "CREATE TABLE companies(company_id TEXT PRIMARY KEY, name TEXT, notes TEXT);"
+                        "INSERT INTO companies(company_id,name,notes) "
+                        "VALUES (:company_id,:company_name,:notes);"
+                        "SELECT company_id,name,notes FROM companies WHERE company_id=:company_id;"
+                    ),
+                    "bindings": bindings,
+                    "will_continue_work": True,
+                },
+            )
+
+        self.assertEqual(out.get("status"), "ok", out.get("message"))
+        self.assertEqual(out["results"][-1]["result"], [{
+            "company_id": bindings["company_id"],
+            "name": bindings["company_name"],
+            "notes": bindings["notes"],
+        }])
+
+    def test_named_bindings_reject_nested_values(self):
+        with self._with_temp_db():
+            out = execute_sqlite_batch(
+                self.agent,
+                {
+                    "sql": "SELECT :value",
+                    "bindings": {"value": {"nested": "not a SQLite scalar"}},
+                    "will_continue_work": True,
+                },
+            )
+
+        self.assertEqual(out.get("status"), "error")
+        self.assertIn("JSON scalar", out.get("message", ""))
+
     def test_cte_insert_reports_actual_changed_rows(self):
         with self._with_temp_db():
             out = execute_sqlite_batch(self.agent, {"sql": (
@@ -373,7 +415,10 @@ class SqliteBatchToolTests(TestCase):
             "SQLite world model + exact logic", "Fetch alone; next completion reconcile and SELECT",
             "SOURCE ARRAYS lists paths", "Every sourced SET/VALUES and write WHERE/ON key",
             "SELECT the model before deciding/reporting", "INSERT ... SELECT / UPDATE ... FROM __tool_results/json_each",
-            "WHERE before ON CONFLICT", "never facts/URLs/keys",
+            "WHERE before ON CONFLICT", "never facts/URLs/keys", "named bindings",
+            "fuzzy extraction from unstructured text", "json_each(:rows)",
+            "Same-shaped sibling results use one set import",
+            "separate statements only for different entity shapes",
         ):
             self.assertIn(expected, description)
         self.assertNotIn("before one terminal send", description)
@@ -399,7 +444,7 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "warning")
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(out.get("advisories", [{}])[0].get("code"), "tool_result_ctas")
             self.assertIn("PRIMARY KEY/UNIQUE", out.get("message", ""))
 
@@ -442,13 +487,14 @@ class SqliteBatchToolTests(TestCase):
                     "will_continue_work": True,
                 },
             )
-            self.assertEqual(unkeyed.get("status"), "error")
+            self.assertEqual(unkeyed.get("status"), "ok")
             self.assertEqual(unkeyed.get("advisories", [{}])[0].get("code"), "reusable_model_missing_identity")
 
             keyed = execute_sqlite_batch(
                 self.agent,
                 {
                     "sql": (
+                        "DROP TABLE vendors;"
                         "CREATE TABLE vendors(vendor TEXT PRIMARY KEY);"
                         "INSERT OR IGNORE INTO vendors SELECT json_extract(p.value, '$.vendor') "
                         "FROM __tool_results JOIN json_each(result_json, '$.plans') p;"
@@ -467,7 +513,6 @@ class SqliteBatchToolTests(TestCase):
                 ],
                 available_tool_result_rows=1,
             )
-            self.assertTrue(one_result_unkeyed[0].blocking)
             self.assertEqual(one_result_unkeyed[0].code, "reusable_model_missing_identity")
 
             one_result_ctas = build_tool_result_query_advisories(
@@ -500,7 +545,7 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "warning")
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(out.get("advisories", [{}])[0].get("code"), "single_tool_result_blob_fetch")
             self.assertIn("query the needed rows together", out.get("message", ""))
 
@@ -542,7 +587,7 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "warning")
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(
                 out.get("advisories", [{}])[0].get("code"),
                 "manual_working_table_from_visible_results",
@@ -555,7 +600,7 @@ class SqliteBatchToolTests(TestCase):
                 conn.close()
             self.assertEqual(row, (40, 900))
 
-    def test_bulk_manual_tool_result_copy_is_rejected_before_execution(self):
+    def test_bulk_manual_tool_result_copy_executes_with_advice(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
             conn = sqlite3.connect(db_path)
             try:
@@ -583,14 +628,12 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "error")
-            self.assertTrue(out.get("retryable"))
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(
                 out.get("advisories", [{}])[0].get("code"),
                 "bulk_manual_working_table_from_visible_results",
             )
-            self.assertIn("used visible facts or URLs", out.get("message", ""))
-            self.assertNotIn("literal-row import", out.get("message", ""))
+            self.assertIn("literal-row import copied visible tool output", out.get("message", ""))
             conn = sqlite3.connect(db_path)
             try:
                 table = conn.execute(
@@ -598,7 +641,9 @@ class SqliteBatchToolTests(TestCase):
                 ).fetchone()
             finally:
                 conn.close()
-            self.assertIsNone(table)
+            self.assertEqual(table, ("copied_rows",))
+            with sqlite3.connect(db_path) as conn:
+                self.assertEqual(conn.execute("SELECT COUNT(*) FROM copied_rows").fetchone(), (4,))
 
     def test_fully_grounded_bulk_insert_executes_instead_of_rejecting_useful_work(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
@@ -633,11 +678,11 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "warning")
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(out.get("advisories", [{}])[0].get("code"), "grounded_literal_model_import")
             self.assertEqual(out.get("results", [])[-1].get("result"), [{"count": 4}])
 
-    def test_literal_insert_cannot_recombine_values_from_different_source_rows(self):
+    def test_literal_insert_recombination_executes_with_advice(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
             payload = json.dumps({
                 "contacts": [
@@ -662,11 +707,12 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "error")
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(out.get("advisories", [{}])[0].get("code"), "source_facts_copied_into_model")
             with sqlite3.connect(db_path) as conn:
-                self.assertIsNone(
-                    conn.execute("SELECT name FROM sqlite_master WHERE name='contacts'").fetchone()
+                self.assertEqual(
+                    conn.execute("SELECT name, role FROM contacts").fetchone(),
+                    ("Alice Example", "Chief Financial Officer"),
                 )
 
     def test_grounded_literal_import_still_requires_stable_model_identity(self):
@@ -689,10 +735,11 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "error")
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(out.get("advisories", [{}])[0].get("code"), "source_facts_copied_into_model")
 
             with sqlite3.connect(db_path) as conn:
+                conn.execute("DROP TABLE contacts")
                 conn.execute("CREATE TABLE contacts(name TEXT, role TEXT)")
             out = execute_sqlite_batch(
                 self.agent,
@@ -701,9 +748,9 @@ class SqliteBatchToolTests(TestCase):
                     "will_continue_work": True,
                 },
             )
-            self.assertEqual(out.get("status"), "error")
+            self.assertEqual(out.get("status"), "ok")
             with sqlite3.connect(db_path) as conn:
-                self.assertEqual(conn.execute("SELECT COUNT(*) FROM contacts").fetchone(), (0,))
+                self.assertEqual(conn.execute("SELECT COUNT(*) FROM contacts").fetchone(), (1,))
 
     def test_grounded_literal_insert_executes_and_source_derived_batch_reconciles(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
@@ -737,7 +784,7 @@ class SqliteBatchToolTests(TestCase):
                 ),
                 "will_continue_work": True,
             })
-            self.assertEqual(copied.get("status"), "warning")
+            self.assertEqual(copied.get("status"), "ok")
             self.assertEqual(copied.get("advisories", [{}])[0].get("code"), "grounded_literal_model_import")
             with sqlite3.connect(db_path) as conn:
                 self.assertEqual(
@@ -776,59 +823,38 @@ class SqliteBatchToolTests(TestCase):
                 [{"account_name": "Aster Labs", "workstream_name": "Redlines", "status": "open"}],
             )
 
-    def test_bulk_manual_tool_result_select_copy_is_rejected_before_execution(self):
-        with self._with_temp_db() as (db_path, _token, _tmp):
-            conn = sqlite3.connect(db_path)
-            try:
-                conn.execute("CREATE TABLE __tool_results (result_id TEXT PRIMARY KEY, result_text TEXT)")
-                conn.executemany(
-                    "INSERT INTO __tool_results (result_id, result_text) VALUES (?, ?)",
-                    [
-                        ("r1", "source https://source.example.test/a"),
-                        ("r2", "source https://source.example.test/b"),
-                    ],
+    def test_bulk_manual_tool_result_select_shapes_receive_advice(self):
+        rows = [
+            f"SELECT {index}, 'https://source.example.test/{'a' if index % 2 else 'b'}'"
+            for index in range(12)
+        ]
+        union_rows = " UNION ALL ".join(rows)
+        json_a = json.dumps([{"id": index} for index in range(2)])
+        json_b = json.dumps([{"id": index} for index in range(2, 4)])
+        queries = (
+            f"CREATE TABLE copied_rows(id INTEGER, label TEXT); INSERT INTO copied_rows {union_rows};",
+            "CREATE TABLE copied_rows(id INTEGER, label TEXT);"
+            + ";".join(f"INSERT INTO copied_rows {row}" for row in rows),
+            f"CREATE TABLE copied_rows AS {union_rows};",
+            "CREATE TABLE copied_rows(id INTEGER, label TEXT);"
+            f"INSERT INTO copied_rows SELECT json_extract(value, '$.id'), 'https://source.example.test/a' FROM json_each('{json_a}');"
+            f"INSERT INTO copied_rows SELECT json_extract(value, '$.id'), 'https://source.example.test/b' FROM json_each('{json_b}');",
+        )
+        payloads = (
+            "source https://source.example.test/a",
+            "source https://source.example.test/b",
+        )
+        for sql in queries:
+            with self.subTest(sql=sql[:80]):
+                advisories = build_tool_result_query_advisories(
+                    [sql],
+                    available_tool_result_rows=2,
+                    tool_result_payloads=payloads,
                 )
-                conn.commit()
-            finally:
-                conn.close()
-
-            rows = [
-                f"SELECT {index}, 'https://source.example.test/{'a' if index % 2 else 'b'}'"
-                for index in range(12)
-            ]
-            union_rows = " UNION ALL ".join(rows)
-            json_a = json.dumps([{"id": index} for index in range(2)])
-            json_b = json.dumps([{"id": index} for index in range(2, 4)])
-            queries = (
-                f"CREATE TABLE copied_rows(id INTEGER, label TEXT); INSERT INTO copied_rows {union_rows};",
-                "CREATE TABLE copied_rows(id INTEGER, label TEXT);"
-                + ";".join(f"INSERT INTO copied_rows {row}" for row in rows),
-                f"CREATE TABLE copied_rows AS {union_rows};",
-                "CREATE TABLE copied_rows(id INTEGER, label TEXT);"
-                f"INSERT INTO copied_rows SELECT json_extract(value, '$.id'), 'https://source.example.test/a' FROM json_each('{json_a}');"
-                f"INSERT INTO copied_rows SELECT json_extract(value, '$.id'), 'https://source.example.test/b' FROM json_each('{json_b}');",
-            )
-            for sql in queries:
-                with self.subTest(sql=sql[:80]):
-                    out = execute_sqlite_batch(
-                        self.agent,
-                        {"sql": sql, "will_continue_work": True},
-                    )
-                    self.assertEqual(out.get("status"), "error")
-                    self.assertTrue(out.get("retryable"))
-                    self.assertEqual(
-                        out.get("advisories", [{}])[0].get("code"),
-                        "bulk_manual_working_table_from_visible_results",
-                    )
-
-            conn = sqlite3.connect(db_path)
-            try:
-                table = conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name='copied_rows'"
-                ).fetchone()
-            finally:
-                conn.close()
-            self.assertIsNone(table)
+                self.assertIn(
+                    "bulk_manual_working_table_from_visible_results",
+                    {advisory.code for advisory in advisories},
+                )
 
     def test_bulk_manual_constants_are_not_blocked_by_unrelated_tool_results(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
@@ -862,7 +888,7 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "warning")
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(out["results"][-1]["result"], [{"count": 12}])
             self.assertNotEqual(
                 out.get("advisories", [{}])[0].get("code"),
@@ -961,7 +987,7 @@ class SqliteBatchToolTests(TestCase):
                     {advisory.code for advisory in advisories},
                 )
 
-    def test_per_result_import_loop_is_rejected_before_execution(self):
+    def test_per_result_import_loop_executes_with_advice(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
             conn = sqlite3.connect(db_path)
             try:
@@ -990,8 +1016,7 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "error")
-            self.assertTrue(out.get("retryable"))
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(out.get("advisories", [{}])[0].get("code"), "tool_result_row_loop")
             conn = sqlite3.connect(db_path)
             try:
@@ -1000,9 +1025,11 @@ class SqliteBatchToolTests(TestCase):
                 ).fetchone()
             finally:
                 conn.close()
-            self.assertIsNone(table)
+            self.assertEqual(table, ("items",))
+            with sqlite3.connect(db_path) as conn:
+                self.assertEqual(conn.execute("SELECT COUNT(*) FROM items").fetchone(), (2,))
 
-    def test_derived_result_loop_is_rejected_before_execution(self):
+    def test_derived_result_loop_executes_with_advice(self):
         with self._with_temp_db() as (db_path, _token, _tmp):
             conn = sqlite3.connect(db_path)
             try:
@@ -1033,8 +1060,7 @@ class SqliteBatchToolTests(TestCase):
                 },
             )
 
-            self.assertEqual(out.get("status"), "error")
-            self.assertTrue(out.get("retryable"))
+            self.assertEqual(out.get("status"), "ok")
             self.assertEqual(out.get("advisories", [{}])[0].get("code"), "tool_result_row_loop")
             conn = sqlite3.connect(db_path)
             try:
@@ -1043,7 +1069,9 @@ class SqliteBatchToolTests(TestCase):
                 ).fetchone()
             finally:
                 conn.close()
-            self.assertIsNone(table)
+            self.assertEqual(table, ("product_pages",))
+            with sqlite3.connect(db_path) as conn:
+                self.assertEqual(conn.execute("SELECT COUNT(*) FROM product_pages").fetchone(), (4,))
 
     def test_derived_result_loop_boundaries(self):
         derived = (
@@ -1063,7 +1091,7 @@ class SqliteBatchToolTests(TestCase):
             + "SELECT * FROM product_pages WHERE entity_id='one';"
             + "SELECT * FROM product_pages WHERE entity_id='two';",
         )
-        blocked_sql = (
+        advised_sql = (
             derived
             + "SELECT result_text FROM product_pages WHERE result_id='r1';"
             + "SELECT result_text FROM product_pages WHERE result_id='r2';",
@@ -1078,20 +1106,20 @@ class SqliteBatchToolTests(TestCase):
                 self.assertLess(summary.single_derived_result_filters, 2)
                 self.assertFalse(
                     any(
-                        advisory.blocking and advisory.code == "tool_result_row_loop"
+                        advisory.code == "tool_result_row_loop"
                         for advisory in build_tool_result_query_advisories(
                             [sql],
                             available_tool_result_rows=4,
                         )
                     )
                 )
-        for sql in blocked_sql:
-            with self.subTest(kind="blocked", sql=sql):
+        for sql in advised_sql:
+            with self.subTest(kind="advised", sql=sql):
                 summary = summarize_sqlite_tool_result_sql([sql])
                 self.assertEqual(summary.single_derived_result_filters, 2)
                 self.assertTrue(
                     any(
-                        advisory.blocking and advisory.code == "tool_result_row_loop"
+                        advisory.code == "tool_result_row_loop"
                         for advisory in build_tool_result_query_advisories(
                             [sql],
                             available_tool_result_rows=4,
@@ -1123,11 +1151,10 @@ class SqliteBatchToolTests(TestCase):
         )
 
         self.assertEqual(one_import[0].code, "single_tool_result_import")
-        self.assertFalse(one_import[0].blocking)
         self.assertEqual(commented, [])
         self.assertEqual(double_quoted_text, [])
 
-    def test_related_model_imports_from_one_source_are_not_a_row_loop(self):
+    def test_related_model_imports_in_one_batch_are_not_a_row_loop(self):
         sql = (
             "INSERT INTO accounts(account_id) SELECT json_extract(result_json,'$.account_id') "
             "FROM __tool_results WHERE result_id='r1';"
@@ -1140,9 +1167,17 @@ class SqliteBatchToolTests(TestCase):
             [sql.replace("result_id='r1';", "result_id='r2';", 1)],
             available_tool_result_rows=4,
         )
+        repeated_target = build_tool_result_query_advisories(
+            [
+                "INSERT INTO accounts SELECT result_json FROM __tool_results WHERE result_id='r1';"
+                "INSERT INTO accounts SELECT result_json FROM __tool_results WHERE result_id='r2';"
+            ],
+            available_tool_result_rows=4,
+        )
 
         self.assertEqual(advisories, [])
-        self.assertIn("tool_result_row_loop", {advisory.code for advisory in split_sources})
+        self.assertEqual(split_sources, [])
+        self.assertIn("tool_result_row_loop", {advisory.code for advisory in repeated_target})
 
     def test_related_model_imports_from_one_source_execute_without_warning(self):
         payload = json.dumps({
@@ -1349,7 +1384,7 @@ class SqliteBatchToolTests(TestCase):
             (),
         )
 
-    def test_source_facts_copied_into_model_are_rejected(self):
+    def test_source_facts_copied_into_model_receive_advice(self):
         payload = (
             '{"account_id":"acct-1","stage":"contracting","next_action":"resolve redlines",'
             '"source_url":"https://crm.example.test/acct-1"}'
@@ -1438,10 +1473,9 @@ class SqliteBatchToolTests(TestCase):
             ),
         )
         self.assertEqual(copied[0].code, "source_facts_copied_into_model")
-        self.assertTrue(copied[0].blocking)
-        self.assertIn("used visible facts or URLs as SQL literals", copied[0].message)
-        self.assertIn("Derive every sourced field", copied[0].message)
-        self.assertIn("omit unavailable URLs", copied[0].message)
+        self.assertIn("copied visible source facts or URLs as SQL literals", copied[0].message)
+        self.assertIn("derive sourced fields", copied[0].message)
+        self.assertIn("refresh provenance", copied[0].message)
         for allowed in (
             derived, unrelated, identity_predicate, single_normalization, arrow_derived, parsed_text, case_logic,
         ):

--- a/tests/unit/test_sqlite_source_array_eval.py
+++ b/tests/unit/test_sqlite_source_array_eval.py
@@ -4,13 +4,17 @@ from types import SimpleNamespace
 from django.test import SimpleTestCase, tag
 
 import api.evals.loader  # noqa: F401 - registers scenarios and suites
+from api.agent.tools.sqlite_query_quality import summarize_sqlite_tool_result_sql
 from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.sqlite_tool_results import (
+    SQLITE_INCREMENTAL_DOMAIN_MODEL,
     SQLITE_SOURCE_ARRAY_FIRST_WRITE,
     SQLITE_TOOL_RESULT_SCENARIO_SLUGS,
     SQLITE_TOOL_RESULT_SUITE_SLUG,
+    SqliteIncrementalDomainModelScenario,
     SqliteSourceArrayFirstWriteScenario,
     _source_array_first_write_failures,
+    _uses_queryable_source_model,
 )
 from api.evals.suites import SuiteRegistry
 
@@ -84,6 +88,44 @@ class SqliteSourceArrayEvalTests(SimpleTestCase):
 
         for leaked_term in ("sqlite", "__tool_results", "json_each", "insert", "select", "table"):
             self.assertNotIn(leaked_term, prompt)
+
+    def test_incremental_domain_model_case_is_registered_without_teaching_sql(self):
+        suite = SuiteRegistry.get(SQLITE_TOOL_RESULT_SUITE_SLUG)
+        scenario = ScenarioRegistry.get(SQLITE_INCREMENTAL_DOMAIN_MODEL)
+
+        self.assertIsNotNone(scenario)
+        self.assertIn(SQLITE_INCREMENTAL_DOMAIN_MODEL, SQLITE_TOOL_RESULT_SCENARIO_SLUGS)
+        self.assertIn(SQLITE_INCREMENTAL_DOMAIN_MODEL, suite.scenario_slugs)
+        self.assertEqual(
+            [task.name for task in scenario.tasks],
+            [
+                "inject_prompt",
+                "verify_incremental_domain_model",
+                "verify_operating_answer",
+            ],
+        )
+        prompt = SqliteIncrementalDomainModelScenario.prompt.casefold()
+        for leaked_term in ("sqlite", "__tool_results", "json_each", "insert", "select", "table"):
+            self.assertNotIn(leaked_term, prompt)
+
+    def test_existing_item_report_accepts_a_queried_source_model(self):
+        summary = summarize_sqlite_tool_result_sql([
+            "CREATE TABLE vehicles(vin TEXT PRIMARY KEY, price INTEGER);"
+            "INSERT INTO vehicles SELECT json_extract(value,'$.vin'),json_extract(value,'$.price') "
+            "FROM __tool_results,json_each(result_json,'$.content.vehicles') WHERE result_id='feed-a';"
+            "INSERT INTO vehicles SELECT json_extract(value,'$.vin'),json_extract(value,'$.price') "
+            "FROM __tool_results,json_each(result_json,'$.content.vehicles') WHERE result_id='feed-b';"
+            "SELECT vin,price FROM vehicles ORDER BY price;"
+        ])
+
+        self.assertTrue(_uses_queryable_source_model(summary))
+        unkeyed = summarize_sqlite_tool_result_sql([
+            "CREATE TABLE vehicles(vin TEXT, price INTEGER);"
+            "INSERT INTO vehicles SELECT json_extract(value,'$.vin'),json_extract(value,'$.price') "
+            "FROM __tool_results,json_each(result_json,'$.content.vehicles') WHERE result_id='feed-a';"
+            "SELECT vin,price FROM vehicles ORDER BY price;"
+        ])
+        self.assertFalse(_uses_queryable_source_model(unkeyed))
 
     def test_first_write_scorer_accepts_direct_source_array_import(self):
         failures = _source_array_first_write_failures(


### PR DESCRIPTION
## Summary

- Execute valid SQLite work instead of rejecting it through best-practice heuristics. Quality feedback is now post-execution advice; actual SQLite safety and execution guards remain.
- Add standard named scalar bindings with `:name` parameters for messy agent-authored values and known link handles.
- Add one focused multi-source checkpoint that makes agents create or evolve durable keyed entity and relationship tables as work proceeds, then use SQL joins, sets, counts, and ranking before reporting.
- Add a natural real-harness regression for related operating entities, ownership gaps, provenance, and risk ranking. Align the existing item-link eval so a keyed, source-derived, queried model satisfies the same underlying intent as aggregate access.

## Root cause

The production trajectory fetched the portfolio and roughly 25 to 30 founder pages before its first SQLite call. It never created company and founder tables, and instead repeatedly carried the working set in model context.

Two implementation details enabled that pattern:

1. The multi-source checkpoint returned nothing when no named model existed yet.
2. SQL quality heuristics ran as hard pre-execution blockers. They rejected proposed writes that often would have executed, saved no state, and caused retries or abandonment.

The PR fixes those two seams directly. It does not add a SQL parser, rewriting layer, recovery loop, or SQLite rearchitecture.

## Scope and complexity

The product behavior change is 126 additions and 53 deletions across four files. Most of the larger PR diff is regression eval and unit-test coverage.

Rendered prompt size increases by about 2.4 percent, or 1,333 bytes on representative paths: 517 system bytes for the active checkpoint and 816 tool-definition bytes for bindings and concise import guidance. Complexity guardrails were updated to this measured baseline and pass. This is the bounded cost of making the desired behavior explicit and testable.

## Verification

- Full exact-head CI is green: complexity and tag guards, frontend and sandbox tests, all 10 backend shards, and combined results.
- Focused local SQLite, prompt, link-reference, eval-scorer, and complexity tests pass. Diff and Python compile checks are clean.
- DeepSeek V4 Flash, exact final HEAD:
  - New incremental domain-model scenario: 6/6 across two consecutive runs, suite `6daa7c56-8116-4d56-aea3-2e36b6ba32f6`.
  - First source-array write regression: 4/4, suite `6fef777a-7e8b-4b07-9214-3c419aec7c3b`.
- DeepSeek V4 Flash targeted existing scenarios also have clean passes for multi-result synthesis, reusable working tables, item links, modeled truth, and the bounded portfolio/founder report. Model-level stochastic misses seen in a broader exploratory pass were not hidden or used to weaken scorers; affected cases were rerun individually against their intended assertions.
- Exact-head preview deployment succeeded: https://pr-1357.ship.gobii.ai
  - Public page, app shell, and login surface return 200.
  - `/healthz/` returns `OK`.
  - Rendered HTML and static assets resolve release SHA `09785cf2c43a185afb26880ff8543828ca2d2f3b`.

This PR is intentionally left open and unmerged for human review.