### PR TITLE
Ensure Discord research starts with a kickoff

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -364,6 +364,12 @@ NON_SUBSTANTIAL_WORK_RE = re.compile(
     r"\b(?:not|isn'?t|is not|don'?t|do not)\s+(?:an?\s+)?(?:deep|exhaustive|comprehensive|thorough|extensive)\b",
     re.IGNORECASE,
 )
+EXPLICIT_RESEARCH_REQUEST_RE = re.compile(
+    r"\b(?:research|investigate)\b|\b(?:look|dig)\s+into\b|\b(?:find|figure)\s+out\b", re.IGNORECASE
+)
+NEGATED_RESEARCH_REQUEST_RE = re.compile(
+    r"\b(?:don'?t|do not|no need to|without)\b.{0,24}\b(?:research|investigat|look|dig|find|figur)", re.IGNORECASE
+)
 DEEP_WORK_UPDATE_CORRECTION_PREFIX = "Deep-work communication correction:"
 # Canonical phrase the agent should use to signal continuation.
 # Prompts tell the agent to include this exact phrase when it has more work.
@@ -385,6 +391,11 @@ CONTINUATION_PHRASES = (
     "moving on to ",
     "more data coming",
 )
+
+
+def _is_explicit_research_request(text: str) -> bool:
+    return bool(EXPLICIT_RESEARCH_REQUEST_RE.search(text or "") and not NEGATED_RESEARCH_REQUEST_RE.search(text or ""))
+
 
 class OrchestratorPromptStale(RuntimeError):
     """Raised when newer human input makes an in-flight orchestrator prompt stale."""
@@ -410,6 +421,7 @@ def _deep_work_update_gate_reason(
     prior_has_midwork_update: bool = False,
     prior_kickoff_correction: bool = False,
     prior_milestone_correction: bool = False,
+    require_kickoff: bool = False,
 ) -> str | None:
     work_names = [
         name
@@ -419,11 +431,8 @@ def _deep_work_update_gate_reason(
     if not work_names or batch_has_progress_update:
         return None
 
-    substantial_start = bool(
-        SUBSTANTIAL_WORK_RE.search(latest_user_text or "")
-        and not NON_SUBSTANTIAL_WORK_RE.search(latest_user_text or "")
-    )
-    if prior_update_count == 0 and prior_work_count == 0 and substantial_start and not prior_kickoff_correction:
+    substantial_start = bool(SUBSTANTIAL_WORK_RE.search(latest_user_text or "") and not NON_SUBSTANTIAL_WORK_RE.search(latest_user_text or ""))
+    if prior_update_count == 0 and prior_work_count == 0 and (substantial_start or require_kickoff) and not prior_kickoff_correction:
         return "kickoff"
     if (
         substantial_start
@@ -476,6 +485,8 @@ def _deep_work_update_gate_context(
     expected_message_tool = _same_channel_reply_tool_name(latest_inbound)
     if expected_message_tool is None:
         return None
+    latest_user_text = latest_inbound.body or ""
+    require_kickoff = latest_inbound.conversation.channel == CommsChannel.DISCORD and _is_explicit_research_request(latest_user_text)
 
     prior_calls = PersistentAgentToolCall.objects.filter(
         step__agent=agent,
@@ -505,7 +516,7 @@ def _deep_work_update_gate_context(
         ).values_list("description", flat=True)
     )
     return _deep_work_update_gate_reason(
-        latest_inbound.body or "",
+        latest_user_text,
         [_get_tool_call_name(call) or "" for call in tool_calls],
         prior_work_count=prior_work_calls.count(),
         prior_update_count=len(prior_updates),
@@ -523,6 +534,7 @@ def _deep_work_update_gate_context(
             description.startswith(f"{DEEP_WORK_UPDATE_CORRECTION_PREFIX} milestone:")
             for description in prior_correction_descriptions
         ),
+        require_kickoff=require_kickoff,
     )
 
 
@@ -535,10 +547,10 @@ def _record_deep_work_update_correction(
 ) -> None:
     if reason == "kickoff":
         instruction = (
-            "The task calls were held once because this substantial request needs a kickoff. In your next response, "
+            "The task calls were held once because this request needs a kickoff. In your next response, "
             "first use the same-channel send tool with will_continue_work=true, then reissue the intended task calls. "
-            "Briefly name the outcome and when the requester will hear a substantive finding, without listing methods. "
-            "After the first evidence batch, share the strongest concrete finding, not task status like 'sources scraped.'"
+            "Briefly name the outcome and next checkpoint, without listing methods. Short work reports the final next; "
+            "deep/large work shares the strongest finding after the first evidence batch."
         )
     else:
         instruction = (

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3704,9 +3704,8 @@ def _get_first_run_welcome_message_instruction(
 
         "## First-run contact rule\n\n"
         "If there is no concrete task to do yet, your first action should be one concise welcome message.\n"
-        "If a concrete user task, scheduled trigger, or deliverable is already active, start it. Finish ordinary "
-        "work silently and send one result; for explicitly substantial work, follow Work Updates below instead of sending "
-        "an empty greeting like \"I'll start\" or \"let me fetch that\".\n\n"
+        "If a task is active, start it. Finish ordinary work silently and send one result; Discord research and "
+        "substantial work follow Work Updates, never an empty greeting.\n\n"
 
         "## Your welcome message should:\n"
         "- Introduce yourself by first name\n"
@@ -3982,7 +3981,7 @@ def _get_system_instruction(
         "'I'll save/update it' with will_continue_work=false; do it first.\n\n"
         f"{LINK_REFERENCE_PROMPT_NOTE}\n\n"
         "## Bounded Current Research (CRITICAL)\n\n"
-        "For one-off latest/current company/batch/funding/pricing/product/news/status asks except finite sets: use bounded research mode. Do one focused search or structured lookup; scrape 1-3 top sources if snippets are insufficient; then send one answer with takeaways and cite at least two distinct source URLs compactly. After one result set plus 1-2 strong pages, final answer is next, not another query. Use at most one web search query unless empty/contradictory. Do not run alternate query variants, call update_plan, send progress-only messages, create files/charts, build an ad hoc SQLite model, or keep searching once sources can answer. Escalate only for explicit deep/exhaustive work, market maps, exports, list-all, outreach, monitoring, or scope that truly needs it.\n\n"
+        "For one-off latest/current company/batch/funding/pricing/product/news/status asks except finite sets: use bounded research mode. Do one focused search or structured lookup; scrape 1-3 top sources if snippets are insufficient; then send one answer with takeaways and cite at least two distinct source URLs compactly. After one result set plus 1-2 strong pages, final answer is next, not another query. Use at most one web search query unless empty/contradictory. Do not run alternate query variants, call update_plan, send progress except the required Discord kickoff, create files/charts, build an ad hoc SQLite model, or keep searching once sources can answer. Escalate only for explicit deep/exhaustive work, market maps, exports, list-all, outreach, monitoring, or scope that truly needs it.\n\n"
 
         "## Deep Research Source Budget (CRITICAL)\n\n"
         "For explicit deep/exhaustive research and finite-set coverage, do not finalize from search results: after discovery, scrape/open at least 4 promising URLs (or every useful URL if fewer), then synthesize. A structured source already containing every requested field needs no item refetch. Snippets are leads, not sources. Start with one broad search, two if it misses an angle. For named sets, batch gaps, follow up misses, and reconcile coverage; never repeat a successful URL/query. Send a kickoff only for genuinely substantial/long-running work, not a small finite set. If sources support the memo, final next with linked evidence; keep chat deep memos under about 5,000 chars unless asked otherwise.\n\n"
@@ -4011,7 +4010,8 @@ def _get_system_instruction(
     )
     base_prompt += (
         "\n\n## Work Updates (CRITICAL)\n\n"
-        "Short work: no updates. Deep/large work:\n"
+        "Short work: no updates; Discord research first sends one same-channel kickoff with will_continue_work=true. "
+        "Deep/large work:\n"
         "1. FIRST send scope + next checkpoint on the inbound channel; will_continue_work=true.\n"
         "2. By work call 4 or the first evidence batch, send the strongest finding; later only ETA/blockers.\n"
         "Updates always use true; a promise of more results isn't terminal. Don't repeat updates or narrate status. After a verified partial with no productive retry, save one cursor in a normal domain row, then deliver the rows + constraint; never inspect or patch charter/schedules/config for this. Kickoff isn't a milestone; later updates need new evidence. Peer: send_agent_message only."

--- a/api/evals/scenarios/discord_native.py
+++ b/api/evals/scenarios/discord_native.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 
 from api.agent.system_skills.defaults import DISCORD_NATIVE_SYSTEM_SKILL_KEY
 from api.agent.system_skills.service import enable_system_skills
+from api.agent.tools.eval_synthetic_tools import EVAL_SYNTHETIC_TOOL_SERVER
+from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
 from api.evals.base import EvalScenario, ScenarioTask
 from api.evals.execution import ScenarioExecutionTools
 from api.evals.registry import ScenarioRegistry, register_scenario
@@ -10,7 +12,10 @@ from api.evals.scenarios.agent_emotions import _assigned_config_fields
 from api.models import (
     EvalRunTask,
     PersistentAgent,
+    PersistentAgentEnabledTool,
     PersistentAgentMessage,
+    PersistentAgentStep,
+    PersistentAgentSystemStep,
     PersistentAgentToolCall,
 )
 from api.services.discord_messages import (
@@ -26,12 +31,19 @@ DISCORD_NATIVE_REACTION_SHARED_WIN = "discord_native_reaction_shared_win"
 DISCORD_NATIVE_REACTION_SERIOUS_REQUEST_RESTRAINT = (
     "discord_native_reaction_serious_request_restraint"
 )
+DISCORD_NATIVE_RESEARCH_KICKOFF = "discord_native_research_kickoff"
 DISCORD_NATIVE_SCENARIO_SLUGS = (
     DISCORD_NATIVE_REACTION_REPLY_CONTEXT,
     DISCORD_NATIVE_REACTION_SHARED_WIN,
     DISCORD_NATIVE_REACTION_SERIOUS_REQUEST_RESTRAINT,
+    DISCORD_NATIVE_RESEARCH_KICKOFF,
 )
 DISCORD_NATIVE_SUITE_SLUG = "discord_native"
+DEEP_WORK_CORRECTION_STEP_PREFIX = "Deep-work communication correction:"
+DISCORD_RESEARCH_TOOL_NAMES = {
+    "mcp_brightdata_search_engine",
+    "mcp_brightdata_scrape_as_markdown",
+}
 
 
 @dataclass(frozen=True)
@@ -297,3 +309,231 @@ def _discord_reaction_scenario_class(case):
 
 for discord_reaction_case in DISCORD_REACTION_CASES[1:]:
     ScenarioRegistry.register(_discord_reaction_scenario_class(discord_reaction_case)())
+
+
+@register_scenario
+class DiscordNativeResearchKickoffScenario(EvalScenario, ScenarioExecutionTools):
+    slug = DISCORD_NATIVE_RESEARCH_KICKOFF
+    description = "An explicit Discord research request should get a short same-channel kickoff before research begins."
+    tier = "core"
+    category = "conversation"
+    expected_runtime = "short"
+    cost_class = "low"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = ("discord", "real_harness", "responsiveness", "research")
+    prompt = (
+        "Could you find out whether ExampleForum visibility restrictions are usually temporary or permanent, "
+        "and tell me what you find."
+    )
+    tasks = [
+        ScenarioTask(name="inject_event", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_kickoff_precedes_research", assertion_type="tool_call"),
+        ScenarioTask(name="verify_sourced_result", assertion_type="tool_call"),
+    ]
+
+    @staticmethod
+    def _message_body(call: PersistentAgentToolCall) -> str:
+        return str((call.tool_params or {}).get("message") or "").strip()
+
+    @staticmethod
+    def _call_succeeded(call: PersistentAgentToolCall) -> bool:
+        try:
+            result = json.loads(call.result or "{}")
+        except (TypeError, ValueError):
+            return False
+        return call.status == "complete" and result.get("status") == "success"
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        PersistentAgent.objects.filter(id=agent_id).update(
+            charter="Research product and community questions carefully and answer with sourced findings.",
+            planning_state=PersistentAgent.PlanningState.SKIPPED,
+        )
+        prior_step = PersistentAgentStep.objects.create(
+            agent_id=agent_id,
+            description="Process events",
+        )
+        PersistentAgentSystemStep.objects.create(
+            step=prior_step,
+            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+        )
+        agent = PersistentAgent.objects.get(id=agent_id)
+        skill_result = enable_system_skills(agent, [DISCORD_NATIVE_SYSTEM_SKILL_KEY])
+        if skill_result.get("invalid"):
+            raise ValueError(f"Could not enable Discord system skill: {skill_result}")
+
+        for tool_name in DISCORD_RESEARCH_TOOL_NAMES:
+            mark_tool_enabled_without_discovery(agent, tool_name)
+            PersistentAgentEnabledTool.objects.filter(
+                agent=agent,
+                tool_full_name=tool_name,
+            ).update(tool_server=EVAL_SYNTHETIC_TOOL_SERVER, tool_name=tool_name)
+
+        channel_id = f"eval-discord-research-{str(run_id)[:8]}"
+        guild_id = "eval-discord-guild"
+        conversation = get_or_create_discord_conversation(
+            agent,
+            address=discord_conversation_address(agent.id, guild_id, channel_id),
+            channel_id=channel_id,
+            channel_name="research",
+        )
+        agent_endpoint, channel_endpoint = ensure_discord_conversation_participants(
+            agent,
+            conversation,
+            platform_channel_address=discord_channel_address(guild_id, channel_id),
+        )
+        inbound = PersistentAgentMessage.objects.create(
+            owner_agent=agent,
+            from_endpoint=channel_endpoint,
+            to_endpoint=agent_endpoint,
+            conversation=conversation,
+            is_outbound=False,
+            body=self.prompt,
+            raw_payload={
+                "source": "discord_bot",
+                "source_kind": "discord",
+                "source_label": "Maya in #research",
+                "discord_message_id": "eval-discord-research-message",
+                "discord_channel_id": channel_id,
+                "discord_channel_name": "research",
+                "discord_author_name": "Maya",
+            },
+        )
+        mock_config = {
+            "send_discord_message": {
+                "rules": [
+                    {
+                        "param_equals": {"will_continue_work": True},
+                        "result": {
+                            "status": "success",
+                            "message_id": "eval-discord-research-kickoff",
+                            "channel_id": channel_id,
+                            "auto_sleep_ok": False,
+                        },
+                    },
+                    {
+                        "param_equals": {"will_continue_work": False},
+                        "result": {
+                            "status": "success",
+                            "message_id": "eval-discord-research-result",
+                            "channel_id": channel_id,
+                            "auto_sleep_ok": True,
+                        },
+                    },
+                ],
+            },
+            "mcp_brightdata_search_engine": {
+                "status": "success",
+                "result": {
+                    "organic": [
+                        {
+                            "link": "https://support.example.test/account-visibility",
+                            "title": "Account visibility restrictions",
+                            "description": (
+                                "Visibility restrictions may be temporary, but unresolved policy violations "
+                                "can require an appeal."
+                            ),
+                        }
+                    ]
+                },
+                "auto_sleep_ok": False,
+            },
+            "mcp_brightdata_scrape_as_markdown": {
+                "status": "success",
+                "result": (
+                    "ExampleForum says visibility restrictions may be temporary. Accounts should review their "
+                    "status notice and appeal when a restriction was applied in error."
+                ),
+                "auto_sleep_ok": False,
+            },
+        }
+
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="inject_event")
+        with self.wait_for_agent_idle(agent_id, timeout=180):
+            self.trigger_processing(
+                agent_id,
+                eval_run_id=run_id,
+                mock_config=mock_config,
+                eval_stop_policy={
+                    "max_relevant_tool_calls": 8,
+                    "ignored_tool_names": ["sleep_until_next_trigger", "update_plan"],
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_event",
+            observed_summary="An explicit research request arrived through a real Discord conversation.",
+            artifacts={"message": inbound},
+        )
+
+        calls = list(
+            PersistentAgentToolCall.objects.filter(
+                step__eval_run_id=run_id,
+                step__created_at__gte=inbound.timestamp,
+            ).order_by("step__created_at", "step__id")
+        )
+        first_research_index = next(
+            (index for index, call in enumerate(calls) if call.tool_name in DISCORD_RESEARCH_TOOL_NAMES),
+            None,
+        )
+        kickoff_indexes = [
+            index
+            for index, call in enumerate(calls)
+            if call.tool_name == "send_discord_message"
+            and (call.tool_params or {}).get("channel_id") == channel_id
+            and (call.tool_params or {}).get("will_continue_work") is True
+            and len(self._message_body(call).split()) >= 4
+            and self._call_succeeded(call)
+        ]
+        corrections = PersistentAgentStep.objects.filter(
+            agent_id=agent_id,
+            created_at__gte=inbound.timestamp,
+            description__startswith=DEEP_WORK_CORRECTION_STEP_PREFIX,
+        ).count()
+        kickoff_passed = (
+            first_research_index is not None
+            and kickoff_indexes == [0]
+            and kickoff_indexes[0] < first_research_index
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if kickoff_passed else EvalRunTask.Status.FAILED,
+            task_name="verify_kickoff_precedes_research",
+            observed_summary=(
+                "One Discord kickoff preceded the first executed research call."
+                if kickoff_passed
+                else (
+                    "Expected one Discord kickoff before executed research; "
+                    f"call_order={[call.tool_name for call in calls]}, corrections={corrections}."
+                )
+            ),
+            artifacts={"step": calls[0].step} if calls else {},
+        )
+
+        final_calls = [
+            call
+            for index, call in enumerate(calls)
+            if first_research_index is not None
+            and index > first_research_index
+            and call.tool_name == "send_discord_message"
+            and (call.tool_params or {}).get("channel_id") == channel_id
+            and (call.tool_params or {}).get("will_continue_work") is False
+            and len(self._message_body(call).split()) >= 12
+            and self._call_succeeded(call)
+        ]
+        result_passed = len(final_calls) == 1
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if result_passed else EvalRunTask.Status.FAILED,
+            task_name="verify_sourced_result",
+            observed_summary=(
+                "The agent delivered one substantive Discord result after research."
+                if result_passed
+                else f"Expected one final Discord result after research; saw {len(final_calls)}."
+            ),
+            artifacts={"step": final_calls[0].step} if final_calls else {},
+        )

--- a/api/evals/tests/test_discord_native.py
+++ b/api/evals/tests/test_discord_native.py
@@ -10,9 +10,11 @@ from api.evals.scenarios.discord_native import (
     DISCORD_NATIVE_REACTION_SERIOUS_REQUEST_RESTRAINT,
     DISCORD_NATIVE_REACTION_REPLY_CONTEXT,
     DISCORD_NATIVE_REACTION_SHARED_WIN,
+    DISCORD_NATIVE_RESEARCH_KICKOFF,
     DISCORD_NATIVE_SCENARIO_SLUGS,
     DISCORD_NATIVE_SUITE_SLUG,
     DiscordNativeReactionReplyContextScenario,
+    DiscordNativeResearchKickoffScenario,
 )
 from api.evals.suites import SuiteRegistry
 
@@ -31,6 +33,20 @@ class DiscordNativeScenarioTests(SimpleTestCase):
         self.assertIsNotNone(
             ScenarioRegistry.get(DISCORD_NATIVE_REACTION_SERIOUS_REQUEST_RESTRAINT)
         )
+        self.assertIsNotNone(ScenarioRegistry.get(DISCORD_NATIVE_RESEARCH_KICKOFF))
+
+    def test_research_kickoff_prompt_does_not_prescribe_responsiveness_contract(self):
+        prompt = DiscordNativeResearchKickoffScenario.prompt.casefold()
+
+        for implementation_term in (
+            "acknowledge",
+            "before",
+            "kickoff",
+            "progress",
+            "working on",
+        ):
+            with self.subTest(implementation_term=implementation_term):
+                self.assertNotIn(implementation_term, prompt)
 
     def test_reaction_tool_contract_requires_target_and_continuation(self):
         tool = get_add_discord_reaction_tool()["function"]

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -120,6 +120,36 @@ class ImpliedSendTests(TestCase):
             )
         )
 
+    def test_discord_research_requires_kickoff_before_first_work_call(self):
+        reason = ep._deep_work_update_gate_reason(
+            "Please research whether this restriction is temporary.",
+            ["mcp_brightdata_search_engine"],
+            prior_work_count=0,
+            prior_update_count=0,
+            batch_has_progress_update=False,
+            require_kickoff=True,
+        )
+
+        self.assertEqual(reason, "kickoff")
+
+    def test_ordinary_web_research_does_not_trigger_deep_work_gate(self):
+        reason = ep._deep_work_update_gate_reason(
+            "Please research whether this restriction is temporary.",
+            ["mcp_brightdata_search_engine"],
+            prior_work_count=0,
+            prior_update_count=0,
+            batch_has_progress_update=False,
+        )
+
+        self.assertIsNone(reason)
+
+    def test_explicit_research_detection_excludes_negated_requests(self):
+        self.assertTrue(ep._is_explicit_research_request("Please research this account restriction."))
+        self.assertTrue(ep._is_explicit_research_request("Could you look into this?"))
+        self.assertTrue(ep._is_explicit_research_request("Find out why the visibility changed."))
+        self.assertFalse(ep._is_explicit_research_request("No need to research this; use the supplied answer."))
+        self.assertFalse(ep._is_explicit_research_request("Don't figure this out; just use the supplied note."))
+
     def test_run_setup_resets_inbound_scope_when_prompt_cache_setup_fails(self):
         with patch.object(ep, "PromptRunCache", side_effect=RuntimeError("cache setup failed")), \
              self.assertRaisesRegex(RuntimeError, "cache setup failed"):


### PR DESCRIPTION
## Summary

- require one brief same-channel kickoff before explicit Discord research begins
- enforce kickoff-before-work ordering at runtime while keeping ordinary web research silent
- add a generic real-harness regression using a fictional topic, independent of Jordan, Reddit, or any particular research tool
- integrate the latest mainline parallel-tool and outbound-message changes without raising source or prompt limits

## Root cause

Jordan received the Discord request at 17:02:19Z, began research at 17:02:59Z, and did not reply until 17:05:52Z. The prompt explicitly suppressed progress for bounded one-off research, while the runtime kickoff gate only recognized work labeled deep, exhaustive, or similarly substantial. No delivery or Discord tool failure occurred: Jordan followed policy and left 3m32s of user-visible silence.

## Verification

- pre-fix DeepSeek V4 Flash regression: 2/3; research executed before any Discord message (`937d6abc-6eda-41d2-856b-f7e2b6e1ab42`)
- exact rebased-head DeepSeek V4 Flash regression: 3/3 (`b93f8fbe-d96f-43ee-bef8-c94194ecd97a`)
- exact-head affected Discord suite: 8/9 (`ad1e0709-0197-4926-8501-6ccb7f5236bd`); the unrelated reaction-context case selected the immediately preceding message ID, then passed 2/2 unchanged on rerun (`fd2a88dd-c978-472f-ade4-9e42927fee75`)
- adjacent bounded web-research regression: 8/8 (`b2415493-f378-4fd3-b448-85d3f7bf9e87`), preserving silent web-chat behavior
- focused Django tests: 8/8
- source and prompt complexity guardrails pass without raising limits
- exact-head GitHub CI: all 10 backend shards, frontend, sandbox, complexity, tag, and combined checks pass (`30031523698`)

One exploratory DeepSeek run of the existing explicit-deep-research scenario passed 7/10 after overrunning its tool budget before the milestone/final report. The failure was outside this Discord-only path and is unchanged here.