### PR TITLE
Stop rendering charter and schedule writes as mood-settle cards

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -117,7 +117,10 @@ from ..tools.sqlite_agent_config import (
     seed_sqlite_agent_config,
     sqlite_statement_mutates_agent_schedules,
 )
-from ..tools.sqlite_config_statements import sqlite_statement_assigns_agent_config_field
+from ..tools.sqlite_config_statements import (
+    sqlite_batch_statements as _sqlite_batch_statements,
+    sqlite_statement_assigns_agent_config_field,
+)
 from ..tools.sqlite_skills import apply_sqlite_skill_updates, refresh_skills_for_tool, seed_sqlite_skills
 from ..tools.custom_tools import execute_create_custom_tool
 from ..tools.custom_tool_names import CREATE_CUSTOM_TOOL_NAME
@@ -2586,17 +2589,6 @@ def _normalize_tool_params(tool_name: str, tool_params: Dict[str, Any]) -> Dict[
     return normalized_params
 
 
-def _sqlite_batch_statements(tool_params: Dict[str, Any]) -> list[str]:
-    raw_sql = tool_params.get("queries", tool_params.get("sql", tool_params.get("query")))
-    raw_items = raw_sql if isinstance(raw_sql, list) else [raw_sql]
-    statements: list[str] = []
-    for raw_item in raw_items:
-        if not isinstance(raw_item, str):
-            continue
-        statements.extend(statement.strip() for statement in sqlparse.split(raw_item) if statement.strip())
-    return statements
-
-
 def _sqlite_single_result_read_call_count(tool_calls: list[Any]) -> int:
     count = 0
     for call in tool_calls:
@@ -3170,26 +3162,26 @@ def _capture_tool_display_metadata(
     prepared: _PreparedToolExecution,
     result: Any,
 ) -> Dict[str, Any]:
-    if (
-        prepared.tool_name != "sqlite_batch"
-        or not _tool_result_is_success(result)
-        or not _sqlite_batch_agent_config_attempted_fields(prepared.exec_params)
-    ):
+    if prepared.tool_name != "sqlite_batch" or not _tool_result_is_success(result):
+        return {}
+    fields = _sqlite_batch_agent_config_attempted_fields(prepared.exec_params)
+    if not fields:
         return {}
 
     snapshot = read_sqlite_agent_config_snapshot()
     if snapshot is None:
         return {}
-    return {
-        "agent_config": {
-            "charter": snapshot.charter,
-            "schedule": snapshot.schedule,
-            # Carried so the timeline can show a mood change as a mood change. Without it the
-            # write is indistinguishable from any other row update by the time it reaches the UI.
-            "emotion": snapshot.emotion,
-            "emotion_timeout_seconds": snapshot.emotion_timeout_seconds,
-        },
+    agent_config: Dict[str, Any] = {
+        "charter": snapshot.charter,
+        "schedule": snapshot.schedule,
     }
+    # Carried so the timeline can show a mood change as a mood change — but only when this write
+    # actually touched the mood. Stamping every config write with an emotion slot made charter and
+    # schedule updates by a mood-less agent render as "let their mood settle" (bug #462).
+    if "emotion" in fields:
+        agent_config["emotion"] = snapshot.emotion
+        agent_config["emotion_timeout_seconds"] = snapshot.emotion_timeout_seconds
+    return {"agent_config": agent_config}
 
 
 def _mark_tool_outcome_failed(

--- a/api/agent/tools/sqlite_config_statements.py
+++ b/api/agent/tools/sqlite_config_statements.py
@@ -1,4 +1,7 @@
 import re
+from typing import Any
+
+import sqlparse
 
 
 AGENT_CONFIG_UPDATE_RE = re.compile(
@@ -34,3 +37,30 @@ def sqlite_statement_assigns_agent_config_field(statement: str, field_name: str)
         for column in insert_match.group("columns").split(",")
     }
     return field in columns
+
+
+def sqlite_batch_statements(tool_params: Any) -> list[str]:
+    if not isinstance(tool_params, dict):
+        return []
+    raw_sql = tool_params.get("queries", tool_params.get("sql", tool_params.get("query")))
+    raw_items = raw_sql if isinstance(raw_sql, list) else [raw_sql]
+    statements: list[str] = []
+    for raw_item in raw_items:
+        if not isinstance(raw_item, str):
+            continue
+        statements.extend(statement.strip() for statement in sqlparse.split(raw_item) if statement.strip())
+    return statements
+
+
+def sqlite_params_assign_emotion(tool_params: Any) -> bool:
+    """Whether this sqlite_batch call actually wrote the agent's mood.
+
+    Display metadata alone cannot answer this: during the #462 regression window every
+    config write was stamped with an `emotion` slot, so a charter edit and a deliberate
+    mood clear look identical there. The SQL is the ground truth for what the step did.
+    """
+    return any(
+        sqlite_statement_assigns_agent_config_field(statement, "emotion")
+        or sqlite_statement_assigns_agent_config_field(statement, "emotion_timeout_seconds")
+        for statement in sqlite_batch_statements(tool_params)
+    )

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -49,6 +49,7 @@ from api.models import (
 )
 
 from api.agent.tools.plan import PlanSnapshot, build_plan_snapshot
+from api.agent.tools.sqlite_config_statements import sqlite_params_assign_emotion
 from .access import user_can_manage_agent_settings
 from .plan_events import ensure_plan_baseline_event
 
@@ -810,7 +811,10 @@ def _serialize_step_entry(env: StepEnvelope, labels: Mapping[str, str]) -> dict:
             schedule_value = agent_config.get("schedule")
             if schedule_value is None or isinstance(schedule_value, str):
                 entry["scheduleValue"] = schedule_value
-        if "emotion" in agent_config:
+        # Steps persisted during the #462 regression window carry an `emotion` slot on every
+        # config write, so the metadata alone can't distinguish a charter edit from a deliberate
+        # mood clear. The step's own SQL can — a mood travels only when the write assigned one.
+        if "emotion" in agent_config and sqlite_params_assign_emotion(tool_call.tool_params):
             emotion_value = agent_config.get("emotion")
             if emotion_value is None or isinstance(emotion_value, str):
                 entry["emotion"] = emotion_value

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,18 +1,18 @@
 {
-  "baseline_sha": "962953b9b3231f0160bb24588de9861f6c431d77",
+  "baseline_sha": "a86cecd7b507475a08f69eaa25a67909fd42cbfd",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9248,
+        "fitted_tokens": 9258,
         "system_bytes": 32495,
         "tools_bytes": 23302,
         "total_bytes": 67506,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8670,
+        "fitted_tokens": 8650,
         "system_bytes": 29452,
         "tools_bytes": 23302,
         "total_bytes": 64496,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 257879
+    "limit": 257901
   }
 }

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -253,14 +253,14 @@ class ToolDisplayMetadataTests(TestCase):
             },
         )
 
+        # Emotion travels only on writes that assign it; a charter patch is not a mood event
+        # even when the agent happens to have one set (bug #462).
         self.assertEqual(
             _capture_tool_display_metadata(patch_call, {"status": "ok"}),
             {
                 "agent_config": {
                     "charter": "Updated full assignment",
                     "schedule": "0 9 * * *",
-                    "emotion": "\U0001F60A",
-                    "emotion_timeout_seconds": 3600,
                 },
             },
         )
@@ -280,8 +280,6 @@ class ToolDisplayMetadataTests(TestCase):
                 "agent_config": {
                     "charter": "Updated full assignment",
                     "schedule": "0 9 * * *",
-                    "emotion": "\U0001F60A",
-                    "emotion_timeout_seconds": 3600,
                 },
             },
         )
@@ -315,8 +313,6 @@ class ToolDisplayMetadataTests(TestCase):
                 "agent_config": {
                     "charter": "Updated full assignment",
                     "schedule": "0 9 * * *",
-                    "emotion": "\U0001F60A",
-                    "emotion_timeout_seconds": 3600,
                 },
             },
         )

--- a/tests/unit/test_timeline_emotion_entry.py
+++ b/tests/unit/test_timeline_emotion_entry.py
@@ -72,12 +72,42 @@ class EmotionDisplayMetadataTests(SimpleTestCase):
         self.assertEqual(captured["charter"], "the charter")
         self.assertEqual(captured["schedule"], "0 9 * * *")
 
+    def test_a_charter_only_write_carries_no_emotion(self):
+        """A charter edit is not a mood event, even though the snapshot always has an emotion slot.
+
+        Carrying `emotion: None` for a write that never touched the mood made every charter or
+        schedule update by a mood-less agent render as "let their mood settle" (bug #462).
+        """
+        from api.agent.tools.sqlite_agent_config import AgentConfigSnapshot
+
+        snapshot = AgentConfigSnapshot(charter="c", schedule=None, emotion=None)
+
+        captured = self._capture(
+            snapshot, {"sql": "UPDATE __agent_config SET charter = 'new charter' WHERE id = 1;"}
+        )["agent_config"]
+
+        self.assertNotIn("emotion", captured)
+        self.assertNotIn("emotion_timeout_seconds", captured)
+
+    def test_a_schedule_timer_write_carries_no_emotion(self):
+        """Timer inserts hit the same capture path and were the other source of phantom cards."""
+        from api.agent.tools.sqlite_agent_config import AgentConfigSnapshot
+
+        snapshot = AgentConfigSnapshot(charter="c", schedule=None, emotion=None)
+
+        captured = self._capture(
+            snapshot,
+            {"sql": "INSERT INTO __agent_schedules (name, cron) VALUES ('recheck', '0 9 * * *');"},
+        )["agent_config"]
+
+        self.assertNotIn("emotion", captured)
+
 
 @tag("batch_agent_chat")
 class EmotionTimelineEntryTests(SimpleTestCase):
     """What the serializer puts on the entry is what the card can render."""
 
-    def _entry(self, agent_config: dict) -> dict:
+    def _entry(self, agent_config: dict, params: dict | None = None) -> dict:
         from unittest.mock import MagicMock
 
         from console.agent_chat.timeline import _serialize_step_entry
@@ -88,7 +118,7 @@ class EmotionTimelineEntryTests(SimpleTestCase):
         step.created_at = None
         tool_call = MagicMock()
         tool_call.tool_name = "sqlite_batch"
-        tool_call.tool_params = EMOTION_SQL
+        tool_call.tool_params = params if params is not None else EMOTION_SQL
         tool_call.result = {"status": "ok"}
         tool_call.status = "complete"
         tool_call.display_metadata = {"agent_config": agent_config}
@@ -115,3 +145,36 @@ class EmotionTimelineEntryTests(SimpleTestCase):
         entry = self._entry({"charter": "just the charter"})
 
         self.assertNotIn("emotion", entry)
+
+    def test_stale_metadata_on_a_charter_write_is_not_a_mood(self):
+        """Steps persisted during the #462 regression window already carry `emotion: None`.
+
+        Their display metadata cannot be trusted, but their SQL can: if the statement never
+        assigned an emotion column, the entry must not claim a mood settled (bug #462, the
+        "Jordan let their mood settle" cards on charter updates).
+        """
+        entry = self._entry(
+            {"charter": "c", "emotion": None},
+            params={"sql": "UPDATE __agent_config SET charter = 'new charter' WHERE id = 1;"},
+        )
+
+        self.assertNotIn("emotion", entry)
+        self.assertNotIn("emotionTimeoutSeconds", entry)
+
+    def test_stale_metadata_on_a_timer_write_is_not_a_mood(self):
+        entry = self._entry(
+            {"charter": "c", "emotion": None},
+            params={"sql": "INSERT INTO __agent_schedules (name, cron) VALUES ('recheck', '0 9 * * *');"},
+        )
+
+        self.assertNotIn("emotion", entry)
+
+    def test_a_real_mood_clear_still_reads_as_cleared(self):
+        """The guard must not swallow deliberate clears, which share the `None` value."""
+        entry = self._entry(
+            {"emotion": None},
+            params={"sql": "UPDATE __agent_config SET emotion = NULL WHERE id = 1;"},
+        )
+
+        self.assertIn("emotion", entry)
+        self.assertIsNone(entry["emotion"])


### PR DESCRIPTION
## What

Fixes bug #462: repeated "Jordan let their mood settle" cards on charter updates and schedule-timer writes.

## Root cause

Regression from #1416. `_capture_tool_display_metadata` fires for **any** successful agent-config write (charter, schedule, appearance, `__agent_schedules` timer inserts) and unconditionally embedded `emotion: <current value>` — `null` for an agent with no active mood. The timeline serializer treated the presence of the `emotion` key as "this write changed the mood" and emitted `emotion: null`, which the frontend correctly renders as a cleared mood ("let their mood settle"). The frontend comment in `sqliteEntries.ts` documents the intended contract — "the serializer sets `emotion` only for writes that actually changed the mood" — which the backend violated.

## Fix (two layers, same semantics)

1. **Capture** (`event_processing.py`): emotion is embedded only when the write's SQL actually assigned `emotion`/`emotion_timeout_seconds` (reuses the existing attempted-fields analysis). Fixes all new steps at the source.
2. **Serializer** (`timeline.py`): re-checks the step's own SQL before emitting the emotion key. This also cleans steps **already persisted** during the regression window (e.g. Jordan Reed's feed) without a data migration — their metadata is untrustworthy but their SQL is ground truth.

Shared SQL-inspection helpers moved to `api/agent/tools/sqlite_config_statements.py` (`sqlite_batch_statements` extracted from event_processing, new `sqlite_params_assign_emotion`). Deliberate mood sets and clears (`SET emotion = …` / `SET emotion = NULL`) are unchanged. No frontend changes.

## Evidence

- Reproduced from the reporter's screenshot (Jordan Reed's feed: three mood-settle cards interleaved with planning cards, agent's own message "Done. Updated the charter to add: …").
- Red→green: 4 new red tests (2 capture, 2 serializer incl. the historic-data case) + 1 guard test that a genuine `SET emotion = NULL` still reads as cleared.
- `tests.unit.test_timeline_emotion_entry` 11/11, `tests.unit.test_event_processing` + `test_chat_email_autolink` 199/199, `test_agent_chat_api` + timeline email suites OK, `test_sqlite_agent_config` OK.
- Frontend: full vitest 278/278 (no frontend changes; MoodShiftCard contract already assumed this fix).
- Complexity budgets updated (+22 LoC, tests + fix).

Validation plan before merge: preview env against Jordan Reed's real timeline (prod DB fork) — the phantom cards must be gone from his existing feed while genuine mood cards elsewhere still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)