### PR TITLE
Key the agent roster cache by the agent it was scoped to (#363)

### DIFF
--- a/frontend/src/hooks/useAgentRoster.ts
+++ b/frontend/src/hooks/useAgentRoster.ts
@@ -18,11 +18,16 @@ export function useAgentRoster(options?: UseAgentRosterOptions) {
   const contextKey = options?.contextKey ?? 'default'
   const refetchIntervalMs = options?.refetchIntervalMs ?? false
 
+  // The roster scoped to a specific agent comes back with that agent's own context, which can
+  // differ from the one the key describes. Leaving forAgentId out of the key filed that response
+  // under the wrong entry, and the caller then discarded it as a context mismatch.
+  const forAgentId = options?.forAgentId ?? null
+
   return useQuery({
-    queryKey: ['agent-roster', contextKey] as const,
+    queryKey: ['agent-roster', contextKey, forAgentId] as const,
     queryFn: () => fetchAgentRoster({
       context: context ?? undefined,
-      forAgentId: options?.forAgentId,
+      forAgentId: forAgentId ?? undefined,
       staffContext: options?.staffContext,
     }),
     placeholderData: keepPreviousData,

--- a/frontend/src/hooks/useAgentRosterScoping.test.tsx
+++ b/frontend/src/hooks/useAgentRosterScoping.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Regression coverage for #363: the agent roster was fetched and then discarded.
+ *
+ * A roster scoped to a specific agent (`for_agent`) comes back carrying that agent's own console
+ * context, which can differ from the context the cache key describes. `forAgentId` was missing from
+ * the query key, so the scoped response was filed under the unscoped entry and served back for a
+ * key it did not belong to. The caller compared the two contexts, called it a mismatch, and emptied
+ * the list — a sidebar showing one agent when the server had returned a hundred.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { PropsWithChildren, ReactElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ConsoleContext } from '../api/context'
+import { useAgentRoster } from './useAgentRoster'
+
+const { fetchAgentRosterMock } = vi.hoisted(() => ({ fetchAgentRosterMock: vi.fn() }))
+
+vi.mock('../api/agents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/agents')>()),
+  fetchAgentRoster: fetchAgentRosterMock,
+}))
+
+const PERSONAL: ConsoleContext = { type: 'personal', id: 'user-1', name: 'User' }
+const CONTEXT_KEY = 'personal:user-1:normal'
+
+describe('useAgentRoster scoping by agent', () => {
+  let queryClient: QueryClient
+  let wrapper: ({ children }: PropsWithChildren) => ReactElement
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    wrapper = ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    fetchAgentRosterMock.mockReset()
+    fetchAgentRosterMock.mockResolvedValue({ agents: [] })
+  })
+
+  it('refetches when the route agent changes within one context', async () => {
+    const { rerender } = renderHook(
+      ({ forAgentId }) => useAgentRoster({ context: PERSONAL, contextKey: CONTEXT_KEY, forAgentId }),
+      { initialProps: { forAgentId: 'agent-a' }, wrapper },
+    )
+
+    await waitFor(() => expect(fetchAgentRosterMock).toHaveBeenCalledTimes(1))
+
+    // A different agent is a different request: it resolves a different console context server side.
+    rerender({ forAgentId: 'agent-b' })
+
+    await waitFor(() => expect(fetchAgentRosterMock).toHaveBeenCalledTimes(2))
+    expect(fetchAgentRosterMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ forAgentId: 'agent-b' }))
+  })
+
+  it('does not serve an agent-scoped roster to an unscoped caller', async () => {
+    const scoped = { agents: [{ id: 'a' }, { id: 'b' }], context: { type: 'organization', id: 'org-1' } }
+    fetchAgentRosterMock.mockResolvedValueOnce(scoped)
+
+    const { rerender } = renderHook(
+      ({ forAgentId }) => useAgentRoster({ context: PERSONAL, contextKey: CONTEXT_KEY, forAgentId }),
+      { initialProps: { forAgentId: 'agent-a' as string | undefined }, wrapper },
+    )
+    await waitFor(() => expect(fetchAgentRosterMock).toHaveBeenCalledTimes(1))
+
+    fetchAgentRosterMock.mockResolvedValue({ agents: [], context: { type: 'personal', id: 'user-1' } })
+    rerender({ forAgentId: undefined })
+
+    // The unscoped read must issue its own request rather than inherit the organization-scoped one.
+    await waitFor(() => expect(fetchAgentRosterMock).toHaveBeenCalledTimes(2))
+    expect(fetchAgentRosterMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ forAgentId: undefined }))
+  })
+
+  it('still reuses the cache when neither context nor agent changed', async () => {
+    const { rerender } = renderHook(
+      ({ forAgentId }) => useAgentRoster({ context: PERSONAL, contextKey: CONTEXT_KEY, forAgentId }),
+      { initialProps: { forAgentId: 'agent-a' }, wrapper },
+    )
+
+    await waitFor(() => expect(fetchAgentRosterMock).toHaveBeenCalledTimes(1))
+    rerender({ forAgentId: 'agent-a' })
+
+    expect(fetchAgentRosterMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('remains reachable by the bare prefix callers invalidate with', async () => {
+    renderHook(() => useAgentRoster({ context: PERSONAL, contextKey: CONTEXT_KEY, forAgentId: 'agent-a' }), { wrapper })
+
+    await waitFor(() => expect(fetchAgentRosterMock).toHaveBeenCalledTimes(1))
+
+    expect(queryClient.getQueryCache().findAll({ queryKey: ['agent-roster'] })).toHaveLength(1)
+  })
+})

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,18 +1,18 @@
 {
-  "baseline_sha": "d66f08464b7c72b53c49e61213eb5741add14eaf",
+  "baseline_sha": "fa59c448c385b6b7d60af42e9487f7ee7970e07f",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 8598,
+        "fitted_tokens": 8573,
         "system_bytes": 28589,
         "tools_bytes": 21801,
         "total_bytes": 62041,
         "user_bytes": 11651
       },
       "normal_explicit_send": {
-        "fitted_tokens": 7912,
+        "fitted_tokens": 7927,
         "system_bytes": 25846,
         "tools_bytes": 21801,
         "total_bytes": 59331,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253542
+    "limit": 253535
   }
 }


### PR DESCRIPTION
Fixes **#363**, which I found and filed while validating #1398 on a preview but did not fix at the time.

## The symptom

Open a link to an agent in an organization while your active context is personal, and the sidebar shows **one agent** — that agent — while the server returned the full roster. Nothing indicates a problem: `rosterLoading` stays pinned true forever.

Network trace from preview `pr-1398`:

```
1797ms  200  /console/api/agents/roster/                       ctx: personal,      agents: 0
4008ms  200  /console/switch-context/?for_agent=957e0a0b...    ctx: organization
```

An earlier trace of the same path showed the scoped roster returning **105 agents** — all discarded.

## Root cause

`useAgentRoster` passes three inputs to the fetch but keys the cache on two:

```ts
queryKey: ['agent-roster', contextKey],                          // context + staffContext only
queryFn: () => fetchAgentRoster({ context, forAgentId, staffContext }),
```

`context` and `staffContext` are folded into `contextKey`. **`forAgentId` is not.**

A roster scoped to an agent comes back carrying *that agent's own console context*, which need not match the context the key describes. So the scoped response was filed under the unscoped entry, and with `placeholderData: keepPreviousData` it was served back for a key it did not belong to. The caller then compared `rosterQuery.data.context` against `effectiveContext`, saw a mismatch, and emptied the list:

```ts
const agents = contextReady && !rosterContextMismatch ? rosterQuery.data?.agents ?? [] : []
```

This is a cache-key correctness bug, not a context-switching bug: the key must capture every input the query function depends on.

## Fix

Include `forAgentId` in the query key. One line, plus the comment explaining why.

Invalidation is unaffected — every caller uses the bare `['agent-roster']` prefix without `exact: true`, and prefix matching still covers the widened key. There is a test asserting exactly that, because it was the obvious way for this change to break something.

## Verification

**4 tests, 2 red on `main`** (verified by stashing the hook and re-running):

- a different route agent triggers its own fetch rather than reusing a foreign entry
- an unscoped caller is not served an agent-scoped roster
- an unchanged context and agent still reuses the cache — the fix must not defeat caching
- the entry is still reachable by the bare prefix callers invalidate with

I initially wrote these as key-construction assertions, which would have passed on `main`. Rewrote them to drive the real hook.

- Frontend suite **268/268**, `tsc -b --force` clean, lint identical to `main` (201 both).

## Note on scope

This addresses the cache collision that produced the observed failure. It does **not** rework how `rosterContextMismatch` handles a genuinely stale context — if that state is still reachable another way, the list will still empty, and that remains worth its own look. Preview validation below is what decides whether the observed symptom is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)