### PR TITLE
Fix the newline contract and remove the output rewriting (#228)

### DIFF
--- a/api/agent/tools/charter_text.py
+++ b/api/agent/tools/charter_text.py
@@ -29,3 +29,14 @@ def repair_structural_literal_newlines(value: str | None) -> tuple[str, int, int
     repaired = STRUCTURAL_LITERAL_NEWLINE_RE.sub("\n", repaired)
     remaining = count_literal_newlines(repaired)
     return repaired, before - remaining, remaining
+
+
+def literal_newline_failure(value: str | None) -> bool:
+    """True when a body uses literal backslash-n where a line break was meant.
+
+    Only the unambiguous positions count: a run of them, or one before a heading, bullet or
+    numbered item. A lone occurrence in prose -- someone writing about the escape sequence -- is
+    not a formatting failure.
+    """
+    text = value or ""
+    return bool(LITERAL_NEWLINE_RUN_RE.search(text) or STRUCTURAL_LITERAL_NEWLINE_RE.search(text))

--- a/api/agent/tools/send_discord_message.py
+++ b/api/agent/tools/send_discord_message.py
@@ -42,7 +42,11 @@ def get_send_discord_message_tool() -> Dict[str, Any]:
                                        "Discord cannot render tables: never send pipe-separated columns with a "
                                        "hyphen-divider row, even as a summary. "
                                        "Use Markdown only; raw HTML is rejected. Use code formatting to show HTML literally. "
-                                       "Do not pass tool-call/XML syntax; it is sent literally.",
+                                       "Do not pass tool-call/XML syntax; it is sent literally. "
+                                       "Write line breaks as real newlines in the string value. A backslash "
+                                       "followed by n is sent literally and the reader sees those two "
+                                       "characters instead of a line break, which breaks every heading, "
+                                       "bullet and paragraph above.",
                     },
                     "attachments": {
                         "type": "array",

--- a/api/agent/tools/send_discord_message.py
+++ b/api/agent/tools/send_discord_message.py
@@ -10,7 +10,6 @@ from api.agent.files.attachment_helpers import AttachmentResolutionError, resolv
 from api.agent.comms.outbound_content_policy import markdown_only_error
 from api.agent.tools.attachment_guidance import SEND_TOOL_ATTACHMENTS_DESCRIPTION
 from api.agent.tools.agent_variables import substitute_variables_with_filespace
-from api.agent.tools.charter_text import repair_structural_literal_newlines
 from api.agent.core.link_references import handle_link_reference_errors
 from api.models import PersistentAgent
 from api.services.discord_bot import DiscordBotIntegrationError, send_channel_message
@@ -72,16 +71,6 @@ def execute_send_discord_message(agent: PersistentAgent, params: Dict[str, Any])
     if not channel_id:
         return {"status": "error", "message": "channel_id is required."}
     body = substitute_variables_with_filespace(body, agent)
-    # A double-escaped body reaches us as the two characters backslash-n, which Discord renders
-    # verbatim. Repair only the unambiguous structural cases; a lone \n being discussed as text
-    # is left alone.
-    body, repaired_newlines, _ = repair_structural_literal_newlines(body)
-    if repaired_newlines:
-        logger.info(
-            "Repaired %d literal newline(s) in outbound Discord message for agent %s",
-            repaired_newlines,
-            agent.id,
-        )
     if content_error := markdown_only_error(body, surface="Discord"):
         return content_error
     try:

--- a/api/evals/scenarios/message_quality.py
+++ b/api/evals/scenarios/message_quality.py
@@ -14,6 +14,7 @@ from api.agent.tools.web_chat_sender import WEB_CHAT_UNAVAILABLE_MESSAGE
 from api.evals.base import EvalScenario, ScenarioTask
 from api.evals.execution import ScenarioExecutionTools
 from api.evals.registry import ScenarioRegistry, register_scenario
+from api.agent.tools.charter_text import literal_newline_failure
 from api.evals.tool_params import resolved_tool_param
 from api.models import (
     AgentCollaborator,
@@ -861,6 +862,12 @@ class MessageQualityScenario(EvalScenario, ScenarioExecutionTools):
         result = self._tool_result(send_call) if send_call is not None else {}
         if params.get("will_continue_work") is not False and result.get("auto_sleep_ok") is not True:
             failures.append("will_continue_work should be false for final report delivery.")
+
+        if literal_newline_failure(body):
+            failures.append(
+                "Message body used literal backslash-n instead of real line breaks; "
+                "recipients see the escape sequence."
+            )
 
         if case.channel == "email":
             if params.get("to_address") != case.recipient:

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,11 +1,11 @@
 {
-  "baseline_sha": "d4189cbad4138af124fcb9deed8aea233863a88f",
+  "baseline_sha": "d66f08464b7c72b53c49e61213eb5741add14eaf",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 8578,
+        "fitted_tokens": 8598,
         "system_bytes": 28589,
         "tools_bytes": 21801,
         "total_bytes": 62041,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253530
+    "limit": 253542
   }
 }

--- a/tests/unit/test_discord_literal_newlines.py
+++ b/tests/unit/test_discord_literal_newlines.py
@@ -1,8 +1,12 @@
-"""Outbound Discord messages must not render literal backslash-n (#228, #289).
+"""Detection of literal backslash-n used where a line break was meant (#228, #289).
 
-A double-escaped body arrives as the two characters backslash and n, which Discord renders
-verbatim. Repair the unambiguous structural cases only: a lone \\n being discussed as text, such as
-a bug report about this very defect, must survive untouched.
+This backs two things: the eval assertion that fails a model whose message body uses the escape
+sequence instead of a real newline, and the one-off charter repair command. Nothing rewrites live
+message output -- the contract tells the model how to write a line break, and the eval measures
+whether it did.
+
+Only unambiguous positions count. A lone \\n discussed as text, such as a bug report about this
+very defect, must never be treated as a failure or rewritten.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Andrew asked whether #1404 was a layered-on hack or a root cause fix. **It was a hack**, and a partial one. This removes it and fixes the cause instead.

## What #1404 did wrong

It rewrote model output before sending — the platform-side output filtering `AGENTS.md` explicitly rules out. I found `charter_text.py` already doing this for charters and treated that precedent as permission. A precedent is not a justification; that helper may itself have been the original mistake.

It was also only partial. Prose line breaks still shipped literally:

```
in : 'Hi Ben,\n\nQuick question about territory.\n\nBest,\nBelle'
out: 'Hi Ben,\n\nQuick question about territory.\n\nBest,\\nBelle'   ← signature still literal
in : 'Address:\n123 Main St\nBoston MA'
out: unchanged — both still literal
```

A real outbound email still rendered `Best,\nBelle` to a prospect. It looked fixed, which is worse than untouched.

## What this does

**Removes the runtime rewriting entirely.** Not kept as a mitigation — stacking a contract fix on top of an output filter is two layers doing the same job, and the wrong one silently wins.

**Fixes the actual cause.** The `message` contract described markdown sections, bullets, bold labels, tables, HTML and XML, and said nothing about newlines. It even warned that XML "is sent literally", so the concept was present. It demanded structure that requires line breaks without ever saying how to express one. That is an information gap.

**Adds eval coverage.** The message-quality suite now deterministically fails a body that uses literal `\n` where a line break was meant, reading the **model's own tool parameters** — so it measures behavior, and there is no repair layer left to mask it.

The helper survives only in the explicit `repair_agent_charter_newlines` management command — a deliberate one-off tool, not silent runtime rewriting — and the run-handling fix makes that command work correctly on paragraph breaks it previously half-repaired.

## What I can prove, and what I cannot

Analytics replica, 30 days of outbound Discord:

| group | n | avg length | avg bold markers |
|---|---|---|---|
| clean | 1434 | 599 | 6 |
| contains literal `\n` | 24 | 768 | 12 |

Base rate **1.6%**, correlated with markdown density — offending bodies carry twice the bold markers and run 28% longer.

**No feasible number of eval runs can resolve that.** Detecting 1.6% → 0.4% at 80% power needs ~1,500 runs per arm; even 1.6% → 0% needs ~250. The standing bar is ≥16 per arm, which measures nothing here.

So, per `AGENTS.md` — *"if measurement shows no effect, land the eval as coverage and leave the bug open"*:

- the contract change ships as a **justified information fix**, defensible on inspection
- the eval ships as **coverage** that will catch any regression raising the rate
- it is **not** reported as a proven fix, and **#228 stays open**

With the rewriting removed, the defect is now visible again when it occurs, which is the point — a symptom the platform hides cannot be measured or fixed.

## Verification

- 60 tests across the discord, charter and newline modules: green.
- Eval harness smoke-run on `message_quality_chat_project_update`, DeepSeek V4 Flash: 8/8 tasks passed including the new assertion, confirming no false positives on clean output.
- Complexity budget recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)