### PR TITLE
Let chat tables scroll instead of crushing their columns (#315)

### DIFF
--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3492,8 +3492,12 @@
     overflow-wrap: anywhere;
     word-break: break-word;
 }
+/* Sized to its content so the surrounding overflow-x-auto wrapper can scroll. Pinning the table to
+   the container instead made every column shrink until the cells were unreadable on a phone. */
 .chat-content table {
-    width: 100%;
+    width: max-content;
+    min-width: 100%;
+    max-width: none;
     border-collapse: collapse;
     margin: 0.75rem 0;
     font-size: 0.875rem;
@@ -3503,6 +3507,9 @@
     padding: 0.5rem 0.75rem;
     text-align: left;
     border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    /* Prose wants long URLs to break anywhere; inside a cell that shatters ordinary words. */
+    overflow-wrap: normal;
+    word-break: normal;
 }
 .chat-content th {
     font-weight: 600;

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "5ae8852167307145021993150777c9bf99d54c57",
+  "baseline_sha": "44130d1256108bc0a784423f0c01b5283a26f122",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7909,
+        "fitted_tokens": 7914,
         "system_bytes": 25846,
         "tools_bytes": 21536,
         "total_bytes": 59107,
         "user_bytes": 11725
       },
       "planning_first_run": {
-        "fitted_tokens": 8745,
+        "fitted_tokens": 8760,
         "system_bytes": 31516,
         "tools_bytes": 12530,
         "total_bytes": 54473,
         "user_bytes": 10427
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8077,
+        "fitted_tokens": 8065,
         "system_bytes": 26346,
         "tools_bytes": 21536,
         "total_bytes": 59610,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253159
+    "limit": 253166
   }
 }


### PR DESCRIPTION
## The report

Tables in agent messages render "ultra squished" on mobile — cells compressed until the text shatters. Reported 2026-07-25 with a screenshot.

**Reproduced on current `main`** at an iPhone 13 viewport before writing anything. A 7-column pipeline table rendered like this:

```
Fabri   Sa     Dis    $9    20     W     2
kam     m      cov    80    26     at    we
Logis   Oko    ery          -0     ch    eks
tics    nkw                 8-           ag
        o                   20           o
```

## Root cause — two rules in `.chat-content`

```css
.chat-content { overflow-wrap: anywhere; word-break: break-word; }  /* shatters words */
.chat-content table { width: 100%; }                                /* pins to container */
```

The markdown renderer **already** wraps tables in an `overflow-x-auto` container. But a table pinned to that container never overflows, so the wrapper had nothing to scroll — and the prose-level `overflow-wrap: anywhere`, which exists so long URLs break, then fragmented ordinary words inside cells.

The HTML/email path solved this some time ago with `width: max-content` + `min-width: 100%` and normal wrapping in cells. This applies the same treatment to the markdown path so both behave alike.

## Measured, same message before and after (iPhone 13)

| | Before | After |
|---|---|---|
| Wrapper scrollable | **false** | **true** |
| Table width vs 340px container | 340px (pinned) | **769px** (overflows → scrolls) |
| "Northwind Trading Co" cell | 60px | **180px** |
| "Dana Whitfield" cell | 51px | **120px** |

That is the difference between `Fabri kam Logis tics` and `Fabrikam Logistics`.

## Checked for collateral damage

- **Small table** (2 cols): sizes neatly to content instead of stretching — cleaner, not a regression
- **Wide table, desktop 1280px**: fits without scrolling, no page overflow
- **HTML/email tables**: untouched, they use `.chat-html-content`

## No unit test, deliberately

This is a layout fix and jsdom does not perform layout, so a passing assertion there would prove nothing. The browser measurements above are the evidence. Frontend suite **247/247**, `tsc --noEmit` clean.

Budget bump: **+7 LoC**, recorded through the documented path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)