### PR TITLE
Repair literal newline runs before sending to Discord (#228)

### DIFF
--- a/api/agent/tools/charter_text.py
+++ b/api/agent/tools/charter_text.py
@@ -2,6 +2,14 @@ import re
 
 
 LITERAL_NEWLINE = "\\n"
+# Two or more in a row is a paragraph break. Nothing writes that on purpose, and matching the whole
+# run matters: a lookahead that only inspects the next token repairs the first of a pair and leaves
+# the second stranded, which is how "\n\n## Heading" used to come out as a real break followed by a
+# visible \n.
+LITERAL_NEWLINE_RUN_RE = re.compile(r"(?:\\n){2,}")
+# A single one is only unambiguous when what follows can only begin a line: another break, a
+# heading, a bullet, or a numbered item. A lone \n in prose -- including one inside backticks being
+# discussed as text -- is left exactly as written.
 STRUCTURAL_LITERAL_NEWLINE_RE = re.compile(
     r"\\n(?=(?:\\n|#{1,6}(?:\s|$)|[-*+]\s|\d+[.)]\s))"
 )
@@ -13,5 +21,11 @@ def count_literal_newlines(value: str | None) -> int:
 
 def repair_structural_literal_newlines(value: str | None) -> tuple[str, int, int]:
     text = value or ""
-    repaired, repaired_count = STRUCTURAL_LITERAL_NEWLINE_RE.subn("\n", text)
-    return repaired, repaired_count, count_literal_newlines(repaired)
+    before = count_literal_newlines(text)
+    repaired = LITERAL_NEWLINE_RUN_RE.sub(
+        lambda match: "\n" * (len(match.group(0)) // len(LITERAL_NEWLINE)),
+        text,
+    )
+    repaired = STRUCTURAL_LITERAL_NEWLINE_RE.sub("\n", repaired)
+    remaining = count_literal_newlines(repaired)
+    return repaired, before - remaining, remaining

--- a/api/agent/tools/send_discord_message.py
+++ b/api/agent/tools/send_discord_message.py
@@ -10,6 +10,7 @@ from api.agent.files.attachment_helpers import AttachmentResolutionError, resolv
 from api.agent.comms.outbound_content_policy import markdown_only_error
 from api.agent.tools.attachment_guidance import SEND_TOOL_ATTACHMENTS_DESCRIPTION
 from api.agent.tools.agent_variables import substitute_variables_with_filespace
+from api.agent.tools.charter_text import repair_structural_literal_newlines
 from api.agent.core.link_references import handle_link_reference_errors
 from api.models import PersistentAgent
 from api.services.discord_bot import DiscordBotIntegrationError, send_channel_message
@@ -67,6 +68,16 @@ def execute_send_discord_message(agent: PersistentAgent, params: Dict[str, Any])
     if not channel_id:
         return {"status": "error", "message": "channel_id is required."}
     body = substitute_variables_with_filespace(body, agent)
+    # A double-escaped body reaches us as the two characters backslash-n, which Discord renders
+    # verbatim. Repair only the unambiguous structural cases; a lone \n being discussed as text
+    # is left alone.
+    body, repaired_newlines, _ = repair_structural_literal_newlines(body)
+    if repaired_newlines:
+        logger.info(
+            "Repaired %d literal newline(s) in outbound Discord message for agent %s",
+            repaired_newlines,
+            agent.id,
+        )
     if content_error := markdown_only_error(body, surface="Discord"):
         return content_error
     try:

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "224bfe39cac4e540887ceff3dcf3ae05a21010a1",
+  "baseline_sha": "d4189cbad4138af124fcb9deed8aea233863a88f",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
@@ -19,7 +19,7 @@
         "user_bytes": 11684
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8052,
+        "fitted_tokens": 8064,
         "system_bytes": 26346,
         "tools_bytes": 21801,
         "total_bytes": 59834,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253505
+    "limit": 253530
   }
 }

--- a/tests/unit/test_discord_literal_newlines.py
+++ b/tests/unit/test_discord_literal_newlines.py
@@ -1,0 +1,75 @@
+"""Outbound Discord messages must not render literal backslash-n (#228, #289).
+
+A double-escaped body arrives as the two characters backslash and n, which Discord renders
+verbatim. Repair the unambiguous structural cases only: a lone \\n being discussed as text, such as
+a bug report about this very defect, must survive untouched.
+"""
+from __future__ import annotations
+
+from django.test import SimpleTestCase, tag
+
+from api.agent.tools.charter_text import repair_structural_literal_newlines
+
+
+@tag("batch_agent_chat")
+class LiteralNewlineRepairTests(SimpleTestCase):
+    def test_repairs_both_halves_of_a_paragraph_break(self):
+        """The original fix repaired the first of a pair and stranded the second."""
+        body = "**#314 logged**\\n\\n**Status:** minor\\n\\nAndrew reports glitchy UI."
+
+        repaired, count, remaining = repair_structural_literal_newlines(body)
+
+        self.assertEqual(remaining, 0)
+        self.assertEqual(count, 4)
+        self.assertEqual(
+            repaired, "**#314 logged**\n\n**Status:** minor\n\nAndrew reports glitchy UI."
+        )
+
+    def test_repairs_a_run_longer_than_two(self):
+        repaired, _, remaining = repair_structural_literal_newlines("a\\n\\n\\nb")
+
+        self.assertEqual(remaining, 0)
+        self.assertEqual(repaired, "a\n\n\nb")
+
+    def test_repairs_before_a_bullet_list(self):
+        repaired, _, remaining = repair_structural_literal_newlines("Blockers:\\n- one\\n- two")
+
+        self.assertEqual(remaining, 0)
+        self.assertEqual(repaired, "Blockers:\n- one\n- two")
+
+    def test_repairs_before_a_heading(self):
+        repaired, _, remaining = repair_structural_literal_newlines("Intro\\n## Heading")
+
+        self.assertEqual(remaining, 0)
+        self.assertEqual(repaired, "Intro\n## Heading")
+
+    def test_leaves_a_lone_newline_being_discussed_as_text(self):
+        """A bug report about literal newlines must not have its own example rewritten."""
+        body = "Agent output displayed literal `\\n` character sequences instead of breaks."
+
+        repaired, count, remaining = repair_structural_literal_newlines(body)
+
+        self.assertEqual(repaired, body)
+        self.assertEqual(count, 0)
+        self.assertEqual(remaining, 1)
+
+    def test_leaves_prose_mentions_alone(self):
+        body = "I sent literal `\\n` text instead of real line breaks."
+
+        repaired, count, _ = repair_structural_literal_newlines(body)
+
+        self.assertEqual(repaired, body)
+        self.assertEqual(count, 0)
+
+    def test_leaves_real_newlines_untouched(self):
+        body = "Already fine.\n\n## Heading\n- one"
+
+        repaired, count, remaining = repair_structural_literal_newlines(body)
+
+        self.assertEqual(repaired, body)
+        self.assertEqual(count, 0)
+        self.assertEqual(remaining, 0)
+
+    def test_handles_empty_and_none(self):
+        self.assertEqual(repair_structural_literal_newlines(None), ("", 0, 0))
+        self.assertEqual(repair_structural_literal_newlines(""), ("", 0, 0))


### PR DESCRIPTION
Fixes Troy's **#228**, reported by Andrew with a screenshot. Andrew noted he hadn't seen it recently and asked whether it was still real, so I checked production before writing anything.

## It is still real, but rarer than the ticket implies

Outbound Discord messages containing a literal backslash-n, from the analytics replica:

| day | with literal `\n` | total outbound discord |
|---|---|---|
| 2026-07-25 | 5 | 352 |
| 2026-07-24 | 1 | 302 |
| 2026-07-23 | 2 | 141 |
| 2026-07-21 | 2 | 78 |

So roughly **1–2% of messages**, ongoing, including today — not "every Discord user every time". That matches Andrew's sense that it had gone quiet. Worth fixing, not worth calling MAJOR.

Sampling the real bodies separates two classes:

- **Genuine defects** — `**#314 logged**\n\n**Status:** minor\n\nAndrew reports…`
- **Legitimate mentions** — bug reports that *quote* a literal `\n` in backticks while describing this very defect

Any fix has to repair the first and leave the second alone.

## Two defects, not one

**1. The #176 repair never ran on Discord.** `repair_structural_literal_newlines` was only ever applied to charters. Outbound message bodies were never covered.

**2. The repair was incomplete.** Its lookahead required the *next* token to be structural, so on the most common real case it repaired the first of a pair and stranded the second:

```
'**#314 logged**\n\\n**Status:** minor\n\\nAndrew reports...'   ← before: still broken
'**#314 logged**\n\n**Status:** minor\n\nAndrew reports...'     ← after
```

That is why this reads as a regression of a fix that shipped months ago: it never fully worked. A run of two or more is now treated as the paragraph break it can only be.

## Verification

Validated against the **actual production strings** pulled from the replica:

| case | before | after |
|---|---|---|
| `#314` paragraph breaks | 2 repaired, **2 still literal** | 4 repaired, **0 remaining** |
| `#288` paragraph break | 1 repaired, 1 remaining | 2 repaired, 0 remaining |
| bullet list | 2 repaired, 0 remaining | unchanged |
| backticked mention | left alone | **left alone** |
| prose mention | left alone | **left alone** |

- **8 new tests**, 2 red before the change.
- Charter tests, Discord tests, and the 347 tests in modules consuming this helper all still pass — the helper is shared with charter repair, so this improves that path too.

Second commit records the +25 LoC budget.

Preview validation to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)