### PR TITLE
Name the recipient on sent email cards (#240)

### DIFF
--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -536,6 +536,14 @@ def _serialize_message(
     sender_user_id: int | None = None
     sender_name: str | None = None
     sender_address = message.from_endpoint.address if message.from_endpoint_id else None
+    # An email conversation is keyed by the human counterparty, so on an outbound message that
+    # address is who the agent wrote to. Without it a sent card only implies its recipient through
+    # the salutation, which leaves no reliable audit trail of who an agent contacted.
+    recipient_address: str | None = None
+    recipient_name: str | None = None
+    if message.is_outbound and channel.lower() == CommsChannel.EMAIL and conversation is not None:
+        recipient_address = (conversation.address or "").strip() or None
+        recipient_name = (conversation.display_name or "").strip() or None
     if not is_mcp and channel.lower() == "web" and sender_address:
         user_id, agent_id = parse_web_user_address(sender_address)
         if user_id is not None and (not agent_id or not message.owner_agent_id or str(message.owner_agent_id) == agent_id):
@@ -591,6 +599,8 @@ def _serialize_message(
             "senderUserId": None if is_mcp else sender_user_id,
             "senderName": sender_name,
             "senderAddress": None if is_mcp else sender_address,
+            "recipientName": recipient_name,
+            "recipientAddress": recipient_address,
             "sourceKind": source_kind,
             "sourceLabel": source_label,
             "channelLabel": discord_channel_label or None,

--- a/frontend/src/components/agentChat/MessageEventCard.test.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { MessageEventCard } from './MessageEventCard'
+import type { AgentMessage } from './types'
+
+vi.mock('../../api/agentChat', () => ({ trackAgentMessageCopy: vi.fn() }))
+
+function emailMessage(overrides: Partial<AgentMessage> = {}): AgentMessage {
+  return {
+    id: 'msg-1',
+    cursor: 'cursor-1',
+    bodyText: 'Derraleigh,\n\nLoved this.',
+    isOutbound: true,
+    channel: 'email',
+    subject: 'loved this',
+    timestamp: '2026-07-21T19:10:39Z',
+    relativeTimestamp: null,
+    recipientName: null,
+    recipientAddress: 'derraleigh@example.com',
+    ...overrides,
+  } as AgentMessage
+}
+
+function renderCard(message: AgentMessage) {
+  return render(
+    <MessageEventCard
+      eventCursor="cursor-1"
+      message={message}
+      agentFirstName="Alpha"
+    />,
+  )
+}
+
+describe('MessageEventCard email recipient', () => {
+  it('names the recipient on a sent email so the card is auditable', () => {
+    renderCard(emailMessage())
+
+    expect(screen.getByText('derraleigh@example.com')).toBeInTheDocument()
+  })
+
+  it('prefers a display name and keeps the address available on hover', () => {
+    renderCard(emailMessage({ recipientName: 'Derraleigh Vance' }))
+
+    expect(screen.getByText('Derraleigh Vance')).toBeInTheDocument()
+    expect(screen.getByTitle('Derraleigh Vance <derraleigh@example.com>')).toBeInTheDocument()
+  })
+
+  it('announces the recipient to assistive tech rather than relying on the visual label', () => {
+    renderCard(emailMessage())
+
+    expect(screen.getByText('Sent to')).toBeInTheDocument()
+  })
+
+  it('does not label a received email with a recipient', () => {
+    renderCard(emailMessage({ isOutbound: false, recipientAddress: null }))
+
+    expect(screen.queryByText('Sent to')).not.toBeInTheDocument()
+  })
+
+  it('stays quiet when no recipient is available', () => {
+    renderCard(emailMessage({ recipientAddress: null }))
+
+    expect(screen.queryByText('Sent to')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/agentChat/MessageEventCard.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.tsx
@@ -176,6 +176,15 @@ export const MessageEventCard = memo(function MessageEventCard({
       : null,
   ].filter(Boolean)
   const emailSubject = channel === 'email' ? message.subject?.trim() : ''
+  // A sent email otherwise names its recipient only inside the body, which is not an audit trail.
+  const emailRecipient = channel === 'email' && message.isOutbound
+    ? message.recipientAddress?.trim() || ''
+    : ''
+  const emailRecipientName = message.recipientName?.trim() || ''
+  const emailRecipientLabel = emailRecipientName || emailRecipient
+  const emailRecipientTitle = emailRecipientName
+    ? `${emailRecipientName} <${emailRecipient}>`
+    : emailRecipient
 
   const contentTone = isPeer ? 'text-slate-800' : isAgent ? 'text-slate-800' : ''
 
@@ -260,6 +269,12 @@ export const MessageEventCard = memo(function MessageEventCard({
           ) : null}
           <span className="chat-author-name">{authorLabel}</span>
           {showChannelTag ? <span className={channelTagClass}>{channelIcon}{channelLabel}</span> : null}
+          {emailRecipient ? (
+            <span className="chat-email-recipient-inline" title={emailRecipientTitle}>
+              <span className="sr-only">Sent to </span>
+              <span className="chat-email-recipient-text">{emailRecipientLabel}</span>
+            </span>
+          ) : null}
           {emailSubject ? <span className="chat-email-subject-inline" title={emailSubject}>{emailSubject}</span> : null}
           <span className="chat-message-meta-slot">
             <span className="chat-timestamp" title={metaTitle}>{metaLabel}</span>

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3742,6 +3742,36 @@
     color: #94a3b8;
     font-weight: 700;
 }
+/* Pairs with the channel badge as one routing unit, EMAIL → recipient. Capped so a long address
+   truncates before crowding out the subject; the full value stays in the title attribute. */
+.chat-email-recipient-inline {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 40%;
+    padding: 0.0625rem 0.5rem;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    border-radius: 9999px;
+    background: rgba(248, 250, 252, 0.9);
+    color: #475569;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0;
+}
+.chat-email-recipient-inline::before {
+    content: "→";
+    flex: 0 0 auto;
+    color: #94a3b8;
+    font-weight: 700;
+}
+.chat-email-recipient-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .chat-author--user {
     color: #6366f1;
 }

--- a/frontend/src/types/agentChat.ts
+++ b/frontend/src/types/agentChat.ts
@@ -54,6 +54,8 @@ export type AgentMessage = {
   senderUserId?: number | null
   senderName?: string | null
   senderAddress?: string | null
+  recipientName?: string | null
+  recipientAddress?: string | null
   sourceKind?: string | null
   sourceLabel?: string | null
   channelLabel?: string | null

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "933b5e902a6ff6975d65a6704996c59ba953e166",
+  "baseline_sha": "5ae8852167307145021993150777c9bf99d54c57",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7919,
+        "fitted_tokens": 7909,
         "system_bytes": 25846,
         "tools_bytes": 21536,
         "total_bytes": 59107,
         "user_bytes": 11725
       },
       "planning_first_run": {
-        "fitted_tokens": 8770,
+        "fitted_tokens": 8745,
         "system_bytes": 31516,
         "tools_bytes": 12530,
         "total_bytes": 54473,
         "user_bytes": 10427
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8053,
+        "fitted_tokens": 8077,
         "system_bytes": 26346,
         "tools_bytes": 21536,
         "total_bytes": 59610,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253102
+    "limit": 253159
   }
 }

--- a/tests/unit/test_timeline_email_recipient.py
+++ b/tests/unit/test_timeline_email_recipient.py
@@ -1,0 +1,81 @@
+"""#240: a sent-email card must identify who the agent wrote to.
+
+An email conversation is keyed by the human counterparty, so on an outbound message that address is
+the recipient. It was never serialized, leaving the recipient implied only by the salutation.
+"""
+from django.contrib.auth import get_user_model
+from django.test import TestCase, tag
+
+from api.models import (
+    BrowserUseAgent,
+    CommsChannel,
+    PersistentAgent,
+    PersistentAgentCommsEndpoint,
+    PersistentAgentConversation,
+    PersistentAgentMessage,
+)
+from console.agent_chat.timeline import serialize_message_event
+
+
+@tag("batch_agent_chat")
+class TimelineEmailRecipientTests(TestCase):
+    def setUp(self):
+        user = get_user_model().objects.create_user(
+            username="recipient-card@example.test",
+            email="recipient-card@example.test",
+        )
+        self.agent = PersistentAgent.objects.create(
+            user=user,
+            name="Alpha Scout",
+            charter="Send email.",
+            browser_use_agent=BrowserUseAgent.objects.create(user=user, name="browser"),
+        )
+        self.agent_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="alpha.scout@my.gobii.ai",
+        )
+
+    def _email_message(self, *, is_outbound: bool, address: str, display_name: str = "") -> PersistentAgentMessage:
+        conversation = PersistentAgentConversation.objects.create(
+            channel=CommsChannel.EMAIL,
+            address=address,
+            display_name=display_name,
+        )
+        return PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            from_endpoint=self.agent_endpoint,
+            conversation=conversation,
+            is_outbound=is_outbound,
+            body="Derraleigh,\n\nLoved this.",
+            raw_payload={"subject": "loved this"},
+        )
+
+    def test_outbound_email_reports_the_recipient_address(self):
+        message = self._email_message(is_outbound=True, address="derraleigh@example.com")
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertEqual(payload["recipientAddress"], "derraleigh@example.com")
+        self.assertIsNone(payload["recipientName"])
+
+    def test_outbound_email_reports_a_display_name_when_one_exists(self):
+        message = self._email_message(
+            is_outbound=True,
+            address="derraleigh@example.com",
+            display_name="Derraleigh Vance",
+        )
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertEqual(payload["recipientName"], "Derraleigh Vance")
+        self.assertEqual(payload["recipientAddress"], "derraleigh@example.com")
+
+    def test_inbound_email_has_no_recipient(self):
+        """The counterparty address is the sender there, so labelling it "to" would be wrong."""
+        message = self._email_message(is_outbound=False, address="cantey@example.com")
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertIsNone(payload["recipientAddress"])
+        self.assertIsNone(payload["recipientName"])


### PR DESCRIPTION
## The report

An outbound email card showed `Gayle · EMAIL · loved this` with the salutation `Derraleigh,` — and **no indication of who it went to**. Reported 2026-07-21, the oldest remaining major UI bug.

**Reproduced on current `main`** before writing anything, since it was screenshot-backed and unverified. Rendering a real outbound email locally:

```
A · Alpha · EMAIL · loved this · 1 minute ago
Derraleigh, / Loved this - following up on the pilot timeline.
```

`derraleigh@example.com` appeared **nowhere on the page**.

## Root cause

Not a display bug — the recipient was **never serialized**. The timeline payload carried `senderName`/`senderAddress` and no recipient field at all, so the UI had nothing to show.

An email conversation is keyed by the human counterparty, so on an outbound message `conversation.address` **is** the recipient:

| Direction | `conversation.address` | `from_endpoint` |
|---|---|---|
| Inbound | the sender | the human |
| Outbound | **the recipient** | the agent |

**Worth recording for anyone who revisits this:** `to_endpoint` looks like the obvious source and is already `select_related`, but it is **null on every outbound email in production — 1842 of 1842 over three days**. Serializing it would have shipped a permanently empty field.

## The change

Backend emits `recipientName`/`recipientAddress` for **outbound email only**. Inbound is deliberately untouched: there the counterparty address is the sender, and labelling it as a destination would be wrong.

The card renders it as a chip beside the channel badge so the two read as one routing unit — `EMAIL → recipient` — keeping the subject as the bold title. Display name preferred when present, full `Name <address>` in the title attribute, and the label is announced to assistive tech rather than relying on the visual arrow. The chip is width-capped so a long address truncates before crowding out the subject.

## Visual QA — rendered and inspected, not assumed

| Case | Result |
|---|---|
| Outbound, bare address | `Alpha · EMAIL · [→ derraleigh@example.com] · **loved this**` |
| Outbound, display name | `Bravo · EMAIL · [→ Dana Whitfield] · **Q3 numbers**`, address in tooltip |
| Inbound email | **no chip** — correct, a received mail has no "to" |
| 80-char address, iPhone viewport | truncates in-chip, **no horizontal overflow** (390 = 390) |

## Evidence

- 3 backend + 5 frontend tests, **all red before the change** (verified by stashing it)
- Frontend suite **247/247**, `batch_agent_chat` **256/256**, `tsc --noEmit` clean

## Disclosure

`scripts/budgets/complexity_budgets.json` is bumped by **+57 LoC**, recorded through the documented path. The bulk is 34 lines of chip CSS; I trimmed what I could without compromising the treatment.

## Known limitation

`.chat-author` is `nowrap`, so on a very narrow screen a pathological address and a long subject both ellipsize hard. Letting the header wrap on mobile would be nicer but changes layout for **every** card type, which is broader than this ticket and not verifiable in one pass. Left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)