### PR TITLE
Preserve omitted agent fields during updates

### DIFF
--- a/api/agent/tools/meta_gobii.py
+++ b/api/agent/tools/meta_gobii.py
@@ -36,7 +36,7 @@ from api.models import (
     PersistentAgentSystemSkillState,
     UserPhoneNumber,
 )
-from api.services.daily_credit_limits import calculate_daily_credit_slider_bounds, get_tier_credit_multiplier, scale_daily_credit_limit_for_tier_change
+from api.services.daily_credit_limits import calculate_daily_credit_slider_bounds, get_tier_credit_multiplier
 from api.services.daily_credit_settings import get_daily_credit_settings_for_owner
 from api.services.agent_email_provisioning import (
     configure_custom_agent_email,
@@ -1060,7 +1060,6 @@ def _tool_update_agent(invoking_agent: PersistentAgent, params: dict[str, Any]) 
 
     previous_daily_credit_limit = agent.daily_credit_limit
     previous_tier_id = agent.preferred_llm_tier_id
-    previous_tier = agent.preferred_llm_tier
     previous_tier_key = getattr(getattr(agent, "preferred_llm_tier", None), "key", "standard")
     changed_fields: set[str] = set()
     browser_name_changed = False
@@ -1097,24 +1096,6 @@ def _tool_update_agent(invoking_agent: PersistentAgent, params: dict[str, Any]) 
         if agent.preferred_llm_tier_id != tier.id:
             agent.preferred_llm_tier = tier
             changed_fields.add("preferred_llm_tier")
-            if "daily_credit_limit" not in params:
-                owner = agent.organization or agent.user
-                credit_settings = get_daily_credit_settings_for_owner(owner)
-                new_tier_multiplier = get_tier_credit_multiplier(tier)
-                slider_bounds = calculate_daily_credit_slider_bounds(
-                    credit_settings,
-                    tier_multiplier=new_tier_multiplier,
-                )
-                scaled_limit = scale_daily_credit_limit_for_tier_change(
-                    agent.daily_credit_limit,
-                    from_multiplier=get_tier_credit_multiplier(previous_tier),
-                    to_multiplier=new_tier_multiplier,
-                    slider_min=slider_bounds["slider_min"],
-                    slider_max=slider_bounds["slider_limit_max"],
-                )
-                if agent.daily_credit_limit != scaled_limit:
-                    agent.daily_credit_limit = scaled_limit
-                    changed_fields.add("daily_credit_limit")
     if "daily_credit_limit" in params:
         daily_credit_limit = _normalize_daily_credit_limit(params.get("daily_credit_limit"))
         if agent.daily_credit_limit != daily_credit_limit:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -7,8 +7,6 @@ from django.db import transaction
 from rest_framework import serializers
 from api.agent.core.llm_config import resolve_intelligence_tier_for_owner
 from api.agent.short_description import build_listing_description, build_mini_description
-from api.services.daily_credit_limits import calculate_daily_credit_slider_bounds, get_tier_credit_multiplier, scale_daily_credit_limit_for_tier_change
-from api.services.daily_credit_settings import get_daily_credit_settings_for_owner
 from .models import ApiKey, BrowserUseAgent, BrowserUseAgentTask, CommsChannel, IntelligenceTier, PersistentAgent, PersistentAgentCommsEndpoint
 from jsonschema import Draft202012Validator, ValidationError as JSValidationError
 from util.analytics import AnalyticsSource
@@ -655,27 +653,6 @@ class PersistentAgentSerializer(serializers.ModelSerializer):
             preferred_endpoint = serializers.empty
 
         validated_data.pop('template_code', None)
-
-        preferred_tier = validated_data.get('preferred_llm_tier', serializers.empty)
-        preferred_tier_changed = (
-            preferred_tier is not serializers.empty
-            and preferred_tier != instance.preferred_llm_tier
-        )
-        if preferred_tier_changed and 'daily_credit_limit' not in validated_data:
-            owner = instance.organization or instance.user
-            credit_settings = get_daily_credit_settings_for_owner(owner)
-            new_tier_multiplier = get_tier_credit_multiplier(preferred_tier)
-            slider_bounds = calculate_daily_credit_slider_bounds(
-                credit_settings,
-                tier_multiplier=new_tier_multiplier,
-            )
-            validated_data['daily_credit_limit'] = scale_daily_credit_limit_for_tier_change(
-                instance.daily_credit_limit,
-                from_multiplier=get_tier_credit_multiplier(instance.preferred_llm_tier),
-                to_multiplier=new_tier_multiplier,
-                slider_min=slider_bounds["slider_min"],
-                slider_max=slider_bounds["slider_limit_max"],
-            )
 
         dirty_fields = set()
         for field, value in validated_data.items():

--- a/api/services/remote_mcp.py
+++ b/api/services/remote_mcp.py
@@ -382,7 +382,10 @@ TOOL_DEFINITIONS = [
     {
         "name": "gobii_update_agent",
         "title": "Update Gobii Agent",
-        "description": "Update mutable persistent agent settings such as name, charter, schedule, active state, or whitelist policy.",
+        "description": (
+            "Update only the supplied persistent agent settings; omitted mutable fields retain their current values. "
+            "Send null for schedule or daily_credit_limit to clear that field."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/docs/content/developers/mcp-server.mdx
+++ b/docs/content/developers/mcp-server.mdx
@@ -121,8 +121,10 @@ Use `gobii_get_agent_config_options` before setting operational config. It retur
 
 - `preferred_llm_tier`: the agent's preferred intelligence level. Values are the configured Gobii intelligence tier keys, commonly `standard`, `premium`, `max`, `ultra`, and `ultra_max`. Plan and quota limits are enforced.
 - `daily_credit_limit`: the soft daily credit target. `null` means unlimited. Gobii derives and enforces the hard runtime stop from the configured hard-limit multiplier.
-- `schedule`: optional cron-like schedule, `@daily`, or `@every` interval. Omitted, empty, or `null` means unscheduled. Invalid schedules return an MCP tool result with `isError: true` and field details.
+- `schedule`: optional cron-like schedule, `@daily`, or `@every` interval. On create, omitted, empty, or `null` means unscheduled. On update, omitted preserves the current schedule, while empty or `null` unschedules the agent. Invalid schedules return an MCP tool result with `isError: true` and field details.
 - `whitelist_policy`, `is_active`, and `proactive_opt_in`: existing Gobii policy and lifecycle fields.
+
+`gobii_update_agent` changes only fields supplied in the call. Every omitted mutable field retains its current value. For nullable fields, send `null` explicitly to clear the value.
 
 Unsupported fields are not ignored. A tool call with unsupported arguments returns `isError: true` with `unsupported_fields` and `supported_fields`.
 

--- a/tests/unit/test_api_persistent_agents.py
+++ b/tests/unit/test_api_persistent_agents.py
@@ -687,10 +687,12 @@ class PersistentAgentAPITests(TestCase):
         self.assertEqual(agent.charter, 'Refine outreach list')
         self.assertFalse(agent.is_active)
 
-    def test_update_agent_preferred_llm_tier_triggers_immediate_resume(self):
+    def test_update_agent_preferred_llm_tier_retains_credit_limit_and_triggers_immediate_resume(self):
         payload = self._create_agent_via_api()
         agent_id = payload['id']
         agent = PersistentAgent.objects.get(id=agent_id)
+        PersistentAgent.objects.filter(id=agent_id).update(daily_credit_limit=12000)
+        agent.refresh_from_db()
         self.process_events_mock.reset_mock()
         self.standard_process_events_mock.reset_mock()
         # Ensure target tier exists in lean test fixtures.
@@ -721,6 +723,7 @@ class PersistentAgentAPITests(TestCase):
 
         agent.refresh_from_db()
         self.assertEqual(getattr(agent.preferred_llm_tier, "key", None), 'premium')
+        self.assertEqual(agent.daily_credit_limit, 12000)
         self.standard_process_events_mock.assert_called_once_with(str(agent.id))
 
         latest_system_step = (
@@ -732,6 +735,7 @@ class PersistentAgentAPITests(TestCase):
         )
         self.assertIsNotNone(latest_system_step)
         self.assertIn("Intelligence level changed", latest_system_step.step.description)
+        self.assertNotIn("Daily credit soft target changed", latest_system_step.step.description)
 
     def test_update_agent_name_syncs_blank_email_display_name(self):
         payload = self._create_agent_via_api({'name': 'Original Agent'})

--- a/tests/unit/test_meta_gobii_tools.py
+++ b/tests/unit/test_meta_gobii_tools.py
@@ -22,6 +22,7 @@ from api.models import (
     CommsAllowlistEntry,
     CommsAllowlistRequest,
     CommsChannel,
+    IntelligenceTier,
     PersistentAgent,
     PersistentAgentCommsEndpoint,
     PersistentAgentEmailEndpoint,
@@ -313,6 +314,51 @@ class MetaGobiiDirectToolTests(TestCase):
             },
         )
         self.assertEqual(denied["status"], "error")
+
+    @patch("api.services.agent_settings_resume.process_agent_events_task.delay")
+    def test_update_agent_preferred_tier_retains_omitted_credit_limit(self, _mock_delay):
+        standard_tier, _ = IntelligenceTier.objects.update_or_create(
+            key="standard",
+            defaults={
+                "display_name": "Standard",
+                "rank": 10,
+                "credit_multiplier": "1.00",
+                "is_default": True,
+            },
+        )
+        premium_tier, _ = IntelligenceTier.objects.update_or_create(
+            key="premium",
+            defaults={
+                "display_name": "Premium",
+                "rank": 20,
+                "credit_multiplier": "2.00",
+                "is_default": False,
+            },
+        )
+        PersistentAgent.objects.filter(id=self.peer.id).update(
+            preferred_llm_tier=standard_tier,
+            daily_credit_limit=12000,
+        )
+
+        with patch(
+            "api.agent.tools.meta_gobii._resolve_requested_tier_or_error",
+            return_value=premium_tier,
+        ):
+            updated = execute_meta_gobii_tool(
+                self.manager,
+                "meta_gobii_update_agent",
+                {
+                    "agent_id": str(self.peer.id),
+                    "preferred_llm_tier": "premium",
+                    "user_confirmed": True,
+                },
+            )
+
+        self.assertEqual(updated["status"], "ok")
+        self.peer.refresh_from_db()
+        self.assertEqual(self.peer.preferred_llm_tier, premium_tier)
+        self.assertEqual(self.peer.daily_credit_limit, 12000)
+        self.assertEqual(updated["changed_fields"], ["preferred_llm_tier"])
 
     def test_link_and_unlink_accessible_agents_only_after_confirmation(self):
         blocked_link = execute_meta_gobii_tool(

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import uuid
+from contextlib import ExitStack
 from decimal import Decimal
 from datetime import timedelta
 from unittest.mock import patch
@@ -9,6 +10,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 from django.utils import timezone
 
+from api.agent.core.llm_config import AgentLLMTier
 from api.models import (
     AgentPeerLink,
     BrowserUseAgent,
@@ -159,6 +161,47 @@ class RemoteMCPViewTests(TestCase):
 
     def _structured_content(self, response):
         return response.json()["result"]["structuredContent"]
+
+    @staticmethod
+    def _mutable_agent_state(agent):
+        return {
+            "name": agent.name,
+            "charter": agent.charter,
+            "schedule": agent.schedule,
+            "is_active": agent.is_active,
+            "preferred_llm_tier": getattr(agent.preferred_llm_tier, "key", None),
+            "daily_credit_limit": agent.daily_credit_limit,
+            "whitelist_policy": agent.whitelist_policy,
+            "proactive_opt_in": agent.proactive_opt_in,
+        }
+
+    def _remote_update_context(self, *, allow_premium=False):
+        stack = ExitStack()
+        stack.enter_context(patch("api.auth.can_user_use_personal_agents_and_api", return_value=True))
+        stack.enter_context(
+            patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)
+        )
+        stack.enter_context(patch("api.services.agent_settings_resume.process_agent_events_task.delay"))
+        if allow_premium:
+            stack.enter_context(
+                patch(
+                    "api.services.remote_mcp.resolve_preferred_tier_for_owner",
+                    return_value=AgentLLMTier.PREMIUM,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "api.services.remote_mcp.resolve_intelligence_tier_for_owner",
+                    return_value=self.premium_tier,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "api.serializers.resolve_intelligence_tier_for_owner",
+                    return_value=self.premium_tier,
+                )
+            )
+        return stack
 
     def test_requires_api_key(self):
         response = self.client.post(
@@ -506,32 +549,111 @@ class RemoteMCPViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.json()["result"]["isError"])
+        self.assertFalse(response.json()["result"]["isError"], response.content)
         agent.refresh_from_db()
         self.assertIsNone(agent.schedule)
         self.assertEqual(agent.preferred_llm_tier, self.premium_tier)
         self.assertEqual(agent.daily_credit_limit, 11)
 
-    def test_update_unscheduled_agent_with_explicit_null_schedule(self):
-        agent = self._create_agent(self.user, "Explicit Null Schedule Update")
-        PersistentAgent.objects.filter(id=agent.id).update(schedule="@daily")
-
-        response = self._call_tool(
-            "gobii_update_agent",
-            {
-                "agent_id": str(agent.id),
-                "schedule": None,
-                "preferred_llm_tier": "premium",
-                "daily_credit_limit": 13,
-            },
+    def test_update_agent_tier_and_explicit_null_schedule_retain_omitted_credit_limit(self):
+        agent = self._create_agent(self.user, "Retain Credit Limit Update")
+        PersistentAgent.objects.filter(id=agent.id).update(
+            schedule="@every 1h",
+            daily_credit_limit=12000,
         )
 
+        with self._remote_update_context(allow_premium=True):
+            response = self._call_tool(
+                "gobii_update_agent",
+                {
+                    "agent_id": str(agent.id),
+                    "schedule": None,
+                    "preferred_llm_tier": "premium",
+                },
+            )
+
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.json()["result"]["isError"])
+        self.assertFalse(response.json()["result"]["isError"], response.content)
+        content = self._structured_content(response)["agent"]
         agent.refresh_from_db()
         self.assertIsNone(agent.schedule)
         self.assertEqual(agent.preferred_llm_tier, self.premium_tier)
-        self.assertEqual(agent.daily_credit_limit, 13)
+        self.assertEqual(agent.daily_credit_limit, 12000)
+        self.assertEqual(content["daily_credit_limit"], 12000)
+        self.assertIsNotNone(content["daily_credit_soft_target"])
+        self.assertIsNotNone(content["daily_credit_hard_limit"])
+
+    def test_update_agent_explicit_null_daily_credit_limit_clears_derived_limits(self):
+        agent = self._create_agent(self.user, "Explicit Null Credit Limit")
+        PersistentAgent.objects.filter(id=agent.id).update(
+            schedule="@every 1h",
+            daily_credit_limit=12000,
+        )
+
+        with self._remote_update_context():
+            response = self._call_tool(
+                "gobii_update_agent",
+                {
+                    "agent_id": str(agent.id),
+                    "daily_credit_limit": None,
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["result"]["isError"], response.content)
+        content = self._structured_content(response)["agent"]
+        agent.refresh_from_db()
+        self.assertEqual(agent.schedule, "@every 1h")
+        self.assertIsNone(agent.daily_credit_limit)
+        self.assertIsNone(content["daily_credit_limit"])
+        self.assertIsNone(content["daily_credit_soft_target"])
+        self.assertIsNone(content["daily_credit_hard_limit"])
+
+    def test_update_agent_only_changes_supplied_mutable_field(self):
+        cases = {
+            "name": "Updated Agent Name",
+            "charter": "Updated charter.",
+            "schedule": "@every 2h",
+            "is_active": False,
+            "preferred_llm_tier": "premium",
+            "daily_credit_limit": 37,
+            "whitelist_policy": "manual",
+            "proactive_opt_in": True,
+        }
+
+        with self._remote_update_context(allow_premium=True):
+            for index, (field, value) in enumerate(cases.items()):
+                with self.subTest(field=field):
+                    agent = self._create_agent(self.user, f"Mutable Field Agent {index}")
+                    PersistentAgent.objects.filter(id=agent.id).update(
+                        schedule="@every 1h",
+                        is_active=True,
+                        daily_credit_limit=12000,
+                        whitelist_policy="default",
+                        proactive_opt_in=False,
+                    )
+                    agent.refresh_from_db()
+                    before = self._mutable_agent_state(agent)
+
+                    response = self._call_tool(
+                        "gobii_update_agent",
+                        {
+                            "agent_id": str(agent.id),
+                            field: value,
+                        },
+                    )
+
+                    self.assertEqual(response.status_code, 200)
+                    self.assertFalse(response.json()["result"]["isError"], response.content)
+                    agent.refresh_from_db()
+                    after = self._mutable_agent_state(agent)
+                    self.assertEqual(after[field], value)
+                    for omitted_field in before.keys() - {field}:
+                        self.assertEqual(
+                            after[omitted_field],
+                            before[omitted_field],
+                            f"{omitted_field} changed when only {field} was supplied",
+                        )
 
     def test_update_agent_invalid_schedule_returns_structured_tool_error(self):
         agent = self._create_agent(self.user, "Invalid Schedule Update")


### PR DESCRIPTION
## Summary

- Ensure agent updates modify only explicitly supplied fields.
- Preserve daily credit limits when changing intelligence tiers.
- Support explicit `null` clearing for schedules and daily credit limits.
- Clarify MCP tool behavior in its description and documentation.
- Add regression coverage for API, direct tool, and remote MCP updates.

## Testing

- Added and updated focused unit tests covering field retention, explicit null clearing, and tier changes.