### PR TITLE
Ignore redundant SQLite transaction wrappers

### DIFF
--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -1698,23 +1698,22 @@ def _clean_statement(statement: str) -> Optional[str]:
     return trimmed or None
 
 
-def _statement_has_sql(statement: Statement) -> bool:
-    for token in statement.flatten():
-        if token.is_whitespace:
-            continue
-        if token.ttype in sql_tokens.Comment:
-            continue
-        if token.ttype in sql_tokens.Punctuation and token.value == ";":
-            continue
-        return True
-    return False
+def _structural_sql(statement: Statement, *, omit_strings: bool = False) -> str:
+    return " ".join(
+        token.value
+        for token in statement.flatten()
+        if not token.is_whitespace
+        and token.ttype not in sql_tokens.Comment
+        and not (omit_strings and token.ttype in sql_tokens.Literal.String.Single)
+        and not (token.ttype in sql_tokens.Punctuation and token.value == ";")
+    )
 
 
 def _split_sqlite_statements(sql: str) -> List[str]:
     """Split SQL into statements using sqlparse."""
     statements: List[str] = []
     for statement in sqlparse.parse(sql):
-        if not _statement_has_sql(statement):
+        if not _structural_sql(statement):
             continue
         cleaned = _clean_statement(str(statement))
         if cleaned:
@@ -1723,18 +1722,23 @@ def _split_sqlite_statements(sql: str) -> List[str]:
     return statements
 
 
+_TRANSACTION_WRAPPER_RE = re.compile(
+    r"^(?:BEGIN(?:\s+(?:DEFERRED|IMMEDIATE|EXCLUSIVE))?(?:\s+TRANSACTION)?|COMMIT(?:\s+TRANSACTION)?|END(?:\s+TRANSACTION)?)$",
+    re.IGNORECASE,
+)
+
+
+def _is_redundant_transaction_wrapper(sql: str) -> bool:
+    statements = sqlparse.parse(sql)
+    return len(statements) == 1 and bool(_TRANSACTION_WRAPPER_RE.fullmatch(_structural_sql(statements[0]).strip()))
+
+
 def _non_persisting_agent_config_patch(queries: List[str]) -> Optional[str]:
     for query in queries:
         for statement in sqlparse.parse(query):
-            if not _statement_has_sql(statement):
+            if not _structural_sql(statement):
                 continue
-            structural_sql = " ".join(
-                token.value
-                for token in statement.flatten()
-                if not token.is_whitespace
-                and token.ttype not in sql_tokens.Comment
-                and token.ttype not in sql_tokens.Literal.String.Single
-            )
+            structural_sql = _structural_sql(statement, omit_strings=True)
             if (
                 re.search(r"\bpatch_text\s*\(", structural_sql, re.IGNORECASE)
                 and re.search(r"\b__agent_config\b", structural_sql, re.IGNORECASE)
@@ -1806,6 +1810,7 @@ def _normalize_queries(params: Dict[str, Any]) -> Optional[List[str]]:
         if split_items:
             queries.extend(split_items)
 
+    queries = [query for query in queries if not _is_redundant_transaction_wrapper(query)]
     return queries if queries else None
 
 

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -29,6 +29,7 @@ from api.agent.tools.sqlite_batch import (
     _fix_python_operators,
     _fix_singular_plural_columns,
     _fix_singular_plural_tables,
+    _is_redundant_transaction_wrapper,
     _is_typo,
     _SqliteBatchLimits,
     _should_skip_memory_limits_for_virtualapple_emulation,
@@ -98,6 +99,48 @@ class SqliteBatchToolTests(TestCase):
             self.assertEqual(results[-1]["result"], [{"a": 1}, {"a": 2}])
             self.assertIsInstance(out.get("db_size_mb"), (int, float))
             self.assertIn("Executed 3 queries", out.get("message", ""))
+
+    def test_redundant_transaction_wrapper_does_not_break_batch(self):
+        with self._with_temp_db():
+            out = execute_sqlite_batch(
+                self.agent,
+                {
+                    "sql": (
+                        "BEGIN TRANSACTION;"
+                        "CREATE TABLE prospects(id TEXT PRIMARY KEY, name TEXT);"
+                        "INSERT INTO prospects(id,name) VALUES ('p1','Aster Search');"
+                        "COMMIT;"
+                        "SELECT id,name FROM prospects;"
+                    ),
+                    "will_continue_work": True,
+                },
+            )
+
+        self.assertEqual(out.get("status"), "ok", out.get("message"))
+        self.assertEqual(len(out["results"]), 3)
+        self.assertEqual(
+            out["results"][-1]["result"],
+            [{"id": "p1", "name": "Aster Search"}],
+        )
+        self.assertIn("Executed 3 queries", out.get("message", ""))
+
+    def test_only_transaction_boundaries_are_treated_as_wrappers(self):
+        for sql in (
+            "BEGIN",
+            "BEGIN IMMEDIATE TRANSACTION;",
+            "/* generated wrapper */ COMMIT TRANSACTION;",
+            "END",
+        ):
+            with self.subTest(sql=sql):
+                self.assertTrue(_is_redundant_transaction_wrapper(sql))
+
+        for sql in (
+            "ROLLBACK",
+            "SAVEPOINT agent_work",
+            "SELECT 'BEGIN TRANSACTION' AS note",
+        ):
+            with self.subTest(sql=sql):
+                self.assertFalse(_is_redundant_transaction_wrapper(sql))
 
     def test_named_bindings_preserve_messy_values_across_a_batch(self):
         bindings = {


### PR DESCRIPTION
## Why

A sampled production trajectory wrapped a valid `sqlite_batch` in `BEGIN … COMMIT`. The tool already commits each statement for durable partial progress, so `BEGIN` was immediately committed and the final `COMMIT` returned `cannot commit - no transaction is active` after the intervening writes had succeeded. That false failure can trigger retries, duplicate data, and misleading completion state.

## What changed

- Ignore standalone `BEGIN`, `COMMIT`, and `END` transaction boundaries during batch normalization.
- Preserve the tool's existing per-statement durability semantics; this does not claim atomic transactions.
- Keep `ROLLBACK`, savepoints, transaction-like string values, and substantive SQL untouched.
- Reuse one structural-SQL tokenizer so the production source stays within the existing LoC budget.

## Verification

- Regression test reproduced the production failure before the fix: `Query 3 failed: cannot commit - no transaction is active`.
- `tests.unit.test_sqlite_batch.SqliteBatchToolTests`: **145/145 passed**.
- Source LoC: **250242/250242**; prompt complexity: unchanged and green.
- DeepSeek V4 Flash real-harness `sqlite_tool_results` run: suite `8633b809-528d-43e0-8873-b851b717e1fe`, **29/36 task checks passed**. No transaction-wrapper/commit failure occurred. The seven failed checks were model-level efficiency/format variance (extra reads/import cycles, report hierarchy, and one tool-budget exhaustion), not errors on the changed path; this PR does not weaken those scorers or claim to fix them.

## Risk

Low and bounded to input normalization. The filtered statements cannot provide transaction semantics in the current subprocess because the executor commits after every statement. Explicit rollback/savepoint operations are deliberately not filtered.
