### PR TITLE
Keep deep-work updates bound to the active turn

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -466,13 +466,7 @@ def _deep_work_update_gate_context(
     agent: PersistentAgent,
     tool_calls: list[Any],
 ) -> str | None:
-    latest_inbound = (
-        PersistentAgentMessage.objects.filter(owner_agent=agent, is_outbound=False)
-        .order_by("-timestamp", "-seq")
-        .select_related("conversation")
-        .only("timestamp", "body", "conversation__channel", "conversation__is_peer_dm")
-        .first()
-    )
+    latest_inbound = get_current_inbound_message(agent)
     if latest_inbound is None or latest_inbound.conversation is None:
         return None
     expected_message_tool = _same_channel_reply_tool_name(latest_inbound)

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -143,6 +143,50 @@ class ImpliedSendTests(TestCase):
 
         self.assertIsNone(reason)
 
+    def test_deep_work_gate_uses_bound_inbound_when_newer_channel_message_exists(self):
+        task_message = self._add_inbound_web_message(
+            "Run a comprehensive audit of the release evidence."
+        )
+        task_scope = capture_inbound_routing_scope(self.agent)
+        discord_conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.DISCORD,
+            address=f"discord://agent/{self.agent.id}/channel/infra",
+        )
+        discord_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            channel=CommsChannel.DISCORD,
+            address="discord://guild/example/channel/infra",
+        )
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=discord_endpoint,
+            conversation=discord_conversation,
+            body="Research the unrelated infrastructure alert.",
+        )
+        tool_calls = [
+            {
+                "function": {
+                    "name": "send_chat_message",
+                    "arguments": json.dumps(
+                        {
+                            "body": "I’m starting the release audit and will return with the first evidence.",
+                            "will_continue_work": True,
+                        }
+                    ),
+                }
+            },
+            {"function": {"name": "mcp_brightdata_search_engine", "arguments": "{}"}},
+        ]
+
+        self.assertEqual(ep._deep_work_update_gate_context(self.agent, tool_calls), "kickoff")
+        token = bind_inbound_routing_scope(task_scope)
+        try:
+            self.assertEqual(task_scope.message_id, task_message.id)
+            self.assertIsNone(ep._deep_work_update_gate_context(self.agent, tool_calls))
+        finally:
+            reset_inbound_routing_scope(token)
+
     def test_explicit_research_detection_excludes_negated_requests(self):
         self.assertTrue(ep._is_explicit_research_request("Please research this account restriction."))
         self.assertTrue(ep._is_explicit_research_request("Could you look into this?"))


### PR DESCRIPTION
Fixes #284.

## Root cause
The deep-work kickoff/progress gate independently queried the newest inbound message across the whole agent. A later unrelated Discord broadcast could therefore change the expected reply tool and reset the update window for work already bound to web chat, MCP, or a peer DM.

## Fix
Reuse the inbound routing scope already bound to the active processing turn. The existing fallback still resolves the newest inbound when the helper is called outside a bound turn. No prompt heuristics or output suppression were added.

## Verification
- Deterministic regression reproduced the failure before the fix and passes after it.
- Full 94-test ImpliedSendTests batch passes.
- Complexity budgets pass; production source is net -6 LOC.
- DeepSeek V4 Flash web-channel continuity: 3/3 tasks passed (suite 27d0b934-e86b-4163-8e90-f6889ad312ce).
- DeepSeek V4 Flash Discord research: the touched kickoff behavior passed in one run; two 2/3 runs had complementary stochastic failures outside this deterministic routing change (suite runs 76f2d580-abe5-40fc-b274-8e99fc032acd and cd802e0f-da3a-4701-ab66-1574f43216be).

## Scope
This fixes the gate/prompt routing mismatch proven in the production trajectory. It does not change general Discord wake/subscription policy or suppress legitimate spontaneous collaboration.