### PR TITLE
Return to the live edge when sending a chat message (#287)

### DIFF
--- a/frontend/src/store/chatSlice.test.ts
+++ b/frontend/src/store/chatSlice.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fetchProcessingStatus, sendAgentMessage } from '../api/agentChat'
 import { fetchAgentSpawnIntent, type AgentSpawnIntent } from '../api/agentSpawnIntent'
+import { timelineQueryKey } from '../hooks/useAgentTimeline'
 import type { TimelineEvent } from '../types/agentChat'
 import { createAppStore } from './appStore'
 import {
@@ -115,7 +116,23 @@ describe('chatSlice message sending', () => {
   })
 
   it('adds an optimistic sending message before the backend send resolves', async () => {
-    const store = createAppStore()
+    // Sending returns the session to the live edge (#287), so the optimistic event is observed in
+    // the timeline cache rather than the pending buffer that holds events while scrolled away.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const store = createAppStore({ queryClient })
+    queryClient.setQueryData(timelineQueryKey('agent-1'), {
+      pages: [{
+        events: [],
+        hasMoreOlder: false,
+        hasMoreNewer: false,
+        oldestCursor: null,
+        newestCursor: null,
+        currentPlan: null,
+        pendingActionsStateOrder: 0,
+        raw: {},
+      }],
+      pageParams: [undefined],
+    })
     let resolveSend: (event: TimelineEvent) => void = () => {}
     vi.mocked(sendAgentMessage).mockReturnValue(new Promise<TimelineEvent>((resolve) => {
       resolveSend = resolve
@@ -126,15 +143,17 @@ describe('chatSlice message sending', () => {
     const sendResult = store.dispatch(sendMessage({ body: 'hello backend' }))
 
     expect(sendAgentMessage).toHaveBeenCalledWith('agent-1', 'hello backend', [])
-    const pendingEvents = selectActiveChatTestSnapshot(store.getState()).pendingEvents
-    expect(pendingEvents).toHaveLength(1)
-    expect(pendingEvents[0]).toMatchObject({
+    const cached = (queryClient.getQueryData(timelineQueryKey('agent-1')) as { pages: { events: TimelineEvent[] }[] })
+      .pages.flatMap((page) => page.events)
+    expect(cached).toHaveLength(1)
+    expect(cached[0]).toMatchObject({
       kind: 'message',
       message: {
         bodyText: 'hello backend',
         status: 'sending',
       },
     })
+    expect(selectActiveChatTestSnapshot(store.getState()).pendingEvents).toHaveLength(0)
     expect(selectActiveChatTestSnapshot(store.getState()).awaitingResponse).toBe(true)
 
     resolveSend({

--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -713,6 +713,9 @@ export const sendMessage = createAsyncThunk<
   }
 
   const { event, clientId } = buildOptimisticMessageEvent(trimmed, attachments, requestedClientId)
+  // Sending is an explicit move to the live edge. Without this the optimistic event is routed to
+  // the invisible pending buffer and the sender never sees their own message (#287).
+  dispatch(setAutoScrollPinned(true))
   dispatch(chatActions.messageSendStarted({ agentId }))
   if (retry) {
     if (extra.queryClient) {

--- a/frontend/src/store/chatSliceLiveEdge.test.ts
+++ b/frontend/src/store/chatSliceLiveEdge.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression coverage for #287: a message sent while the session was not pinned never reached the
+ * render cache, and the jump control stayed lit while the viewport was at the live edge.
+ */
+import { QueryClient, type InfiniteData } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { sendAgentMessage } from '../api/agentChat'
+import { timelineQueryKey, type TimelinePage } from '../hooks/useAgentTimeline'
+import { createAppStore } from './appStore'
+import { chatActions, sendMessage } from './chatSlice'
+
+vi.mock('../api/agentChat', () => ({
+  sendAgentMessage: vi.fn(),
+  fetchProcessingStatus: vi.fn(),
+}))
+
+const AGENT = 'agent-1'
+const BODY = 'does that all check out?'
+
+/** The exact visibility expression used by AgentChatLayout. */
+function showJumpButton(options: {
+  hasMoreNewer: boolean
+  autoScrollPinned: boolean
+  hasUnseenActivity: boolean
+  isNearBottom: boolean
+}): boolean {
+  return options.hasMoreNewer
+    || (!options.autoScrollPinned && (options.hasUnseenActivity || !options.isNearBottom))
+}
+
+function seedTimelineCache(queryClient: QueryClient) {
+  const page: TimelinePage = {
+    events: [],
+    hasMoreOlder: false,
+    hasMoreNewer: false,
+    oldestCursor: null,
+    newestCursor: null,
+    currentPlan: null,
+    pendingActionsStateOrder: 0,
+    raw: {} as TimelinePage['raw'],
+  }
+  queryClient.setQueryData<InfiniteData<TimelinePage>>(timelineQueryKey(AGENT), {
+    pages: [page],
+    pageParams: [undefined],
+  })
+}
+
+function cachedMessageBodies(queryClient: QueryClient): string[] {
+  const data = queryClient.getQueryData<InfiniteData<TimelinePage>>(timelineQueryKey(AGENT))
+  return (data?.pages ?? []).flatMap((page) =>
+    page.events.filter((event) => event.kind === 'message').map((event) => event.message.bodyText ?? ''),
+  )
+}
+
+describe('sending while unpinned', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(sendAgentMessage).mockResolvedValue({ ok: true } as never)
+  })
+
+  it('renders the sender their own message and returns to the live edge', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const store = createAppStore({ queryClient })
+    seedTimelineCache(queryClient)
+    store.dispatch(chatActions.agentSelected({ agentId: AGENT }))
+    store.dispatch(chatActions.autoScrollPinnedSet({ agentId: AGENT, pinned: false }))
+
+    await store.dispatch(sendMessage({ body: BODY }) as never)
+
+    const session = store.getState().chat.sessionsByAgentId[AGENT]
+    expect(cachedMessageBodies(queryClient)).toContain(BODY)
+    expect(session.timelineUi.autoScrollPinned).toBe(true)
+    expect(session.timelineUi.pendingEvents).toEqual([])
+  })
+
+  it('leaves the jump control hidden at the live edge after sending', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const store = createAppStore({ queryClient })
+    seedTimelineCache(queryClient)
+    store.dispatch(chatActions.agentSelected({ agentId: AGENT }))
+    store.dispatch(chatActions.autoScrollPinnedSet({ agentId: AGENT, pinned: false }))
+
+    await store.dispatch(sendMessage({ body: BODY }) as never)
+
+    const session = store.getState().chat.sessionsByAgentId[AGENT]
+    expect(showJumpButton({
+      hasMoreNewer: false,
+      autoScrollPinned: session.timelineUi.autoScrollPinned,
+      hasUnseenActivity: session.timelineUi.hasUnseenActivity,
+      isNearBottom: true,
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
## The bug

An outbound message vanished after send, while **Jump to latest** appeared even though the thread was already at the bottom. A refresh restored both.

## Root cause — one flag, both symptoms

The optimistic event is dispatched through `receiveRealtimeEvent`, which writes the render cache **only when `timelineUi.autoScrollPinned` is true**:

```js
dispatch(receiveRealtimeEvent(agentId, event))     // chatSlice.ts:723, the optimistic insert
...
if (session?.timelineUi.autoScrollPinned && extra?.queryClient) {
  injectRealtimeEventIntoCache(...)                 // only writes the cache when pinned
}
```

Unpinned, the sender's own message is diverted to an invisible `pendingEvents` buffer and `hasUnseenActivity` is set. That same flag lights the jump control, whose expression ORs `hasUnseenActivity` with `isNearBottom`, so being at the bottom **cannot** suppress it:

```js
hasMoreNewer || (!autoScrollPinned && (hasUnseenActivity || !isNearBottom))
```

The two flags disagree by construction:

| | unpin | "at the bottom" |
|---|---|---|
| threshold | **any** upward wheel tick, no distance | 96px of slack |
| recovery | requires an explicit **downward scroll event** | — |

Nudge the wheel up ~20px and start typing: viewport is at the live edge, session is marked as not following. Refresh fixes it because sessions initialise to `autoScrollPinned: true` and the server had the message all along.

## The fix

Sending is an explicit move to the live edge, so pin before inserting the optimistic event. That renders the sender's message, flushes buffered events, and clears `hasUnseenActivity` — putting the jump control back in sync. Three lines.

## What I tried and dropped

I first also made `suspendAutoFollow` ignore upward scrolls inside the live-edge threshold, to remove the divergence at its source. It broke an existing contract test — *"does not re-pin when an upward wheel overtakes a live Thinking scroll event"* — which guarantees a user can escape auto-follow **while the agent is streaming**. Trapping someone at the bottom mid-stream is worse than the bug being fixed, so that half was dropped rather than weakened.

## Test changed, deliberately

`adds an optimistic sending message before the backend send resolves` set `autoScrollPinned(false)` and asserted the message landed in the pending buffer — it encoded the defect as intended behaviour. It now observes the optimistic event in the timeline cache. Flagging it rather than letting it pass as an incidental edit.

## Evidence

- New regression tests fail **2/2 without** the change, pass with it (verified by stashing the fix).
- Frontend suite **237/237**, `tsc --noEmit` clean, eslint clean, LoC budget passes.

## Known limitation

There is a second, independent way to strand the jump control: `mergeLatestPageIntoTailAndDetectGap` sets `hasMoreNewer = true` and the default `fast` refresh mode never backfills it. That path lights the same button but does **not** hide the sender's message, so it is not what happened here. Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)