### PR TITLE
Preserve spacing across formatted dash boundaries

### DIFF
--- a/tests/unit/test_text_sanitization.py
+++ b/tests/unit/test_text_sanitization.py
@@ -84,6 +84,28 @@ class TextSanitizationTests(TestCase):
             with self.subTest(rich_html=rich_html):
                 self.assertEqual(normalize_humanized_message_style(rich_html), expected)
 
+    def test_humanized_message_style_preserves_word_boundaries_across_inline_html(self):
+        text = (
+            "<p><span>Hey there! I'm Alan</span>—<span>nice to meet you.</span></p>"
+            "<ol>"
+            "<li><strong>OpenCV (computer vision library)</strong>—"
+            "<span>Companies founded around the ecosystem</span></li>"
+            "<li><strong>OCV Capital or a specific VC/accelerator</strong>—A venture firm</li>"
+            "</ol>"
+        )
+
+        self.assertEqual(
+            normalize_humanized_message_style(text),
+            (
+                "<p><span>Hey there! I'm Alan</span>, <span>nice to meet you.</span></p>"
+                "<ol>"
+                "<li><strong>OpenCV (computer vision library)</strong>, "
+                "<span>Companies founded around the ecosystem</span></li>"
+                "<li><strong>OCV Capital or a specific VC/accelerator</strong>, A venture firm</li>"
+                "</ol>"
+            ),
+        )
+
     def test_strip_control_chars_removes_disallowed_characters(self):
         dirty = "Hello\x00World\u0019"
 

--- a/util/text_sanitizer.py
+++ b/util/text_sanitizer.py
@@ -40,7 +40,8 @@ _FORBIDDEN_DASH_RE = re.compile(
     r"(?:[ \t]*(?:[\u2012\u2013\u2014\u2015\u2e3a\u2e3b]+|--+|&(?:mdash|ndash|#8211|#8212|#x2013|#x2014);)[ \t]*|[ \t]+-[ \t]+)",
     re.IGNORECASE,
 )
-_OPENING_INLINE_HTML_TEXT_RE = re.compile(r"(?:<(?:a|b|em|i|span|strong)\b[^>]*>\s*)+[^<\s]", re.IGNORECASE)
+_INLINE_HTML_TEXT_BEFORE_RE = re.compile(r"[^<>\s](?:[ \t]*</?(?:a|abbr|acronym|b|code|em|i|span|strong)\b[^>]*>)*[ \t]*\Z", re.IGNORECASE)
+_INLINE_HTML_TEXT_AFTER_RE = re.compile(r"\A[ \t]*(?:</?(?:a|abbr|acronym|b|code|em|i|span|strong)\b[^>]*>[ \t]*)*[^<>\s]", re.IGNORECASE)
 
 
 def normalize_humanized_message_style(value: str | None) -> str:
@@ -48,10 +49,9 @@ def normalize_humanized_message_style(value: str | None) -> str:
 
     def normalize_prose(prose: str, offset: int) -> str:
         def punctuate(match):
-            before = prose[:match.start()].rstrip(" \t")
-            after = prose[match.end():].lstrip(" \t")
-            visible_after = bool(after) or bool(_OPENING_INLINE_HTML_TEXT_RE.match(text[offset + match.end():]))
-            return ", " if before and visible_after and not (before.endswith("\n") or after.startswith("\n")) else ""
+            has_before = bool(_INLINE_HTML_TEXT_BEFORE_RE.search(text[:offset + match.start()]))
+            has_after = bool(_INLINE_HTML_TEXT_AFTER_RE.match(text[offset + match.end():]))
+            return ", " if has_before and has_after else ""
 
         return _FORBIDDEN_DASH_RE.sub(punctuate, prose)
 
@@ -499,7 +499,6 @@ def strip_llm_artifacts(value: str | None) -> str:
 # Quote characters that might wrap blockquote content redundantly
 # Includes straight quotes, smart quotes, and various international quotation marks
 _OPENING_QUOTES = {'"', "\u201c", "\u201e", "\u00ab", "\u2039", "\u2018", "'"}
-_CLOSING_QUOTES = {'"', "\u201c", "\u201d", "\u00bb", "\u203a", "\u2019", "'"}
 _QUOTE_PAIRS = {
     '"': '"',           # straight double
     "\u201c": "\u201d",  # smart double " → "


### PR DESCRIPTION
## Summary
- preserve word boundaries when outbound dash normalization crosses inline HTML tags
- keep the existing no-dash behavior by replacing the separator with `, ` instead of deleting it
- add the exact email regression shape covering `Alannice`, `library)Companies`, and `acceleratorA`

## Root cause
Outbound message params are humanized before delivery. The dash normalizer protected HTML tags as non-prose and only inspected text within each prose fragment. When a dash followed a closing inline tag, it could not see the preceding word and returned an empty replacement. That converted markup such as `<span>Alan</span>—<span>nice</span>` into `<span>Alan</span><span>nice</span>`, which browsers correctly render as `Alannice`. Markdown conversion, email HTML sanitization, and web-chat CSS all preserved ordinary paragraph and `<br>` spacing; they were not the corrupting layer.

## Verification
- regression reproduced against the pre-fix normalizer (test failed)
- `uv run python manage.py test tests.unit.test_text_sanitization tests.unit.test_event_processing_implied_send tests.unit.test_email_body_rendering --settings=config.test_settings` (253 passed)
- `npm test -- --run src/components/agentChat/MessageContent.test.tsx` (3 passed)
- rendered the before/after email HTML through the real `MessageContent` component and chat CSS in Chromium; the three joins reproduce before the fix and render with visible separators after it

No prompt/eval change: this is deterministic post-model corruption, so a focused unit regression is the honest coverage.
