### PR TITLE
Fix cross-account agent name validation

### DIFF
--- a/console/agent_settings/service.py
+++ b/console/agent_settings/service.py
@@ -1809,15 +1809,12 @@ class _AgentSettingsService(AgentOwnerContextOverrideMixin, ConsoleViewMixin, De
             ):
                 return _general_error("That dedicated IP is already assigned to another agent.")
 
-        # Check for uniqueness, excluding the current agent's BrowserUseAgent (if present)
-        exclude_pk = browser_agent.id if browser_agent else agent.browser_use_agent_id
-        browser_name_conflict = BrowserUseAgent.objects.filter(
-            user=request.user,
-            name=new_name
-        )
-        if exclude_pk:
-            browser_name_conflict = browser_name_conflict.exclude(pk=exclude_pk)
-        if browser_name_conflict.exists():
+        if PersistentAgent.has_active_name_conflict(
+            user_id=agent.user_id,
+            organization_id=agent.organization_id,
+            name=new_name,
+            exclude_id=agent.id,
+        ):
             return _general_error(f"You already have an agent named '{new_name}'.")
 
         try:

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -140,6 +140,13 @@ class ConsoleViewsTest(TestCase):
             )
         return organization
 
+    def _select_organization_context(self, organization):
+        session = self.client.session
+        session["context_type"] = "organization"
+        session["context_id"] = str(organization.id)
+        session["context_name"] = organization.name
+        session.save()
+
     def _create_staff_test_agent(
         self,
         *,
@@ -3374,6 +3381,106 @@ class ConsoleViewsTest(TestCase):
         browser_agent.refresh_from_db()
         self.assertEqual(agent.name, long_name)
         self.assertEqual(browser_agent.name, long_name)
+
+    @tag("batch_console_agents_management")
+    def test_org_agent_avatar_save_ignores_deleted_personal_agent_name(self):
+        from api.models import BrowserUseAgent, OrganizationMembership, PersistentAgent
+
+        organization = self._create_organization(
+            name="Avatar Name Scope Org",
+            slug="avatar-name-scope-org",
+            role=OrganizationMembership.OrgRole.OWNER,
+        )
+        self._select_organization_context(organization)
+
+        personal_browser_agent = BrowserUseAgent.objects.create(user=self.user, name="John Pork")
+        personal_agent = PersistentAgent.objects.create(
+            user=self.user,
+            name="John Pork",
+            charter="Personal archived work",
+            browser_use_agent=personal_browser_agent,
+        )
+        personal_agent.soft_delete()
+
+        organization_creator = get_user_model().objects.create_user(
+            username="avatar-name-scope-creator@example.com",
+            email="avatar-name-scope-creator@example.com",
+            password="testpass123",
+        )
+        organization_agent = self._create_staff_test_agent(
+            user=organization_creator,
+            name="John Pork",
+            organization=organization,
+        )
+
+        tmp_media = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_media, ignore_errors=True)
+        png_bytes = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x0bIDAT\x08\xd7c\xf8\x0f"
+            b"\x00\x01\x01\x01\x00\x18\xdd\x8d\x1d\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+
+        with override_settings(MEDIA_ROOT=tmp_media, MEDIA_URL="/media/"):
+            response = self.client.post(
+                reverse("console_agent_settings", kwargs={"agent_id": organization_agent.id}),
+                {
+                    "name": organization_agent.name,
+                    "charter": organization_agent.charter,
+                    "is_active": "on",
+                    "avatar": SimpleUploadedFile("avatar.png", png_bytes, content_type="image/png"),
+                },
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+            )
+
+            self.assertEqual(response.status_code, 200, response.content)
+            self.assertTrue(response.json()["success"])
+            organization_agent.refresh_from_db()
+            self.assertTrue(organization_agent.avatar)
+            self.assertTrue(default_storage.exists(organization_agent.avatar.name))
+
+    @tag("batch_console_agents_management")
+    def test_org_agent_settings_reject_active_name_conflict_in_same_org(self):
+        from api.models import OrganizationMembership
+
+        organization = self._create_organization(
+            name="Active Name Scope Org",
+            slug="active-name-scope-org",
+            role=OrganizationMembership.OrgRole.OWNER,
+        )
+        self._select_organization_context(organization)
+
+        self._create_staff_test_agent(
+            user=self.user,
+            organization=organization,
+            name="Existing Agent",
+        )
+        renamed_agent = self._create_staff_test_agent(
+            user=self.user,
+            organization=organization,
+            name="Renamed Agent",
+        )
+        renamed_browser_agent = renamed_agent.browser_use_agent
+
+        response = self.client.post(
+            reverse("console_agent_settings", kwargs={"agent_id": renamed_agent.id}),
+            {
+                "name": "Existing Agent",
+                "charter": renamed_agent.charter,
+                "is_active": "on",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["error"],
+            "You already have an agent named 'Existing Agent'.",
+        )
+        renamed_agent.refresh_from_db()
+        renamed_browser_agent.refresh_from_db()
+        self.assertEqual(renamed_agent.name, "Renamed Agent")
+        self.assertEqual(renamed_browser_agent.name, "Renamed Agent Browser")
 
     @tag("batch_console_agents_management")
     def test_agent_settings_formats_validation_errors(self):


### PR DESCRIPTION
## Summary

- validate settings names against active PersistentAgent records in the agent owner scope
- allow organization settings and avatar saves when a deleted personal agent has the same name
- preserve rejection of active duplicate names within the same organization

## Root cause

The settings endpoint queried BrowserUseAgent rows owned by the viewing user. Those legacy backing rows survive soft deletion and do not represent the organization ownership scope, so an unchanged organization agent name could collide with a deleted personal agent before an unrelated avatar save ran.

## Red-first evidence

Before the fix, test_org_agent_avatar_save_ignores_deleted_personal_agent_name failed with HTTP 400 and the exact reported error: You already have an agent named John Pork.

## Verification

- focused red/green regression pair: 2 passed
- batch_console_agents_management: 92 tests, 75 passed and 17 skipped
- complexity budgets: passed
- git diff check: passed

No migration, frontend change, or new compatibility layer is involved.