### PR TITLE
Make addresses and links in chat email HTML clickable

### DIFF
--- a/api/agent/comms/chat_email_display_cache.py
+++ b/api/agent/comms/chat_email_display_cache.py
@@ -1,6 +1,7 @@
 from typing import Any, Mapping
 
 from bleach.css_sanitizer import CSSSanitizer
+from bleach.linkifier import Linker
 from bleach.sanitizer import ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS, ALLOWED_TAGS, Cleaner
 
 from api.agent.comms.email_content import convert_body_to_html_and_plaintext
@@ -76,6 +77,9 @@ def _build_html_cleaner(*, allow_cid: bool = False) -> Cleaner:
 HTML_CLEANER = _build_html_cleaner()
 HTML_CID_CLEANER = _build_html_cleaner(allow_cid=True)
 
+# Code shows text exactly as written, so an address quoted as a sample stays text.
+LINKIFY_SKIP_TAGS = {"code", "pre"}
+
 
 def normalize_explicit_email_html(explicit_html: Any) -> str | None:
     if not isinstance(explicit_html, str):
@@ -86,7 +90,19 @@ def normalize_explicit_email_html(explicit_html: Any) -> str | None:
 def sanitize_chat_email_html(html: str | None, *, allow_cid: bool = False) -> str:
     if not html:
         return ""
-    return (HTML_CID_CLEANER if allow_cid else HTML_CLEANER).clean(html)
+    cleaned = (HTML_CID_CLEANER if allow_cid else HTML_CLEANER).clean(html)
+    # Markdown bodies are autolinked on the client by remark-gfm, but HTML reaches the timeline
+    # already rendered and bypasses that entirely, leaving addresses readable but not actionable.
+    # Linkifying here rather than at a call site covers explicit agent HTML, cached bodies, and
+    # cid-rewritten forwards alike, since all of them come through this function.
+    #
+    # A Linker is built per call because it wraps a stateful html5lib parser; sharing one across
+    # concurrently served requests would interleave parses.
+    return Linker(
+        callbacks=[],
+        skip_tags=LINKIFY_SKIP_TAGS,
+        parse_email=True,
+    ).linkify(cleaned)
 
 
 def render_chat_email_body_html(

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "d854ce9ab947bff23710895892bacc3dc762e0b9",
+  "baseline_sha": "9ecc59a22c8003188842798964f413d1c9e651d8",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 8669,
+        "fitted_tokens": 8634,
         "system_bytes": 28966,
         "tools_bytes": 22035,
         "total_bytes": 62652,
         "user_bytes": 11651
       },
       "normal_explicit_send": {
-        "fitted_tokens": 7957,
+        "fitted_tokens": 7942,
         "system_bytes": 26133,
         "tools_bytes": 22035,
         "total_bytes": 59852,
         "user_bytes": 11684
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8168,
+        "fitted_tokens": 8140,
         "system_bytes": 26725,
         "tools_bytes": 22035,
         "total_bytes": 60447,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 253758
+    "limit": 253773
   }
 }

--- a/tests/unit/test_chat_email_autolink.py
+++ b/tests/unit/test_chat_email_autolink.py
@@ -1,0 +1,76 @@
+"""Bare addresses and URLs in chat email HTML must be reachable, not just readable.
+
+Messages rendered from markdown are autolinked on the client by remark-gfm, but anything that
+reaches the timeline as HTML -- an agent's own HTML body, or a markdown body already converted
+server side -- was emitted verbatim. A recipient shown "write to alice@example.com" could read the
+address but not act on it, and the same text in a non-email channel was clickable. This pins the
+two paths to the same contract.
+
+Linkification runs inside the sanitizer so every caller inherits it: explicit agent HTML, cached
+bodies, and cid-rewritten forwards all funnel through that one function.
+"""
+from __future__ import annotations
+
+from django.test import SimpleTestCase, tag
+
+from api.agent.comms.chat_email_display_cache import sanitize_chat_email_html
+
+
+@tag("batch_agent_chat")
+class ChatEmailAutolinkTests(SimpleTestCase):
+    def test_bare_email_becomes_a_mailto_link(self):
+        html = sanitize_chat_email_html("<p>Reach out to alice.smith@example.com about it.</p>")
+
+        self.assertIn('href="mailto:alice.smith@example.com"', html)
+        self.assertIn(">alice.smith@example.com<", html)
+
+    def test_bare_url_becomes_a_link(self):
+        """The markdown path already autolinks URLs; the HTML path must not silently differ."""
+        html = sanitize_chat_email_html("<p>See https://example.com/docs for details.</p>")
+
+        self.assertIn('href="https://example.com/docs"', html)
+
+    def test_an_existing_mailto_link_is_left_alone(self):
+        html = sanitize_chat_email_html('<p>Contact <a href="mailto:bob@example.com">bob@example.com</a>.</p>')
+
+        self.assertEqual(html.count("<a "), 1)
+        self.assertNotIn("<a href", html[html.index("<a ") + 3:])
+
+    def test_an_address_used_as_link_text_keeps_its_own_target(self):
+        """Rewriting the href here would silently redirect the reader somewhere else."""
+        html = sanitize_chat_email_html('<p><a href="https://example.com/team">carol@example.com</a></p>')
+
+        self.assertIn('href="https://example.com/team"', html)
+        self.assertNotIn("mailto:", html)
+
+    def test_addresses_inside_code_are_not_linkified(self):
+        """Code shows text as written; turning a sample address into a link misrepresents it."""
+        html = sanitize_chat_email_html("<p><code>alice@example.com</code></p>")
+
+        self.assertNotIn("mailto:", html)
+
+    def test_addresses_inside_preformatted_blocks_are_not_linkified(self):
+        html = sanitize_chat_email_html("<pre>send to alice@example.com</pre>")
+
+        self.assertNotIn("mailto:", html)
+
+    def test_linkifying_does_not_reintroduce_unsafe_markup(self):
+        html = sanitize_chat_email_html('<p>hi@example.com</p><script>alert(1)</script>')
+
+        self.assertIn("mailto:hi@example.com", html)
+        self.assertNotIn("<script", html)
+
+    def test_javascript_urls_are_not_turned_into_links(self):
+        html = sanitize_chat_email_html("<p>javascript:alert(1)</p>")
+
+        self.assertNotIn("<a ", html)
+
+    def test_empty_input_is_unchanged(self):
+        self.assertEqual(sanitize_chat_email_html(""), "")
+        self.assertEqual(sanitize_chat_email_html(None), "")
+
+    def test_cid_images_still_survive_when_allowed(self):
+        """allow_cid callers depend on cid: surviving; linkification must not disturb that."""
+        html = sanitize_chat_email_html('<img src="cid:logo.png" alt="logo">', allow_cid=True)
+
+        self.assertIn('src="cid:logo.png"', html)


### PR DESCRIPTION
Ticket #356 (Troy): email addresses in agent HTML output are not rendered as clickable `mailto:` links.

## What reproduces

Verified in a real browser against a seeded chat before touching anything:

| Case | Before |
|---|---|
| Bare address in agent HTML | not a link |
| Bare `https://` URL in agent HTML | not a link |
| Address already wrapped in `<a href="mailto:">` | correct |

The reported symptom is broader than the ticket: bare URLs are affected too, and it is the same defect. Markdown bodies are autolinked client-side by `remark-gfm`; anything that arrives as HTML skips that path entirely, so identical text is clickable in one channel and dead in another.

## Root cause

`sanitize_chat_email_html` is the single chokepoint every HTML path funnels through — explicit agent HTML, cached bodies, and cid-rewritten forwards. Nothing in that path ever linkified text nodes.

The fix linkifies there, so all three callers inherit it rather than patching one call site. `bleach` was already a dependency.

Deliberate constraints, each pinned by a test:
- existing anchors keep their own `href` (rewriting one would silently redirect the reader)
- `code` and `pre` are skipped, since code shows text as written
- `javascript:` is not turned into a link
- `cid:` images still survive for `allow_cid` callers

A `Linker` is built per call because it wraps a stateful html5lib parser; sharing one across concurrently served requests would interleave parses.

## Tests

`tests/unit/test_chat_email_autolink.py`, 10 tests. Confirmed red first: 3 failed before the change (bare address, bare URL, and the combined safety case), 7 guardrails passed both before and after so a regression in them would be visible.

Adjacent suites green: `test_chat_email_display_cache`, `test_timeline_email_from_cc`, `test_agent_chat_api`, `test_imap_adapter`, `test_api_webhooks`.

Note: `test_outbound_delivery.SMSContentConversionTests.test_markdown_content_conversion` fails on this branch **and on main with this change stashed** — pre-existing, unrelated to this change, reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)