### PR TITLE
Close the reduced-motion media query that swallowed the roster item rule

### DIFF
--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -6169,8 +6169,11 @@
     }
 }
 @media (prefers-reduced-motion: reduce) {
-    .agent-roster-count-pending,
-    .agent-roster-item {
+    .agent-roster-count-pending {
+        animation: none;
+    }
+}
+.agent-roster-item {
     --roster-item-gap: 0.75rem;
     --roster-item-padding: 0.625rem 0.5rem;
     --roster-item-radius: 0.5rem;

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "f31365629625cef28e9775a8ef67603d24ad5124",
+  "baseline_sha": "daab1e19eff3b139759220623a53eb771d4350c3",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
@@ -12,7 +12,7 @@
         "user_bytes": 11651
       },
       "normal_explicit_send": {
-        "fitted_tokens": 7902,
+        "fitted_tokens": 7917,
         "system_bytes": 25846,
         "tools_bytes": 21801,
         "total_bytes": 59331,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253430
+    "limit": 253433
   }
 }


### PR DESCRIPTION
**Regression I introduced in #1398, currently on `main`.** Restores stylesheet balance.

## What happened

Removing the roster placeholder styles in #1398 took the closing brace of the reduced-motion block with it:

```css
@media (prefers-reduced-motion: reduce) {
    .agent-roster-count-pending,
    .agent-roster-item {          /* ← rule absorbed into the media query */
    --roster-item-gap: 0.75rem;
```

The media query never closes, so **every rule after it in the file is nested inside `prefers-reduced-motion` and does not apply** to anyone who has not requested reduced motion. The sidebar, roster and composer render essentially unstyled.

Brace counts: **1511/1511** before #1398 → **1516/1515** after. Now balanced again.

I caught it because a screenshot of an unrelated change showed the sidebar as raw text ("Most recentA-Z", "Alpha ScoutLocal UI check agent."). The build had been emitting `css-syntax-error` as a *warning*, which does not fail CI — worth knowing.

## Verification

- Braces balanced, `css-syntax-error` count **1 → 0**.
- Rebuilt and rendered in a real browser: sidebar sort toggle, agent cards, avatars, subtitles and composer all styled correctly again.
- Frontend suite green.

## Why it was a warning, not a failure

esbuild treats an unbalanced stylesheet as a recoverable warning and ships it. Nothing in CI fails on it. A brace-balance or stylelint check would have caught this at the point I made the mistake — worth raising separately rather than relying on someone noticing a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)