### PR TITLE
Bring desktop chat controls up to the minimum target size

### DIFF
--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -735,6 +735,12 @@
 }
 .banner-name-button {
     overflow: hidden;
+    /* The text line box alone is under the 24px minimum. Pad the target and take the same amount
+       back as negative margin, so it grows without moving the header around it. */
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    margin-top: -0.25rem;
+    margin-bottom: -0.25rem;
 }
 .banner-emotion {
     font-size: 0.875rem;
@@ -750,8 +756,9 @@
 }
 .banner-contact-link {
     display: inline-flex;
-    width: 1.25rem;
-    height: 1.25rem;
+    /* 24px is the minimum target size; the icon inside keeps its own dimensions. */
+    width: 1.5rem;
+    height: 1.5rem;
     align-items: center;
     justify-content: center;
     border-radius: 999px;
@@ -2499,9 +2506,9 @@
     align-items: center;
     justify-content: center;
     gap: 0.25rem;
-    height: 22px;
+    height: 24px;
     border: none;
-    border-radius: 11px;
+    border-radius: 12px;
     background: rgba(255, 255, 255, 0.54);
     cursor: pointer;
     padding: 0 10px;
@@ -3877,8 +3884,8 @@
     pointer-events: auto;
 }
 .chat-message-action-button {
-    width: 1.45rem;
-    height: 1.45rem;
+    width: 1.5rem;
+    height: 1.5rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -5655,6 +5662,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    /* Declared square, but a flex parent was compressing the width to 16px, which put it under the
+       24px minimum target size. Hold the declared width. */
+    flex-shrink: 0;
     width: 1.9rem;
     height: 1.9rem;
     border-radius: 0.45rem;
@@ -6473,6 +6483,8 @@
     outline-offset: 1px;
 }
 .agent-roster-item__favorite {
+    /* Same compression as the sidebar toggle: declared square, squeezed to 14px wide by the row. */
+    flex-shrink: 0;
     width: var(--roster-favorite-size);
     height: var(--roster-favorite-size);
     border-radius: var(--roster-favorite-radius);

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,11 +1,11 @@
 {
-  "baseline_sha": "65d617ef19614a3afd533fa21ee81a0d4960d78f",
+  "baseline_sha": "1309138e47540c8d41f1a51eb2b55ed3944e7177",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 8561,
+        "fitted_tokens": 8551,
         "system_bytes": 28577,
         "tools_bytes": 21795,
         "total_bytes": 62023,
@@ -19,7 +19,7 @@
         "user_bytes": 11684
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8069,
+        "fitted_tokens": 8055,
         "system_bytes": 26336,
         "tools_bytes": 21795,
         "total_bytes": 59818,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253602
+    "limit": 253614
   }
 }


### PR DESCRIPTION
Completes the accessibility gap I deliberately left open in **#337 / PR #1409**, which fixed mobile behind a `(pointer: coarse)` query. On a precise pointer, **11 controls remained under the WCAG 2.5.8 minimum of 24×24 CSS px**, measured identically at 1440px and 1280px.

## Two of them were a layout bug, not a design choice

| control | declares | measured |
|---|---|---|
| `chat-sidebar-toggle` | `1.9rem` square (30.4px) | **16 × 30** |
| `agent-roster-item__favorite` | square from its own variable | **14 × 27** |

Both were being **compressed by their flex parents**. `flex-shrink: 0` restores the size they already ask for — which is also what they visually ought to be. The sidebar toggles now render as proper squares instead of squeezed slivers.

## The rest now meet the minimum for every pointer

| control | before | after |
|---|---|---|
| contact icon | 20 × 20 | 24 × 24 |
| message actions ×4 | 23.2 | 24 |
| insight tabs | 58/67 × **22** | × 24 |
| name button | 82 × **18** | 24 (padding + matching negative margin, no layout shift) |

Mobile keeps its roomier 28px actions with 8px between them — that is a spacing/ergonomics choice, distinct from the conformance minimum, so the coarse-pointer block stays.

## Result

| viewport | controls below minimum |
|---|---|
| 1440 × 900 | **0** |
| 1280 × 800 | **0** |
| 390 × 844 | **0** |
| 375 × 667 | **0** |

Desktop layout confirmed unchanged by screenshot — the changes are 0.8–4px on icon boxes plus two elements no longer being squeezed.

- Frontend suite 268/268, `tsc -b --force` clean, lint identical to `main` (201 both).
- Stylesheet brace-balanced (checked explicitly, after #1398).

## Testing note

**No automated regression test.** jsdom performs no layout and cannot observe a rendered target size, so nothing in the suite can assert this. All numbers above are measured in a real browser. This is the gap tracked as #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)