### PR TITLE
Persist implicit ownership corrections

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -248,7 +248,7 @@ DIRECT_USER_CORRECTION_RE = re.compile(
     r"\b(?:changed|changes|blockers?|next (?:move|step|action))\b|"
     r"(?:^|[.!?]\s+)never\s+(?:store|share|send|include|reveal|expose)\b[^.!?]{0,80}"
     r"\b(?:secrets?|credentials?|passwords?|private|confidential|customer data)\b|"
-    r"\b(?:make (?:that|this|it) a rule|do i have to\b.{0,80}\b(?:each|every) time)\b|"
+    r"\b(?:make (?:that|this|it) a rule|do i have to\b.{0,80}\b(?:each|every) time)\b|\b(?:i|we)\s+(?:did(?:n['’]?t| not)|never)\s+(?:ask|tell|assign|authoriz)\w*\s+you\s+to\s+(?:do\s+(?:that|this|it)|take(?:\s+\w+){0,4}\s+over|own|handle)\b|"
     r"\b(?:(?:(?:that|this|it)(?:['’]?s| is)\s+)?not\s+your\s+(?:job|role|responsibility|lane)|(?:your|the agent['’]?s)\s+(?:job|role|responsibility|scope)\s+(?:(?:isn['’]?t|is not)(?!\s+(?:done|complete|finished)\b)|(?:is to|is|should be)(?!\s+(?:done|complete|finished)\b))|stay (?:in|within) your (?:lane|role|scope))\b",
     re.IGNORECASE,
 )

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -71,6 +71,7 @@ CHARTER_PATCHES_DIRECT_STYLE_CORRECTION = "charter_patches_direct_style_correcti
 CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK = "charter_patches_evaluative_output_feedback"
 CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK = "charter_interprets_ambiguous_operating_feedback"
 CHARTER_INTERPRETS_ROLE_BOUNDARY_CORRECTION = "charter_interprets_role_boundary_correction"
+CHARTER_INFERS_IMPLICIT_OWNERSHIP_CORRECTION = "charter_infers_implicit_ownership_correction"
 CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION = "charter_records_cli_github_secrets_correction"
 CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW = "charter_judge_preserves_cli_github_secret_workflow"
 
@@ -385,6 +386,7 @@ CHARTER_MEMORY_MICRO_SCENARIO_SLUGS = [
     CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK,
     CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK,
     CHARTER_INTERPRETS_ROLE_BOUNDARY_CORRECTION,
+    CHARTER_INFERS_IMPLICIT_OWNERSHIP_CORRECTION,
     CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION,
     CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
 ]
@@ -3178,6 +3180,39 @@ class CharterInterpretsRoleBoundaryCorrectionScenario(CharterMemoryScenario):
             eval_run_id=run_id,
         )
         return super()._inject_charter_prompt(run_id, agent_id)
+
+    def _charter_check(self, agent, mutation_calls):
+        focused_patch = _uses_one_focused_charter_patch(mutation_calls, self.existing_charter)
+        passed = focused_patch and agent.charter != self.existing_charter
+        return passed, f"mutation_count={len(mutation_calls)}, focused={focused_patch}, charter={agent.charter!r}."
+
+
+@register_scenario
+class CharterInfersImplicitOwnershipCorrectionScenario(CharterMemoryScenario):
+    slug = CHARTER_INFERS_IMPLICIT_OWNERSHIP_CORRECTION
+    description = "Plain-language ownership feedback should durably narrow the agent's role without save wording."
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_implicit_ownership_boundary_saved", assertion_type="llm_judge"),
+    ]
+    existing_charter = (
+        "Coordinate release readiness across the team. Track operational blockers and summarize open risks. "
+        "Proactively offer useful follow-up work. Keep a concise weekly readiness digest."
+    )
+    prior_outbound_body = (
+        "I can inspect the deployment logs and rerun Priya's reconciliation to identify the missing records."
+    )
+    prompt = "I didn't ask you to take over Priya's reconciliation."
+    verification_task_name = "verify_implicit_ownership_boundary_saved"
+    success_summary = "Agent inferred the ownership correction and saved a focused role boundary."
+    failure_summary = "Expected one focused patch that preserves coordination while preventing unassigned takeovers"
+    verify_feedback_reply = True
+    semantic_judge_question = (
+        "Does the updated charter preserve release coordination, blocker tracking, risk reporting, and the weekly "
+        "digest while making clear that the agent should not take over another person's assigned work merely because "
+        "it can help, unless an authorized human reassigns or requests that work? Does the reply naturally acknowledge "
+        "the correction without claiming the one incident is a universal ban on collaboration?"
+    )
 
     def _charter_check(self, agent, mutation_calls):
         focused_patch = _uses_one_focused_charter_patch(mutation_calls, self.existing_charter)

--- a/tests/unit/test_eval_behavior_micro_scenarios.py
+++ b/tests/unit/test_eval_behavior_micro_scenarios.py
@@ -29,6 +29,7 @@ from api.evals.scenarios.behavior_micro import (
     CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD,
     CHARTER_EXPANDS_SPARSE_CHARTER_WITH_DETAIL,
     CHARTER_IGNORES_ONE_OFF_PREFERENCE,
+    CHARTER_INFERS_IMPLICIT_OWNERSHIP_CORRECTION,
     CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK,
     CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
     CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK,
@@ -142,6 +143,7 @@ class BehaviorMicroScenarioRegistrationTests(TestCase):
             CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD,
             CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
             CHARTER_INTERPRETS_ROLE_BOUNDARY_CORRECTION,
+            CHARTER_INFERS_IMPLICIT_OWNERSHIP_CORRECTION,
             CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION,
             CHARTER_JUDGE_PRESERVES_CLI_GITHUB_SECRET_WORKFLOW,
         ):
@@ -153,6 +155,7 @@ class BehaviorMicroScenarioRegistrationTests(TestCase):
             CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK,
             CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK,
             CHARTER_INTERPRETS_ROLE_BOUNDARY_CORRECTION,
+            CHARTER_INFERS_IMPLICIT_OWNERSHIP_CORRECTION,
         ):
             prompt = ScenarioRegistry.get(slug).prompt.casefold()
             for forbidden in ("charter", "sqlite", "patch_text", "save this", "update your instructions"):
@@ -915,6 +918,7 @@ class BehaviorMicroHelperTests(TestCase):
             CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION,
             CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
             CHARTER_INTERPRETS_ROLE_BOUNDARY_CORRECTION,
+            CHARTER_INFERS_IMPLICIT_OWNERSHIP_CORRECTION,
             CHARTER_RECORDS_CLI_GITHUB_SECRETS_CORRECTION,
         ):
             scenario = ScenarioRegistry.get(slug)
@@ -947,6 +951,7 @@ class BehaviorMicroHelperTests(TestCase):
             CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION,
             CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
             CHARTER_INTERPRETS_ROLE_BOUNDARY_CORRECTION,
+            CHARTER_INFERS_IMPLICIT_OWNERSHIP_CORRECTION,
         ):
             scenario = ScenarioRegistry.get(slug)
             rule = "Apply the durable correction."

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -249,6 +249,9 @@ class ImpliedSendTests(TestCase):
             "Your job isn't tracking content ideas.",
             "Your job is tracking infrastructure and resource blockers.",
             "Stay in your lane.",
+            "I didn't ask you to do that. Priya was handling the reconciliation.",
+            "We never assigned you to take the migration work over.",
+            "I did not authorize you to own Morgan's investigation.",
         )
         for text in durable_feedback:
             with self.subTest(durable=text):
@@ -280,6 +283,8 @@ class ImpliedSendTests(TestCase):
             "Constraint: do not imply a prior relationship or make unsupported claims. Send the email now.",
             "Your job is done for today.",
             "Your job isn't done yet.",
+            "I didn't ask you to send this email yet.",
+            "I didn't ask you to summarize this report.",
         )
         for text in one_off_or_content:
             with self.subTest(not_durable=text):


### PR DESCRIPTION
## What changed
- recognize plain-language ownership corrections such as “I didn’t ask you to take that over” in the existing durable-feedback path
- keep one-off action requests such as “I didn’t ask you to send this email yet” out of that path
- add a real-harness, LLM-judged charter regression covering focused role-boundary persistence without suppressing collaboration

## Root cause
Bug #323 reached the acknowledgement path but missed durable persistence because the existing correction candidate filter understood explicit role/lane wording and not ordinary ownership language. The existing focused semantic patcher already handled ownership correctly once selected, so this PR only extends that candidate grammar; it adds no new recovery loop or prompt layer.

## Verification
- DeepSeek V4 Flash target eval: 0/16 baseline → 16/16 fixed (two-sided Fisher exact p=3.33e-9)
- `charter_memory_micro`: 31/32; the one stochastic duplicate-patch failure passed immediately in isolation
- 179 focused unit tests passed
- prompt complexity budgets passed with no prompt growth
- rebased onto latest `main` before opening
