### PR TITLE
Tell agents which teammates already see the same channel messages (#277)

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -58,6 +58,7 @@ from ...models import (
     PersistentAgent,
     PersistentAgentCommsEndpoint,
     PersistentAgentCommsSnapshot,
+    PersistentAgentDiscordChannelSubscription,
     PersistentAgentHumanInputRequest,
     PersistentAgentMessage,
     PersistentAgentMessageAttachment,
@@ -983,6 +984,23 @@ def _resolve_max_iterations(max_iterations: Optional[int]) -> int:
 # --------------------------------------------------------------------------- #
 #  Prompt‑building helpers
 # --------------------------------------------------------------------------- #
+def _get_shared_channel_names(agent: PersistentAgent) -> dict:
+    """Map each other agent to the channel names it shares with this one.
+
+    Without this the peer roster reads as a list of agents to message, giving no sign that a
+    named teammate already saw the same request and can answer it.
+    """
+    active = PersistentAgentDiscordChannelSubscription.Status.ACTIVE
+    subscriptions = PersistentAgentDiscordChannelSubscription.objects.filter(status=active)
+    own = dict(subscriptions.filter(agent=agent).values_list("channel_id", "channel_name"))
+    shared: dict = {}
+    for other_id, channel_id in (
+        subscriptions.filter(channel_id__in=list(own)).exclude(agent_id=agent.id).values_list("agent_id", "channel_id")
+    ):
+        shared.setdefault(other_id, []).append(f"#{str(own.get(channel_id) or channel_id).lstrip('#')}")
+    return shared
+
+
 def _get_active_peer_dm_context(agent: PersistentAgent):
     """Return context about the latest inbound peer DM triggering this cycle."""
 
@@ -2602,8 +2620,10 @@ def _build_contacts_block(
 
     if peer_links:
         peer_lines: list[str] = [
-            "These are linked agents you can contact via the send_agent_message tool."
+            "These are linked agents you can contact via the send_agent_message tool. "
+            "Agents listed as sharing a channel already receive the same messages there that you do."
         ]
+        shared_channels = _get_shared_channel_names(agent)
         for link in peer_links:
             counterpart = link.get_other_agent(agent)
             if counterpart is None:
@@ -2625,8 +2645,10 @@ def _build_contacts_block(
             desc_part = ""
             if counterpart.short_description:
                 desc_part = f" - {counterpart.short_description}"
+            names = shared_channels.get(counterpart.id)
+            shared_part = " | shares {} with you".format(", ".join(names)) if names else ""
             peer_lines.append(
-                "- {} (id: {}){}| quota {} msgs / {} h | remaining: {} | next reset: {}".format(
+                "- {} (id: {}){}| quota {} msgs / {} h | remaining: {} | next reset: {}{}".format(
                     counterpart.name,
                     counterpart.id,
                     f"{desc_part} " if desc_part else "",
@@ -2634,6 +2656,7 @@ def _build_contacts_block(
                     link.window_hours,
                     remaining,
                     reset_at,
+                    shared_part,
                 )
             )
 

--- a/api/evals/scenarios/responsibility_boundaries.py
+++ b/api/evals/scenarios/responsibility_boundaries.py
@@ -21,6 +21,8 @@ from api.models import (
     PersistentAgent,
     PersistentAgentCommsEndpoint,
     PersistentAgentConversation,
+    PersistentAgentDiscordChannelSubscription,
+    PersistentAgentDiscordGuild,
     PersistentAgentEnabledTool,
     PersistentAgentMessage,
     PersistentAgentStep,
@@ -219,6 +221,22 @@ class ResponsibilityBoundaryScenario(EvalScenario, ScenarioExecutionTools):
         )
         link = AgentPeerLink.objects.create(agent_a=agent, agent_b=peer, created_by=agent.user)
         return peer, link
+
+    @classmethod
+    def _subscribe_both_to_channel(cls, agent: PersistentAgent, peer: PersistentAgent, run_id: str) -> None:
+        """Put both agents in the channel for real, as production teams are."""
+        _, _, _, channel_id, channel_name = cls._discord_channel(agent, run_id)
+        guild, _ = PersistentAgentDiscordGuild.objects.get_or_create(
+            guild_id=f"eval-guild-{str(run_id)[:8]}",
+            defaults={"name": "Eval Guild", "organization": agent.organization},
+        )
+        for member in (agent, peer):
+            PersistentAgentDiscordChannelSubscription.objects.get_or_create(
+                agent=member,
+                guild=guild,
+                channel_id=channel_id,
+                defaults={"channel_name": channel_name},
+            )
 
     @classmethod
     def _peer_inbound(cls, agent: PersistentAgent, run_id: str, body: str) -> PersistentAgentMessage:
@@ -432,7 +450,8 @@ class ResponsibilityBoundaryScenario(EvalScenario, ScenarioExecutionTools):
                 author_name="Engineering Agent",
             )
         if is_shared_channel:
-            self._create_peer_link(agent, run_id)
+            peer, _ = self._create_peer_link(agent, run_id)
+            self._subscribe_both_to_channel(agent, peer, run_id)
         terminal_tool = "send_discord_message" if is_shared_channel else "send_agent_message"
         with self.wait_for_agent_idle(agent_id, timeout=120):
             self.trigger_processing(

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,11 +1,11 @@
 {
-  "baseline_sha": "94574150cd22ff9c67aed4c204ea7fe09c3ee451",
+  "baseline_sha": "589ad1e8ee80f4f92d77d6fc5c3b351a63903551",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7914,
+        "fitted_tokens": 7929,
         "system_bytes": 25846,
         "tools_bytes": 21536,
         "total_bytes": 59107,
@@ -19,7 +19,7 @@
         "user_bytes": 10427
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8101,
+        "fitted_tokens": 8059,
         "system_bytes": 26346,
         "tools_bytes": 21536,
         "total_bytes": 59610,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253056
+    "limit": 253076
   }
 }

--- a/tests/unit/test_prompt_context_shared_channels.py
+++ b/tests/unit/test_prompt_context_shared_channels.py
@@ -1,0 +1,69 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase, tag
+
+from api.agent.core import prompt_context
+from api.models import (
+    BrowserUseAgent,
+    PersistentAgent,
+    PersistentAgentDiscordChannelSubscription,
+    PersistentAgentDiscordGuild,
+)
+
+
+@tag("batch_promptree")
+class SharedChannelContextTests(TestCase):
+    """A teammate who already sees the same channel messages should be visible as such."""
+
+    def _make_agent(self, name: str) -> PersistentAgent:
+        user = get_user_model().objects.create_user(
+            username=f"{name}@example.test",
+            email=f"{name}@example.test",
+        )
+        return PersistentAgent.objects.create(
+            user=user,
+            name=name,
+            charter="Test charter.",
+            browser_use_agent=BrowserUseAgent.objects.create(user=user, name=f"{name} browser"),
+        )
+
+    def _subscribe(self, agent: PersistentAgent, channel_id: str, channel_name: str) -> None:
+        guild, _ = PersistentAgentDiscordGuild.objects.get_or_create(
+            guild_id="guild-1",
+            defaults={"name": "Guild", "owner_user": agent.user},
+        )
+        PersistentAgentDiscordChannelSubscription.objects.create(
+            agent=agent,
+            guild=guild,
+            channel_id=channel_id,
+            channel_name=channel_name,
+        )
+
+    def test_no_subscriptions_yields_nothing(self):
+        agent = self._make_agent("solo")
+
+        self.assertEqual(prompt_context._get_shared_channel_names(agent), {})
+
+    def test_only_agents_sharing_a_channel_are_reported(self):
+        agent = self._make_agent("owner")
+        together = self._make_agent("together")
+        apart = self._make_agent("apart")
+        self._subscribe(agent, "chan-1", "infra")
+        self._subscribe(together, "chan-1", "infra")
+        self._subscribe(apart, "chan-2", "random")
+
+        shared = prompt_context._get_shared_channel_names(agent)
+
+        self.assertEqual(shared.get(together.id), ["#infra"])
+        self.assertNotIn(apart.id, shared)
+        self.assertNotIn(agent.id, shared)
+
+    def test_disabled_subscriptions_do_not_count_as_presence(self):
+        agent = self._make_agent("owner2")
+        gone = self._make_agent("gone")
+        self._subscribe(agent, "chan-3", "infra")
+        self._subscribe(gone, "chan-3", "infra")
+        PersistentAgentDiscordChannelSubscription.objects.filter(agent=gone).update(
+            status=PersistentAgentDiscordChannelSubscription.Status.DISABLED,
+        )
+
+        self.assertEqual(prompt_context._get_shared_channel_names(agent), {})


### PR DESCRIPTION
## The bug

#277: an agent answers a request a human addressed to a **different** teammate. In a later recurrence it went further and claimed ownership of a failure another agent had produced.

Verified from production rather than the ticket, which named the wrong agent (Dennis Andrews rather than Dennis Nedry). Discord `#infra`, 2026-07-24 22:51:30Z: a human asks *"boris does that all check out?"* and the non-addressed agent replies 30s ahead of the addressed one, restating its own finding as confirmed.

## Why the previous attempt failed

An earlier prompt sentence — "authoring the finding doesn't make you its verifier" — was measured properly and showed **no effect**, so it was removed rather than shipped. Guidance already exists in the peer instruction block, the `send_discord_message` description, and agent charters, and is still violated. More imperative text was not the answer.

## What was actually missing: information

The dominant measured failure was **peer-DM relay** — forwarding a shared-channel request to a teammate who had already received it. The roster explains why:

> "These are linked agents you can contact via the send_agent_message tool."

An outbound contact list. Nothing told the agent those teammates **already see the same channel messages it does**, so relaying looked helpful and answering looked necessary.

The roster now states that co-presence and marks which channels each peer shares. No new prohibition, and nothing naming the incident's channel, tool, or phrasing.

## Eval fidelity came first

Production had three agents genuinely subscribed to `#infra`. The scenario faked the teammate with a display name and created no subscription, so the agent could not have known the addressee was present. It now creates real channel subscriptions. **Both arms include this change**, so the comparison isolates the prompt change.

## Evidence — DeepSeek V4 Flash, `config.eval_local_settings`

30 runs per arm, pooled across three invocations each because `--n-runs` silently caps at 10.

| Measure | Control | Treatment | Fisher exact |
|---|---|---|---|
| `responsibility_boundary_shared_channel_authored_claim` | 10/30 failed (33%) | **2/30 failed (7%)** | **p = 0.0211** |
| `agent_initiative` (n=48/arm) | 2/48 failed | 3/48 failed | p = 1.0000 |
| `discord_native` | 12/13 | 13/13 | — |
| `responsibility_boundaries` | 12/14 | 13/14 | — |

Unit tests: `batch_promptree` 60/60, responsibility-boundary tests 15/15.

## Not overfit

- The change is factual context, justified without reference to the eval measuring it.
- Validated on adjacent suites, not just the scenario written alongside it.
- `agent_initiative` was run specifically to check the change did not buy compliance with timidity: no regression, and the treatment arm had **zero** emotion/reaction failures where control had one.

## Known limitation

Co-presence renders inside the peer-roster block, so it reaches **peer-linked** agents only. Two agents sharing a channel without a peer link still get nothing. Deliberately out of scope.

## Complexity

+20 LoC; baseline updated through the documented path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)