### PR TITLE
Open the full action list in one click (#313)

### DIFF
--- a/frontend/src/components/agentChat/CollapsedActivityCard.test.tsx
+++ b/frontend/src/components/agentChat/CollapsedActivityCard.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CollapsedActivityCard } from './CollapsedActivityCard'
+import { INLINE_ACTIVITY_ENTRY_LIMIT } from './activityEntryUtils'
+import type { ToolEntryDisplay } from './tooling/types'
+
+vi.mock('./ToolClusterTimelineOverlay', () => ({
+  ToolClusterTimelineOverlay: ({ open, entries }: { open: boolean; entries: unknown[] }) => (
+    open ? <div data-testid="overlay">overlay with {entries.length} entries</div> : null
+  ),
+}))
+
+// Rendering entry internals is not what these tests are about; the click path is.
+vi.mock('./ActivityEntryList', () => ({
+  ActivityEntryList: ({ entries, onViewAll }: { entries: unknown[]; onViewAll?: () => void }) => (
+    <div data-testid="inline-list">
+      inline list with {entries.length} entries
+      {onViewAll ? <button type="button" onClick={onViewAll}>View all actions</button> : null}
+    </div>
+  ),
+}))
+
+function makeEntries(count: number): ToolEntryDisplay[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `entry-${index}`,
+    cursor: `cursor-${index}`,
+    toolName: 'http_request',
+    meta: { label: 'HTTP request' },
+    summary: `Step ${index}`,
+    timestamp: '2026-07-25T13:05:00Z',
+    status: 'complete',
+  })) as unknown as ToolEntryDisplay[]
+}
+
+describe('CollapsedActivityCard', () => {
+  it('opens the full view in one click when the run is too long to show inline', () => {
+    const entries = makeEntries(INLINE_ACTIVITY_ENTRY_LIMIT + 4)
+    render(<CollapsedActivityCard overlayId="overlay-1" entries={entries} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /actions/i }))
+
+    // No truncated intermediate list that would need a second click.
+    expect(screen.queryByText('View all actions')).not.toBeInTheDocument()
+    expect(screen.getByTestId('overlay')).toHaveTextContent(`overlay with ${entries.length} entries`)
+  })
+
+  it('announces that the control opens a dialog when it will not expand inline', () => {
+    render(<CollapsedActivityCard overlayId="overlay-2" entries={makeEntries(INLINE_ACTIVITY_ENTRY_LIMIT + 1)} />)
+
+    expect(screen.getByRole('button', { name: /actions/i })).toHaveAttribute('aria-haspopup', 'dialog')
+  })
+
+  it('still expands in place when every action fits', () => {
+    render(<CollapsedActivityCard overlayId="overlay-3" entries={makeEntries(3)} />)
+    const toggle = screen.getByRole('button', { name: /actions/i })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.queryByTestId('overlay')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/agentChat/CollapsedActivityCard.tsx
+++ b/frontend/src/components/agentChat/CollapsedActivityCard.tsx
@@ -30,29 +30,35 @@ export const CollapsedActivityCard = memo(function CollapsedActivityCard({
     return null
   }
 
+  // Expanding in place can only ever show the tail of a long run, so the card would promise "N
+  // actions" and then reveal fewer, needing a second click to finish the job it advertised.
+  // Go straight to the full view in that case and keep the inline expand for runs that fit.
+  const exceedsInlineLimit = entries.length > INLINE_ACTIVITY_ENTRY_LIMIT
+  const showInlineList = expanded && !exceedsInlineLimit
+
   return (
     <div className="timeline-event collapsed-activity-cluster">
       <button
         type="button"
         className="collapsed-event-group"
-        aria-expanded={expanded ? 'true' : 'false'}
-        onClick={() => setExpanded((current) => !current)}
+        aria-expanded={exceedsInlineLimit ? undefined : (expanded ? 'true' : 'false')}
+        aria-haspopup={exceedsInlineLimit ? 'dialog' : undefined}
+        onClick={() => (exceedsInlineLimit ? setViewerOpen(true) : setExpanded((current) => !current))}
       >
         <span className="collapsed-event-group__label">{resolvedLabel}</span>
         <ChevronRight
           className="collapsed-event-group__chevron"
-          data-expanded={expanded ? 'true' : 'false'}
+          data-expanded={showInlineList ? 'true' : 'false'}
           size={14}
           strokeWidth={2}
         />
       </button>
-      {expanded ? (
+      {showInlineList ? (
         <div className="collapsed-activity-cluster__body">
           <ActivityEntryList
             entries={entries}
             limit={INLINE_ACTIVITY_ENTRY_LIMIT}
             limitStrategy="tail"
-            onViewAll={entries.length > INLINE_ACTIVITY_ENTRY_LIMIT ? () => setViewerOpen(true) : undefined}
           />
         </div>
       ) : null}

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "44130d1256108bc0a784423f0c01b5283a26f122",
+  "baseline_sha": "039e6fa2879b51b4e1da468c2424b7d1eec0518d",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7914,
+        "fitted_tokens": 7909,
         "system_bytes": 25846,
         "tools_bytes": 21536,
         "total_bytes": 59107,
         "user_bytes": 11725
       },
       "planning_first_run": {
-        "fitted_tokens": 8760,
+        "fitted_tokens": 8765,
         "system_bytes": 31516,
         "tools_bytes": 12530,
         "total_bytes": 54473,
         "user_bytes": 10427
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8065,
+        "fitted_tokens": 8053,
         "system_bytes": 26346,
         "tools_bytes": 21536,
         "total_bytes": 59610,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253166
+    "limit": 253171
   }
 }


### PR DESCRIPTION
## The report

> "View Actions widget shows a partial list → must click 'View all actions' to get the full view. Expected: expand fully or navigate directly."

**Reproduced on current `main`**, and it is worse than one extra click — the card advertises a count and then shows fewer:

| Step | Result |
|---|---|
| Initial | Button reads **"14 actions"** |
| Click 1 | Expands to **10 of 14** + a "View all actions" control appears |
| Click 2 | Overlay finally shows all 14 |

## Why the middle state existed

The inline list is capped at `INLINE_ACTIVITY_ENTRY_LIMIT = 10` to keep hundreds of tool entries out of the timeline — a sensible guard. But that means expanding in place can only ever show the *tail* of a long run, so the intermediate state was always going to under-deliver on what its own label promised.

## The change

When a run exceeds the cap, the card opens the full view directly. The inline expand is kept for runs that fit, which is the common case, so the perf guard is untouched.

The control also announces itself correctly now: `aria-haspopup="dialog"` when it will open the full view, and `aria-expanded` only when it genuinely expands in place.

## Verified in a browser, same clusters before and after

| Cluster | Before | After |
|---|---|---|
| 14 actions | expands to 10, second control still to click | **one click → overlay with all 14** |
| 4 actions | expands inline, all 4 | **unchanged** — expands inline, all 4, no overlay |

## Tests

Three, and **2 of 3 fail without the change** (verified by stashing it). The third covers the unchanged small-list path, so a later change cannot quietly route every cluster to the overlay.

Frontend suite **250/250**, `tsc --noEmit` clean, eslint clean on the changed file. Budget bump **+5 LoC**, recorded through the documented path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)