### PR TITLE
Preserve technical literals in HTML emails

### DIFF
--- a/api/agent/comms/email_content.py
+++ b/api/agent/comms/email_content.py
@@ -37,13 +37,16 @@ MARKDOWN_EXTENSIONS = ["extra", "sane_lists", "smarty", "nl2br"]
 
 HTML_TAG_PATTERN = r"</?(?:p|br|hr|img|div|span|a|ul|ol|li|h[1-6]|strong|em|b|i|code|pre|blockquote|table|thead|tbody|tr|th|td)\b[^>]*>"
 
+INLINE_ITALIC_STAR_PATTERN = r"(?<!\*)\*(?![\s*])(.+?)(?<![\s*])\*(?!\*)"
+INLINE_ITALIC_UNDER_PATTERN = r"(?<![\w_])_(?![\s_])(.+?)(?<![\s_])_(?![\w_])"
+
 INLINE_MARKDOWN_PATTERNS = [
     re.compile(r"\*\*.+?\*\*"),
     re.compile(r"__.+?__"),
     re.compile(r"`{1,3}.+?`{1,3}"),
     re.compile(r"\[[^\]]+\]\([^)]+\)"),
-    re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)"),
-    re.compile(r"(?<!_)_(?!_)(.+?)(?<!_)_(?!_)"),
+    re.compile(INLINE_ITALIC_STAR_PATTERN),
+    re.compile(INLINE_ITALIC_UNDER_PATTERN),
 ]
 BLOCK_MARKDOWN_PATTERNS = [
     re.compile(r"^\s{0,3}#", re.MULTILINE),
@@ -99,8 +102,8 @@ INLINE_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 INLINE_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
 INLINE_BOLD_UNDER_RE = re.compile(r"__(.+?)__")
-INLINE_ITALIC_STAR_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
-INLINE_ITALIC_UNDER_RE = re.compile(r"(?<!_)_(?!_)(.+?)(?<!_)_(?!_)")
+INLINE_ITALIC_STAR_RE = re.compile(INLINE_ITALIC_STAR_PATTERN)
+INLINE_ITALIC_UNDER_RE = re.compile(INLINE_ITALIC_UNDER_PATTERN)
 TABLE_CLOSE_RE = re.compile(r"</table>", re.IGNORECASE)
 
 

--- a/tests/unit/test_outbound_delivery.py
+++ b/tests/unit/test_outbound_delivery.py
@@ -1031,6 +1031,29 @@ class EmailContentRenderingTests(TestCase):
         self.assertIn("<strong>bold</strong>", html_snippet)
         self.assertNotIn("**bold**", html_snippet)
 
+    def test_html_technical_literals_do_not_become_emphasis(self):
+        body = (
+            "<p>Call _has_newer_background_trigger() and "
+            "get_current_inbound_message(); cron: 0 13 * * *.</p>"
+        )
+
+        html_snippet, plaintext = convert_body_to_html_and_plaintext(body)
+
+        self.assertEqual(html_snippet, body)
+        self.assertIn("_has_newer_background_trigger()", plaintext)
+        self.assertIn("get_current_inbound_message()", plaintext)
+        self.assertIn("0 13 * * *", plaintext)
+
+    def test_html_intentional_italic_markdown_is_repaired(self):
+        body = "<p>Use *automatic* or _manual_ mode.</p>"
+
+        html_snippet, _ = convert_body_to_html_and_plaintext(body)
+
+        self.assertEqual(
+            html_snippet,
+            "<p>Use <em>automatic</em> or <em>manual</em> mode.</p>",
+        )
+
     def test_html_block_with_markdown_list_is_converted(self):
         body = "<div>\n- First\n- Second\n</div>"
         html_snippet, _ = convert_body_to_html_and_plaintext(body)


### PR DESCRIPTION
## Summary
- stop inline Markdown repair from treating snake_case identifiers as underscore emphasis
- stop whitespace-only cron asterisks from being treated as italic markers
- preserve intentional `*italic*` and `_italic_` formatting inside HTML email bodies

## Root cause
The HTML email repair pass used permissive emphasis regexes after Python-Markdown had already preserved these technical literals correctly. The underscore rule could match within identifiers, while the asterisk rule accepted whitespace-only spans such as cron wildcards.

## Verification
- Red first: the new production-shaped regression failed with `_has_newer_background_trigger()`, `get_current_inbound_message()`, and `0 13 * * *` corrupted into `<em>` tags.
- Green: the two new regressions pass after the fix.
- `EmailContentRenderingTests`, `EmailBodyRenderingTestCase`, and `ChatEmailDisplayCacheTests`: 31 tests passed.

A wider local outbound-delivery invocation reached a pre-existing Apple Silicon environment limitation in the bundled x86 Pandoc executable; required Linux CI remains the authoritative broader gate.