### PR TITLE
Stop repeated reasoning after terminal delivery

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -6774,6 +6774,12 @@ def _run_agent_loop(
                     if not _is_orchestrator_prompt_stale():
                         remove_pending_agent(agent.id, client=redis_client)
 
+                def _finish_agent_loop(*, consume_human: bool = True) -> int:
+                    if consume_human:
+                        _mark_accepted_human_generation_consumed()
+                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
+                    return cumulative_token_usage
+
                 def _attach_prompt_archive(step: PersistentAgentStep) -> None:
                     nonlocal prompt_archive_attached
                     if not prompt_archive_id or prompt_archive_attached:
@@ -6873,22 +6879,13 @@ def _run_agent_loop(
                 if terminal_plan_cleanup_this_iteration:
                     terminal_plan_cleanup_pending = False
                     if "update_plan" not in tool_names:
-                        logger.info(
-                            "Agent %s: update_plan unavailable for terminal closeout; stopping.",
-                            agent.id,
-                        )
-                        _mark_accepted_human_generation_consumed()
-                        _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                        return cumulative_token_usage
+                        logger.info("Agent %s: update_plan unavailable for terminal closeout; stopping.", agent.id)
+                        return _finish_agent_loop()
                     request_tools, request_failover_configs = _focused_tool_completion_request(
                         iteration_tools,
                         request_failover_configs,
                         "update_plan",
-                        (
-                            "The final user-facing delivery already succeeded. This is the only closeout turn: "
-                            "call update_plan once with every current item finished or explicitly deferred. "
-                            "Do not message, research, or take any other action."
-                        ),
+                        "Final delivery succeeded. Only call update_plan once to finish/defer every current item; do nothing else.",
                         fixed_continue=False,
                     )
                 elif direct_correction_pending:
@@ -7215,13 +7212,8 @@ def _run_agent_loop(
                         _mark_accepted_human_generation_consumed()
                         continue
                     if terminal_plan_cleanup_this_iteration:
-                        logger.info(
-                            "Agent %s: bounded terminal plan closeout returned no tool; stopping.",
-                            agent.id,
-                        )
-                        _mark_accepted_human_generation_consumed()
-                        _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                        return cumulative_token_usage
+                        logger.info("Agent %s: bounded terminal plan closeout returned no tool; stopping.", agent.id)
+                        return _finish_agent_loop()
                     if not message_text and not thinking_content:
                         # Truly empty response (no text, no thinking, no tools) = agent is done
                         # Log plan state to help diagnose premature termination
@@ -7241,9 +7233,7 @@ def _run_agent_loop(
                             type(msg_content).__name__,
                             len(msg_content) if msg_content else 0,
                         )
-                        _mark_accepted_human_generation_consumed()
-                        _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                        return cumulative_token_usage
+                        return _finish_agent_loop()
                     if reasoning_step is not None:
                         try:
                             reasoning_step.description = internal_reasoning.build_internal_reasoning_description(
@@ -7292,9 +7282,7 @@ def _run_agent_loop(
                             plan_state,
                             message_text or thinking_content or "(none)",
                         )
-                        _mark_accepted_human_generation_consumed()
-                        _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                        return cumulative_token_usage
+                        return _finish_agent_loop()
                     _mark_accepted_human_generation_consumed()
                     continue
 
@@ -7366,9 +7354,7 @@ def _run_agent_loop(
                         prepared_batch.prepared_calls,
                         reason="Tool call was cancelled before execution by the evaluation stop policy.",
                     )
-                    _mark_accepted_human_generation_consumed()
-                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                    return cumulative_token_usage
+                    return _finish_agent_loop()
 
                 executed_batch = _execute_prepared_tool_batch(
                     agent,
@@ -7460,9 +7446,7 @@ def _run_agent_loop(
                     followup_required = True
 
                 if _should_stop_for_eval_policy(agent, budget_ctx=budget_ctx, span=iter_span):
-                    _mark_accepted_human_generation_consumed()
-                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                    return cumulative_token_usage
+                    return _finish_agent_loop()
 
                 _mark_accepted_human_generation_consumed()
 
@@ -7487,16 +7471,11 @@ def _run_agent_loop(
                         followup_required = True
 
                 if terminal_plan_cleanup_this_iteration:
-                    logger.info(
-                        "Agent %s: bounded terminal plan closeout turn finished; stopping.",
-                        agent.id,
-                    )
-                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                    return cumulative_token_usage
+                    logger.info("Agent %s: bounded terminal plan closeout turn finished; stopping.", agent.id)
+                    return _finish_agent_loop(consume_human=False)
                 elif all_calls_sleep:
                     logger.info("Agent %s is sleeping.", agent.id)
-                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                    return cumulative_token_usage
+                    return _finish_agent_loop(consume_human=False)
                 elif _should_continue_for_unanswered_inbound_after_tools(agent, finalized_batch):
                     logger.info(
                         "Agent %s: non-message tool batch requested stop while latest inbound message "
@@ -7514,8 +7493,7 @@ def _run_agent_loop(
                         "Agent %s: tool batch ended with explicit stop; auto-sleeping.",
                         agent.id,
                     )
-                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                    return cumulative_token_usage
+                    return _finish_agent_loop(consume_human=False)
                 # Implied send without continuation phrase = agent is done, force stop
                 elif (
                     implied_stop_after_send
@@ -7527,8 +7505,7 @@ def _run_agent_loop(
                         "Agent %s: implied send without continuation phrase; auto-sleeping.",
                         agent.id,
                     )
-                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                    return cumulative_token_usage
+                    return _finish_agent_loop(consume_human=False)
                 elif (
                     not followup_required
                     and last_explicit_continue is None
@@ -7539,8 +7516,7 @@ def _run_agent_loop(
                         "Agent %s: tool batch complete with no follow-up required; auto-sleeping.",
                         agent.id,
                     )
-                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
-                    return cumulative_token_usage
+                    return _finish_agent_loop(consume_human=False)
                 elif not followup_required and last_explicit_continue is True:
                     logger.info(
                         "Agent %s: tools returned auto_sleep_ok but agent explicitly requested continuation; continuing.",

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -2297,8 +2297,8 @@ class _FinalizedToolBatch:
 def _plan_has_unfinished_items(agent: PersistentAgent) -> bool:
     try:
         snapshot = build_plan_snapshot(agent)
-    except Exception:
-        logger.debug("Failed to build plan snapshot for terminal-send check.", exc_info=True)
+    except DatabaseError:
+        logger.debug("Failed to build plan snapshot for terminal closeout.", exc_info=True)
         return False
     return snapshot.todo_count > 0 or snapshot.doing_count > 0
 
@@ -4074,22 +4074,6 @@ def _finalize_tool_batch(
             executed_non_message_action = True
 
     followup_required = followup_required or bool(human_input_delivery_tools - successful_message_tools)
-
-    if (
-        agent.planning_state != PersistentAgent.PlanningState.PLANNING
-        and terminal_message_delivery_ok
-        and not followup_required
-        and not is_credit_message_only_mode(daily_credit_state, task_credit_available)
-        and _plan_has_unfinished_items(agent)
-    ):
-        _record_policy_step(
-            agent,
-            "Terminal message delivery requested stop, but the current plan still has unfinished items. "
-            "Call update_plan with the complete current plan state before stopping.",
-            attach_completion=attach_completion,
-            attach_prompt_archive=attach_prompt_archive,
-        )
-        followup_required = True
 
     return _FinalizedToolBatch(
         executed_calls=executed_calls,
@@ -6457,6 +6441,7 @@ def _run_agent_loop(
     direct_correction_reply_pending = False
     direct_feedback_reply_completed = False
     direct_correction_prior_output = ""
+    terminal_plan_cleanup_pending = False
     explicit_prefer_low_latency = prefer_low_latency
 
     def _current_human_inbound_generation() -> int:
@@ -6477,12 +6462,15 @@ def _run_agent_loop(
         routing_scope_tokens.append(bind_inbound_routing_scope(initial_routing_scope))
 
         def _refresh_inbound_routing_scope(generation: int) -> None:
-            nonlocal routing_scope_generation, direct_correction_reply_pending, direct_feedback_reply_completed, direct_correction_prior_output
+            nonlocal routing_scope_generation, direct_correction_reply_pending
+            nonlocal direct_feedback_reply_completed, direct_correction_prior_output
+            nonlocal terminal_plan_cleanup_pending
             routing_scope_tokens.append(bind_inbound_routing_scope(capture_inbound_routing_scope(agent, pending_inbound=True)))
             routing_scope_generation = generation
             direct_correction_reply_pending = False
             direct_feedback_reply_completed = False
             direct_correction_prior_output = ""
+            terminal_plan_cleanup_pending = False
 
         prompt_run_cache = PromptRunCache(
             agent_id=str(agent.id),
@@ -6881,7 +6869,29 @@ def _run_agent_loop(
                 request_tools = iteration_tools
                 focused_feedback_reply_tool_name = None
                 source_reconciliation_directive = prompt_metadata.get("source_reconciliation_directive")
-                if direct_correction_pending:
+                terminal_plan_cleanup_this_iteration = terminal_plan_cleanup_pending
+                if terminal_plan_cleanup_this_iteration:
+                    terminal_plan_cleanup_pending = False
+                    if "update_plan" not in tool_names:
+                        logger.info(
+                            "Agent %s: update_plan unavailable for terminal closeout; stopping.",
+                            agent.id,
+                        )
+                        _mark_accepted_human_generation_consumed()
+                        _attempt_cycle_close_for_sleep(agent, budget_ctx)
+                        return cumulative_token_usage
+                    request_tools, request_failover_configs = _focused_tool_completion_request(
+                        iteration_tools,
+                        request_failover_configs,
+                        "update_plan",
+                        (
+                            "The final user-facing delivery already succeeded. This is the only closeout turn: "
+                            "call update_plan once with every current item finished or explicitly deferred. "
+                            "Do not message, research, or take any other action."
+                        ),
+                        fixed_continue=False,
+                    )
+                elif direct_correction_pending:
                     if not prompt_metadata.get("prompt_message_transform_applied"):
                         request_history = _focused_charter_patch_history(
                             history, agent.charter or "", feedback_analysis.lasting, direct_correction_prior_output,
@@ -7204,6 +7214,14 @@ def _run_agent_loop(
                         reasoning_only_streak = 0
                         _mark_accepted_human_generation_consumed()
                         continue
+                    if terminal_plan_cleanup_this_iteration:
+                        logger.info(
+                            "Agent %s: bounded terminal plan closeout returned no tool; stopping.",
+                            agent.id,
+                        )
+                        _mark_accepted_human_generation_consumed()
+                        _attempt_cycle_close_for_sleep(agent, budget_ctx)
+                        return cumulative_token_usage
                     if not message_text and not thinking_content:
                         # Truly empty response (no text, no thinking, no tools) = agent is done
                         # Log plan state to help diagnose premature termination
@@ -7425,6 +7443,22 @@ def _run_agent_loop(
                 if runtime_errors:
                     followup_required = True
 
+                if (
+                    agent.planning_state != PersistentAgent.PlanningState.PLANNING
+                    and finalized_batch.terminal_message_delivery_ok
+                    and not followup_required
+                    and not is_credit_message_only_mode(daily_state, task_credit_available)
+                    and _plan_has_unfinished_items(agent)
+                ):
+                    _record_policy_step(
+                        agent,
+                        "Final delivery succeeded with unfinished visible plan items. Run one bounded update_plan closeout, then stop.",
+                        attach_completion=_attach_completion,
+                        attach_prompt_archive=_attach_prompt_archive,
+                    )
+                    terminal_plan_cleanup_pending = True
+                    followup_required = True
+
                 if _should_stop_for_eval_policy(agent, budget_ctx=budget_ctx, span=iter_span):
                     _mark_accepted_human_generation_consumed()
                     _attempt_cycle_close_for_sleep(agent, budget_ctx)
@@ -7452,7 +7486,14 @@ def _run_agent_loop(
                     if not _skip_stale_planning_mode_after_terminal_delivery(agent):
                         followup_required = True
 
-                if all_calls_sleep:
+                if terminal_plan_cleanup_this_iteration:
+                    logger.info(
+                        "Agent %s: bounded terminal plan closeout turn finished; stopping.",
+                        agent.id,
+                    )
+                    _attempt_cycle_close_for_sleep(agent, budget_ctx)
+                    return cumulative_token_usage
+                elif all_calls_sleep:
                     logger.info("Agent %s is sleeping.", agent.id)
                     _attempt_cycle_close_for_sleep(agent, budget_ctx)
                     return cumulative_token_usage

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3784,6 +3784,7 @@ def _get_system_instruction(
     continuation_mode_block = "" if is_first_run else _get_continuation_mode_prompt_block()
     has_unfinished_plan = (
         not planning_mode_active
+        and isinstance(agent, PersistentAgent)
         and agent.kanban_cards.filter(status__in=("todo", "doing")).exists()
     )
 

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3782,11 +3782,6 @@ def _get_system_instruction(
     planning_mode_active = agent.planning_state == PersistentAgent.PlanningState.PLANNING
     implied_send_active = implied_send_context is not None
     continuation_mode_block = "" if is_first_run else _get_continuation_mode_prompt_block()
-    has_unfinished_plan = (
-        not planning_mode_active
-        and isinstance(agent, PersistentAgent)
-        and agent.kanban_cards.filter(status__in=("todo", "doing")).exists()
-    )
 
     if implied_send_active:
         display_name = implied_send_context.get("display_name") if implied_send_context else "active web chat user"
@@ -3831,21 +3826,12 @@ def _get_system_instruction(
         if implied_send_active
         else ""
     )
-    plan_closeout_guidance = (
-        "This run has unfinished visible plan items. Before stopping, send the final delivery with true, then make one "
-        "update_plan call that finishes/defers every Doing/Todo item and uses false.\n\n"
-        if has_unfinished_plan
-        else (
-            "Plans: if cleanup remains, send final report with true, update_plan finished/deferred items, "
-            "then stop with false.\n\n"
-        )
-    )
     stop_continue_examples = (
         "## Stop/continue\n\n"
         "Set will_continue_work=true only for immediate work: unsent results, unverified constraints, plan cleanup, or needed tool results. "
         "Set false after delivery/config and no active work; future schedules do not count.\n"
         f"{text_only_guidance}"
-        f"{plan_closeout_guidance}"
+        "Plans: if cleanup remains, send final report with true, update_plan finished/deferred items, then stop with false.\n\n"
         "Recurring or truly multi-phase work may need charter/schedule updates; one-off work usually needs neither.\n"
     )
 

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3782,6 +3782,10 @@ def _get_system_instruction(
     planning_mode_active = agent.planning_state == PersistentAgent.PlanningState.PLANNING
     implied_send_active = implied_send_context is not None
     continuation_mode_block = "" if is_first_run else _get_continuation_mode_prompt_block()
+    has_unfinished_plan = (
+        not planning_mode_active
+        and agent.kanban_cards.filter(status__in=("todo", "doing")).exists()
+    )
 
     if implied_send_active:
         display_name = implied_send_context.get("display_name") if implied_send_context else "active web chat user"
@@ -3826,12 +3830,21 @@ def _get_system_instruction(
         if implied_send_active
         else ""
     )
+    plan_closeout_guidance = (
+        "This run has unfinished visible plan items. Before stopping, send the final delivery with true, then make one "
+        "update_plan call that finishes/defers every Doing/Todo item and uses false.\n\n"
+        if has_unfinished_plan
+        else (
+            "Plans: if cleanup remains, send final report with true, update_plan finished/deferred items, "
+            "then stop with false.\n\n"
+        )
+    )
     stop_continue_examples = (
         "## Stop/continue\n\n"
         "Set will_continue_work=true only for immediate work: unsent results, unverified constraints, plan cleanup, or needed tool results. "
         "Set false after delivery/config and no active work; future schedules do not count.\n"
         f"{text_only_guidance}"
-        "Plans: if cleanup remains, send final report with true, update_plan finished/deferred items, then stop with false.\n\n"
+        f"{plan_closeout_guidance}"
         "Recurring or truly multi-phase work may need charter/schedule updates; one-off work usually needs neither.\n"
     )
 

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -456,7 +456,7 @@ class MessageToolExplicitContinuationTests(TestCase):
 
         self.assertFalse(_tool_call_likely_terminal_message(call))
 
-    def test_terminal_message_with_unfinished_plan_requires_followup(self):
+    def test_terminal_message_with_unfinished_plan_stops(self):
         PersistentAgentKanbanCard.objects.create(
             assigned_agent=self.agent,
             title="Synthesize final report",
@@ -499,9 +499,9 @@ class MessageToolExplicitContinuationTests(TestCase):
         )
 
         self.assertTrue(finalized.terminal_message_delivery_ok)
-        self.assertTrue(finalized.followup_required)
+        self.assertFalse(finalized.followup_required)
         self.assertIs(finalized.last_explicit_continue, False)
-        self.assertTrue(
+        self.assertFalse(
             PersistentAgentStep.objects.filter(
                 agent=self.agent,
                 description__contains="current plan still has unfinished items",

--- a/api/agent/tools/plan.py
+++ b/api/agent/tools/plan.py
@@ -10,7 +10,12 @@ from uuid import UUID
 from django.db import transaction
 from django.utils import timezone
 
-from api.models import PersistentAgentKanbanCard, PersistentAgentMessage, PersistentAgentPlanDeliverable
+from api.models import (
+    PersistentAgent,
+    PersistentAgentKanbanCard,
+    PersistentAgentMessage,
+    PersistentAgentPlanDeliverable,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -469,8 +474,16 @@ def format_current_plan_for_prompt(agent) -> str:
     if not (snapshot.todo_count or snapshot.doing_count or snapshot.done_count):
         return "Current plan: none"
 
+    unfinished = (
+        (snapshot.todo_count or snapshot.doing_count)
+        and agent.planning_state != PersistentAgent.PlanningState.PLANNING
+    )
     lines = [
-        "Current plan:",
+        (
+            "Current plan (before stopping: send the final delivery with true, then finish/defer all Doing/Todo via update_plan false):"
+            if unfinished
+            else "Current plan:"
+        ),
         f"- Doing: {snapshot.doing_count}",
         f"- Todo: {snapshot.todo_count}",
         f"- Done: {snapshot.done_count}",

--- a/api/agent/tools/plan.py
+++ b/api/agent/tools/plan.py
@@ -10,12 +10,7 @@ from uuid import UUID
 from django.db import transaction
 from django.utils import timezone
 
-from api.models import (
-    PersistentAgent,
-    PersistentAgentKanbanCard,
-    PersistentAgentMessage,
-    PersistentAgentPlanDeliverable,
-)
+from api.models import PersistentAgentKanbanCard, PersistentAgentMessage, PersistentAgentPlanDeliverable
 
 logger = logging.getLogger(__name__)
 
@@ -474,16 +469,11 @@ def format_current_plan_for_prompt(agent) -> str:
     if not (snapshot.todo_count or snapshot.doing_count or snapshot.done_count):
         return "Current plan: none"
 
-    unfinished = (
-        (snapshot.todo_count or snapshot.doing_count)
-        and agent.planning_state != PersistentAgent.PlanningState.PLANNING
-    )
+    heading = "Current plan:"
+    if (snapshot.todo_count or snapshot.doing_count) and agent.planning_state != agent.PlanningState.PLANNING:
+        heading += " before stopping: send the final delivery with true, then finish/defer all Doing/Todo via update_plan false"
     lines = [
-        (
-            "Current plan (before stopping: send the final delivery with true, then finish/defer all Doing/Todo via update_plan false):"
-            if unfinished
-            else "Current plan:"
-        ),
+        heading,
         f"- Doing: {snapshot.doing_count}",
         f"- Todo: {snapshot.todo_count}",
         f"- Done: {snapshot.done_count}",

--- a/api/agent/tools/tests/test_plan.py
+++ b/api/agent/tools/tests/test_plan.py
@@ -6,6 +6,7 @@ from django.test import SimpleTestCase, TestCase, tag
 from api.agent.tools.plan import (
     build_redundant_research_plan_skip_result,
     execute_update_plan,
+    format_current_plan_for_prompt,
     get_update_plan_tool,
 )
 from api.models import (
@@ -90,6 +91,33 @@ class UpdatePlanResearchSuppressionTests(TestCase):
             browser_use_agent=self.browser_agent,
             charter="Test agent.",
         )
+
+    def test_unfinished_plan_prompt_places_cleanup_next_to_plan(self):
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Deliver the final report",
+            status=PersistentAgentKanbanCard.Status.TODO,
+            priority=1,
+        )
+
+        prompt = format_current_plan_for_prompt(self.agent)
+
+        self.assertIn("send the final delivery with true", prompt)
+        self.assertIn("finish/defer all Doing/Todo via update_plan false", prompt)
+
+    def test_planning_mode_does_not_prompt_for_final_delivery(self):
+        self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
+        self.agent.save(update_fields=["planning_state"])
+        PersistentAgentKanbanCard.objects.create(
+            assigned_agent=self.agent,
+            title="Deliver the final report",
+            status=PersistentAgentKanbanCard.Status.TODO,
+            priority=1,
+        )
+
+        prompt = format_current_plan_for_prompt(self.agent)
+
+        self.assertNotIn("send the final delivery", prompt)
 
     def test_redundant_research_progress_update_is_skipped(self):
         PersistentAgentKanbanCard.objects.create(

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -476,6 +476,46 @@ def get_tool_calls_for_run(run_id, *, after=None, tool_names=None):
     return list(queryset.select_related("step", "step__agent").order_by("step__created_at", "step__id"))
 
 
+def explicit_stop_is_bounded_to_plan_closeout(run_id, *, after, call):
+    completion_ids = list(
+        PersistentAgentCompletion.objects.filter(
+            eval_run_id=run_id,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+            created_at__gte=after,
+        )
+        .order_by("created_at", "id")
+        .values_list("id", flat=True)
+    )
+    call_completion_id = getattr(getattr(call, "step", None), "completion_id", None)
+    if not call_completion_id or call_completion_id not in completion_ids:
+        return False, (
+            f"stop_completion_id={call_completion_id}, "
+            f"orchestrator_completion_ids={[str(value) for value in completion_ids]}"
+        )
+
+    later_completion_ids = completion_ids[completion_ids.index(call_completion_id) + 1:]
+    if not later_completion_ids:
+        return True, f"stop_completion_id={call_completion_id}, later_completion_ids=[]"
+    if len(later_completion_ids) != 1:
+        return False, (
+            f"stop_completion_id={call_completion_id}, "
+            f"later_completion_ids={[str(value) for value in later_completion_ids]}"
+        )
+
+    closeout_calls = list(
+        PersistentAgentToolCall.objects.filter(
+            step__eval_run_id=run_id,
+            step__completion_id=later_completion_ids[0],
+        ).values_list("tool_name", flat=True)
+    )
+    bounded = closeout_calls == ["update_plan"]
+    return bounded, (
+        f"stop_completion_id={call_completion_id}, "
+        f"later_completion_ids={[str(value) for value in later_completion_ids]}, "
+        f"closeout_calls={closeout_calls}"
+    )
+
+
 def get_first_relevant_tool_call(run_id, *, after=None, ignored_tool_names=None):
     ignored = set(ignored_tool_names or ())
     for call in get_tool_calls_for_run(run_id, after=after):
@@ -1548,6 +1588,7 @@ class PlanningFinalReportCompletesVisiblePlanScenario(BehaviorMicroScenario):
         ScenarioTask(name="inject_prompt", assertion_type="manual"),
         ScenarioTask(name="verify_final_report_sent", assertion_type="manual"),
         ScenarioTask(name="verify_plan_completed", assertion_type="manual"),
+        ScenarioTask(name="verify_terminal_delivery_had_at_most_one_plan_closeout", assertion_type="manual"),
     ]
 
     def _seed_unfinished_plan(self, agent_id):
@@ -1571,7 +1612,11 @@ class PlanningFinalReportCompletesVisiblePlanScenario(BehaviorMicroScenario):
             payload = json.loads(call.result or "{}")
         except json.JSONDecodeError:
             return False
-        return isinstance(payload, dict) and payload.get("status") in {"ok", "sent", "success"}
+        return (
+            isinstance(payload, dict)
+            and payload.get("status") in {"ok", "sent", "success"}
+            and not payload.get("skipped")
+        )
 
     def run(self, run_id, agent_id):
         self._set_planning_state(agent_id, PersistentAgent.PlanningState.COMPLETED)
@@ -1612,13 +1657,13 @@ class PlanningFinalReportCompletesVisiblePlanScenario(BehaviorMicroScenario):
             if self._message_call_was_delivered(call)
         ]
         self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="verify_final_report_sent")
-        if send_calls:
+        if len(send_calls) == 1:
             self.record_task_result(
                 run_id,
                 None,
                 EvalRunTask.Status.PASSED,
                 task_name="verify_final_report_sent",
-                observed_summary="Agent delivered a web chat report.",
+                observed_summary="Agent delivered exactly one web chat report.",
                 artifacts={"step": send_calls[0].step},
             )
         else:
@@ -1627,7 +1672,7 @@ class PlanningFinalReportCompletesVisiblePlanScenario(BehaviorMicroScenario):
                 None,
                 EvalRunTask.Status.FAILED,
                 task_name="verify_final_report_sent",
-                observed_summary="Expected one delivered send_chat_message call.",
+                observed_summary=f"Expected exactly one delivered send_chat_message call; found {len(send_calls)}.",
             )
 
         unfinished = list(
@@ -1663,6 +1708,53 @@ class PlanningFinalReportCompletesVisiblePlanScenario(BehaviorMicroScenario):
                 ),
                 artifacts={"step": (send_calls[0].step if send_calls else None)},
             )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="verify_terminal_delivery_had_at_most_one_plan_closeout",
+        )
+        run_calls = get_tool_calls_for_run(run_id, after=inbound.timestamp)
+        explicit_stop_calls = [
+            call
+            for call in run_calls
+            if resolved_tool_param(call, "will_continue_work") is False
+        ]
+        terminal_delivery_calls = [
+            call
+            for call in send_calls
+            if resolved_tool_param(call, "will_continue_work") is False
+        ]
+        stop_anchor = (
+            terminal_delivery_calls[0]
+            if terminal_delivery_calls
+            else (explicit_stop_calls[-1] if explicit_stop_calls else None)
+        )
+        stopped = False
+        detail = (
+            f"delivered_send_calls={len(send_calls)}, "
+            f"terminal_delivery_calls={len(terminal_delivery_calls)}, "
+            f"explicit_stop_calls={len(explicit_stop_calls)}"
+        )
+        if len(send_calls) == 1 and stop_anchor is not None:
+            stopped, detail = explicit_stop_is_bounded_to_plan_closeout(
+                run_id,
+                after=inbound.timestamp,
+                call=stop_anchor,
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if stopped else EvalRunTask.Status.FAILED,
+            task_name="verify_terminal_delivery_had_at_most_one_plan_closeout",
+            observed_summary=(
+                "The terminal delivery ended processing directly or after one update_plan-only closeout."
+                if stopped
+                else f"Processing continued beyond one bounded plan closeout or no terminal stop was issued: {detail}."
+            ),
+            artifacts={"step": stop_anchor.step} if stop_anchor is not None else {},
+        )
 
 
 @register_scenario

--- a/api/evals/tests/test_behavior_micro.py
+++ b/api/evals/tests/test_behavior_micro.py
@@ -30,6 +30,14 @@ MONITORING_SCOPE_QUESTION = "common_use_case_099_request_monitoring_scope"
 
 @tag("eval_sim")
 class BehaviorMicroScenarioTests(SimpleTestCase):
+    def test_final_report_eval_does_not_count_skipped_send_as_delivered(self):
+        scenario = ScenarioRegistry.get("planning_final_report_completes_visible_plan")
+        skipped_call = SimpleNamespace(result=json.dumps({"status": "ok", "skipped": True}))
+        delivered_call = SimpleNamespace(result=json.dumps({"status": "ok"}))
+
+        self.assertFalse(scenario._message_call_was_delivered(skipped_call))
+        self.assertTrue(scenario._message_call_was_delivered(delivered_call))
+
     def test_planning_questions_eval_exercises_normal_wait_lifecycle(self):
         scenario = ScenarioRegistry.get(PLANNING_FIRST_TURN_ASKS_BOUNDED_QUESTIONS)
         policy = scenario._eval_stop_policy()

--- a/tests/unit/test_eval_behavior_micro_scenarios.py
+++ b/tests/unit/test_eval_behavior_micro_scenarios.py
@@ -61,6 +61,7 @@ from api.evals.scenarios.behavior_micro import (
     get_plan_activity_calls_for_run,
     get_pending_human_input_requests,
     get_planning_mutation_calls_before_end_planning,
+    explicit_stop_is_bounded_to_plan_closeout,
     tool_call_is_plan_activity,
 )
 from api.evals.scenarios.effort_calibration import _hierarchical_report_shape
@@ -741,6 +742,39 @@ class BehaviorMicroHelperTests(TestCase):
 
     def _add_orchestrator_completion(self):
         return PersistentAgentCompletion.objects.create(agent=self.agent, eval_run=self.run)
+
+    def test_explicit_stop_allows_at_most_one_plan_closeout_completion(self):
+        terminal_completion = self._add_orchestrator_completion()
+        terminal_call = self._add_tool_call(
+            "send_chat_message",
+            {"body": "Done.", "will_continue_work": False},
+            completion=terminal_completion,
+        )
+        after = terminal_completion.created_at - timedelta(seconds=1)
+
+        stopped, detail = explicit_stop_is_bounded_to_plan_closeout(
+            self.run.id,
+            after=after,
+            call=terminal_call,
+        )
+        self.assertTrue(stopped, detail)
+
+        closeout_completion = self._add_orchestrator_completion()
+        self._add_tool_call("update_plan", {"plan": [], "will_continue_work": False}, completion=closeout_completion)
+        stopped, detail = explicit_stop_is_bounded_to_plan_closeout(
+            self.run.id,
+            after=after,
+            call=terminal_call,
+        )
+        self.assertTrue(stopped, detail)
+
+        self._add_orchestrator_completion()
+        stopped, detail = explicit_stop_is_bounded_to_plan_closeout(
+            self.run.id,
+            after=after,
+            call=terminal_call,
+        )
+        self.assertFalse(stopped, detail)
 
     def _assert_charter_cases(self, slug, *, old, new, passing, failing):
         scenario = ScenarioRegistry.get(slug)

--- a/tests/unit/test_event_processing_batch_sleep.py
+++ b/tests/unit/test_event_processing_batch_sleep.py
@@ -377,7 +377,7 @@ class TestBatchToolCallsWithSleep(TestCase):
     @patch('api.agent.core.event_processing.execute_send_email', return_value={"status": "ok", "auto_sleep_ok": True})
     @patch('api.agent.core.event_processing.build_prompt_context')
     @patch('api.agent.core.event_processing._completion_with_failover')
-    def test_auto_sleep_not_overridden_with_open_plan_work(
+    def test_terminal_send_allows_only_one_bounded_plan_closeout_turn(
         self,
         mock_completion,
         mock_build_prompt,
@@ -407,7 +407,13 @@ class TestBatchToolCallsWithSleep(TestCase):
             tc.function.arguments = args
             return tc
 
-        tc_email = mk_tc('send_email', '{"to": "a@example.com", "subject": "hi", "mobile_first_html": "<p>Hi</p>"}')
+        tc_email = mk_tc(
+            'send_email',
+            (
+                '{"to_address": "a@example.com", "subject": "hi", '
+                '"mobile_first_html": "<p>Hi</p>", "will_continue_work": false}'
+            ),
+        )
         tc_charter = mk_tc('update_charter', '{"new_charter": "Stay focused"}')
 
         msg = MagicMock()
@@ -418,37 +424,54 @@ class TestBatchToolCallsWithSleep(TestCase):
         resp = MagicMock(); resp.choices = [choice]
         resp.model_extra = {"usage": MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15, prompt_tokens_details=MagicMock(cached_tokens=0))}
 
-        tc_plan = mk_tc(
-            'update_plan',
-            '{"plan": [{"step": "Finish outstanding work", "status": "done"}], "will_continue_work": false}',
-        )
-        followup_msg = MagicMock()
-        followup_msg.tool_calls = [tc_plan]
-        followup_msg.content = None
-        followup_choice = MagicMock(); followup_choice.message = followup_msg
+        followup_choice = MagicMock()
+        followup_choice.message = {
+            "tool_calls": [],
+            "content": None,
+            "reasoning_content": "Let me get my bearings before I update the plan.",
+        }
         followup_resp = MagicMock(); followup_resp.choices = [followup_choice]
         followup_resp.model_extra = {"usage": MagicMock(prompt_tokens=4, completion_tokens=2, total_tokens=6, prompt_tokens_details=MagicMock(cached_tokens=0))}
+
+        third_choice = MagicMock()
+        third_choice.message = {
+            "tool_calls": [],
+            "content": None,
+            "reasoning_content": "Let me assess the current state again.",
+        }
+        third_resp = MagicMock(); third_resp.choices = [third_choice]
+        third_resp.model_extra = {"usage": MagicMock(prompt_tokens=4, completion_tokens=2, total_tokens=6, prompt_tokens_details=MagicMock(cached_tokens=0))}
 
         mock_completion.side_effect = [
             (resp, {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15, "model": "m", "provider": "p"}),
             (followup_resp, {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6, "model": "m", "provider": "p"}),
+            (third_resp, {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6, "model": "m", "provider": "p"}),
         ]
 
         from api.agent.core import event_processing as ep
-        with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 2):
+        with patch.object(ep, 'MAX_AGENT_LOOP_ITERATIONS', 3):
             ep._run_agent_loop(self.agent, is_first_run=False)
 
         self.assertEqual(mock_completion.call_count, 2)
+        closeout_tools = mock_completion.call_args_list[1].kwargs["tools"]
+        self.assertEqual(
+            [tool["function"]["name"] for tool in closeout_tools],
+            ["update_plan"],
+        )
+        self.assertIs(
+            closeout_tools[0]["function"]["parameters"]["properties"]["will_continue_work"]["const"],
+            False,
+        )
         self.assertEqual(len(notices), 2)
         self.assertIsNone(notices[0])
         self.assertIsNone(notices[1])
         self.assertTrue(
             PersistentAgentStep.objects.filter(
                 agent=self.agent,
-                description__contains="current plan still has unfinished items",
+                description__contains="one bounded update_plan closeout",
             ).exists()
         )
-        self.assertFalse(
+        self.assertTrue(
             PersistentAgentKanbanCard.objects.filter(
                 assigned_agent=self.agent,
                 status__in=[


### PR DESCRIPTION
## What changed

- Replaces the open-ended runtime continuation after a successful terminal message with at most one focused `update_plan` closeout turn.
- Constrains that turn to `update_plan` with `will_continue_work=false`, then stops even if the model returns reasoning without a tool.
- Places the preferred final-delivery-then-plan-closeout order beside unfinished execution plans; Planning Mode remains unchanged.
- Extends the real-harness eval to require exactly one delivered report, a completed visible plan, and no more than one `update_plan`-only completion after terminal delivery.

## RCA

Production evidence for #251 showed a successful Discord delivery at 18:24:44Z with `will_continue_work=false` and `auto_sleep_ok=true`. The runtime then overrode that stop solely because a visible plan item remained. At 18:24:54Z the next model completion explicitly cited the injected policy note and resumed, allowing repeated reasoning/tool cycles.

The root was not provider thinking preservation. The batch finalizer converted any successful terminal stop with an unfinished plan into unrestricted follow-up processing. That made plan hygiene capable of reopening the full agent loop.

## Red first

The runtime regression reproduced the failure with a terminal delivery, an unfinished plan, a reasoning-only closeout response, and a third completion waiting. The old behavior consumed the extra completion; the fix stops after the single bounded closeout attempt. The eval also rejects repeated delivered reports or more than one post-delivery completion.

## Verification

- 245/245 focused unit and eval-helper tests pass, plus the exact hosted-CI regression.
- DeepSeek V4 Flash exact regression passes 4/4 tasks on final integrated source (suite `1302682c-4e94-45a3-bf18-80b71dfbce9f`); prior repeated evidence passed 3/3 runs and 12/12 assertions.
- Full GitHub CI is green on `d1ace76857b46589c9e815b69489c52c4e64dc34`, including all ten backend shards, frontend, sandbox, tags, and complexity/prompt budgets.
- Integrated latest `main` without overlap. Source LoC remains within the existing limit at 250,997/251,000; no budget increase.
- Exact-head preview deployed successfully. `/`, `/healthz/`, and the immutable release asset returned 200, and the asset path contains the exact head SHA.
- A pre-existing secure-credential planning eval also fails on isolated exact `main`; it is not introduced by this diff.

Closes #251