### PR TITLE
Submit the homepage charter on cmd/ctrl-Enter (#209)

### DIFF
--- a/pages/templates/home.html
+++ b/pages/templates/home.html
@@ -1069,6 +1069,21 @@
       textarea.addEventListener('focus', toggleGhostVisibility);
       textarea.addEventListener('blur', toggleGhostVisibility);
 
+      // Submit on cmd/ctrl-Enter like the in-app composer. requestSubmit (not submit()) so the
+      // intelligence gate, CSRF, and analytics submit listeners all still run.
+      textarea.addEventListener('keydown', function (event) {
+        if (event.key !== 'Enter' || event.isComposing) return;
+        if (!(event.metaKey || event.ctrlKey) || event.shiftKey || event.altKey) return;
+        const form = textarea.closest('form');
+        if (!form) return;
+        event.preventDefault();
+        if (typeof form.requestSubmit === 'function') {
+          form.requestSubmit();
+        } else {
+          form.submit();
+        }
+      });
+
       toggleGhostVisibility();
 
       if (


### PR DESCRIPTION
## What

Fixes tracker #209: cmd-enter (ctrl-enter on Windows/Linux) did nothing in the marketing homepage create-agent prompt box. Reporter-confirmed surface: Andrew's re-report today at 15:49Z with screenshot (verified as the homepage box via the tracker).

## Root cause

The in-app composer handles ⌘↵ (`AgentComposer.tsx`) and advertises it in its placeholder; the homepage charter textarea had **no keydown handler at all** — the only document-level keydown on the page was Escape-to-close-menu. Repro was deterministic on a preview of main: Meta+Enter and Ctrl+Enter both no-ops.

## Fix

`pages/templates/home.html`: the charter textarea now routes cmd/ctrl-Enter (excluding shift/alt, respecting IME composition) through `form.requestSubmit()`, so the existing intelligence-gate, CSRF, and analytics submit listeners all still run — identical path to clicking "Start Sourcing".

## Validation

- Bug baseline (pre-fix, preview of main): Meta+Enter and Ctrl+Enter → nothing.
- Fix (pr-1423 preview, logged out, real browser): Meta+Enter → form POST to `/spawn-agent/` + navigation, through the real submit path.
- CI fully green. Complexity budgets pass (no baseline bump needed).
- Note plainly: homepage template JS has no unit-test harness, so this is covered by the live preview validation only.

## Verification batch context (tracker updates, no code here)

This PR's preview was also used to verify the rest of the claimed desktop batch: #215 confirmed already fixed (clean "Agent deleted" state, no raw HTML), #30 not reproducible (selector clean on homepage and in-app composer, screenshots on ticket), #54's title mechanism works — the generic-title symptom is an intermittent cold-session bootstrap hang, reclassified with evidence, and #74 not reproducible under automation. All dispositions reported to the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)