### PR TITLE
Meet the minimum touch target size on mobile chat controls (#337)

### DIFF
--- a/frontend/src/components/agentChat/toolDetails/shared.tsx
+++ b/frontend/src/components/agentChat/toolDetails/shared.tsx
@@ -120,7 +120,9 @@ export function TruncatedMarkdown({ content, maxLines = 3 }: { content: string; 
       <button
         type="button"
         onClick={() => setIsExpanded(!isExpanded)}
-        className="inline-flex items-center gap-1 text-xs font-medium text-indigo-600 hover:text-indigo-700 transition-colors"
+        // py-1/-my-1 lifts the target to the 24px minimum without moving the card's layout: the
+        // text alone gives a 16px line box, which is under it.
+        className="inline-flex items-center gap-1 py-1 -my-1 text-xs font-medium text-indigo-600 hover:text-indigo-700 transition-colors"
       >
         {isExpanded ? (
           <>

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3888,6 +3888,36 @@
     color: #64748b;
     transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
 }
+/* WCAG 2.5.8 sets a 24x24 CSS px minimum for pointer targets. Several chat controls sit under it,
+   which matters most on a phone: the four message actions were 23.2px with 4px between them, so a
+   fingertip covered three at once and a mis-tap recorded the wrong feedback rather than missing.
+   Grow the hit area on coarse pointers; precise pointers keep the denser layout. */
+@media (pointer: coarse) {
+    .banner-contact-link {
+        width: 1.5rem;
+        height: 1.5rem;
+    }
+    .composer-insight-tab {
+        height: 24px;
+        border-radius: 12px;
+    }
+    /* A text control's height comes from its line box, which here is under 24px. Pad it out and
+       pull the same amount back as negative margin, so the target grows without moving anything
+       around it. Vertical only, so it cannot reach a neighbouring control. */
+    .banner-name-button {
+        padding-top: 0.25rem;
+        padding-bottom: 0.25rem;
+        margin-top: -0.25rem;
+        margin-bottom: -0.25rem;
+    }
+    .chat-message-actions {
+        gap: 0.5rem;
+    }
+    .chat-message-action-button {
+        width: 1.75rem;
+        height: 1.75rem;
+    }
+}
 .chat-message-action-button:hover,
 .chat-message-action-button:focus-visible {
     border-color: rgba(100, 116, 139, 0.32);

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "0e530a5d3b07e59d8719e4d396da35ee5a23a95d",
+  "baseline_sha": "65d617ef19614a3afd533fa21ee81a0d4960d78f",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 8551,
+        "fitted_tokens": 8561,
         "system_bytes": 28577,
         "tools_bytes": 21795,
         "total_bytes": 62023,
         "user_bytes": 11651
       },
       "normal_explicit_send": {
-        "fitted_tokens": 7889,
+        "fitted_tokens": 7879,
         "system_bytes": 25744,
         "tools_bytes": 21795,
         "total_bytes": 59223,
         "user_bytes": 11684
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8062,
+        "fitted_tokens": 8069,
         "system_bytes": 26336,
         "tools_bytes": 21795,
         "total_bytes": 59818,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253600
+    "limit": 253602
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "404b1c3fe2234317aa79f5633ae86d7dafc97596",
+  "baseline_sha": "0e530a5d3b07e59d8719e4d396da35ee5a23a95d",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 8573,
-        "system_bytes": 28589,
-        "tools_bytes": 21801,
-        "total_bytes": 62041,
+        "fitted_tokens": 8551,
+        "system_bytes": 28577,
+        "tools_bytes": 21795,
+        "total_bytes": 62023,
         "user_bytes": 11651
       },
       "normal_explicit_send": {
-        "fitted_tokens": 7912,
-        "system_bytes": 25846,
-        "tools_bytes": 21801,
-        "total_bytes": 59331,
+        "fitted_tokens": 7889,
+        "system_bytes": 25744,
+        "tools_bytes": 21795,
+        "total_bytes": 59223,
         "user_bytes": 11684
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8064,
-        "system_bytes": 26346,
-        "tools_bytes": 21801,
-        "total_bytes": 59834,
+        "fitted_tokens": 8062,
+        "system_bytes": 26336,
+        "tools_bytes": 21795,
+        "total_bytes": 59818,
         "user_bytes": 11687
       }
     },
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253570
+    "limit": 253600
   }
 }


### PR DESCRIPTION
Fixes **#337**. WCAG 2.5.8 Level AA requires a 24×24 CSS px minimum for pointer targets. Verified still reproducing on current `main` before changing anything.

## Measured at 390px, before

| control | size |
|---|---|
| email header icon | **20 × 20** |
| message actions (copy / 👍 / 👎 / report) | **23.2 × 23.2**, four of them **4px** apart |
| insight tabs | 58 × **22** |
| agent name button | 76 × **16.3** |

The action cluster is the one that matters. Four controls at a **27px centre-to-centre pitch** against a fingertip closer to 40px — a mis-tap there doesn't miss, it **records the wrong feedback or opens a report**.

## After

| viewport | controls below minimum | action size | gaps | overflow |
|---|---|---|---|---|
| 390 × 844 | **none** | 28px | 8, 8, 8 | no |
| 375 × 667 | **none** | 28px | 8, 8, 8 | no |

Scoped to `(pointer: coarse)`, so precise pointers keep the denser layout — the same idiom already used in this file for pointer-aware behaviour.

The name button gains padding with a **matching negative margin**, so the target grows without moving anything around it. Confirmed by screenshot: the header is visually unchanged.

Verified by hit-testing rather than by reading `getBoundingClientRect`, which was necessary — my first attempt used a pseudo-element that measured "fixed" but was not actually clickable (17px real), and my selector targeted `.banner-name`, a `<span>` **inside** the button, rather than `.banner-name-button`. Both only surfaced because I probed the true clickable region with `elementFromPoint`.

## Deliberately not fixed

**Desktop still has controls under the minimum** — sidebar collapse 16×30, favourite 14×27, and the same chat controls at their denser sizes. Real, and I have the measurements, but this ticket was a mobile audit and closing the desktop gap changes visual density enough to deserve its own review. Worth a follow-up ticket rather than smuggling it in here.

## Testing

**No automated regression test.** jsdom performs no layout and does not evaluate media queries, so nothing in the suite can observe a target's rendered size. Everything above was measured in a real browser. A CSS-source assertion would only restate the rule and would not have caught either of the two mistakes described above. This is the gap tracked as #327.

- Frontend suite 268/268, `tsc -b --force` clean, lint identical to `main` (201 both).
- Stylesheet brace-balanced (checked explicitly after #1398).

🤖 Generated with [Claude Code](https://claude.com/claude-code)