### PR TITLE
Auto-open insights for new agent questions

### DIFF
--- a/frontend/src/components/agentChat/AgentComposer.test.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.test.tsx
@@ -296,7 +296,7 @@ describe('AgentComposer pending action insights panel', () => {
     expect(screen.getByText('Stripe API key')).toBeInTheDocument()
   })
 
-  it('keeps a saved collapsed preference when pending requests arrive', async () => {
+  it('temporarily opens a saved collapsed panel when new questions arrive', async () => {
     const handleExpandedPreferenceChange = vi.fn()
     const { rerender } = renderAgentComposer({
       insightsPanelExpandedPreference: false,
@@ -308,7 +308,7 @@ describe('AgentComposer pending action insights panel', () => {
     rerender(
       <AgentComposer
         onSubmit={vi.fn(async () => undefined)}
-        pendingActionRequests={[makeRequestedSecretsAction()]}
+        pendingActionRequests={[makeHumanInputAction()]}
         insightsLoading={false}
         isProcessing={false}
         insightsPanelExpandedPreference={false}
@@ -319,13 +319,13 @@ describe('AgentComposer pending action insights panel', () => {
     await waitFor(() => {
       expect(screen.getByText('Needs your input')).toBeInTheDocument()
     })
-    expect(screen.getByText('1 request')).toBeInTheDocument()
-    expect(screen.queryByText('Stripe API key')).not.toBeInTheDocument()
+    expect(screen.getByText('Which account should I use?')).toBeInTheDocument()
     expect(handleExpandedPreferenceChange).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByText('Needs your input').closest('.composer-working-header-row') as HTMLElement)
 
-    expect(handleExpandedPreferenceChange).toHaveBeenCalledWith(true)
+    expect(handleExpandedPreferenceChange).toHaveBeenCalledWith(false)
+    expect(screen.queryByText('Which account should I use?')).not.toBeInTheDocument()
   })
 
   it('stays collapsed while a saved panel preference hydrates', () => {

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -722,7 +722,9 @@ export const AgentComposer = memo(function AgentComposer({
   const [draftHumanInputResponses, setDraftHumanInputResponses] = useState<Record<string, HumanInputComposerResponse>>({})
   const draftHumanInputResponsesRef = useRef<Record<string, HumanInputComposerResponse>>({})
   const [autoWorkingExpanded, setAutoWorkingExpanded] = useState(true)
-  const [pendingActionsForceExpanded, setPendingActionsForceExpanded] = useState(() => pendingActionRequests.length > 0)
+  const hasPendingActions = pendingActionRequests.length > 0
+  const hasPendingQuestions = pendingActionRequests.some((action) => action.kind === 'human_input')
+  const [pendingQuestionsForceExpanded, setPendingQuestionsForceExpanded] = useState(hasPendingQuestions)
   const { isProprietaryMode } = useAppSelector(selectSubscriptionState)
   const [appsModal, showAppsModal] = useModal()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
@@ -765,11 +767,10 @@ export const AgentComposer = memo(function AgentComposer({
   // Track previous processing state for auto-expand/collapse
   const wasProcessingRef = useRef(isProcessing)
   const isProcessingRef = useRef(isProcessing)
-  const hadPendingActionsRef = useRef(false)
-  const hasPendingActions = pendingActionRequests.length > 0
-  const resolvedWorkingExpanded = insightsPanelPreferenceHydrated
-    ? insightsPanelExpandedPreference ?? (pendingActionsForceExpanded || autoWorkingExpanded)
-    : false
+  const resolvedWorkingExpanded = pendingQuestionsForceExpanded
+    || (insightsPanelPreferenceHydrated
+      ? insightsPanelExpandedPreference ?? autoWorkingExpanded
+      : false)
 
   useEffect(() => {
     isProcessingRef.current = isProcessing
@@ -788,15 +789,6 @@ export const AgentComposer = memo(function AgentComposer({
     }
     wasProcessingRef.current = isProcessing
   }, [insightsPanelExpandedPreference, isProcessing])
-
-  useEffect(() => {
-    if (hasPendingActions && !hadPendingActionsRef.current) {
-      setPendingActionsForceExpanded(true)
-    } else if (!hasPendingActions && hadPendingActionsRef.current) {
-      setPendingActionsForceExpanded(false)
-    }
-    hadPendingActionsRef.current = hasPendingActions
-  }, [hasPendingActions])
 
   const MAX_COMPOSER_HEIGHT = 320
 
@@ -967,18 +959,22 @@ export const AgentComposer = memo(function AgentComposer({
       signature: pendingActionTabSignature,
     }
 
+    if (!hasPendingQuestions) setPendingQuestionsForceExpanded(false)
     if (!pendingActionTabs.length || !hasPendingSignatureChanged) {
       return
     }
 
-    setPendingActionsForceExpanded(true)
+    const shouldRevealChangedQuestion = changedPendingTab?.pendingKind === 'questions'
+    if (shouldRevealChangedQuestion) {
+      setPendingQuestionsForceExpanded(true)
+    }
 
     const activePendingTabStillOpen = Boolean(
       activeWorkingTabId
       && workingTabIds.has(activeWorkingTabId)
       && isPendingWorkingTabId(activeWorkingTabId),
     )
-    if (activePendingTabStillOpen) {
+    if (activePendingTabStillOpen && (!shouldRevealChangedQuestion || resolvedWorkingExpanded)) {
       return
     }
 
@@ -990,8 +986,10 @@ export const AgentComposer = memo(function AgentComposer({
     activeWorkingTabId,
     agentId,
     focusKey,
+    hasPendingQuestions,
     pendingActionTabSignature,
     pendingActionTabs,
+    resolvedWorkingExpanded,
     selectWorkingTab,
     workingTabIds,
   ])
@@ -1074,7 +1072,7 @@ export const AgentComposer = memo(function AgentComposer({
   const handlePanelToggle = useCallback(() => {
     const newExpanded = !resolvedWorkingExpanded
     if (!newExpanded) {
-      setPendingActionsForceExpanded(false)
+      setPendingQuestionsForceExpanded(false)
     }
     if (onInsightsPanelExpandedPreferenceChange) {
       onInsightsPanelExpandedPreferenceChange(newExpanded)


### PR DESCRIPTION
## Summary
- temporarily expand a collapsed insights panel when a new human-input question arrives
- keep the per-user, per-agent collapsed preference unchanged so the panel returns to the saved state
- preserve manual re-collapse and existing credential/contact approval behavior

## Verification
- reproduced the regression with the focused composer test before the implementation
- `npm test -- --run src/components/agentChat/AgentComposer.test.tsx src/store/agentRosterPreferencesSlice.test.ts` (43 passed)
- `npm run build:app` and `./node_modules/.bin/tsc -b --pretty false`
- source-LoC and prompt complexity guards passed; production source is net -2 lines
- full CI passed on exact head `099e1ed42`
- exact-head preview deployed; homepage and app sign-in rendered cleanly in Chrome, and release JS/CSS returned 200

## Scope
Frontend composer state only; no preference schema, backend, or agent behavior changes.