### PR TITLE
Support dollar-style secret placeholders in HTTP requests

### DIFF
--- a/api/agent/tools/http_request.py
+++ b/api/agent/tools/http_request.py
@@ -32,10 +32,7 @@ RESPONSE_MAX_BYTES = 5 * 1024 * 1024
 PREVIEW_MAX_BYTES = RESPONSE_MAX_BYTES
 DOWNLOAD_CHUNK_SIZE = 64 * 1024
 API_ERROR_MESSAGE_MAX_CHARS = 1200
-_SECRET_PLACEHOLDER_RE = re.compile(
-    r"\$\[secret:\s*(?P<bracket_key>[A-Za-z0-9_]+)\s*\]"
-    r"|<<<\s*(?P<legacy_key>[A-Za-z0-9_]+)\s*>>>"
-)
+_SECRET_PLACEHOLDER_RE = re.compile(r"\$\[secret:\s*(?P<bracket_key>[A-Za-z0-9_]+)\s*\]|<<<\s*(?P<legacy_key>[A-Za-z0-9_]+)\s*>>>")
 
 _JSON_PREFIXES = (
     ")]}',",
@@ -366,11 +363,7 @@ def get_http_request_tool() -> Dict[str, Any]:
                 "When this tool returns a successful payload that answers the user's request, answer from that payload; do not open a browser task just to verify the same data. "
                 "For weather, a geocoding endpoint only resolves coordinates; call a forecast/current-conditions endpoint before replying with weather. "
                 "Do NOT use this when the task is to read or verify what appears on a webpage; use `spawn_web_task` for user-visible pages even if they are simple HTML. "
-                "The URL, headers, and body can include secret placeholders using `$[secret:my_api_key]`. "
-                "These placeholders will be replaced with the corresponding secret values at execution time. "
-                "The response is truncated to 5MB. Text content is returned even if served with "
-                "application/octet-stream; only truly binary data (images, etc.) is omitted. You may need to look "
-                "up API docs using the mcp_brightdata_search_engine tool."
+                "The URL, headers, and body can include secret placeholders using `$[secret:my_api_key]`. These placeholders will be replaced with the corresponding secret values at execution time. The response is truncated to 5MB. Text content is returned even if served with application/octet-stream; only truly binary data (images, etc.) is omitted. You may need to look up API docs using the mcp_brightdata_search_engine tool."
             ),
             "parameters": {
                 "type": "object",

--- a/api/agent/tools/http_request.py
+++ b/api/agent/tools/http_request.py
@@ -367,10 +367,10 @@ def get_http_request_tool() -> Dict[str, Any]:
                 "For weather, a geocoding endpoint only resolves coordinates; call a forecast/current-conditions endpoint before replying with weather. "
                 "Do NOT use this when the task is to read or verify what appears on a webpage; use `spawn_web_task` for user-visible pages even if they are simple HTML. "
                 "The URL, headers, and body can include secret placeholders using `$[secret:my_api_key]`. "
-                "The legacy form `<<<my_api_key>>>` is also supported. These placeholders will be replaced with "
-                "the corresponding secret values at execution time. The response is truncated to 5MB. Text content "
-                "is returned even if served with application/octet-stream; only truly binary data (images, etc.) is "
-                "omitted. You may need to look up API docs using the mcp_brightdata_search_engine tool."
+                "These placeholders will be replaced with the corresponding secret values at execution time. "
+                "The response is truncated to 5MB. Text content is returned even if served with "
+                "application/octet-stream; only truly binary data (images, etc.) is omitted. You may need to look "
+                "up API docs using the mcp_brightdata_search_engine tool."
             ),
             "parameters": {
                 "type": "object",

--- a/api/agent/tools/http_request.py
+++ b/api/agent/tools/http_request.py
@@ -32,6 +32,10 @@ RESPONSE_MAX_BYTES = 5 * 1024 * 1024
 PREVIEW_MAX_BYTES = RESPONSE_MAX_BYTES
 DOWNLOAD_CHUNK_SIZE = 64 * 1024
 API_ERROR_MESSAGE_MAX_CHARS = 1200
+_SECRET_PLACEHOLDER_RE = re.compile(
+    r"\$\[secret:\s*(?P<bracket_key>[A-Za-z0-9_]+)\s*\]"
+    r"|<<<\s*(?P<legacy_key>[A-Za-z0-9_]+)\s*>>>"
+)
 
 _JSON_PREFIXES = (
     ")]}',",
@@ -362,7 +366,11 @@ def get_http_request_tool() -> Dict[str, Any]:
                 "When this tool returns a successful payload that answers the user's request, answer from that payload; do not open a browser task just to verify the same data. "
                 "For weather, a geocoding endpoint only resolves coordinates; call a forecast/current-conditions endpoint before replying with weather. "
                 "Do NOT use this when the task is to read or verify what appears on a webpage; use `spawn_web_task` for user-visible pages even if they are simple HTML. "
-                "The URL, headers, and body can include secret placeholders using the unique pattern <<<my_api_key>>>. These placeholders will be replaced with the corresponding secret values at execution time. The response is truncated to 5MB. Text content is returned even if served with application/octet-stream; only truly binary data (images, etc.) is omitted. You may need to look up API docs using the mcp_brightdata_search_engine tool."
+                "The URL, headers, and body can include secret placeholders using `$[secret:my_api_key]`. "
+                "The legacy form `<<<my_api_key>>>` is also supported. These placeholders will be replaced with "
+                "the corresponding secret values at execution time. The response is truncated to 5MB. Text content "
+                "is returned even if served with application/octet-stream; only truly binary data (images, etc.) is "
+                "omitted. You may need to look up API docs using the mcp_brightdata_search_engine tool."
             ),
             "parameters": {
                 "type": "object",
@@ -470,20 +478,18 @@ def execute_http_request(agent: PersistentAgent, params: Dict[str, Any]) -> Dict
     # agent credentials override them on matching placeholder keys.
     secret_map = _resolved_credential_secret_map(agent)
 
-    UNIQUE_PATTERN_RE = re.compile(r"<<<\s*([A-Za-z0-9_]+)\s*>>>")
-    
     # Track which placeholders we find for logging
     found_placeholders = set()
 
     def _replace_placeholders(obj):
-        """Recursively replace <<<secret_key>>> placeholders in strings and collections."""
+        """Recursively replace secret placeholders in strings and collections."""
         if isinstance(obj, str):
             def _repl(match):
-                key = match.group(1)
+                key = match.group("bracket_key") or match.group("legacy_key")
                 found_placeholders.add(key)
                 return secret_map.get(key, match.group(0))
 
-            new_val = UNIQUE_PATTERN_RE.sub(_repl, obj)
+            new_val = _SECRET_PLACEHOLDER_RE.sub(_repl, obj)
             # If the whole string exactly matches a secret key, replace it outright (edge case)
             if new_val in secret_map:
                 found_placeholders.add(new_val)

--- a/api/agent/tools/tests/test_http_request.py
+++ b/api/agent/tools/tests/test_http_request.py
@@ -9,7 +9,7 @@ class NativeHttpErrorMessageTests(SimpleTestCase):
         description = get_http_request_tool()["function"]["description"]
 
         self.assertIn("$[secret:my_api_key]", description)
-        self.assertIn("<<<my_api_key>>>", description)
+        self.assertNotIn("<<<my_api_key>>>", description)
 
     def test_extracts_google_error_message(self):
         message = _native_api_error_message(

--- a/api/agent/tools/tests/test_http_request.py
+++ b/api/agent/tools/tests/test_http_request.py
@@ -1,10 +1,16 @@
 from django.test import SimpleTestCase, tag
 
-from api.agent.tools.http_request import _native_api_error_message
+from api.agent.tools.http_request import _native_api_error_message, get_http_request_tool
 
 
 @tag("http_request_batch")
 class NativeHttpErrorMessageTests(SimpleTestCase):
+    def test_tool_description_prefers_dollar_secret_placeholders(self):
+        description = get_http_request_tool()["function"]["description"]
+
+        self.assertIn("$[secret:my_api_key]", description)
+        self.assertIn("<<<my_api_key>>>", description)
+
     def test_extracts_google_error_message(self):
         message = _native_api_error_message(
             {

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -103,6 +103,7 @@ from api.models import (
     BrowserUseAgentTaskStep,
     AgentOwnerCustomInstructions,
     AgentPeerLink,
+    GlobalSecret,
     MCPServerConfig,
     Organization,
     OrganizationMembership,
@@ -4290,6 +4291,24 @@ class HttpRequestSecretPlaceholderTests(TestCase):
         secret.save()
         return secret
 
+    def _create_global_secret(
+        self,
+        key,
+        value,
+        domain="https://api.example.com",
+        name=None,
+    ):
+        secret = GlobalSecret(
+            user=self.user,
+            domain_pattern=domain,
+            name=name or key,
+            key=key,
+            secret_type=GlobalSecret.SecretType.CREDENTIAL,
+        )
+        secret.set_value(value)
+        secret.save()
+        return secret
+
     @patch('requests.request')
     @patch('api.agent.tools.http_request.select_proxy_for_persistent_agent')
     def test_secret_substitution_in_headers(self, mock_proxy, mock_request):
@@ -4328,6 +4347,90 @@ class HttpRequestSecretPlaceholderTests(TestCase):
         headers = call_args[1]["headers"]
         self.assertEqual(headers["Authorization"], "Bearer secret-api-key-value")
         self.assertEqual(headers["X-API-Key"], "secret-api-key-value")
+
+    @patch('requests.request')
+    @patch('api.agent.tools.http_request.select_proxy_for_persistent_agent')
+    def test_dollar_secret_substitution_across_request_fields(self, mock_proxy, mock_request):
+        self._create_secret("base_url", "https://api.secret.com")
+        self._create_secret("api_token", "secret-token")
+
+        mock_proxy.return_value = type('ProxyServer', (), {'proxy_url': 'http://proxy:8080'})()
+        mock_response = type('Response', (), {
+            'status_code': 200,
+            'headers': {'Content-Type': 'application/json'},
+            'iter_content': lambda self, chunk_size: [b'{"success": true}'],
+            'close': lambda self: None
+        })()
+        mock_request.return_value = mock_response
+
+        params = {
+            "method": "POST",
+            "url": "$[secret: base_url ]/endpoint",
+            "headers": {
+                "Authorization": "Bearer $[secret:api_token]",
+                "X-Legacy-Token": "<<<api_token>>>",
+            },
+            "body": {
+                "token": "$[secret: api_token ]",
+                "callback": {
+                    "url": "$[secret:base_url]/callback",
+                    "legacy_token": "<<<api_token>>>",
+                },
+            },
+        }
+
+        result = _execute_http_request(self.agent, params)
+
+        self.assertEqual(result["status"], "ok", result)
+        call_args = mock_request.call_args
+        self.assertEqual(call_args[0][1], "https://api.secret.com/endpoint")
+        self.assertEqual(call_args[1]["headers"]["Authorization"], "Bearer secret-token")
+        self.assertEqual(call_args[1]["headers"]["X-Legacy-Token"], "secret-token")
+        body_data = json.loads(call_args[1]["data"])
+        self.assertEqual(body_data["token"], "secret-token")
+        self.assertEqual(body_data["callback"]["url"], "https://api.secret.com/callback")
+        self.assertEqual(body_data["callback"]["legacy_token"], "secret-token")
+
+    @patch('requests.request')
+    @patch('api.agent.tools.http_request.select_proxy_for_persistent_agent')
+    def test_dollar_secret_preserves_secret_resolution_rules(self, mock_proxy, mock_request):
+        self._create_global_secret("shared_token", "global-token")
+        self._create_global_secret("global_only", "global-only-token")
+        self._create_secret("shared_token", "agent-token")
+        self._create_secret(
+            "ENV_ONLY",
+            "env-var-token",
+            secret_type=PersistentAgentSecret.SecretType.ENV_VAR,
+        )
+
+        mock_proxy.return_value = type('ProxyServer', (), {'proxy_url': 'http://proxy:8080'})()
+        mock_response = type('Response', (), {
+            'status_code': 200,
+            'headers': {'Content-Type': 'text/plain'},
+            'iter_content': lambda self, chunk_size: [b'ok'],
+            'close': lambda self: None
+        })()
+        mock_request.return_value = mock_response
+
+        params = {
+            "method": "GET",
+            "url": "https://api.example.com/data",
+            "headers": {
+                "X-Agent-Override": "$[secret:shared_token]",
+                "X-Global": "$[secret:global_only]",
+                "X-Missing": "$[secret:missing_token]",
+                "X-Env": "$[secret:ENV_ONLY]",
+            },
+        }
+
+        result = _execute_http_request(self.agent, params)
+
+        self.assertEqual(result["status"], "ok", result)
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers["X-Agent-Override"], "agent-token")
+        self.assertEqual(headers["X-Global"], "global-only-token")
+        self.assertEqual(headers["X-Missing"], "$[secret:missing_token]")
+        self.assertEqual(headers["X-Env"], "$[secret:ENV_ONLY]")
 
     @patch('requests.request')
     @patch('api.agent.tools.http_request.select_proxy_for_persistent_agent')


### PR DESCRIPTION
## Summary

- Add `$[secret:key]` placeholder substitution across HTTP request URLs, headers, and nested bodies.
- Preserve legacy `<<<key>>>` placeholder compatibility.
- Update tool guidance to prefer the new placeholder format.
- Add coverage for substitution and agent-over-global secret resolution behavior.

## Testing

- Added focused unit tests for placeholder parsing, nested request fields, fallback behavior, and secret precedence.
- Added validation that the tool description documents only the preferred placeholder format.