### PR TITLE
Keep the composer auto-focus off touch-primary devices (#310)

### DIFF
--- a/frontend/src/components/agentChat/AgentComposer.test.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.test.tsx
@@ -328,6 +328,81 @@ describe('AgentComposer pending action insights panel', () => {
     expect(screen.queryByText('Which account should I use?')).not.toBeInTheDocument()
   })
 
+  function setPointer(kind: 'fine' | 'coarse') {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: kind === 'fine' && query.includes('pointer: fine'),
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    })
+  }
+
+  function switchAgent(rerender: (ui: React.ReactElement) => void, focusKey: string) {
+    rerender(
+      <AgentComposer
+        onSubmit={vi.fn(async () => undefined)}
+        pendingActionRequests={[]}
+        insightsLoading={false}
+        isProcessing={false}
+        autoFocus
+        focusKey={focusKey}
+      />,
+    )
+  }
+
+  it('does not raise the keyboard on a touch-primary device when switching agents', async () => {
+    setPointer('coarse')
+    const { rerender } = renderAgentComposer({ autoFocus: true })
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    const focusSpy = vi.spyOn(textarea, 'focus')
+
+    switchAgent(rerender, 'agent-2')
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    expect(focusSpy).not.toHaveBeenCalled()
+    focusSpy.mockRestore()
+  })
+
+  it('still focuses the composer when switching agents with a fine pointer', async () => {
+    setPointer('fine')
+    const { rerender } = renderAgentComposer({ autoFocus: true })
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    const focusSpy = vi.spyOn(textarea, 'focus')
+
+    switchAgent(rerender, 'agent-2')
+
+    await waitFor(() => {
+      expect(focusSpy).toHaveBeenCalled()
+    })
+    focusSpy.mockRestore()
+  })
+
+  it('never pulls focus out of another field the user is typing in', async () => {
+    setPointer('fine')
+    const { rerender } = renderAgentComposer({ autoFocus: true })
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    const focusSpy = vi.spyOn(textarea, 'focus')
+    const other = document.createElement('input')
+    document.body.appendChild(other)
+
+    other.focus()
+    switchAgent(rerender, 'agent-2')
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    expect(focusSpy).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(other)
+    focusSpy.mockRestore()
+    other.remove()
+  })
+
   it('keeps a saved collapse when a native tab becomes available', async () => {
     const handleExpandedPreferenceChange = vi.fn()
     // The user already collapsed the panel for this agent and the preference is hydrated.

--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -79,6 +79,15 @@ function getBurnRateUsageLevel(metadata: BurnRateMetadata): 'normal' | 'warning'
 
 const DEFAULT_INSIGHT_TAB_COLOR = '#AA74CE'
 const INLINE_HTML_TAG_PATTERN = /<\/?[a-z][\s\S]*>/i
+const EDITABLE_TAG_PATTERN = /^(input|textarea|select)$/i
+
+// Focusing costs nothing with a fine pointer, but where touch is the primary input it raises the
+// on-screen keyboard over the conversation. Keyed to pointer rather than touch support, so a
+// touchscreen laptop keeps the convenience.
+function prefersPointerAutoFocus(): boolean {
+  return typeof window === 'undefined' || typeof window.matchMedia !== 'function'
+    || window.matchMedia('(hover: hover) and (pointer: fine)').matches
+}
 const GOOGLE_SHEETS_DRIVE_TAB_KEY = 'googleSheetsDrive'
 const APOLLO_NATIVE_TAB_KEY = 'apolloNative'
 const HUBSPOT_NATIVE_TAB_KEY = 'hubspotNative'
@@ -1318,9 +1327,13 @@ export const AgentComposer = memo(function AgentComposer({
 
   // Auto-focus after agent switches, including callers that still pass an explicit focus key.
   useEffect(() => {
-    if (!autoFocus) return
+    if (!autoFocus || !prefersPointerAutoFocus()) return
     // Use a small delay to ensure the DOM is ready after navigation
     const timer = setTimeout(() => {
+      // Leave focus where the user put it rather than pulling it out of another field.
+      const active = document.activeElement as HTMLElement | null
+      if (active && active !== document.body && active !== textareaRef.current
+        && (active.isContentEditable || EDITABLE_TAG_PATTERN.test(active.tagName))) return
       textareaRef.current?.focus()
       moveTextareaCursorToEnd()
     }, 100)

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "589ad1e8ee80f4f92d77d6fc5c3b351a63903551",
+  "baseline_sha": "f461dd6cf8a3dbebe7fbfccfddeb0967bc772f4f",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7929,
+        "fitted_tokens": 7919,
         "system_bytes": 25846,
         "tools_bytes": 21536,
         "total_bytes": 59107,
         "user_bytes": 11725
       },
       "planning_first_run": {
-        "fitted_tokens": 8750,
+        "fitted_tokens": 8770,
         "system_bytes": 31516,
         "tools_bytes": 12530,
         "total_bytes": 54473,
         "user_bytes": 10427
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8059,
+        "fitted_tokens": 8053,
         "system_bytes": 26346,
         "tools_bytes": 21536,
         "total_bytes": 59610,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253076
+    "limit": 253088
   }
 }


### PR DESCRIPTION
## The report

Switching agents on mobile raises the on-screen keyboard unasked. Reported as a *"super important UX issue."*

## Root cause

`AgentComposer.tsx` auto-focuses the composer on every `agentId`/`focusKey` change:

```js
useEffect(() => {
  if (!autoFocus) return
  const timer = setTimeout(() => {
    textareaRef.current?.focus()   // this is what raises the keyboard
    ...
  }, 100)
}, [agentId, autoFocus, focusKey, moveTextareaCursorToEnd])
```

`AgentChatPage.tsx:4433` passes `autoFocusComposer` unconditionally, so it fires on every switch with no device check. Focusing a textarea *is* the API that opens the keyboard on iOS and Android.

Worth noting a full page **reload** does not reproduce it — only client-side switching does, which is why it shows up while using the app rather than on load.

## The fix: keep it where it helps, drop it where it hurts

Auto-focus now requires a **fine pointer**. Desktop still lands in the composer on switch; a phone or tablet leaves focus alone until the user taps the field. That matches what Slack, iMessage, WhatsApp and Telegram all do.

Deliberately `(hover: hover) and (pointer: fine)` rather than the `isTouchDevice` check already in this file — that one keys off touch *support*, so it would wrongly disable auto-focus on a touchscreen laptop.

It also no longer pulls focus out of another field already in use, which is the same principle applied to desktop.

## Verified in a real browser, not just jsdom

Local stack, iPhone 13 viewport, logged in, switching agents through the actual in-app switcher:

| Device | Pointer | Switch happened | `document.activeElement` after |
|---|---|---|---|
| Mobile, **before fix** | coarse | yes | **`textarea` in `.composer-shell`** → keyboard pops |
| Mobile, **after fix** | coarse | yes | **`body`** → no keyboard |
| Desktop, after fix | fine | yes | **`textarea` in `.composer-shell`** → convenience kept |

## Tests

Three behaviours, and **2 of the 3 fail without the fix** (verified by stashing it):

1. Touch-primary device: switching agents does not focus the composer
2. Fine pointer: switching agents still focuses it — guards against over-correcting
3. Focus is never pulled out of another field in use

Frontend suite **242/242**, `tsc --noEmit` clean. The 2 eslint warnings in this file are unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)