### PR TITLE
Ground database work in live schemas

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -682,10 +682,12 @@ def _get_sqlite_guidance() -> str:
     """Return the compact contract for data retrieval, storage, and analysis."""
     return (
         "## SQLite Data\n\n"
+        "SCHEMA FIRST: for an existing table whose full current definition is absent, search the catalog by a task-relevant name fragment, not a full table listing. Then make one metadata-only call with no target-table read and read its result. Only afterward query using confirmed tables, columns, and join keys. After a schema error inspect, don't guess again; for external SQL, roll back or reconnect before another statement. "
         "Named tables are the world model: query, don't remember; fetch stale/missing facts only. Tool results don't update it. "
         "Same-path results across vendors form one set: one batch evolves/imports via INSERT SELECT/json_each over tool_name/multi-ID, then queries coverage. No per-result import or source literals. SELECT fields/URL/result_id; unstructured work uses bound JSON :rows joined by result_id. "
         "Key entities, children, relations, evidence, coverage; normalize/evolve, refresh provenance, query gaps/joins/counts/ranks. Authored values bind :name; source facts derive from __tool_results. "
-        "Different shapes may use separate statements in that batch. Custom tools may write keyed models. CTAS/TEMP is one-off. Inspect unknown structure once. Locate payloads with analysis_json/top_keys; http_request JSON is result_json $.content. Prefer known-path result_json, else result_text.\n\n"
+        "Different shapes may use separate statements in that batch. Custom tools may write keyed models. CTAS/TEMP is one-off. "
+        "Locate payloads with analysis_json/top_keys; http_request JSON is result_json $.content. Prefer known-path result_json, else result_text.\n\n"
         "Snapshots:\n"
         "* __tool_results: result_id, tool_name, created_at, result_json, result_text, analysis_json, is_truncated, top_keys.\n"
         "* __messages: message_id, seq, timestamp, channel, is_outbound, from_address, to_address, subject, body, "

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -1595,7 +1595,7 @@ def _get_error_hint(error_msg: str, sql: str = "") -> str:
             for alias in aliases:
                 if _is_typo(missing, alias):
                     return f" FIX: Typo? You defined alias '{alias}' but referenced '{missing}'."
-        return " FIX: Check column name spelling matches your SELECT aliases or table schema."
+        return " FIX: Do not guess another field. In a separate call, run PRAGMA table_info for each referenced table, then retry using only returned columns."
     if "no such table" in error_lower:
         # Extract the missing table name
         match = re.search(r'no such table:\s*(\w+)', error_msg, re.IGNORECASE)
@@ -1605,7 +1605,7 @@ def _get_error_hint(error_msg: str, sql: str = "") -> str:
             for cte in cte_names:
                 if _is_typo(missing, cte):
                     return f" FIX: Typo? You defined CTE '{cte}' but referenced '{missing}'."
-        return " FIX: Create the table first with CREATE TABLE before querying it."
+        return " FIX: Do not assume the table name or create a replacement yet. Query sqlite_master to find existing tables, inspect the intended table with PRAGMA table_info, then retry."
     if "syntax error" in error_lower:
         # Check if it might be a quote escaping issue
         if "'" in sql and ("regexp" in sql.lower() or "pattern" in sql.lower()):
@@ -2110,12 +2110,16 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
         "function": {
             "name": "sqlite_batch",
             "description": (
-                "SQLite world model + exact logic. After a fetch, reconcile and SELECT. SOURCE ARRAYS lists paths. "
+                "SQLite world model + exact logic. SCHEMA FIRST: if an existing schema is absent/stale, query sqlite_master by a "
+                "task-relevant name fragment, never list every table. Then use one PRAGMA-only call with no target-table SELECT; "
+                "read its result before querying confirmed fields. "
+                "After a fetch, reconcile and SELECT. SOURCE ARRAYS lists paths. "
                 "ONE IMPORT PER SHAPE: same-path results across vendors use one INSERT SELECT/json_each over tool_name/multi-ID, "
                 "never per-result DML. SELECT source fields, URL, result_id. Unstructured: bind JSON :rows and join "
                 "__tool_results by result_id. Never transcribe visible rows. Source fields/keys derive in INSERT "
                 "SELECT/UPDATE FROM __tool_results; only paths/tool_name/result_id are literals. "
-                "Key/evolve/normalize/query. Bind authored values; never hand-escape. "
+                "Key/evolve/normalize/query. "
+                "Bind authored values; never hand-escape. "
                 "http_request JSON: result_json $.content. INSERT SELECT needs WHERE before ON CONFLICT. No ATTACH. "
                 "Apostrophe: 'O''Brien'. grep_context_all/split_sections arrays: json_each + ctx.value."
             ),

--- a/api/evals/scenarios/__init__.py
+++ b/api/evals/scenarios/__init__.py
@@ -63,6 +63,7 @@ from .sqlite_tool_results import (
     SqliteIntermediateWorkingTableScenario,
     SqliteItemLinkReportScenario,
     SqliteMultiResultWebSynthesisScenario,
+    SqliteSchemaGroundedExistingTableScenario,
     SqliteSourceArrayFirstWriteScenario,
 )
 from .message_quality import MESSAGE_QUALITY_SCENARIO_SLUGS, MESSAGE_QUALITY_SUITE_SLUG, MessageQualityScenario

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -44,6 +44,7 @@ SQLITE_NATURAL_RESULT_ACCESS = "sqlite_tool_results_natural_result_access"
 SQLITE_BOUNDED_PORTFOLIO_REPORT = "sqlite_tool_results_bounded_portfolio_report"
 SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY = "sqlite_domain_truth_over_stale_history"
 SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES = "sqlite_domain_model_refreshes_and_evolves"
+SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE = "sqlite_schema_grounded_existing_table"
 SQLITE_SOURCE_ARRAY_FIRST_WRITE = "sqlite_source_array_first_write"
 SQLITE_INCREMENTAL_DOMAIN_MODEL = "sqlite_incremental_domain_model"
 SQLITE_PROSPECT_PIPELINE_COMPLETES = "sqlite_prospect_pipeline_completes"
@@ -56,6 +57,7 @@ SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_BOUNDED_PORTFOLIO_REPORT,
     SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY,
     SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES,
+    SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE,
     SQLITE_SOURCE_ARRAY_FIRST_WRITE,
     SQLITE_INCREMENTAL_DOMAIN_MODEL,
     SQLITE_PROSPECT_PIPELINE_COMPLETES,
@@ -109,6 +111,13 @@ DOMAIN_LEGACY_ACCOUNT = (
 DOMAIN_WORKSTREAMS = (
     ("ws-security-17", "Security packet", "complete", "Maya Chen", "2026-07-22"),
     ("ws-legal-04", "Contract redlines", "open", "Noah Reed", "2026-07-24"),
+)
+HANDOFF_LEDGER_TABLE = "z_handoff_ledger"
+HANDOFF_ROWS = (
+    ("handoff-01", "agent-red", "open"),
+    ("handoff-02", "agent-red", "blocked"),
+    ("handoff-03", "agent-blue", "open"),
+    ("handoff-04", "agent-green", "resolved"),
 )
 RELEASE_CALENDAR_URL = "https://ops.example.test/releases/calendar.json"
 RELEASE_CALENDAR_OBSERVED_AT = "2026-07-22T14:15:00Z"
@@ -974,6 +983,62 @@ def _seed_domain_account(
             conn.close()
 
 
+def _seed_hidden_handoff_ledger(agent_id: str) -> None:
+    with agent_sqlite_db(str(agent_id)) as db_path:
+        conn = open_guarded_sqlite_connection(db_path)
+        try:
+            for index in range(28):
+                conn.execute(
+                    f"CREATE TABLE a_reference_{index:02d} "
+                    "(record_key TEXT PRIMARY KEY, recorded_value TEXT);"
+                )
+            conn.execute(
+                f"CREATE TABLE {HANDOFF_LEDGER_TABLE} ("
+                "handoff_key TEXT PRIMARY KEY, worker_ref TEXT NOT NULL, "
+                "resolution_code TEXT NOT NULL);"
+            )
+            conn.executemany(
+                f"INSERT INTO {HANDOFF_LEDGER_TABLE} "
+                "(handoff_key, worker_ref, resolution_code) VALUES (?, ?, ?);",
+                HANDOFF_ROWS,
+            )
+            conn.commit()
+        finally:
+            clear_guarded_connection(conn)
+            conn.close()
+
+
+def _schema_grounded_read_failures(calls) -> list[str]:
+    calls = list(calls)
+    failures = _sqlite_attempt_failures(calls)
+    schema_call_indexes = []
+    data_reads = []
+    for call_index, call in enumerate(calls):
+        sql = str((call.tool_params or {}).get("sql") or "")
+        schema_evidence = json.dumps(_result_payload(call) or {})
+        if (
+            HANDOFF_LEDGER_TABLE.casefold() in sql.casefold()
+            and all(field in schema_evidence.casefold() for field in (
+                "handoff_key",
+                "worker_ref",
+                "resolution_code",
+            ))
+        ):
+            schema_call_indexes.append(call_index)
+        for statement in sqlparse.split(sql):
+            structural = _structural_sql(statement)
+            if _reads_table(structural, HANDOFF_LEDGER_TABLE):
+                data_reads.append((call_index, structural))
+
+    if not schema_call_indexes:
+        failures.append("existing ledger schema was not inspected")
+    if not data_reads:
+        failures.append("existing ledger was not queried")
+    if schema_call_indexes and data_reads and min(schema_call_indexes) >= min(item[0] for item in data_reads):
+        failures.append("ledger columns were referenced before schema inspection completed")
+    return failures
+
+
 def _inspect_domain_refresh_state(agent_id: str) -> tuple[list[str], str | None]:
     expected_ids = {row[0] for row in DOMAIN_WORKSTREAMS}
     failures = []
@@ -1567,6 +1632,58 @@ class SqliteDomainModelScenario(SqliteToolResultScenario):
             task_name=task_name,
             observed_summary="; ".join(failures) if failures else success,
             artifacts={},
+        )
+
+
+@register_scenario
+class SqliteSchemaGroundedExistingTableScenario(SqliteDomainModelScenario):
+    slug = SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE
+    description = "Existing database work should inspect an unavailable schema before referencing its fields."
+    expected_runtime = "short"
+    tags = (*SqliteToolResultScenario.tags, "schema_discovery", "trajectory_regression")
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_schema_grounded_query", assertion_type="tool_call"),
+        ScenarioTask(name="verify_unresolved_handoff_answer", assertion_type="manual"),
+    ]
+    prompt = (
+        "Check the existing handoff ledger and tell me who still has unfinished work, "
+        "with the count for each. Use the ledger as the source of truth."
+    )
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._ready_agent(agent_id)
+        PersistentAgent.objects.filter(id=agent_id).update(
+            charter="Own internal operations and treat established ledger state as the source of truth."
+        )
+        _seed_hidden_handoff_ledger(agent_id)
+        inbound = self._inject_and_wait(
+            run_id,
+            agent_id,
+            self.prompt,
+            {},
+            allowed_tool_names={"sqlite_batch", "send_chat_message"},
+            max_relevant_tool_calls=6,
+        )
+        calls = _tool_calls_for_run(
+            run_id,
+            after=inbound.timestamp,
+            tool_names={"sqlite_batch"},
+        )
+        self._record_check(
+            run_id,
+            "verify_schema_grounded_query",
+            _schema_grounded_read_failures(calls),
+            "Inspected the live ledger schema before querying it, without a failed attempt.",
+        )
+        self._record_sourced_answer(
+            run_id,
+            agent_id=agent_id,
+            after=inbound.timestamp,
+            task_name="verify_unresolved_handoff_answer",
+            source_urls=(),
+            required_terms=("agent-red", "2", "agent-blue", "1"),
+            min_sources=0,
         )
 
 

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -57,6 +57,7 @@ from api.evals.scenarios.sqlite_tool_results import (
     SQLITE_BOUNDED_PORTFOLIO_REPORT,
     SQLITE_ITEM_LINK_REPORT,
     SQLITE_NATURAL_RESULT_ACCESS,
+    SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE,
     SQLITE_TOOL_RESULT_SCENARIO_SLUGS,
     SQLITE_TOOL_RESULT_SUITE_SLUG,
     SqliteBoundedPortfolioReportScenario,
@@ -70,6 +71,7 @@ from api.evals.scenarios.sqlite_tool_results import (
     _first_shot_source_phase_failures,
     _portfolio_mock,
     _source_write_effect_failures,
+    _schema_grounded_read_failures,
     _sqlite_attempt_failures,
 )
 from api.evals.stop_policy import should_stop_for_eval_policy
@@ -152,6 +154,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertIn(SQLITE_BOUNDED_PORTFOLIO_REPORT, suite.scenario_slugs)
         self.assertIn(sqlite_evals.SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY, suite.scenario_slugs)
         self.assertIn(sqlite_evals.SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES, suite.scenario_slugs)
+        self.assertIn(SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE, suite.scenario_slugs)
         self.assertIn(sqlite_evals.SQLITE_PROSPECT_PIPELINE_COMPLETES, suite.scenario_slugs)
 
     def test_trajectory_regression_prompts_do_not_prescribe_tools_or_format(self):
@@ -159,6 +162,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             SqliteMultiResultWebSynthesisScenario.prompt,
             SqliteNaturalResultAccessScenario.prompt,
             SqliteBoundedPortfolioReportScenario.prompt,
+            sqlite_evals.SqliteSchemaGroundedExistingTableScenario.prompt,
             sqlite_evals.SqliteProspectPipelineCompletesScenario.prompt,
         )
 
@@ -171,6 +175,53 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertNotIn("every company", portfolio_scenario.prompt.casefold())
         self.assertNotIn("llm_judge", portfolio_scenario.tags)
         self.assertEqual(portfolio_scenario.tasks[-1].assertion_type, "manual")
+
+    def test_schema_grounded_query_requires_successful_inspection_before_data_read(self):
+        good_calls = [
+            _eval_tool_call(
+                "sqlite_batch",
+                {"sql": "PRAGMA table_info('z_handoff_ledger')"},
+                result=(
+                    '{"status":"ok","results":[{"result":['
+                    '{"name":"handoff_key"},{"name":"worker_ref"},{"name":"resolution_code"}]}]}'
+                ),
+            ),
+            _eval_tool_call(
+                "sqlite_batch",
+                {
+                    "sql": (
+                        "SELECT worker_ref, COUNT(*) AS unresolved_count "
+                        "FROM z_handoff_ledger WHERE resolution_code <> 'resolved' "
+                        "GROUP BY worker_ref ORDER BY unresolved_count DESC"
+                    )
+                },
+            ),
+        ]
+
+        self.assertEqual(_schema_grounded_read_failures(good_calls), [])
+
+        sqlite_master_calls = [
+            _eval_tool_call(
+                "sqlite_batch",
+                {"sql": "SELECT sql FROM sqlite_master WHERE name='z_handoff_ledger'"},
+                result=(
+                    '{"status":"ok","results":[{"result":[{"sql":"CREATE TABLE z_handoff_ledger '
+                    '(handoff_key TEXT, worker_ref TEXT, resolution_code TEXT)"}]}]}'
+                ),
+            ),
+            good_calls[1],
+        ]
+        self.assertEqual(_schema_grounded_read_failures(sqlite_master_calls), [])
+
+        guessed = _eval_tool_call(
+            "sqlite_batch",
+            {"sql": "SELECT owner_name, COUNT(*) FROM z_handoff_ledger GROUP BY owner_name"},
+            result='{"status":"error","message":"no such column: owner_name"}',
+        )
+        failures = _schema_grounded_read_failures([guessed, *good_calls])
+
+        self.assertTrue(any("SQLite attempt 1" in failure for failure in failures))
+        self.assertIn("ledger columns were referenced before schema inspection completed", failures)
 
     def test_natural_result_access_requires_aggregate_sqlite_for_large_fixture(self):
         scenario, recorded = SqliteNaturalResultAccessScenario(), []

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "1309138e47540c8d41f1a51eb2b55ed3944e7177",
+  "baseline_sha": "4cd2e0106fe467e12cfc2c98fee4c28598e1df8b",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 8551,
-        "system_bytes": 28577,
-        "tools_bytes": 21795,
-        "total_bytes": 62023,
+        "fitted_tokens": 8639,
+        "system_bytes": 28966,
+        "tools_bytes": 22035,
+        "total_bytes": 62652,
         "user_bytes": 11651
       },
       "normal_explicit_send": {
-        "fitted_tokens": 7879,
-        "system_bytes": 25744,
-        "tools_bytes": 21795,
-        "total_bytes": 59223,
+        "fitted_tokens": 7972,
+        "system_bytes": 26133,
+        "tools_bytes": 22035,
+        "total_bytes": 59852,
         "user_bytes": 11684
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8055,
-        "system_bytes": 26336,
-        "tools_bytes": 21795,
-        "total_bytes": 59818,
+        "fitted_tokens": 8147,
+        "system_bytes": 26725,
+        "tools_bytes": 22035,
+        "total_bytes": 60447,
         "user_bytes": 11687
       }
     },

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -37,7 +37,12 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
         self.assertIn("fields/URL/result_id", guidance)
         self.assertIn("unstructured work uses bound JSON :rows", guidance)
         self.assertIn("joined by result_id", guidance)
-        self.assertIn("Inspect unknown structure once", guidance)
+        self.assertIn("SCHEMA FIRST: for an existing table", guidance)
+        self.assertIn("task-relevant name fragment, not a full table listing", guidance)
+        self.assertIn("one metadata-only call with no target-table read", guidance)
+        self.assertIn("Only afterward query using confirmed tables, columns, and join keys", guidance)
+        self.assertIn("After a schema error inspect, don't guess again", guidance)
+        self.assertIn("roll back or reconnect before another statement", guidance)
         self.assertNotIn("Copy names/paths/values/URLs", guidance)
 
     def test_low_iteration_warning_keeps_unfinished_work_active(self):

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -465,6 +465,10 @@ class SqliteBatchCoreTests(SqliteBatchTestCase):
             "join __tool_results by result_id", "ONE IMPORT PER SHAPE",
             "same-path results", "across vendors",
             "source fields, URL, result_id",
+            "SCHEMA FIRST: if an existing", "task-relevant name fragment",
+            "never list every table", "one PRAGMA-only call",
+            "no target-table SELECT",
+            "querying confirmed fields",
         ):
             self.assertIn(expected, description)
         self.assertNotIn("before one terminal send", description)
@@ -2492,6 +2496,23 @@ class SqliteBatchAutocorrectTests(SqliteBatchTestCase):
         self.assertIn("SQLite string literals do not use backslash escaping", hint)
         self.assertIn('"AI Engineer"', hint)
         self.assertIn("O''Brien", hint)
+
+    def test_missing_schema_hints_require_inspection_before_retry(self):
+        column_hint = _get_error_hint(
+            "no such column: owner_name",
+            "SELECT owner_name FROM handoff_ledger",
+        )
+        table_hint = _get_error_hint(
+            "no such table: handoffs",
+            "SELECT * FROM handoffs",
+        )
+
+        self.assertIn("Do not guess another field", column_hint)
+        self.assertIn("PRAGMA table_info", column_hint)
+        self.assertIn("only returned columns", column_hint)
+        self.assertIn("Do not assume the table name", table_hint)
+        self.assertIn("sqlite_master", table_hint)
+        self.assertIn("PRAGMA table_info", table_hint)
 
     def test_fix_unescaped_single_quote_runs(self):
         """Balances odd-length runs of single quotes."""


### PR DESCRIPTION
## Summary

- require agents to inspect unknown pre-existing schemas before composing dependent SQL
- replace guess-again SQLite error hints with concrete schema discovery guidance
- add a real-harness regression based on the Natalya, Hilda, and Keith incidents without exposing table or column names in the eval prompt

## Root cause

The database contract reduced schema discovery to “Inspect unknown structure once” while rendered schema context is bounded and shrinkable. DeepSeek could therefore infer fields from task wording or memory, retry another guessed field, and—in external SQL—continue after a failed statement left the transaction aborted. The executor was not the primary cause.

This changes model inputs only. It adds no runtime SQL gating, query rewriting, or recovery loop.

## Validation

- DeepSeek V4 Flash regression, 16 runs per arm: schema-grounded execution improved from **3/16 to 11/16**; Fisher two-sided **p=0.0113**. Correct answers improved from 9/16 to 12/16.
  - red suites: `07118e5f`, `0495ed5b`, `e5056fc1`
  - green suites: `622ce3a7`, `4ca45634`, `49e2d321`
- one-pass affected SQLite suite: 31/42 tasks (`2a09b030`); targeted reruns recovered item links, natural result access, modeled truth, and incremental modeling
- unchanged-production controls reproduced the persistent source-array miss 0/3 (`4a357fc2`) and aggregate intermediate-model miss 0/3 (`2690e664`)
- committed branch refresh control passed 3/3 (`b4bac5af`), versus 2/3 on unchanged production prompting (`70bcfc13`)
- `eval_sim`: 252 tests passed
- `batch_promptree`: passed
- `batch_sqlite`: 101 tests passed
- focused new/changed tests: 6 passed
- source LoC budget: green at the rebased main limit
- prompt budget: green after an intentional 629-byte rendered increase (about 1% of the smallest representative prompt)

## Delivery gates

- full GitHub CI green, including all 10 backend shards, frontend, sandbox, tag, and complexity checks
- preview deployment run `30206086602` succeeded
- authenticated preview ping, MCP list call, and headed-browser agent-page rendering passed on `pr-1413.ship.gobii.ai`
- branch is clean, mergeable, and based on current `main` (`4cd2e010`)

The affected-suite misses are disclosed rather than rerun away. Direct controls show the persistent unrelated misses are present on production prompting, while the targeted behavior has a statistically significant improvement.