### PR TITLE
Stop the mobile agent switcher covering a suggestion tap target

### DIFF
--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -7765,6 +7765,14 @@
     .agent-fab {
         display: flex;
     }
+    /* The switcher is fixed over the bottom-right of the timeline, so whatever comes to rest
+       there is covered by it. At the default scroll position that is a suggested-follow-up row,
+       and tapping the row opens the switcher instead of running the prompt. Reserve the strip
+       the switcher occupies -- its own height plus the gap it leaves above the composer -- so
+       content can always scroll clear of it. Keep in step with .agent-fab. */
+    .agent-chat-workspace-main:has(.composer-shell) #timeline-inner {
+        padding-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--composer-height, 6.5rem) + 1.625rem + 2.75rem);
+    }
 }
 .agent-fab:hover {
     transform: scale(1.08);

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "59209d90ce52bc9b95aa49eac6473fbd54bd5078",
+  "baseline_sha": "40bc6c7eccb93e98833876196088ab5769604391",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
     "limits": {
       "normal_explicit_send": {
-        "fitted_tokens": 7919,
+        "fitted_tokens": 7909,
         "system_bytes": 25846,
         "tools_bytes": 21536,
         "total_bytes": 59107,
         "user_bytes": 11725
       },
       "planning_first_run": {
-        "fitted_tokens": 8755,
+        "fitted_tokens": 8735,
         "system_bytes": 31516,
         "tools_bytes": 12530,
         "total_bytes": 54473,
         "user_bytes": 10427
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8071,
+        "fitted_tokens": 8083,
         "system_bytes": 26346,
         "tools_bytes": 21536,
         "total_bytes": 59610,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253183
+    "limit": 253191
   }
 }


### PR DESCRIPTION
Found while doing visual QA on the previous PR, then validated as a current, reproducible bug on `main` before touching anything.

## The bug

The agent-switcher FAB is `position: fixed` over the bottom-right of the timeline on mobile. Whatever comes to rest there is underneath it — and at the default scroll position, the state you land in **every time you open a chat on a phone**, that is a suggested-follow-up row.

Proved functionally, not just geometrically. Tapping the point where the row is visible:

```
run1: row under fab = "Create a PDF or CSV report and email it to m" -> drawerOpen=true, prompt did NOT run
run2: row under fab = "Create a PDF or CSV report and email it to m" -> drawerOpen=true, prompt did NOT run
```

The user sees a suggestion, taps it, and the agent drawer opens instead.

Reproduced on fresh loads at **four** mobile widths on `main`: 375, 390, 412, 344.

## Cause

`#timeline-inner` already reserves the composer's height so content clears it:

```css
.agent-chat-workspace-main:has(.composer-shell) #timeline-inner {
    padding-bottom: calc(var(--composer-height, 6.5rem) + 0.75rem);
}
```

The FAB sits *above* the composer by a further `1.625rem`, and is `2.75rem` tall. That strip was never reserved, so content rests under it.

## Fix

Extend the same reservation on mobile by the FAB's own offset plus its height, so content can always scroll clear of it. Expressed to mirror `.agent-fab`'s own positioning so the two stay in step.

## Verification

Full viewport matrix, before on `main` and after, same seeded data. `covered` = what interactive element sits under the FAB's centre.

| Viewport | Before (`main`) | After |
|---|---|---|
| 375×667 | **covered: suggestion row** | covered: none |
| 390×844 | **covered: suggestion row** | covered: none |
| 412×915 | **covered: suggestion row** | covered: none |
| 344×882 | **covered: suggestion row** | covered: none |
| 768×1024 | pad 267.594px | pad 267.594px |
| 834×1112 | pad 293.594px | pad 293.594px |
| 1024×768 | pad 293.594px | pad 293.594px |
| 1280×800 | pad 285.594px | pad 285.594px |
| 1440×900 | pad 285.594px | pad 285.594px |
| 1920×1080 | pad 285.594px | pad 285.594px |

Every size at or above the breakpoint is byte-identical — the FAB is not rendered there at all. No horizontal overflow at any size.

Adjacent path re-checked, since this touches the scroll container's height and #1385 changed live-edge scrolling: sending a message on mobile still auto-scrolls and the new bubble lands fully visible, not behind the composer and not under the FAB (`bubbleBottom 312 < fabTop 450 < composerTop 520`).

Looked at every state in a real browser rather than trusting the numbers: the FAB now sits in its own gutter with both suggestion chevrons visible and tappable.

- Frontend suite 250/250, `npm run build` (tsc) clean.
- Lint identical to `main` (201 problems both).

## What I did not do

**No automated regression test** — same gap as #1395, now tracked as Troy's #327. jsdom performs no layout, evaluates no media queries, and has no `elementFromPoint` hit-testing, so nothing in the current harness can observe a fixed element covering another element's tap target. Everything above was measured in a real browser by hand. I would rather state that than add a CSS-source assertion that restates the rule and would not have caught this.

Second commit records the +8 LoC budget via the documented `--update-baselines` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)