### PR TITLE
Teach agents to honor Discord reply addressees

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -4230,8 +4230,22 @@ def _format_discord_reply_context(raw_payload: Mapping[str, Any]) -> str:
     message_id = str(reply_to.get("message_id") or "").strip()
     if not message_id:
         return ""
-    lines = [f"Message ID: {message_id}"]
     author_name = str(reply_to.get("author_name") or "").strip()
+    reply_target = author_name or "the referenced message author"
+    lines = [
+        f"Discord reply addressee: {reply_target}.",
+        (
+            "Unqualified instructions and second-person language belong to this addressee, "
+            "even when they overlap another subscriber's charter."
+        ),
+        (
+            "If you are not this participant, treat delivery as context, not an invitation; join only "
+            "when the text includes you or the room, or silence would drop a necessary, non-duplicative "
+            "contribution only you can provide. Otherwise stay silent without reacting, updating your own "
+            "records, or announcing that you have no action."
+        ),
+        f"Message ID: {message_id}",
+    ]
     if author_name:
         lines.append(f"Author: {author_name}")
     content = str(reply_to.get("content") or "").strip()

--- a/api/agent/system_skills/defaults.py
+++ b/api/agent/system_skills/defaults.py
@@ -931,7 +931,7 @@ DISCORD_NATIVE_SYSTEM_SKILL = SystemSkillDefinition(
         f"To upload files: {SEND_TOOL_ATTACHMENTS_DESCRIPTION} "
         "The backend sends through a channel webhook using the agent's name and avatar.\n"
         "Use `add_discord_reaction` for lightweight social moments such as acknowledgement, thanks, agreement, humor, congratulations, or a shared win, even when no reaction was explicitly requested. "
-        "For a lightweight Discord social moment, use one fitting reaction, then stop; do not also reply. Do not react to every message or stack reactions. Do not react to a serious question, request, blocker, or important nuance; give it a substantive reply instead. "
+        "For a lightweight Discord social moment, use one fitting reaction, then stop; do not also reply. A direct reply to someone else is not your social moment unless its text includes you or the room. Do not react to every message or stack reactions. Do not react to a serious question, request, blocker, or important nuance; give it a substantive reply instead. "
         "Pass the subscribed `channel_id`, the message's `discord_message_id` as `message_id`, one Unicode or Discord custom emoji, and the correct `will_continue_work` value. "
         "This tool only adds the Gobii bot's own reaction; it does not remove or manage other reactions.\n"
         "Use `list` before creating duplicates when the current subscription state is unclear. Use `disable` only when the user asks to stop receiving messages from a subscribed channel.\n"

--- a/api/evals/scenarios/responsibility_boundaries.py
+++ b/api/evals/scenarios/responsibility_boundaries.py
@@ -43,6 +43,8 @@ RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNER = "responsibility_boundary_shared_c
 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNED_REPLY = "responsibility_boundary_shared_channel_owned_reply"
 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_NOISY_YIELD = "responsibility_boundary_shared_channel_noisy_yield"
 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_AUTHORED_CLAIM = "responsibility_boundary_shared_channel_authored_claim"
+RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_DIRECTED_REPLY = "responsibility_boundary_shared_channel_directed_reply"
+RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OPEN_REPLY = "responsibility_boundary_shared_channel_open_reply"
 RESPONSIBILITY_BOUNDARY_SUITE_SLUG = "responsibility_boundaries"
 RESPONSIBILITY_BOUNDARY_SCENARIO_SLUGS = (
     RESPONSIBILITY_BOUNDARY_PEER_FYI_NO_ACK,
@@ -51,6 +53,8 @@ RESPONSIBILITY_BOUNDARY_SCENARIO_SLUGS = (
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNED_REPLY,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_NOISY_YIELD,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_AUTHORED_CLAIM,
+    RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_DIRECTED_REPLY,
+    RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OPEN_REPLY,
 )
 
 LEDGER_CHARTER = (
@@ -149,6 +153,30 @@ RESPONSIBILITY_BOUNDARY_CASES = (
         tasks=(
             ScenarioTask(name="inject_event", assertion_type="agent_processing"),
             ScenarioTask(name="verify_yields_verification", assertion_type="llm_judge"),
+        ),
+    ),
+    ResponsibilityBoundaryCase(
+        slug=RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_DIRECTED_REPLY,
+        description="A direct Discord reply to one teammate should not draw acknowledgment chatter from another.",
+        event_kind="shared_channel_directed_reply",
+        prompt="no need for you to investigate this one, just keep it logged for the interface team",
+        tasks=(
+            ScenarioTask(name="inject_event", assertion_type="agent_processing"),
+            ScenarioTask(name="verify_no_interference", assertion_type="tool_call"),
+        ),
+    ),
+    ResponsibilityBoundaryCase(
+        slug=RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OPEN_REPLY,
+        description="A direct reply that invites relevant help from the room should still get an owned contribution.",
+        event_kind="shared_channel_open_reply",
+        prompt=(
+            "great, keep it logged for the interface team. anyone with confirmed customer context, check "
+            "https://api.example.test/customer-signals-summary.json and add the top theme and report count here"
+        ),
+        tasks=(
+            ScenarioTask(name="inject_event", assertion_type="agent_processing"),
+            ScenarioTask(name="verify_owned_work", assertion_type="tool_call"),
+            ScenarioTask(name="verify_channel_result", assertion_type="manual"),
         ),
     ),
 )
@@ -298,8 +326,22 @@ class ResponsibilityBoundaryScenario(EvalScenario, ScenarioExecutionTools):
         body: str,
         *,
         author_name: str = "Andrew",
+        discord_message_id: str = "",
+        reply_to: dict[str, Any] | None = None,
     ) -> PersistentAgentMessage:
         conversation, agent_endpoint, channel_endpoint, channel_id, channel_name = cls._discord_channel(agent, run_id)
+        raw_payload = {
+            "source": "discord_bot",
+            "source_kind": "discord",
+            "source_label": f"{author_name} in #{channel_name}",
+            "discord_channel_id": channel_id,
+            "discord_channel_name": channel_name,
+            "discord_author_name": author_name,
+        }
+        if discord_message_id:
+            raw_payload["discord_message_id"] = discord_message_id
+        if reply_to:
+            raw_payload["discord_reply_to"] = reply_to
         return PersistentAgentMessage.objects.create(
             owner_agent=agent,
             from_endpoint=channel_endpoint,
@@ -307,14 +349,7 @@ class ResponsibilityBoundaryScenario(EvalScenario, ScenarioExecutionTools):
             conversation=conversation,
             is_outbound=False,
             body=body,
-            raw_payload={
-                "source": "discord_bot",
-                "source_kind": "discord",
-                "source_label": f"{author_name} in #{channel_name}",
-                "discord_channel_id": channel_id,
-                "discord_channel_name": channel_name,
-                "discord_author_name": author_name,
-            },
+            raw_payload=raw_payload,
         )
 
     @classmethod
@@ -432,12 +467,33 @@ class ResponsibilityBoundaryScenario(EvalScenario, ScenarioExecutionTools):
                 "I'm fixing the account now and will update this channel when it is ready.",
                 author_name="Priya",
             )
+        reply_to = None
+        if self.case.event_kind in {"shared_channel_directed_reply", "shared_channel_open_reply"}:
+            peer_name = f"Engineering Agent {str(run_id)[:8]}"
+            referenced_message = self._discord_inbound(
+                agent,
+                run_id,
+                "I logged the report as a front-end issue and can investigate it.",
+                author_name=peer_name,
+                discord_message_id=f"eval-engineering-message-{str(run_id)[:8]}",
+            )
+            reply_to = {
+                "message_id": referenced_message.raw_payload["discord_message_id"],
+                "channel_id": referenced_message.raw_payload["discord_channel_id"],
+                "guild_id": "eval-guild",
+                "author_id": "engineering-agent",
+                "author_name": peer_name,
+                "content": referenced_message.body,
+                "attachment_filenames": [],
+                "unavailable": False,
+            }
         inbound = (
             self._discord_inbound(
                 agent,
                 run_id,
                 self.case.prompt.replace("Customer Signals Agent", agent.name),
                 author_name="Maya",
+                reply_to=reply_to,
             )
             if is_shared_channel
             else self._peer_inbound(agent, run_id, self.case.prompt)
@@ -460,7 +516,7 @@ class ResponsibilityBoundaryScenario(EvalScenario, ScenarioExecutionTools):
                 mock_config=self._mock_config(),
                 eval_stop_policy=self._stop_policy(
                     terminal_tool,
-                    allow_http=self.case.event_kind == "shared_channel_owned",
+                    allow_http=self.case.event_kind in {"shared_channel_owned", "shared_channel_open_reply"},
                 ),
             )
         self.record_task_result(
@@ -477,7 +533,7 @@ class ResponsibilityBoundaryScenario(EvalScenario, ScenarioExecutionTools):
             self._verify_silence(run_id, agent_id, inbound, calls)
         elif self.case.event_kind == "peer_request":
             self._verify_handoff(run_id, agent_id, inbound, calls)
-        elif self.case.event_kind == "shared_channel_owned":
+        elif self.case.event_kind in {"shared_channel_owned", "shared_channel_open_reply"}:
             self._verify_owned_request(run_id, inbound, calls)
         elif self.case.event_kind == "shared_channel_authored_claim":
             self._verify_yields_verification(run_id, calls)

--- a/api/evals/tests/test_responsibility_boundaries.py
+++ b/api/evals/tests/test_responsibility_boundaries.py
@@ -17,6 +17,8 @@ from api.evals.scenarios.responsibility_boundaries import (
     RESPONSIBILITY_BOUNDARY_PEER_REQUEST_HANDOFF,
     RESPONSIBILITY_BOUNDARY_SCENARIO_SLUGS,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_AUTHORED_CLAIM,
+    RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_DIRECTED_REPLY,
+    RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OPEN_REPLY,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNER,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_NOISY_YIELD,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNED_REPLY,
@@ -77,6 +79,8 @@ class ResponsibilityBoundaryScenarioTests(SimpleTestCase):
                 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNED_REPLY,
                 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_NOISY_YIELD,
                 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_AUTHORED_CLAIM,
+                RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_DIRECTED_REPLY,
+                RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OPEN_REPLY,
             },
         )
 
@@ -105,6 +109,27 @@ class ResponsibilityBoundaryScenarioTests(SimpleTestCase):
         self.assertNotIn("shared channels", LEDGER_CHARTER)
         self.assertNotIn("stay in your lane", COORDINATOR_CHARTER.lower())
         self.assertIn("customer-signal curation and reporting", LEDGER_CHARTER)
+
+    def test_directed_reply_case_relies_on_discord_reply_metadata(self):
+        case = next(
+            case for case in RESPONSIBILITY_BOUNDARY_CASES
+            if case.event_kind == "shared_channel_directed_reply"
+        )
+
+        self.assertEqual(case.slug, RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_DIRECTED_REPLY)
+        self.assertNotIn("engineering agent", case.prompt.lower())
+        self.assertNotIn("customer signals", case.prompt.lower())
+        self.assertIn("you", case.prompt.lower())
+
+    def test_open_reply_case_invites_owned_help_without_naming_the_agent(self):
+        case = next(
+            case for case in RESPONSIBILITY_BOUNDARY_CASES
+            if case.event_kind == "shared_channel_open_reply"
+        )
+
+        self.assertEqual(case.slug, RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OPEN_REPLY)
+        self.assertNotIn("customer signals agent", case.prompt.lower())
+        self.assertIn("anyone with confirmed customer context", case.prompt.lower())
 
     def test_noisy_shared_channel_allows_silent_sqlite_tracking(self):
         case = next(case for case in RESPONSIBILITY_BOUNDARY_CASES if case.event_kind == "shared_channel_noisy")

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "f461dd6cf8a3dbebe7fbfccfddeb0967bc772f4f",
+  "baseline_sha": "933b5e902a6ff6975d65a6704996c59ba953e166",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253088
+    "limit": 253102
   }
 }

--- a/tests/unit/test_discord_bot.py
+++ b/tests/unit/test_discord_bot.py
@@ -471,6 +471,7 @@ class NativeDiscordBotTests(TestCase):
         self.assertEqual(gateway_message.reply_to["message_id"], "499")
         self.assertTrue(gateway_message.reply_to["unavailable"])
         prompt_context = _format_discord_reply_context({"discord_reply_to": gateway_message.reply_to})
+        self.assertIn("Discord reply addressee: the referenced message author", prompt_context)
         self.assertIn("Message ID: 499", prompt_context)
         self.assertIn("referenced message is unavailable or deleted", prompt_context)
 
@@ -558,6 +559,11 @@ class NativeDiscordBotTests(TestCase):
         self.assertIn("<discord_message_id>500</discord_message_id>", user_prompt)
         self.assertIn("<discord_channel_id>10</discord_channel_id>", user_prompt)
         self.assertIn("<discord_reply_context>", user_prompt)
+        self.assertIn("Discord reply addressee: Ada.", user_prompt)
+        self.assertIn("instructions and second-person language belong to this addressee", user_prompt)
+        self.assertIn("treat delivery as context, not an invitation", user_prompt)
+        self.assertIn("contribution only you can provide", user_prompt)
+        self.assertIn("announcing that you have no action", user_prompt)
         self.assertIn("Message ID: 499", user_prompt)
         self.assertIn("Author: Ada", user_prompt)
         self.assertIn("Ship the updated report", user_prompt)
@@ -1467,6 +1473,7 @@ class NativeDiscordBotTests(TestCase):
         self.assertIn("filespace paths or $[/path]", skill.prompt_instructions)
         self.assertIn("Body text never attaches files", skill.prompt_instructions)
         self.assertIn("Use `add_discord_reaction`", skill.prompt_instructions)
+        self.assertIn("A direct reply to someone else is not your social moment", skill.prompt_instructions)
         self.assertIn("Discord cannot render tables", skill.prompt_instructions)
         self.assertIn("never send pipe-separated columns with a hyphen-divider row", skill.prompt_instructions)
 


### PR DESCRIPTION
## What changed
- label Discord reply metadata as an actual conversational addressee, including how shared-channel delivery and pronouns should be interpreted
- align reaction guidance so social reactions do not become cross-agent receipt chatter
- add paired real-harness evals for silence on another teammate's reply and useful participation when the reply invites the room

## Evidence
- DeepSeek V4 Flash directed-reply control: 1/16 passed
- DeepSeek V4 Flash treatment: 12/16 passed (two-sided Fisher exact p=0.00017)
- open-room positive control: 5/5 runs fully passed (15/15 tasks)
- responsibility-boundaries suite: 17/19 tasks initially; both stochastic misses passed on immediate isolated rerun
- focused Django tests: 64 passed
- full CI: all 10 backend shards, frontend, sandbox, tag, complexity, and combined checks passed
- preview: deployment health gate passed; authenticated API/MCP ping, discovery, contained agent round trip, trace inspection, and archival passed

No wake routing or output suppression was added; this is a model-input behavioral fix. Addresses the multi-agent failure documented in #294.