### PR TITLE
Settle a sent message by its own id instead of guessing (#48)

### DIFF
--- a/frontend/src/hooks/useTimelineCacheInjector.ts
+++ b/frontend/src/hooks/useTimelineCacheInjector.ts
@@ -448,6 +448,46 @@ export function updateOptimisticEventInCache(
   return found
 }
 
+/**
+ * Drop an optimistic event from the cache by clientId. The sender knows exactly which event its
+ * own request created, so settling it needs no content guessing.
+ */
+export function removeOptimisticEventFromCache(
+  queryClient: QueryClient,
+  agentId: string,
+  clientId: string,
+): boolean {
+  const key = timelineQueryKey(agentId)
+  let removed = false
+
+  queryClient.setQueryData<InfiniteData<TimelinePage>>(key, (old) => {
+    if (!old?.pages?.length) {
+      return old
+    }
+
+    const pages = [...old.pages]
+    for (let pageIdx = pages.length - 1; pageIdx >= 0; pageIdx--) {
+      const page = pages[pageIdx]
+      const eventIdx = page.events.findIndex(
+        (event) => event.kind === 'message' && event.message.clientId === clientId,
+      )
+      if (eventIdx < 0) {
+        continue
+      }
+      removed = true
+      pages[pageIdx] = {
+        ...page,
+        events: [...page.events.slice(0, eventIdx), ...page.events.slice(eventIdx + 1)],
+      }
+      break
+    }
+
+    return removed ? { ...old, pages } : old
+  })
+
+  return removed
+}
+
 function hasCursorAdvanced(previous: string | null, next: string | null): boolean {
   if (!next) {
     return false

--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/tool
 import type { InfiniteData, QueryClient } from '@tanstack/react-query'
 
 import { sendAgentMessage, fetchProcessingStatus } from '../api/agentChat'
-import { flushPendingEventsToCache, injectRealtimeEventIntoCache, refreshLoadedTimelineVariantsInCache, refreshTimelineLatestInCache, replacePendingActionRequestsInCache, updateOptimisticEventInCache, updateRosterProcessingInCache } from '../hooks/useTimelineCacheInjector'
+import { flushPendingEventsToCache, injectRealtimeEventIntoCache, removeOptimisticEventFromCache, refreshLoadedTimelineVariantsInCache, refreshTimelineLatestInCache, replacePendingActionRequestsInCache, updateOptimisticEventInCache, updateRosterProcessingInCache } from '../hooks/useTimelineCacheInjector'
 import { timelineQueryKey, type TimelinePage } from '../hooks/useAgentTimeline'
 import { mergeTimelineEvents, normalizeTimelineEvent } from '../stores/agentChatTimeline'
 import type { AgentMessage, PendingActionRequest, ProcessingSnapshot, ProcessingWebTask, StreamEventPayload, StreamState, ThinkingEvent, TimelineEvent } from '../types/agentChat'
@@ -727,6 +727,22 @@ export const sendMessage = createAsyncThunk<
   }
   try {
     const serverEvent = await sendAgentMessage(agentId, trimmed, attachments)
+    // The echo is reconciled against the optimistic copy by guessing -- matching text, attachment
+    // count and a two minute timestamp window. Any disagreement leaves both on screen, one stuck
+    // on "Sending" (#48). Here the sender knows exactly which event it created, so settle it by
+    // clientId and let the guess remain only as the fallback for an echo that arrives on its own.
+    // Only settle once the response actually carries a replacement. A send that resolves without
+    // a message event still has to leave the sender looking at their own words.
+    const echoCarriesMessage = Boolean(
+      serverEvent && typeof serverEvent === 'object'
+      && (serverEvent as { kind?: unknown }).kind === 'message',
+    )
+    if (echoCarriesMessage) {
+      if (extra.queryClient) {
+        removeOptimisticEventFromCache(extra.queryClient, agentId, clientId)
+      }
+      dispatch(chatActions.optimisticMessageSettled({ agentId, clientId }))
+    }
     dispatch(receiveRealtimeEvent(agentId, serverEvent))
     return { clientId }
   } catch (error) {
@@ -975,6 +991,12 @@ const chatSlice = createSlice({
       )
       session.processing.awaitingResponse = false
       session.processing.processingStartedAt = null
+    },
+    optimisticMessageSettled(state, action: PayloadAction<{ agentId: string; clientId: string }>) {
+      const session = ensureSession(state, action.payload.agentId)
+      session.timelineUi.pendingEvents = session.timelineUi.pendingEvents.filter(
+        (event) => !(event.kind === 'message' && event.message.clientId === action.payload.clientId),
+      )
     },
     optimisticMessageRetryStarted(state, action: PayloadAction<{ agentId: string; clientId: string }>) {
       const session = ensureSession(state, action.payload.agentId)

--- a/frontend/src/store/chatSliceDuplicateProbe.test.ts
+++ b/frontend/src/store/chatSliceDuplicateProbe.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Probe for #48: a sent message rendering twice, one copy stuck on "Sending".
+ *
+ * The optimistic bubble and the server echo carry different cursors, so mergeTimelineEvents can
+ * never collapse them. Reconciliation used to rest entirely on a signature guess -- normalized
+ * text, attachment count, and timestamps within OPTIMISTIC_MATCH_WINDOW_MS -- and every case
+ * below marked "the guess cannot see this" rendered two copies before the sender started
+ * settling its own send by clientId.
+ */
+import { QueryClient, type InfiniteData } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { sendAgentMessage } from '../api/agentChat'
+import { timelineQueryKey, type TimelinePage } from '../hooks/useAgentTimeline'
+import { createAppStore } from './appStore'
+import { chatActions, sendMessage } from './chatSlice'
+
+vi.mock('../api/agentChat', () => ({
+  sendAgentMessage: vi.fn(),
+  fetchProcessingStatus: vi.fn(),
+}))
+
+const AGENT = 'agent-dup'
+const BODY = 'did the invoice go out?'
+
+function seedTimelineCache(queryClient: QueryClient) {
+  const page: TimelinePage = {
+    events: [],
+    hasMoreOlder: false,
+    hasMoreNewer: false,
+    oldestCursor: null,
+    newestCursor: null,
+    currentPlan: null,
+    pendingActionsStateOrder: 0,
+    raw: {} as TimelinePage['raw'],
+  }
+  queryClient.setQueryData<InfiniteData<TimelinePage>>(timelineQueryKey(AGENT), {
+    pages: [page],
+    pageParams: [undefined],
+  })
+}
+
+/** Every message copy the user would see, with the status badge that renders on it. */
+function renderedMessages(queryClient: QueryClient): Array<{ body: string; status?: string }> {
+  const data = queryClient.getQueryData<InfiniteData<TimelinePage>>(timelineQueryKey(AGENT))
+  return (data?.pages ?? []).flatMap((page) =>
+    page.events
+      .filter((event) => event.kind === 'message')
+      .map((event) => ({ body: event.message.bodyText ?? '', status: event.message.status })),
+  )
+}
+
+/** A faithful server echo, with individual fields overridable to model a degraded one. */
+function serverEcho(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: 'message',
+    cursor: '1784997786629681:message:01SERVERCURSOR',
+    message: {
+      id: 'server-msg-1',
+      cursor: '1784997786629681:message:01SERVERCURSOR',
+      bodyText: BODY,
+      bodyHtml: '',
+      isOutbound: false,
+      channel: 'web',
+      attachments: [],
+      timestamp: new Date().toISOString(),
+      relativeTimestamp: 'now',
+      ...overrides,
+    },
+  }
+}
+
+async function sendAndCount(echo: unknown) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const store = createAppStore({ queryClient })
+  seedTimelineCache(queryClient)
+  store.dispatch(chatActions.agentSelected({ agentId: AGENT }))
+  vi.mocked(sendAgentMessage).mockResolvedValue(echo as never)
+
+  await store.dispatch(sendMessage({ body: BODY }) as never)
+  return renderedMessages(queryClient)
+}
+
+describe('#48 optimistic reconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('collapses to one copy when the echo is faithful', async () => {
+    const rendered = await sendAndCount(serverEcho())
+    expect(rendered).toHaveLength(1)
+    expect(rendered[0].status).not.toBe('sending')
+  })
+
+  it('collapses when the echo timestamp is inside the match window', async () => {
+    const rendered = await sendAndCount(
+      serverEcho({ timestamp: new Date(Date.now() + 119_000).toISOString() }),
+    )
+    expect(rendered).toHaveLength(1)
+  })
+
+  // Was red: a device clock more than two minutes off duplicated on every single send.
+  it('collapses when the echo timestamp is outside the match window', async () => {
+    const rendered = await sendAndCount(
+      serverEcho({ timestamp: new Date(Date.now() + 121_000).toISOString() }),
+    )
+    expect(rendered).toHaveLength(1)
+    expect(rendered.some((m) => m.status === 'sending')).toBe(false)
+  })
+
+  // Was red: the window is symmetric, so a slow clock broke it too.
+  it('collapses when the clock disagreement runs the other way', async () => {
+    const rendered = await sendAndCount(
+      serverEcho({ timestamp: new Date(Date.now() - 121_000).toISOString() }),
+    )
+    expect(rendered).toHaveLength(1)
+  })
+
+  // Was red, and needs no broken clock: a rejected or late-linked upload is enough.
+  it('collapses when the echo reports an attachment the optimistic copy did not count', async () => {
+    const rendered = await sendAndCount(
+      serverEcho({ attachments: [{ id: 'a1', filename: 'invoice.pdf', url: '' }] }),
+    )
+    expect(rendered).toHaveLength(1)
+  })
+
+  // Was red: any character the two sides normalize differently was enough.
+  it('collapses when the server rewrites the body text', async () => {
+    const rendered = await sendAndCount(serverEcho({ bodyText: `${BODY} ` + '​' }))
+    expect(rendered).toHaveLength(1)
+  })
+
+  // Stripping tags off the html lands back on the same normalized text, so this one is safe.
+  it('collapses when the echo carries only rendered html', async () => {
+    const rendered = await sendAndCount(
+      serverEcho({ bodyText: '', bodyHtml: `<p>${BODY}</p>` }),
+    )
+    expect(rendered).toHaveLength(1)
+  })
+
+  // A missing timestamp skips the window comparison rather than failing it.
+  it('collapses when the echo has no timestamp at all', async () => {
+    const rendered = await sendAndCount(serverEcho({ timestamp: null }))
+    expect(rendered).toHaveLength(1)
+  })
+})

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "b532cbb1fa5d4fac73815f4869c2f4b27289741c",
+  "baseline_sha": "2fea7b2fb18efe4767076707fafb0f8f87ddb121",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send/planning paths.",
@@ -12,14 +12,14 @@
         "user_bytes": 11725
       },
       "planning_first_run": {
-        "fitted_tokens": 8745,
+        "fitted_tokens": 8760,
         "system_bytes": 31516,
         "tools_bytes": 12530,
         "total_bytes": 54473,
         "user_bytes": 10427
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8083,
+        "fitted_tokens": 8065,
         "system_bytes": 26346,
         "tools_bytes": 21835,
         "total_bytes": 59909,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253748
+    "limit": 253805
   }
 }


### PR DESCRIPTION
Fixes Troy's **#48** — a sent message rendering twice, one copy stuck on "Sending…". Reported by Andrew with a screenshot.

## Cause

The optimistic bubble and the server echo carry **different cursors**, so `mergeTimelineEvents` (which keys on cursor alone) can never collapse them. Removing the optimistic copy rested entirely on a *guess* in `receiveRealtimeEvent`, requiring all three of:

1. normalized body text equal
2. attachment count equal
3. timestamps within `OPTIMISTIC_MATCH_WINDOW_MS = 120_000`

The backend echoes no client id, so this guess was the only thing preventing a duplicate. Both the React Query cache and the Redux pending buffer depend on the same signature — one point of failure, two paths.

## Three ways it fails, all reproduced

| Condition | Before |
|---|---|
| Device clock >2min off the server, **either direction** | duplicates **every send** for that user |
| Echo reports a different attachment count | duplicates — **needs no clock problem** |
| Body text differs by any character the two sides normalize differently | duplicates |

The attachment case matters most: a rejected or late-linked upload is enough, and it hits users whose clocks are perfectly fine.

Two hypotheses I tested and **disproved**: an html-only echo reconciles fine (tag-stripping lands on the same normalized text), and a missing timestamp is safe by design (it skips the window comparison rather than failing it). Both are now pinned by tests so nobody re-derives them.

## Fix

The sender already knows which event its own request created. Settle that event by `clientId`, and leave the signature guess as the fallback for an echo that arrives on its own.

Guarded: only settle when the response actually carries a message event. Without that guard a send resolving without one would delete the user's message entirely — a worse bug than the duplicate. My own #287 regression test caught this during development.

## Verification

**Real browser, A/B on the same seeded data**, sampling the DOM every 60ms:

| | skew 121s | control |
|---|---|---|
| `main` | **2 copies** (`"ago+Sending"`) | 1 |
| this branch | **1 copy** | 1 |

Also verified at −121s and 150s: 1 copy.

**Boundary isolated exactly**, before the fix — 60s, 110s, 119s → 1 copy; 121s, 150s, −121s, −300s → 2 copies. That is `OPTIMISTIC_MATCH_WINDOW_MS` to the second.

**8 new unit tests** map the whole failure space end-to-end through the real store. Four were red before this change.

- Frontend suite 258/258, `npm run build` (tsc) clean.
- Lint identical to `main` (201 problems both).

## Honest limits

I could **not** reproduce the duplicate under normal conditions with a correct clock — a `direction=initial` refetch fires ~260ms after every send and repairs the view locally. So I have proven three mechanisms that produce exactly the reported symptom, but not which one hit Andrew specifically. This copy also runs the in-memory channel layer and eager Celery, so local timing is not production timing.

That is why the fix removes the guessing entirely rather than patching one trigger: it closes all three paths, including whichever one actually fired.

Second commit records the +57 LoC budget via the documented `--update-baselines` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)