### PR TITLE
Stop an automatic tab reveal from storing a panel preference (#286)

### DIFF
--- a/frontend/src/components/agentChat/AgentComposer.test.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -326,6 +326,55 @@ describe('AgentComposer pending action insights panel', () => {
 
     expect(handleExpandedPreferenceChange).toHaveBeenCalledWith(false)
     expect(screen.queryByText('Which account should I use?')).not.toBeInTheDocument()
+  })
+
+  it('keeps a saved collapse when a native tab becomes available', async () => {
+    const handleExpandedPreferenceChange = vi.fn()
+    // The user already collapsed the panel for this agent and the preference is hydrated.
+    const { store } = renderAgentComposer({
+      insightsPanelExpandedPreference: false,
+      insightsPanelPreferenceHydrated: true,
+      discordNativeTabEnabled: false,
+      onInsightsPanelExpandedPreferenceChange: handleExpandedPreferenceChange,
+    })
+
+    expect(handleExpandedPreferenceChange).not.toHaveBeenCalled()
+
+    // Integration data finishes loading and the Discord tab flips available, as on every reload.
+    act(() => {
+      store.dispatch(chatActions.agentSelected({
+        agentId: 'agent-1',
+        options: {
+          agentName: 'Test Agent',
+          planningState: 'skipped',
+          enabledIntegrationTabs: { discordNative: true },
+        },
+      }))
+    })
+
+    // The tab is revealed and auto-selected, proving the auto-select effect ran...
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'View Discord connection' }))
+        .toHaveAttribute('data-active', 'true')
+    })
+    // ...while the panel honours the saved collapse.
+    expect(screen.getByRole('button', { name: /Ready/ })).toHaveAttribute('aria-expanded', 'false')
+    // ...but it must never write a preference the user did not ask for.
+    expect(handleExpandedPreferenceChange).not.toHaveBeenCalled()
+  })
+
+  it('still stores the preference when the user expands the panel themselves', async () => {
+    const handleExpandedPreferenceChange = vi.fn()
+    renderAgentComposer({
+      insightsPanelExpandedPreference: false,
+      insightsPanelPreferenceHydrated: true,
+      pendingActionRequests: [makeRequestedSecretsAction()],
+      onInsightsPanelExpandedPreferenceChange: handleExpandedPreferenceChange,
+    })
+
+    fireEvent.click(screen.getByText('Needs your input').closest('.composer-working-header-row') as HTMLElement)
+
+    expect(handleExpandedPreferenceChange).toHaveBeenCalledWith(true)
   })
 
   it('stays collapsed while a saved panel preference hydrates', () => {

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -914,9 +914,11 @@ export const AgentComposer = memo(function AgentComposer({
     onRequestScrollToBottom?.()
   }, [isTouchDevice, onRequestScrollToBottom])
 
-  const selectWorkingTab = useCallback((tabId: string, expandPanel = true) => {
+  const selectWorkingTab = useCallback((tabId: string, expandPanel = true, persistPreference = true) => {
     if (expandPanel && !resolvedWorkingExpanded) {
-      if (onInsightsPanelExpandedPreferenceChange) {
+      // Only a deliberate click may store a preference. Expanding on the user's behalf must stay
+      // local, or an automatic reveal overwrites the collapse they chose for this agent.
+      if (persistPreference && onInsightsPanelExpandedPreferenceChange) {
         onInsightsPanelExpandedPreferenceChange(true)
       } else {
         setAutoWorkingExpanded(true)
@@ -1011,7 +1013,7 @@ export const AgentComposer = memo(function AgentComposer({
       }
     }
     if (nextAutoSelectedTab) {
-      selectWorkingTab(nextAutoSelectedTab)
+      selectWorkingTab(nextAutoSelectedTab, true, false)
     }
   }, [activeWorkingTabId, agentId, focusKey, nativeTabAvailability, pendingActionTabs.length, selectWorkingTab])
 


### PR DESCRIPTION
## The report

> "put something in to remember open/closed state. I find myself often having to close these, over and over, so I think it's not working/not remembering"

It reads as a persistence failure. **It isn't one.** The preference is stored correctly — a `uuid_boolean_map` merged under `select_for_update`, so it genuinely is per-user, per-agent and cross-device, which is the intended behaviour. Checking that first mattered: "add persistence" would have been the wrong fix.

## Root cause: the app overwrites the user's choice

`selectWorkingTab()` defaults `expandPanel` to `true`, and expanding **persists**:

```js
if (expandPanel && !resolvedWorkingExpanded) {
  onInsightsPanelExpandedPreferenceChange(true)   // writes expanded:true to the account
}
```

The auto-select effect for native integration tabs (`AgentComposer.tsx:1013`) called it with that default, so *revealing a tab wrote a preference the user never expressed*.

**Why it hits on every reload:** the tab flags (Discord, Google Drive, Apollo, HubSpot, Meta Ads) start `false` and flip `true` once identity data loads. That false→true transition is the trigger. Collapse the panel, reload, and the app immediately stores the opposite of the choice just made — which is exactly why it looked like amnesia.

## The fix

Automatic reveals expand locally; only a deliberate click persists.

Where a stored collapse exists it now wins, because `resolvedWorkingExpanded` prefers the stored preference over the local auto value. The tab is still selected and revealed — the panel just stays collapsed, honouring the choice. `handlePanelToggle` and tab clicks still persist normally.

## Evidence

- New test **fails without the fix** — spy called once with `true` (the unwanted write) — and passes with it. Verified by stashing the change.
- The test proves the auto-select genuinely ran (tab becomes `data-active="true"`) while the panel stays `aria-expanded="false"`, so it can't pass by the effect simply not firing.
- Companion test asserts a real user expand **still** persists, so the fix doesn't disable the feature.
- Frontend suite **239/239**, `tsc --noEmit` clean.
- The 11 eslint findings in these files are **identical on `main`** — pre-existing, none introduced.

## Deliberately not in scope

The persist thunk drops writes issued before the preference map hydrates (`agentRosterPreferencesSlice.ts:302`). That guard is intentional and has its own test asserting it. In practice it affects *expanding* rather than collapsing, since the panel already renders collapsed pre-hydration, so it is not the reported symptom. Changing it is a separate decision, not a silent policy flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)