### PR TITLE
Name the sending mailbox and cc on email cards

### DIFF
--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -541,9 +541,21 @@ def _serialize_message(
     # the salutation, which leaves no reliable audit trail of who an agent contacted.
     recipient_address: str | None = None
     recipient_name: str | None = None
+    cc_addresses: list[str] = []
     if message.is_outbound and channel.lower() == CommsChannel.EMAIL and conversation is not None:
         recipient_address = (conversation.address or "").strip() or None
         recipient_name = (conversation.display_name or "").strip() or None
+    if channel.lower() == CommsChannel.EMAIL:
+        # Who else received it. Bcc is deliberately absent: it is never persisted on the message,
+        # so the card cannot claim to show a complete recipient list.
+        cc_addresses = [
+            address
+            for address in (
+                (endpoint.address or "").strip()
+                for endpoint in message.cc_endpoints.all()
+            )
+            if address
+        ]
     if not is_mcp and channel.lower() == "web" and sender_address:
         user_id, agent_id = parse_web_user_address(sender_address)
         if user_id is not None and (not agent_id or not message.owner_agent_id or str(message.owner_agent_id) == agent_id):
@@ -601,6 +613,7 @@ def _serialize_message(
             "senderAddress": None if is_mcp else sender_address,
             "recipientName": recipient_name,
             "recipientAddress": recipient_address,
+            "ccAddresses": cc_addresses,
             "sourceKind": source_kind,
             "sourceLabel": source_label,
             "channelLabel": discord_channel_label or None,
@@ -832,7 +845,7 @@ def _messages_queryset(agent: PersistentAgent, direction: TimelineDirection, cur
             "peer_agent",
             "owner_agent",
         )
-        .prefetch_related("attachments__filespace_node")
+        .prefetch_related("attachments__filespace_node", "cc_endpoints")
         .order_by("-timestamp", "-seq")
     )
     if direction == "older" and cursor is not None:

--- a/frontend/src/components/agentChat/MessageEventCard.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.tsx
@@ -185,6 +185,15 @@ export const MessageEventCard = memo(function MessageEventCard({
   const emailRecipientTitle = emailRecipientName
     ? `${emailRecipientName} <${emailRecipient}>`
     : emailRecipient
+  // Which mailbox actually sent it. Agents send from several custom domains, so "who sent this"
+  // is not answerable from the agent name alone.
+  const emailSender = channel === 'email' && message.isOutbound
+    ? message.senderAddress?.trim() || ''
+    : ''
+  const emailCc = channel === 'email'
+    ? (message.ccAddresses ?? []).map((address) => address.trim()).filter(Boolean)
+    : []
+  const showEmailMeta = Boolean(emailSender) || emailCc.length > 0
 
   const contentTone = isPeer ? 'text-slate-800' : isAgent ? 'text-slate-800' : ''
 
@@ -304,6 +313,22 @@ export const MessageEventCard = memo(function MessageEventCard({
             ) : null}
           </span>
         </div>
+        {showEmailMeta ? (
+          <div className="chat-email-meta">
+            {emailSender ? (
+              <span className="chat-email-meta__item">
+                <span className="chat-email-meta__label">From</span>
+                <span className="chat-email-meta__value" title={emailSender}>{emailSender}</span>
+              </span>
+            ) : null}
+            {emailCc.length > 0 ? (
+              <span className="chat-email-meta__item">
+                <span className="chat-email-meta__label">Cc</span>
+                <span className="chat-email-meta__value" title={emailCc.join(', ')}>{emailCc.join(', ')}</span>
+              </span>
+            ) : null}
+          </div>
+        ) : null}
         {isWebhook && webhookMetaBits.length > 0 ? (
           <div className="mb-2 flex flex-wrap gap-2 text-[11px] font-medium text-slate-500">
             {webhookMetaBits.map((bit) => (

--- a/frontend/src/components/agentChat/MessageEventCardEmailMeta.test.tsx
+++ b/frontend/src/components/agentChat/MessageEventCardEmailMeta.test.tsx
@@ -29,7 +29,7 @@ function emailMessage(overrides: Partial<AgentMessage> = {}): AgentMessage {
 }
 
 function renderCard(message: AgentMessage) {
-  return render(<MessageEventCard message={message} agentFirstName="Alpha" />)
+  return render(<MessageEventCard message={message} eventCursor={message.cursor ?? 'cursor-1'} agentFirstName="Alpha" />)
 }
 
 describe('email card sender and cc', () => {

--- a/frontend/src/components/agentChat/MessageEventCardEmailMeta.test.tsx
+++ b/frontend/src/components/agentChat/MessageEventCardEmailMeta.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Email cards must name the sending mailbox and any cc recipients. Agents send from several
+ * custom-domain mailboxes, so "which mailbox sent this" cannot be read off the agent name -- and
+ * lead-gen work depends on knowing it. Bcc is never persisted, so it is deliberately not shown.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { MessageEventCard } from './MessageEventCard'
+import type { AgentMessage } from '../../types/agentChat'
+
+function emailMessage(overrides: Partial<AgentMessage> = {}): AgentMessage {
+  return {
+    id: 'msg-1',
+    cursor: '1:message:msg-1',
+    bodyText: 'Following up on the pilot scope.',
+    bodyHtml: '',
+    subject: 'Pilot scope follow-up',
+    isOutbound: true,
+    channel: 'email',
+    attachments: [],
+    timestamp: '2026-07-25T20:00:00Z',
+    relativeTimestamp: 'just now',
+    senderAddress: 'alpha@primeforge-outbound.test',
+    recipientAddress: 'dana@northwind.test',
+    recipientName: 'Dana Whitfield',
+    ...overrides,
+  } as unknown as AgentMessage
+}
+
+function renderCard(message: AgentMessage) {
+  return render(<MessageEventCard message={message} agentFirstName="Alpha" />)
+}
+
+describe('email card sender and cc', () => {
+  it('names the mailbox the email was actually sent from', () => {
+    renderCard(emailMessage())
+
+    expect(screen.getByText('alpha@primeforge-outbound.test')).toBeInTheDocument()
+    expect(screen.getByText('From')).toBeInTheDocument()
+  })
+
+  it('lists cc recipients when there are any', () => {
+    renderCard(emailMessage({ ccAddresses: ['priya@northwind.test', 'sam@northwind.test'] } as Partial<AgentMessage>))
+
+    expect(screen.getByText('Cc')).toBeInTheDocument()
+    expect(screen.getByText('priya@northwind.test, sam@northwind.test')).toBeInTheDocument()
+  })
+
+  it('omits the cc line entirely when there are none', () => {
+    renderCard(emailMessage({ ccAddresses: [] } as Partial<AgentMessage>))
+
+    expect(screen.queryByText('Cc')).not.toBeInTheDocument()
+  })
+
+  it('does not add a sender line to a non-email message', () => {
+    renderCard(emailMessage({ channel: 'web', subject: null } as Partial<AgentMessage>))
+
+    expect(screen.queryByText('From')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3773,6 +3773,39 @@
     color: #94a3b8;
     font-weight: 700;
 }
+/* Sending mailbox and cc, kept off the author line so the header stays legible on a phone. */
+.chat-email-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.75rem;
+    margin: -0.125rem 0 0.5rem;
+    font-size: 0.6875rem;
+    line-height: 1.4;
+    color: #64748b;
+    letter-spacing: 0;
+}
+.chat-email-meta__item {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3125rem;
+    min-width: 0;
+    max-width: 100%;
+}
+.chat-email-meta__label {
+    flex: 0 0 auto;
+    font-weight: 700;
+    color: #94a3b8;
+    text-transform: uppercase;
+    font-size: 0.625rem;
+    letter-spacing: 0.04em;
+}
+.chat-email-meta__value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+}
 .chat-email-recipient-text {
     min-width: 0;
     overflow: hidden;

--- a/frontend/src/types/agentChat.ts
+++ b/frontend/src/types/agentChat.ts
@@ -56,6 +56,7 @@ export type AgentMessage = {
   senderAddress?: string | null
   recipientName?: string | null
   recipientAddress?: string | null
+  ccAddresses?: string[] | null
   sourceKind?: string | null
   sourceLabel?: string | null
   channelLabel?: string | null

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "daab1e19eff3b139759220623a53eb771d4350c3",
+  "baseline_sha": "224bfe39cac4e540887ceff3dcf3ae05a21010a1",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
@@ -12,14 +12,14 @@
         "user_bytes": 11651
       },
       "normal_explicit_send": {
-        "fitted_tokens": 7917,
+        "fitted_tokens": 7912,
         "system_bytes": 25846,
         "tools_bytes": 21801,
         "total_bytes": 59331,
         "user_bytes": 11684
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8046,
+        "fitted_tokens": 8052,
         "system_bytes": 26346,
         "tools_bytes": 21801,
         "total_bytes": 59834,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253433
+    "limit": 253505
   }
 }

--- a/tests/unit/test_timeline_email_from_cc.py
+++ b/tests/unit/test_timeline_email_from_cc.py
@@ -1,0 +1,85 @@
+"""The chat timeline must name the sending mailbox and any cc recipients.
+
+Agents send from several custom-domain mailboxes, so "which mailbox sent this" is not answerable
+from the agent name. Bcc is deliberately absent: it is never persisted on the message.
+"""
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, tag
+
+from api.models import (
+    BrowserUseAgent,
+    CommsChannel,
+    PersistentAgent,
+    PersistentAgentCommsEndpoint,
+    PersistentAgentConversation,
+    PersistentAgentMessage,
+)
+from console.agent_chat.timeline import serialize_message_event
+
+
+@tag("batch_agent_chat")
+class EmailFromAndCcSerializationTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="sender@example.test", email="sender@example.test", password="pw-12345"
+        )
+        browser_agent = BrowserUseAgent.objects.create(user=cls.user, name="Sender Agent")
+        cls.agent = PersistentAgent.objects.create(
+            user=cls.user, name="Sender Agent", charter="Send email.", browser_use_agent=browser_agent
+        )
+
+    def _outbound_email(self, *, sender: str, cc: list[str]) -> PersistentAgentMessage:
+        from_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
+            owner_agent=self.agent, channel=CommsChannel.EMAIL, address=sender
+        )
+        conversation, _ = PersistentAgentConversation.objects.get_or_create(
+            channel=CommsChannel.EMAIL,
+            address="prospect@example.test",
+            defaults={"display_name": "Prospect"},
+        )
+        message = PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            from_endpoint=from_endpoint,
+            conversation=conversation,
+            is_outbound=True,
+            body="Following up.",
+        )
+        for address in cc:
+            endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
+                owner_agent=None, channel=CommsChannel.EMAIL, address=address
+            )
+            message.cc_endpoints.add(endpoint)
+        return message
+
+    def _serialized_message(self, message: PersistentAgentMessage) -> dict:
+        return serialize_message_event(message)["message"]
+
+    def test_reports_the_mailbox_that_actually_sent_it(self):
+        message = self._outbound_email(sender="alpha@custom-domain.test", cc=[])
+
+        serialized = self._serialized_message(message)
+
+        self.assertEqual(serialized["senderAddress"], "alpha@custom-domain.test")
+
+    def test_lists_cc_recipients(self):
+        message = self._outbound_email(
+            sender="alpha@custom-domain.test",
+            cc=["one@example.test", "two@example.test"],
+        )
+
+        serialized = self._serialized_message(message)
+
+        self.assertEqual(
+            sorted(serialized["ccAddresses"]), ["one@example.test", "two@example.test"]
+        )
+
+    def test_cc_is_empty_rather_than_absent_when_there_are_none(self):
+        message = self._outbound_email(sender="alpha@custom-domain.test", cc=[])
+
+        serialized = self._serialized_message(message)
+
+        self.assertEqual(serialized["ccAddresses"], [])


### PR DESCRIPTION
Andrew's request in #bugs: *"the email cards should show the from address as well. high prio fix because this affects our outbound as well as customers (sales lead gen is #1 use case rn)"* and *"also cc bcc and all that if set"*.

## The gap

The card named the recipient but never the mailbox that sent it. With agents sending from several custom-domain mailboxes, the agent name does not answer "which mailbox was this?" — and that is the question outbound work actually needs. Cc was not shown at all.

Reproduced on `main`:

```
PAYLOAD  senderAddress = "alpha@primeforge-outbound.com"   ccAddresses = null
CARD     "Alpha | EMAIL | Sent to | Dana Whitfield | Pilot scope follow-up"
         showsFrom: false   showsCc: false
```

The sending address was **already in the payload and simply never rendered**.

## Change

```
Alpha  [EMAIL]  [→ Dana Whitfield]  •  Pilot scope follow-up          6 minutes ago
FROM alpha@primeforge-outbound.com   CC priya.raman@…, sam.okonkwo@…
```

- **From** — frontend only; the data was already there.
- **Cc** — new, from the message's `cc_endpoints`, with `prefetch_related("cc_endpoints")` so a long timeline does not issue a query per message. The preview fork is production-scale, and an N+1 there is not theoretical.
- Placed on their own line rather than in the header, so the mobile truncation fix from #1395 still holds.

## Bcc is not shown, deliberately

**It is not persisted anywhere.** No field on `PersistentAgentMessage`, no migration, and `api/agent/tools/email_sender.py` hardcodes `has_bcc=False`. A recipient list that silently omits bcc is worse than no list, so persisting it is a separate backend change rather than something quietly skipped here.

## Verification

- **3 backend tests** (2 red without the serializer change), **4 frontend tests** (2 red without the card change).
- Full suite **264/264**, build clean, **0 CSS syntax errors**, lint identical to `main` (201 both).
- Rendered in a real browser against seeded data: a custom-domain sender with two cc recipients renders as above.

## Related

While screenshotting this I found and fixed an unrelated live regression I had introduced in #1398 — a regex CSS deletion swallowed a brace and left `@media (prefers-reduced-motion)` unclosed, silently disabling every rule after it. Fixed separately in #1402 (`b115ad6cb`).

Preview validation to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)