### PR TITLE
Let a finished thought keep the room a streaming one gets

### DIFF
--- a/frontend/src/components/agentChat/ToolClusterLivePreview.tsx
+++ b/frontend/src/components/agentChat/ToolClusterLivePreview.tsx
@@ -7,7 +7,7 @@ import { formatRelativeTimestamp } from '../../util/time'
 import { getFriendlyToolInfo, type FriendlyToolInfo } from '../tooling/toolMetadata'
 import { extractBrightDataSearchQuery } from '../tooling/brightdata'
 import { ToolIconSlot } from './ToolIconSlot'
-import { deriveSemanticPreview } from './tooling/clusterPreviewText'
+import { deriveSemanticPreview, deriveThinkingSummary } from './tooling/clusterPreviewText'
 import type { ToolClusterTransform, ToolEntryDisplay } from './tooling/types'
 import { parseToolSearchResult } from './tooling/searchUtils'
 
@@ -997,7 +997,9 @@ function deriveActivityDescriptor(entry: ToolEntryDisplay): ActivityDescriptor {
   }
 
   if (kind === 'thinking') {
-    const thought = clampText(semantic ?? 'Planning next steps')
+    // A finished thought keeps the room a streaming one gets, instead of collapsing to its
+    // opening clause the moment it completes.
+    const thought = deriveThinkingSummary(entry) ?? clampText(semantic ?? 'Planning next steps')
     return {
       kind,
       label: 'Planning next step',
@@ -1450,6 +1452,7 @@ export function ToolClusterLivePreview({
                         <motion.span
                           key={`${entry.id}-profile-subtitle-${linkedInProfile.subtitle ?? item.activity.label}`}
                           className="tool-cluster-live-preview__entry-caption"
+                          data-activity-kind={item.activity.kind}
                           initial={!shouldAnimateIncoming ? { opacity: 1, y: 0 } : { opacity: 0, y: 2 }}
                           animate={!shouldAnimateIncoming ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 }}
                           exit={reduceMotion ? { opacity: 1 } : { opacity: 0, y: -2 }}
@@ -1463,6 +1466,7 @@ export function ToolClusterLivePreview({
                         <motion.span
                           key={`${entry.id}-page-title-${visual.pageTitle}`}
                           className="tool-cluster-live-preview__entry-caption"
+                          data-activity-kind={item.activity.kind}
                           initial={!shouldAnimateIncoming ? { opacity: 1, y: 0 } : { opacity: 0, y: 2 }}
                           animate={!shouldAnimateIncoming ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 }}
                           exit={reduceMotion ? { opacity: 1 } : { opacity: 0, y: -2 }}
@@ -1474,6 +1478,7 @@ export function ToolClusterLivePreview({
                         <motion.span
                           key={`${entry.id}-detail-${detailText}`}
                           className="tool-cluster-live-preview__entry-caption"
+                          data-activity-kind={item.activity.kind}
                           initial={!shouldAnimateIncoming ? { opacity: 1, y: 0 } : { opacity: 0, y: 2 }}
                           animate={!shouldAnimateIncoming ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 }}
                           exit={reduceMotion ? { opacity: 1 } : { opacity: 0, y: -2 }}

--- a/frontend/src/components/agentChat/tooling/clusterPreviewText.test.ts
+++ b/frontend/src/components/agentChat/tooling/clusterPreviewText.test.ts
@@ -1,0 +1,65 @@
+/**
+ * A planning step's reasoning is shown over three lines while it streams, then collapsed to the
+ * first clause of a single-line caption the moment it finished -- so the timeline lost the thought
+ * exactly when it became complete, and the card read as a label with nothing under it. These pin
+ * the summary that replaced it.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { deriveThinkingSummary } from './clusterPreviewText'
+import type { ToolEntryDisplay } from './types'
+
+function thinking(reasoning: unknown, toolName = 'thinking'): ToolEntryDisplay {
+  return { id: 't1', toolName, result: reasoning } as unknown as ToolEntryDisplay
+}
+
+describe('deriveThinkingSummary', () => {
+  it('keeps reasoning that runs past its first line', () => {
+    // The whole defect: only the opening line survived, so multi-line thinking lost its substance.
+    const summary = deriveThinkingSummary(thinking(
+      'Let me process the current state.\nThe user asked for a pipeline summary.\nI will query the CRM table.',
+    ))
+
+    expect(summary).toContain('pipeline summary')
+    expect(summary).toContain('CRM table')
+  })
+
+  it('collapses the line breaks so it reads as one thought', () => {
+    const summary = deriveThinkingSummary(thinking('First line.\n\n   Second line.'))
+
+    expect(summary).toBe('First line. Second line.')
+  })
+
+  it('ends on a sentence rather than mid-word when it has to cut', () => {
+    const long = `${'This is a complete sentence about the pipeline. '.repeat(12)}trailing fragment that runs on`
+
+    const summary = deriveThinkingSummary(thinking(long)) ?? ''
+
+    expect(summary.endsWith('.')).toBe(true)
+    expect(summary).not.toContain('…')
+    expect(summary.length).toBeLessThanOrEqual(260)
+  })
+
+  it('falls back to an ellipsis when there is no sentence to end on', () => {
+    const summary = deriveThinkingSummary(thinking('x'.repeat(400))) ?? ''
+
+    expect(summary.endsWith('…')).toBe(true)
+    expect(summary.length).toBeLessThanOrEqual(261)
+  })
+
+  it('strips bold markers so the summary reads as prose', () => {
+    const summary = deriveThinkingSummary(thinking('**Plan:** query the table'))
+
+    expect(summary).toBe('Plan: query the table')
+  })
+
+  it('says nothing for entries that are not thinking', () => {
+    expect(deriveThinkingSummary(thinking('Some reasoning', 'sqlite_batch'))).toBeNull()
+  })
+
+  it('says nothing when the reasoning is empty or not text', () => {
+    expect(deriveThinkingSummary(thinking('   '))).toBeNull()
+    expect(deriveThinkingSummary(thinking(null))).toBeNull()
+    expect(deriveThinkingSummary(thinking({ status: 'ok' }))).toBeNull()
+  })
+})

--- a/frontend/src/components/agentChat/tooling/clusterPreviewText.ts
+++ b/frontend/src/components/agentChat/tooling/clusterPreviewText.ts
@@ -1,6 +1,8 @@
 import type { ToolEntryDisplay } from './types'
 
 const MAX_PREVIEW_TEXT_LENGTH = 160
+/** Roughly three lines at the size the summary renders, matching the live thinking stream. */
+const MAX_THINKING_SUMMARY_LENGTH = 260
 
 function normalizeInlineText(value: string): string {
   return value.replace(/\s+/g, ' ').trim()
@@ -52,6 +54,35 @@ export function deriveThinkingPreview(entry: ToolEntryDisplay): string | null {
     return null
   }
   return clampPreviewText(stripBasicMarkdown(firstLine))
+}
+
+/**
+ * The reasoning as a short summary rather than a clipped opening line.
+ *
+ * While a thought is streaming it is shown over three lines; the moment it finished it collapsed
+ * to the first line of a single-line caption, so the timeline lost the thinking exactly when it
+ * became complete. This keeps enough of it to be worth reading, and the full text stays one click
+ * away in the detail view.
+ */
+export function deriveThinkingSummary(entry: ToolEntryDisplay): string | null {
+  if (entry.toolName !== 'thinking') {
+    return null
+  }
+  const reasoning = typeof entry.result === 'string' ? entry.result : ''
+  const normalized = normalizeInlineText(stripBasicMarkdown(reasoning))
+  if (!normalized) {
+    return null
+  }
+  if (normalized.length <= MAX_THINKING_SUMMARY_LENGTH) {
+    return normalized
+  }
+  // Prefer to end on a sentence so the summary reads as a thought, not a truncation.
+  const window = normalized.slice(0, MAX_THINKING_SUMMARY_LENGTH)
+  const lastStop = Math.max(window.lastIndexOf('. '), window.lastIndexOf('? '), window.lastIndexOf('! '))
+  if (lastStop > MAX_THINKING_SUMMARY_LENGTH * 0.5) {
+    return window.slice(0, lastStop + 1)
+  }
+  return `${window.trimEnd()}…`
 }
 
 export function deriveSemanticPreview(entry: ToolEntryDisplay): string | null {

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -4362,6 +4362,19 @@
     color: #0f4c81;
     line-height: 1.28;
 }
+/* A finished thought keeps the room a streaming one gets. Collapsing it to a single 0.6rem line
+   the instant it completed made the timeline lose the reasoning exactly when it became worth
+   reading, and left the planning step looking like a label with no content. This is the quiet
+   counterpart to the mood card: that one is a feeling shown at a glance, this one is a thought
+   given enough space to actually be read. */
+.tool-cluster-live-preview__entry-caption[data-activity-kind="thinking"] {
+    -webkit-line-clamp: 3;
+    font-size: 0.66rem;
+    line-height: 1.4;
+    color: #475569;
+    overflow-wrap: anywhere;
+}
+
 .tool-cluster-live-preview__entry[data-live-thinking="true"] {
     align-items: flex-start;
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,18 +1,18 @@
 {
-  "baseline_sha": "c59ee3a226fcc13fe2780504d385890c50aafd52",
+  "baseline_sha": "2d0c38d41665ae5c2443f8cfe6cd225dbbd630e6",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 8649,
+        "fitted_tokens": 8644,
         "system_bytes": 28966,
         "tools_bytes": 22035,
         "total_bytes": 62652,
         "user_bytes": 11651
       },
       "normal_explicit_send": {
-        "fitted_tokens": 7962,
+        "fitted_tokens": 7952,
         "system_bytes": 26133,
         "tools_bytes": 22035,
         "total_bytes": 59852,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 254021
+    "limit": 254068
   }
 }


### PR DESCRIPTION
Ticket #405: planning steps in the timeline lack the thinking summary present in the detail view.

## What was wrong

While an agent is thinking, its reasoning renders over three lines (`.tool-cluster-live-preview__thinking-stream`, `max-height: calc(1.35em * 3)`). The instant the thought **completed**, it collapsed to the first clause of a single-line `0.6rem` caption.

So the thought visually degraded exactly when it became complete, and the planning step read as a label with nothing under it:

> **Planning next step**
> `PLAN-PROBE Let me process the current state. The user asked for a pipeline summary. I w…`

The full text was already being sent to the browser and already sat one click away in the detail popup. It simply wasn't shown.

Confirmed on **real staging data** before writing code: **137 of 380** timeline events carried non-empty reasoning, none of it visible in the timeline.

## The change

`deriveThinkingSummary` keeps the thought rather than its opening line — the previous helper took `firstMeaningfulLine`, so any multi-line reasoning lost everything after the first newline. It ends on a sentence boundary where one is available, so the summary reads as a thought rather than a truncation, and falls back to an ellipsis only when there's no sentence to end on.

It renders at the size and line count the streaming view already uses, so a thought no longer changes appearance the moment it finishes.

After:

> **Planning next step**
> `PLAN-PROBE Let me process the current state. The user asked for a pipeline summary. I will query the CRM table, filter to open opportunities, then summarise by owner before replying.`

One thing worth noting for review: the caption is rendered from **three** separate sites in `ToolClusterLivePreview`, and tagging only the first left the change invisible in the live DOM even though the summary text had already lengthened. All three are tagged now.

## Design

This is deliberately the quiet counterpart to the mood card from #404 — that one is a feeling shown at a glance, warm and hue-tinted; this one is a thought given enough space to actually be read, cool and text-forward. Together the timeline shows what an agent felt and what it was thinking.

## Verification

`clusterPreviewText.test.ts`, 7 tests, **confirmed red first** (helper absent → all fail). Covers the core regression — reasoning past the first line survives — plus sentence-boundary truncation, ellipsis fallback, markdown stripping, and non-thinking entries.

Rendered and inspected at 1440×900 and 390×844: summary wraps and ends on a complete sentence at both widths.

`tsc -b --force` clean · 51 test files / 285 tests green · CSS braces balanced 1555/1555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)