### PR TITLE
Keep SQLite enrichment refreshes first-shot and grounded

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -97,7 +97,15 @@ from ..tools.attachment_guidance import SYSTEM_ATTACHMENT_PREFLIGHT_GUIDANCE
 from ..tools.plan import format_current_plan_for_prompt
 from ..tools.spawn_web_task import get_browser_daily_task_limit
 from ..tools.static_tools import get_static_tool_definitions
-from ..tools.sqlite_state import AGENT_CONFIG_TABLE, AGENT_SKILLS_TABLE, CONTACTS_TABLE, FILES_TABLE, get_sqlite_digest_prompt, get_sqlite_schema_prompt
+from ..tools.sqlite_state import (
+    AGENT_CONFIG_TABLE,
+    AGENT_SKILLS_TABLE,
+    CONTACTS_TABLE,
+    FILES_TABLE,
+    get_sqlite_digest_prompt,
+    get_sqlite_model_table_columns,
+    get_sqlite_schema_prompt,
+)
 from ..tools.sqlite_query_quality import (
     named_model_read_tables,
     source_derived_model_mutation_tables,
@@ -1720,6 +1728,7 @@ def _render_prompt_context_once(
         )
 
     sqlite_schema_block = get_sqlite_schema_prompt()
+    named_model_columns = get_sqlite_model_table_columns()
     named_model_tables = {
         match.group(1)
         for match in re.finditer(r"^Table ([^\s(]+)", sqlite_schema_block, re.MULTILINE)
@@ -1735,6 +1744,7 @@ def _render_prompt_context_once(
         is_first_run=is_first_run,
         run_cache=run_cache,
         named_model_tables=named_model_tables,
+        named_model_columns=named_model_columns,
     )
 
     variable_group = prompt.group("variable", weight=4)
@@ -4505,6 +4515,7 @@ def _get_unified_history_prompt(
     is_first_run: bool = False,
     run_cache: PromptRunCache | None = None,
     named_model_tables: Set[str] | None = None,
+    named_model_columns: Mapping[str, Set[str]] | None = None,
 ) -> Tuple[Set[str], bool, Tuple[str, ...]]:
     """Add summaries + interleaved recent steps & messages to the provided promptree group."""
     epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
@@ -4815,6 +4826,7 @@ def _get_unified_history_prompt(
         ),
         paired_url_step_ids=paired_url_step_ids,
         named_model_tables=named_model_tables,
+        named_model_columns=named_model_columns,
     )
 
     for s in steps:

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -3,7 +3,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 from ..tools.context_hints import URL_FIELD_PRIORITY, extract_context_hint, hint_from_unstructured_text
 from ..tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
@@ -235,11 +235,13 @@ def _build_optional_source_write_hint(
             )
         else:
             stable_key_guidance = (
-                f"Use the shown stable key `{first_key}`. " if first_key else ""
+                f" Use the shown stable key `{first_key}`; do not invent identity."
+                if first_key
+                else ""
             )
             model_guidance = (
-                f"No fitting durable model: {stable_key_guidance}create one with {key_expr} "
-                "as PRIMARY KEY/UNIQUE, then upsert. "
+                f"No fitting durable model: create one with {key_expr} "
+                f"as PRIMARY KEY/UNIQUE, then upsert.{stable_key_guidance} "
             )
         return (
             f"[SOURCE SET; exact stored arrays: {schema_text}. "
@@ -302,6 +304,7 @@ def prepare_tool_results_for_prompt(
     paired_url_rewriter: Optional[Callable[[str, ToolCallResultRecord], str]] = None,
     paired_url_step_ids: Optional[Set[str]] = None,
     named_model_tables: Optional[Set[str]] = None,
+    named_model_columns: Optional[Mapping[str, Set[str]]] = None,
 ) -> Dict[str, ToolResultPromptInfo]:
     prompt_info: Dict[str, ToolResultPromptInfo] = {}
     rows: List[Tuple] = []
@@ -311,6 +314,11 @@ def prepare_tool_results_for_prompt(
         fresh_step_ids.add(fresh_tool_call_step_id)
     paired_step_ids = set(paired_url_step_ids or ())
     model_tables = {table.casefold() for table in (named_model_tables or ())}
+    model_columns = {
+        table.casefold(): {column.casefold() for column in columns}
+        for table, columns in (named_model_columns or {}).items()
+        if table.casefold() in model_tables
+    }
     emitted_source_write_hints: set[str] = set()
     emitted_source_import_sets: set[tuple[str, str]] = set()
     emitted_prose_guidance: set[tuple[str, tuple[str, ...]]] = set()
@@ -447,6 +455,7 @@ def prepare_tool_results_for_prompt(
             and is_current_source_batch
         )
         source_import_prefix, source_write_hint_prefix = "", ""
+        refresh_model_tables: set[str] = set()
         requires_source_import = False
         hide_literal_result_id = keep_source_import_hint and bool(_optional_source_array_schemas(analysis))
         if keep_source_import_hint:
@@ -490,12 +499,21 @@ def prepare_tool_results_for_prompt(
                     )
                     emitted_source_import_sets.add(source_import_key)
         if not requires_source_import and hide_literal_result_id:
+            source_schemas = _optional_source_array_schemas(analysis)
+            source_key = source_schemas[0][2] if source_schemas else None
+            if source_key:
+                refresh_model_tables = {
+                    table for table, columns in model_columns.items()
+                    if source_key.casefold() in columns
+                }
             source_write_hint_prefix = _build_optional_source_write_hint(
                 record.tool_name,
                 analysis,
-                tuple(model_tables),
+                tuple(refresh_model_tables),
             )
-        preserve_raw_model_source_values = bool(source_write_hint_prefix and model_tables)
+        preserve_raw_model_source_values = bool(
+            source_write_hint_prefix and refresh_model_tables
+        )
         if source_write_hint_prefix in emitted_source_write_hints:
             source_write_hint_prefix = ""
         elif source_write_hint_prefix:

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -208,37 +208,45 @@ def _optional_source_array_schemas(
 
 
 def _build_optional_source_write_hint(
-    source_batch_id: str,
     tool_name: str,
     analysis: ResultAnalysis | None,
+    model_tables: Sequence[str] = (),
 ) -> str:
-    """Give safe first-write mechanics without requiring a model for one-off work."""
+    """Give source-shape mechanics that fit both new and existing domain models."""
     schemas = _optional_source_array_schemas(analysis)
     if not schemas or len(tool_name) > 100:
         return ""
 
     first_path, _first_schema, first_key = schemas[0]
     first_path = first_path.replace("'", "''")
-    escaped_batch_id = source_batch_id.replace("'", "''")
     escaped_tool_name = tool_name.replace("'", "''")
     def render_hint(schema_text: str) -> str:
-        key_guidance = (
-            f"Use the shown stable key `{first_key}`; canonical row expression "
-            f"`json_extract(j.value,'$.{first_key}')`."
+        key_expr = (
+            f"`json_extract(j.value,'$.{first_key}')`"
             if first_key
-            else "Choose a stable PRIMARY KEY or composite UNIQUE key only from the shown item fields."
+            else "a stable key derived only from shown item fields"
         )
+        if model_tables:
+            table_list = ",".join(sorted(model_tables)[:4])
+            model_guidance = (
+                f"Existing durable tables: {table_list}. Refresh in place; never DELETE/rebuild; preserve schema and "
+                f"unrelated rows. Join its scalar key directly to {key_expr}; use JSON functions only on j.value/result_json, "
+                "not model columns. Introduce every UPDATE alias in FROM/JOIN. "
+            )
+        else:
+            model_guidance = (
+                f"No fitting durable model: create one with {key_expr} as PRIMARY KEY/UNIQUE, then upsert. "
+            )
         return (
             f"[SOURCE SET; exact stored arrays: {schema_text}. "
-            f"New table first: CREATE TABLE IF NOT EXISTS with a stable key. {key_guidance} "
-            "Use rows=[]; never invent result IDs. "
-            "Then upsert in this call with `INSERT ... SELECT` "
-            f"FROM __tool_results AS t, json_each(t.result_json,'{first_path}') AS j "
+            f"{model_guidance}"
+            "Use rows=[]. No pre-read, preview, or bound/copied rows. Current batch plus tool_name is exact; add no "
+            "source_url/result_id/source_batch_id filter. "
+            "Use one set-wise write plus decision SELECT: `FROM __tool_results AS t, "
+            f"json_each(t.result_json,'{first_path}') AS j "
             f"WHERE t.is_current_batch=1 AND t.tool_name='{escaped_tool_name}'. "
-            f"source_batch_id={escaped_batch_id}; do not filter it. Current batch plus tool_name is the exact set. "
-            "Add no source_url/result_id predicate; store t.source_url/t.result_id as provenance. "
-            "Every item field/URL comes from j.value; t.result_id is shared row provenance, never item identity. "
-            "Parent-only fields use t.result_json; siblings differ by derived parent fields. Use all listed paths together.]\n"
+            "Store t.source_url/t.result_id provenance. Item fields/URLs come from j.value; result_id is not item "
+            "identity. Use all paths; final SELECT returns every known item/source URL for links.]\n"
         )
 
     hint = render_hint("; ".join(schema for _path, schema, _key in schemas))
@@ -478,7 +486,12 @@ def prepare_tool_results_for_prompt(
                     )
                     emitted_source_import_sets.add(source_import_key)
         if not requires_source_import and hide_literal_result_id:
-            source_write_hint_prefix = _build_optional_source_write_hint(source_batch_id, record.tool_name, analysis)
+            source_write_hint_prefix = _build_optional_source_write_hint(
+                record.tool_name,
+                analysis,
+                tuple(model_tables),
+            )
+        preserve_raw_model_source_values = bool(source_write_hint_prefix and model_tables)
         if source_write_hint_prefix in emitted_source_write_hints:
             source_write_hint_prefix = ""
         elif source_write_hint_prefix:
@@ -496,7 +509,7 @@ def prepare_tool_results_for_prompt(
             if paired_url_rewriter and record.step_id in paired_step_ids
             else url_rewriter
         )
-        if active_url_rewriter:
+        if active_url_rewriter and not preserve_raw_model_source_values:
             if context_hint:
                 context_hint = active_url_rewriter(context_hint, record)
             if preview_text and not source_import_prefix:

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -234,8 +234,12 @@ def _build_optional_source_write_hint(
                 "not model columns. Introduce every UPDATE alias in FROM/JOIN. "
             )
         else:
+            stable_key_guidance = (
+                f"Use the shown stable key `{first_key}`. " if first_key else ""
+            )
             model_guidance = (
-                f"No fitting durable model: create one with {key_expr} as PRIMARY KEY/UNIQUE, then upsert. "
+                f"No fitting durable model: {stable_key_guidance}create one with {key_expr} "
+                "as PRIMARY KEY/UNIQUE, then upsert. "
             )
         return (
             f"[SOURCE SET; exact stored arrays: {schema_text}. "

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -1178,13 +1178,22 @@ def _rewrite_result_id_comparisons(
         r"|\d+(?:\.\d+)?"
         r")"
     )
+    qualified_operand = (
+        r"(?:"
+        r"json_extract\s*\(\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*\s*,\s*__lit_\d+__\s*\)"
+        r"|:[A-Za-z_]\w*"
+        r"|__lit_\d+__"
+        r"|[A-Za-z_]\w*\.[A-Za-z_]\w*"
+        r"|\d+(?:\.\d+)?"
+        r")"
+    )
     patterns = [
         (
             rf"{col_pattern}\s*=\s*({simple_operand})",
             rf"({column_ref} = \1 OR {compat_ref} = \1)",
         ),
         (
-            rf"({simple_operand})\s*=\s*{col_pattern}",
+            rf"({qualified_operand})\s*=\s*{col_pattern}",
             rf"(\1 = {column_ref} OR \1 = {compat_ref})",
         ),
         (
@@ -1628,6 +1637,20 @@ def _get_error_hint(error_msg: str, sql: str = "") -> str:
                 return (
                     f" FIX: {qualifier} is a json_each alias and exposes only {qualifier}.value. "
                     f"Use json_extract({qualifier}.value, '$.{missing_field}')."
+                )
+            if qualifier and not re.search(
+                rf"\b(?:WITH\s+{re.escape(qualifier)}\s+AS|"
+                rf"AS\s+{re.escape(qualifier)}\b|"
+                rf"(?:FROM|JOIN|UPDATE)\s+{re.escape(qualifier)}\b|"
+                rf"(?:FROM|JOIN)\s+[\w.\"`\[\]-]+\s+{re.escape(qualifier)}\b)",
+                sql,
+                re.IGNORECASE | re.DOTALL,
+            ):
+                return (
+                    f" FIX: alias '{qualifier}' was never introduced. Add its source in FROM or JOIN "
+                    f"before referencing {missing_raw}; for tool-result arrays, introduce it with "
+                    "json_each(t.result_json, '$.actual_array_path') AS "
+                    f"{qualifier}."
                 )
         match = re.search(r'no such column:\s*(\w+)', error_msg, re.IGNORECASE)
         if not match:

--- a/api/agent/tools/sqlite_state.py
+++ b/api/agent/tools/sqlite_state.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shutil
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -181,6 +182,41 @@ def get_sqlite_schema_prompt() -> str:
                 conn.close()
             except Exception:
                 pass
+
+
+def get_sqlite_model_table_columns() -> dict[str, set[str]]:
+    """Return durable agent-model columns for matching source enrichment rows."""
+    db_path = _sqlite_db_path_var.get(None)
+    if not db_path or not os.path.exists(db_path):
+        return {}
+
+    conn = None
+    try:
+        conn = open_guarded_sqlite_connection(db_path)
+        table_rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+        model_columns: dict[str, set[str]] = {}
+        for (table_name,) in table_rows[:MAX_TABLES]:
+            if table_name.startswith("__"):
+                continue
+            quoted_name = table_name.replace('"', '""')
+            column_rows = conn.execute(
+                f'PRAGMA table_info("{quoted_name}")'
+            ).fetchall()
+            model_columns[table_name] = {
+                str(row[1]).casefold() for row in column_rows
+            }
+        return model_columns
+    except (OSError, sqlite3.Error):
+        logger.debug("Failed to inspect SQLite model columns", exc_info=True)
+        return {}
+    finally:
+        if conn is not None:
+            with contextlib.suppress(sqlite3.Error):
+                clear_guarded_connection(conn)
+                conn.close()
 
 
 def get_sqlite_digest_prompt() -> str:

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -2854,7 +2854,8 @@ class SqliteEnrichmentRefreshUnderPressureScenario(SqliteDomainModelScenario):
     ]
     prompt = (
         "I need the launch contact roster now. Refresh our existing contacts from all three completed regional "
-        "exports, then tell me which contacts still lack a verified email and give me the missing count by owner. "
+        "exports, then tell me which contacts still lack a verified email, give me the missing count by owner, and "
+        "link each missing contact's known profile. "
         "Keep the other active threads intact; I'll return to those after this.\n\n"
         + "\n".join(f"- {url}" for url in ENRICHMENT_FEED_URLS)
     )
@@ -3044,7 +3045,7 @@ class SqliteEnrichmentRefreshUnderPressureScenario(SqliteDomainModelScenario):
             (scalar_json_misuse, "plain scalar identity columns were treated as JSON"),
             (not modeled_rows_match, "contact model was incomplete, stale, or missing row provenance"),
             (
-                not re.search(r"\bgroup\s+by\s+owner\b", combined_sql, re.I)
+                not re.search(r"\bgroup\s+by\s+(?:[a-z_]\w*\.)?owner\b", combined_sql, re.I)
                 or not re.search(r"\bverified_email\b[\s\S]*\bis\s+null\b", combined_sql, re.I),
                 "contact model was not queried for missing-email coverage by owner",
             ),

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -29,9 +29,12 @@ from api.evals.registry import register_scenario
 from api.evals.tool_params import resolved_tool_param
 from api.evals.scenarios.effort_calibration import MESSAGE_TOOL_NAMES, STOP_TOOL_NAMES, _outbound_messages_after, _tool_calls_for_run
 from api.models import (
+    CommsChannel,
     EvalRunTask,
     PersistentAgent,
+    PersistentAgentCommsEndpoint,
     PersistentAgentCompletion,
+    PersistentAgentConversation,
     PersistentAgentEnabledTool,
     PersistentAgentMessage,
     PersistentAgentStep,
@@ -55,6 +58,7 @@ SQLITE_SIBLING_RESULT_SET_FIRST_WRITE = "sqlite_sibling_result_set_first_write"
 SQLITE_UNSTRUCTURED_BINDINGS_FIRST_WRITE = "sqlite_unstructured_bindings_first_write"
 SQLITE_INCREMENTAL_DOMAIN_MODEL = "sqlite_incremental_domain_model"
 SQLITE_PROSPECT_PIPELINE_COMPLETES = "sqlite_prospect_pipeline_completes"
+SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE = "sqlite_enrichment_refresh_under_pressure"
 SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_MULTI_RESULT_WEB_SYNTHESIS,
     SQLITE_INTERMEDIATE_WORKING_TABLE,
@@ -70,6 +74,7 @@ SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_UNSTRUCTURED_BINDINGS_FIRST_WRITE,
     SQLITE_INCREMENTAL_DOMAIN_MODEL,
     SQLITE_PROSPECT_PIPELINE_COMPLETES,
+    SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE,
 ]
 
 
@@ -195,6 +200,22 @@ PROSPECT_PROFILE_URLS = (
 PROSPECT_COMPANY_FEED_URL = "https://crm.example.test/staffing/companies.json"
 PROSPECT_PEOPLE_FEED_URL = "https://crm.example.test/staffing/people.json"
 PROSPECT_FEED_URLS = (PROSPECT_COMPANY_FEED_URL, PROSPECT_PEOPLE_FEED_URL)
+ENRICHMENT_FEED_URLS = (
+    "https://directory.example.test/enrichment/east.json",
+    "https://directory.example.test/enrichment/central.json",
+    "https://directory.example.test/enrichment/west.json",
+)
+ENRICHED_CONTACTS = (
+    ("contact-101", "Mina Patel", "Aster Forge", "Priya Shah", "mina@aster.example.test"),
+    ("contact-102", "Jonah Reed", "Bramble Health", "Priya Shah", None),
+    ("contact-103", "Leo Martin", "Cinderline", "Priya Shah", "leo@cinderline.example.test"),
+    ("contact-201", "Naomi Brooks", "Lattice Harbor", "Mateo Ruiz", "naomi@lattice.example.test"),
+    ("contact-202", "Evan Cho", "Quarry Labs", "Mateo Ruiz", None),
+    ("contact-203", "Sofia Alvarez", "Ternary Field", "Mateo Ruiz", "sofia@ternary.example.test"),
+    ("contact-301", "Maya Chen", "Umbra Works", "Hana Lee", "maya@umbra.example.test"),
+    ("contact-302", "Rowan Kim", "Driftwood Robotics", "Hana Lee", "rowan@driftwood.example.test"),
+    ("contact-303", "Avery Cole", "Northstar Systems", "Hana Lee", None),
+)
 INITIATIVES = (
     ("init-checkout", "Checkout Recovery", "active", "revenue"),
     ("init-search", "Search Relevance", "active", "discovery"),
@@ -987,6 +1008,97 @@ def _prospect_pipeline_mock() -> dict:
             "default": {"status": "error", "message": "Unknown eval URL."},
         }
     }
+
+
+def _enrichment_pressure_mock() -> dict:
+    rules = []
+    for index, url in enumerate(ENRICHMENT_FEED_URLS):
+        batch = ENRICHED_CONTACTS[index * 3:(index + 1) * 3]
+        rules.append({
+            "url_contains": url,
+            "result": {
+                "status": "ok",
+                "status_code": 200,
+                "url": url,
+                "content": {
+                    "matches": [
+                        {
+                            "provider_id": provider_id,
+                            "full_name": full_name,
+                            "account_name": account_name,
+                            "owner": owner,
+                            "verified_email": email,
+                            "profile_url": (
+                                "https://profiles.example.test/people/"
+                                f"{provider_id}"
+                            ),
+                        }
+                        for provider_id, full_name, account_name, owner, email in batch
+                    ],
+                },
+            },
+        })
+    return {
+        "http_request": {
+            "rules": rules,
+            "default": {"status": "error", "message": "Unknown eval URL."},
+        }
+    }
+
+
+def _seed_pressure_history(agent: PersistentAgent, run_id: str) -> None:
+    """Create realistic background traffic without making it part of the active request."""
+    run_token = str(run_id).replace("-", "")[:8]
+    thread_specs = (
+        (
+            CommsChannel.DISCORD,
+            f"discord://eval/launch-ops-{run_token}",
+            f"discord://eval/priya-{run_token}",
+            "Priya: I own the latency review and will post the verified cause here.",
+            24,
+        ),
+        (
+            CommsChannel.EMAIL,
+            f"renewals-{run_id}@eval.example.test",
+            f"finance-{run_id}@eval.example.test",
+            "For tomorrow: please reconcile the renewal forecast after today's launch roster is complete.",
+            20,
+        ),
+        (
+            CommsChannel.DISCORD,
+            f"discord://eval/customer-escalations-{run_token}",
+            f"discord://eval/mateo-{run_token}",
+            "Mateo: the customer escalation is contained; support owns the follow-up.",
+            16,
+        ),
+        (
+            CommsChannel.SMS,
+            f"+1555000{run_token[:4]}",
+            f"+1555111{run_token[:4]}",
+            "Hana: I uploaded the west-region export and am checking its source freshness.",
+            12,
+        ),
+    )
+    for channel, conversation_address, sender_address, body, age_minutes in thread_specs:
+        conversation = PersistentAgentConversation.objects.create(
+            channel=channel,
+            address=conversation_address,
+            owner_agent=agent,
+        )
+        sender = PersistentAgentCommsEndpoint.objects.create(
+            channel=channel,
+            address=sender_address,
+        )
+        message = PersistentAgentMessage.objects.create(
+            owner_agent=agent,
+            from_endpoint=sender,
+            conversation=conversation,
+            is_outbound=False,
+            body=body,
+        )
+        PersistentAgentMessage.objects.filter(id=message.id).update(
+            timestamp=timezone.now() - timedelta(minutes=age_minutes),
+        )
 
 
 MOCK_BUILDERS = {
@@ -2717,6 +2829,241 @@ class SqliteProspectPipelineCompletesScenario(SqliteDomainModelScenario):
             task_name,
             failures,
             f"Modeled {sorted(model_tables)}, queried the company-person relationship, and delivered after sourcing.",
+        )
+
+
+@register_scenario
+class SqliteEnrichmentRefreshUnderPressureScenario(SqliteDomainModelScenario):
+    slug = SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE
+    description = (
+        "An agent carrying unrelated cross-channel traffic should refresh an existing domain model from every "
+        "same-shaped enrichment result in one clean set-wise pass."
+    )
+    expected_runtime = "medium"
+    tags = (
+        *SqliteToolResultScenario.tags,
+        "trajectory_regression",
+        "set_wise_import",
+        "multi_channel_pressure",
+        "existing_model_refresh",
+    )
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_pressure_refresh", assertion_type="tool_call"),
+        ScenarioTask(name="verify_missing_contact_answer", assertion_type="manual"),
+    ]
+    prompt = (
+        "I need the launch contact roster now. Refresh our existing contacts from all three completed regional "
+        "exports, then tell me which contacts still lack a verified email and give me the missing count by owner. "
+        "Keep the other active threads intact; I'll return to those after this.\n\n"
+        + "\n".join(f"- {url}" for url in ENRICHMENT_FEED_URLS)
+    )
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._ready_agent(agent_id)
+        agent = PersistentAgent.objects.get(id=agent_id)
+        PersistentAgent.objects.filter(id=agent_id).update(
+            charter=(
+                "Maintain the launch contact model while coordinating work across the owner, operations, support, "
+                "and finance channels. Preserve explicit ownership and priority."
+            ),
+        )
+        _seed_pressure_history(agent, run_id)
+        with agent_sqlite_db(str(agent_id)) as db_path:
+            conn = open_guarded_sqlite_connection(db_path)
+            try:
+                conn.execute(
+                    """
+                    CREATE TABLE contacts(
+                        provider_id TEXT PRIMARY KEY,
+                        full_name TEXT,
+                        account_name TEXT,
+                        owner TEXT NOT NULL,
+                        verified_email TEXT,
+                        profile_url TEXT,
+                        source_url TEXT,
+                        result_id TEXT
+                    );
+                    """
+                )
+                conn.executemany(
+                    """
+                    INSERT INTO contacts(provider_id, owner)
+                    VALUES (?, ?);
+                    """,
+                    [(provider_id, owner) for provider_id, _name, _account, owner, _email in ENRICHED_CONTACTS],
+                )
+                conn.commit()
+            finally:
+                clear_guarded_connection(conn)
+                conn.close()
+        self._enable_tools(agent_id, ("http_request",))
+        inbound = self._inject_and_wait(
+            run_id,
+            agent_id,
+            self.prompt,
+            _enrichment_pressure_mock(),
+            allowed_tool_names={
+                "http_request",
+                "sqlite_batch",
+                "send_chat_message",
+                "update_plan",
+            },
+            max_relevant_tool_calls=16,
+        )
+        self._record_pressure_refresh(run_id, agent_id=agent_id, after=inbound.timestamp)
+        missing = tuple(
+            f"https://profiles.example.test/people/{provider_id}"
+            for provider_id, _name, _account, _owner, email in ENRICHED_CONTACTS
+            if email is None
+        )
+        self._record_sourced_answer(
+            run_id,
+            agent_id=agent_id,
+            after=inbound.timestamp,
+            task_name="verify_missing_contact_answer",
+            source_urls=missing,
+            required_terms=("Jonah Reed", "Evan Cho", "Avery Cole", "3"),
+            min_sources=3,
+        )
+
+    def _record_pressure_refresh(self, run_id: str, *, agent_id: str, after) -> None:
+        task_name = "verify_pressure_refresh"
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name=task_name)
+        calls = _tool_calls_for_run(run_id, after=after)
+        source_calls = [call for call in calls if call.tool_name == "http_request"]
+        sqlite_attempts = [call for call in calls if call.tool_name == "sqlite_batch"]
+        successful_sqlite = [
+            call for call in sqlite_attempts
+            if str(getattr(call, "status", "")).casefold() == "complete"
+            and str((_result_payload(call) or {}).get("status") or "").casefold() == "ok"
+        ]
+        sql_values = [str((call.tool_params or {}).get("sql") or "") for call in successful_sqlite]
+        combined_sql = "\n".join(sql_values)
+        model_write_calls = [
+            call for call in successful_sqlite
+            if "contacts" in source_derived_model_mutation_tables(
+                (str((call.tool_params or {}).get("sql") or ""),)
+            )
+        ]
+        summary = summarize_sqlite_tool_result_calls(successful_sqlite)
+        source_positions = [
+            index for index, call in enumerate(calls)
+            if call.tool_name == "http_request"
+            and str(getattr(call, "status", "")).casefold() == "complete"
+        ]
+        model_write_positions = [
+            index for index, call in enumerate(calls)
+            if call in model_write_calls
+        ]
+        terminal_positions = [
+            index for index, call in enumerate(calls)
+            if call.tool_name == "send_chat_message"
+            and resolved_tool_param(call, "will_continue_work") is False
+            and str(getattr(call, "status", "")).casefold() == "complete"
+            and not (_result_payload(call) or {}).get("skipped")
+        ]
+        fetch_counts = _source_fetch_counts(
+            source_calls,
+            tool_names={"http_request"},
+            source_urls=ENRICHMENT_FEED_URLS,
+        )
+        scalar_json_misuse = bool(
+            re.search(
+                r"\bjson\s*\(\s*(?:[a-z_]\w*\.)?(?:provider_id|result_id)\s*\)"
+                r"|\bjson_extract\s*\(\s*(?:[a-z_]\w*\.)?(?:provider_id|result_id)\b",
+                combined_sql,
+                re.I,
+            )
+        )
+        with agent_sqlite_db(str(agent_id)) as db_path:
+            conn = open_guarded_sqlite_connection(db_path)
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT provider_id, full_name, account_name, owner, verified_email,
+                           profile_url, source_url, result_id
+                    FROM contacts
+                    ORDER BY provider_id;
+                    """
+                ).fetchall()
+            finally:
+                clear_guarded_connection(conn)
+                conn.close()
+        expected_rows = [
+            (
+                provider_id,
+                full_name,
+                account_name,
+                owner,
+                email,
+                f"https://profiles.example.test/people/{provider_id}",
+            )
+            for provider_id, full_name, account_name, owner, email in ENRICHED_CONTACTS
+        ]
+        modeled_rows_match = (
+            len(rows) == len(expected_rows)
+            and all(
+                row[:6] == expected
+                and row[6] in ENRICHMENT_FEED_URLS
+                and bool(row[7])
+                for row, expected in zip(rows, expected_rows)
+            )
+        )
+        failures = _tool_attempt_failures(source_calls, "Enrichment fetch")
+        failures.extend(_sqlite_attempt_failures(sqlite_attempts))
+        failures.extend(message for failed, message in (
+            (
+                any(count != 1 for count in fetch_counts.values()),
+                f"expected each enrichment feed once, found {fetch_counts}",
+            ),
+            (
+                len(model_write_calls) != 1,
+                f"expected one source-derived contact refresh, found {len(model_write_calls)}",
+            ),
+            (
+                bool(source_positions)
+                and bool(model_write_positions)
+                and model_write_positions[0] <= max(source_positions),
+                "contact refresh began before every regional result was available",
+            ),
+            (
+                summary.aggregate_tool_result_queries < 1,
+                "regional enrichment siblings were not handled as one source set",
+            ),
+            (
+                summary.single_result_id_filters > 0,
+                f"regional results were handled one result_id at a time ({summary.single_result_id_filters})",
+            ),
+            (
+                not re.search(r"\bis_current_batch\b\s*=\s*1", combined_sql, re.I)
+                or not re.search(r"\btool_name\b\s*=\s*'http_request'", combined_sql, re.I)
+                or not re.search(r"\bjson_each\s*\([^;]*\$\.(?:content\.)?matches", combined_sql, re.I),
+                "contact refresh did not use the complete typed current-source shape",
+            ),
+            (scalar_json_misuse, "plain scalar identity columns were treated as JSON"),
+            (not modeled_rows_match, "contact model was incomplete, stale, or missing row provenance"),
+            (
+                not re.search(r"\bgroup\s+by\s+owner\b", combined_sql, re.I)
+                or not re.search(r"\bverified_email\b[\s\S]*\bis\s+null\b", combined_sql, re.I),
+                "contact model was not queried for missing-email coverage by owner",
+            ),
+            (
+                len(terminal_positions) != 1,
+                f"expected one terminal roster report, found {len(terminal_positions)}",
+            ),
+            (
+                bool(terminal_positions)
+                and bool(model_write_positions)
+                and terminal_positions[0] <= model_write_positions[-1],
+                "agent reported before refreshing the contact model",
+            ),
+        ) if failed)
+        self._record_check(
+            run_id,
+            task_name,
+            failures,
+            "Kept cross-channel work intact and refreshed every contact from all sibling exports in one clean set.",
         )
 
 

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -2502,6 +2502,75 @@ class SqliteBatchAutocorrectTests(SqliteBatchTestCase):
             self.assertEqual(out.get("status"), "ok", out.get("message"))
             self.assertEqual(out["results"][0]["result"], [{"vendor": "AxonFlow", "ok": 1}])
 
+    def test_tool_results_legacy_compat_does_not_rewrite_update_assignments(self):
+        with self._with_temp_db() as (db_path, _token, _tmp):
+            with sqlite3.connect(db_path) as conn:
+                conn.executescript(
+                    """
+                    CREATE TABLE __tool_results (
+                        result_id TEXT PRIMARY KEY,
+                        legacy_result_id TEXT,
+                        tool_name TEXT,
+                        is_current_batch INTEGER,
+                        source_url TEXT,
+                        result_json TEXT
+                    );
+                    CREATE TABLE contacts (
+                        provider_id TEXT PRIMARY KEY,
+                        full_name TEXT,
+                        source_url TEXT,
+                        result_id TEXT
+                    );
+                    INSERT INTO contacts(provider_id) VALUES ('contact-1');
+                    """
+                )
+                conn.execute(
+                    "INSERT INTO __tool_results VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        "short-1",
+                        "legacy-1",
+                        "http_request",
+                        1,
+                        "https://source.example.test/one",
+                        json.dumps({
+                            "content": {
+                                "matches": [{
+                                    "provider_id": "contact-1",
+                                    "full_name": "Ari Bell",
+                                }],
+                            },
+                        }),
+                    ),
+                )
+
+            out = execute_sqlite_batch(
+                self.agent,
+                {
+                    "sql": (
+                        "UPDATE contacts SET "
+                        "full_name=json_extract(j.value,'$.full_name'),"
+                        "source_url=t.source_url,result_id=t.result_id "
+                        "FROM __tool_results AS t,"
+                        "json_each(t.result_json,'$.content.matches') AS j "
+                        "WHERE t.is_current_batch=1 "
+                        "AND contacts.provider_id=json_extract(j.value,'$.provider_id');"
+                        "SELECT provider_id,full_name,source_url,result_id FROM contacts;"
+                    ),
+                    "rows": [],
+                },
+            )
+
+        self.assertEqual(out.get("status"), "ok", out.get("message"))
+        self.assertEqual(
+            out["results"][-1]["result"],
+            [{
+                "provider_id": "contact-1",
+                "full_name": "Ari Bell",
+                "source_url": "https://source.example.test/one",
+                "result_id": "short-1",
+            }],
+        )
+
     def test_autocorrect_missing_column_with_schema_unqualified(self):
         """Auto-corrects unqualified column names using schema."""
         with self._with_temp_db():
@@ -2820,6 +2889,28 @@ class SqliteBatchAutocorrectTests(SqliteBatchTestCase):
         self.assertIn("r is a json_each alias", hint)
         self.assertIn("r.value", hint)
         self.assertIn("json_extract(r.value, '$.result_id')", hint)
+
+    def test_missing_qualified_alias_hint_does_not_misdiagnose_schema(self):
+        hint = _get_error_hint(
+            "no such column: m.value",
+            (
+                "UPDATE contacts SET full_name=json_extract(m.value,'$.full_name') "
+                "WHERE provider_id=json_extract(m.value,'$.provider_id')"
+            ),
+        )
+
+        self.assertIn("alias 'm' was never introduced", hint)
+        self.assertIn("FROM or JOIN", hint)
+        self.assertNotIn("PRAGMA table_info", hint)
+
+    def test_missing_qualified_column_hint_respects_declared_alias(self):
+        hint = _get_error_hint(
+            "no such column: m.value",
+            "UPDATE contacts AS m SET full_name=m.value",
+        )
+
+        self.assertNotIn("alias 'm' was never introduced", hint)
+        self.assertIn("PRAGMA table_info", hint)
 
     def test_fix_unescaped_single_quote_runs(self):
         """Balances odd-length runs of single quotes."""

--- a/tests/unit/test_sqlite_schema_prompt.py
+++ b/tests/unit/test_sqlite_schema_prompt.py
@@ -5,7 +5,12 @@ import tempfile
 
 from django.test import TestCase, tag
 
-from api.agent.tools.sqlite_state import get_sqlite_schema_prompt, reset_sqlite_db_path, set_sqlite_db_path
+from api.agent.tools.sqlite_state import (
+    get_sqlite_model_table_columns,
+    get_sqlite_schema_prompt,
+    reset_sqlite_db_path,
+    set_sqlite_db_path,
+)
 
 
 @tag("batch_sqlite")
@@ -69,3 +74,16 @@ class SqliteSchemaPromptTests(TestCase):
         self.assertRegex(prompt, r"csv_blob.*csv")
         # Notes column may or may not detect email pattern depending on analysis
         self.assertIn("notes", prompt)
+
+    def test_model_columns_include_durable_tables_only(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("CREATE TABLE __internal (secret TEXT)")
+            conn.commit()
+        finally:
+            conn.close()
+
+        self.assertEqual(
+            get_sqlite_model_table_columns(),
+            {"events": {"id", "payload", "notes", "csv_blob"}},
+        )

--- a/tests/unit/test_sqlite_source_array_eval.py
+++ b/tests/unit/test_sqlite_source_array_eval.py
@@ -7,12 +7,14 @@ import api.evals.loader  # noqa: F401 - registers scenarios and suites
 from api.agent.tools.sqlite_query_quality import summarize_sqlite_tool_result_sql
 from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.sqlite_tool_results import (
+    SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE,
     SQLITE_INCREMENTAL_DOMAIN_MODEL,
     SQLITE_SIBLING_RESULT_SET_FIRST_WRITE,
     SQLITE_SOURCE_ARRAY_FIRST_WRITE,
     SQLITE_TOOL_RESULT_SCENARIO_SLUGS,
     SQLITE_TOOL_RESULT_SUITE_SLUG,
     SQLITE_UNSTRUCTURED_BINDINGS_FIRST_WRITE,
+    SqliteEnrichmentRefreshUnderPressureScenario,
     SqliteIncrementalDomainModelScenario,
     SqliteIntermediateWorkingTableScenario,
     SqliteSiblingResultSetFirstWriteScenario,
@@ -149,6 +151,25 @@ class SqliteSourceArrayEvalTests(SimpleTestCase):
             ],
         )
         prompt = SqliteIncrementalDomainModelScenario.prompt.casefold()
+        for leaked_term in ("sqlite", "__tool_results", "json_each", "insert", "select", "table"):
+            self.assertNotIn(leaked_term, prompt)
+
+    def test_pressure_refresh_case_is_registered_without_teaching_sql(self):
+        suite = SuiteRegistry.get(SQLITE_TOOL_RESULT_SUITE_SLUG)
+        scenario = ScenarioRegistry.get(SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE)
+
+        self.assertIsNotNone(scenario)
+        self.assertIn(SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE, SQLITE_TOOL_RESULT_SCENARIO_SLUGS)
+        self.assertIn(SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE, suite.scenario_slugs)
+        self.assertEqual(
+            [task.name for task in scenario.tasks],
+            [
+                "inject_prompt",
+                "verify_pressure_refresh",
+                "verify_missing_contact_answer",
+            ],
+        )
+        prompt = SqliteEnrichmentRefreshUnderPressureScenario.prompt.casefold()
         for leaked_term in ("sqlite", "__tool_results", "json_each", "insert", "select", "table"):
             self.assertNotIn(leaked_term, prompt)
 

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -1106,19 +1106,19 @@ class PreviewByteLimitTests(SimpleTestCase):
         for expected in (
             "[SOURCE SET; exact stored arrays:",
             "exact stored arrays: $.content.prospects(name,title,profile_url)",
-            "New table first: CREATE TABLE IF NOT EXISTS with a stable key",
-            "Use the shown stable key `profile_url`",
+            "No fitting durable model: create one",
             "`json_extract(j.value,'$.profile_url')`",
             "Use rows=[]",
-            "never invent result IDs",
-            "Then upsert in this call with `INSERT ... SELECT`",
+            "No pre-read, preview, or bound/copied rows",
+            "add no source_url/result_id/source_batch_id filter",
+            "Use one set-wise write plus decision SELECT",
             "FROM __tool_results AS t, json_each(t.result_json,'$.content.prospects') AS j",
             "WHERE t.is_current_batch=1 AND t.tool_name='http_request'",
-            "Current batch plus tool_name is the exact set",
-            "Add no source_url/result_id predicate",
-            "store t.source_url/t.result_id as provenance",
-            "Every item field/URL comes from j.value",
-            "siblings differ by derived parent fields",
+            "Current batch plus tool_name is exact",
+            "Store t.source_url/t.result_id provenance",
+            "Item fields/URLs come from j.value",
+            "Use all paths",
+            "final SELECT returns every known item/source URL for links",
         ):
             self.assertIn(expected, info.meta)
         self.assertNotIn("[SOURCE ARRAYS", info.preview_text)
@@ -1127,6 +1127,61 @@ class PreviewByteLimitTests(SimpleTestCase):
         self.assertNotIn("result_id=", info.meta)
         self.assertNotIn("json_extract(j.value,'$.id')", info.meta)
         self.assertIsNone(info.source_reconciliation_directive)
+
+    def test_generic_enrichment_array_gets_existing_model_refresh_shape(self):
+        payload = {
+            "status": "ok",
+            "content": {
+                "matches": [{
+                    "provider_id": "contact-101",
+                    "full_name": "Ari Bell",
+                    "verified_email": "ari@example.test",
+                }],
+            },
+        }
+        info, _record = self._prepare_http_result(
+            "step-enrichment",
+            payload,
+            named_model_tables={"contacts"},
+        )
+
+        for expected in (
+            "Existing durable tables: contacts",
+            "Refresh in place",
+            "never DELETE/rebuild",
+            "preserve schema and unrelated rows",
+            "Join its scalar key directly to `json_extract(j.value,'$.provider_id')`",
+            "use JSON functions only on j.value/result_json, not model columns",
+            "Introduce every UPDATE alias in FROM/JOIN",
+            "WHERE t.is_current_batch=1 AND t.tool_name='http_request'",
+        ):
+            self.assertIn(expected, info.meta)
+        self.assertNotIn("New table first", info.meta)
+
+    def test_existing_model_source_preview_keeps_raw_urls_for_sql(self):
+        payload = {
+            "status": "ok",
+            "content": {
+                "matches": [{
+                    "provider_id": "contact-101",
+                    "profile_url": "https://example.test/people/contact-101",
+                }],
+            },
+        }
+        info, _record = self._prepare_http_result(
+            "step-enrichment-link",
+            payload,
+            named_model_tables={"contacts"},
+            paired_url_rewriter=lambda text, _record: text.replace(
+                "https://example.test/people/contact-101",
+                "https://example.test/people/contact-101 [link_ref: $[link:CONTACT]]",
+            ),
+            paired_url_step_ids={"step-enrichment-link"},
+        )
+
+        self.assertIn("https://example.test/people/contact-101", info.preview_text)
+        self.assertNotIn("link_ref", info.preview_text)
+        self.assertNotIn("VERIFIED LINK PRESENTATION", info.preview_text)
 
     def test_source_write_hint_uses_the_actual_array_identity(self):
         payload = {
@@ -1199,10 +1254,11 @@ class PreviewByteLimitTests(SimpleTestCase):
         self.assertFalse(info[records[0].step_id].suppress_from_prompt)
         source_set_meta = "\n".join(item.meta for item in info.values())
         self.assertEqual(source_set_meta.count("[SOURCE SET"), 1)
-        self.assertIn("source_batch_id=batch-current", source_set_meta)
+        self.assertNotIn("source_batch_id=batch-current", source_set_meta)
         self.assertNotIn("source_batch_id=batch-historical", source_set_meta)
+        self.assertIn("add no source_url/result_id/source_batch_id filter", source_set_meta)
         self.assertIn("is_current_batch=1", source_set_meta)
-        self.assertIn("t.result_id is shared row provenance, never item identity", source_set_meta)
+        self.assertIn("result_id is not item identity", source_set_meta)
 
         modeled = tool_results.prepare_tool_results_for_prompt(
             records,
@@ -1268,7 +1324,7 @@ class PreviewByteLimitTests(SimpleTestCase):
 
         hint = info.meta.split("]\n", 1)[0] + "]\n"
         schema_list = hint.split("exact stored arrays: ", 1)[1].split(
-            ". New table first", 1
+            ". No fitting durable model", 1
         )[0]
         self.assertLessEqual(len(schema_list.split("; ")), tool_results.MAX_OPTIONAL_SOURCE_ARRAYS)
         self.assertLessEqual(len(hint), tool_results.MAX_OPTIONAL_SOURCE_HINT_CHARS)
@@ -1297,10 +1353,10 @@ class PreviewByteLimitTests(SimpleTestCase):
         hint = info.meta.split("]\n", 1)[0] + "]\n"
         self.assertIn("[SOURCE SET", hint)
         self.assertIn("$.content.events", hint)
-        self.assertIn("CREATE TABLE IF NOT EXISTS with a stable key", hint)
-        self.assertIn("Use the shown stable key `release_id`", hint)
-        self.assertIn("upsert in this call with `INSERT ... SELECT`", hint)
-        self.assertIn("Every item field/URL comes from j.value", hint)
+        self.assertIn("No fitting durable model: create one", hint)
+        self.assertIn("`json_extract(j.value,'$.release_id')` as PRIMARY KEY/UNIQUE", hint)
+        self.assertIn("Use one set-wise write plus decision SELECT", hint)
+        self.assertIn("Item fields/URLs come from j.value", hint)
         self.assertLessEqual(len(hint), tool_results.MAX_OPTIONAL_SOURCE_HINT_CHARS)
 
     def test_four_source_parallel_batch_keeps_each_brief_preview_visible(self):

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -1143,6 +1143,9 @@ class PreviewByteLimitTests(SimpleTestCase):
             "step-enrichment",
             payload,
             named_model_tables={"contacts"},
+            named_model_columns={
+                "contacts": {"provider_id", "full_name", "verified_email"},
+            },
         )
 
         for expected in (
@@ -1172,6 +1175,7 @@ class PreviewByteLimitTests(SimpleTestCase):
             "step-enrichment-link",
             payload,
             named_model_tables={"contacts"},
+            named_model_columns={"contacts": {"provider_id", "profile_url"}},
             paired_url_rewriter=lambda text, _record: text.replace(
                 "https://example.test/people/contact-101",
                 "https://example.test/people/contact-101 [link_ref: $[link:CONTACT]]",
@@ -1182,6 +1186,26 @@ class PreviewByteLimitTests(SimpleTestCase):
         self.assertIn("https://example.test/people/contact-101", info.preview_text)
         self.assertNotIn("link_ref", info.preview_text)
         self.assertNotIn("VERIFIED LINK PRESENTATION", info.preview_text)
+
+    def test_generic_source_does_not_refresh_an_unrelated_model(self):
+        payload = {
+            "status": "ok",
+            "content": {
+                "prospects": [{
+                    "provider_id": "contact-101",
+                    "full_name": "Ari Bell",
+                }],
+            },
+        }
+        info, _record = self._prepare_http_result(
+            "step-unrelated-model",
+            payload,
+            named_model_tables={"accounts"},
+            named_model_columns={"accounts": {"account_id", "company_name"}},
+        )
+
+        self.assertIn("No fitting durable model", info.meta)
+        self.assertNotIn("Existing durable tables: accounts", info.meta)
 
     def test_source_write_hint_uses_the_actual_array_identity(self):
         payload = {


### PR DESCRIPTION
## Outcome

Fixes a backend corruption bug and tightens the dynamic source contract used when agents refresh an existing SQLite domain model.

- Valid `UPDATE ... SET result_id=t.result_id ... FROM __tool_results t` statements now reach SQLite unchanged. The legacy-ID compatibility pass previously rewrote the SET assignment as a boolean predicate and produced `near "=": syntax error`.
- Generic enrichment arrays such as `$.content.matches` now tell the model to refresh the fitting durable table set-wise, preserve unrelated rows, use scalar keys correctly, and return known URLs.
- Existing-model source previews retain raw URLs instead of contaminating SQL-visible values with presentation-only `link_ref` tokens.
- Undefined SQL aliases get an accurate recovery hint instead of irrelevant schema-guessing advice.
- Adds a trajectory-shaped pressure eval with three sibling exports plus unrelated Discord, email, and SMS traffic.

The production change remains focused at roughly 150 lines; most of the diff is the pressure eval and focused regression coverage. Source refresh guidance now also proves table compatibility from the durable schema before naming a refresh target.

## Root cause

The production trajectory showed a generic `matches` array beside an existing contacts model, but the dynamic contract still described a new-table workflow. The agent invented an undeclared alias and recovered with split sibling updates. During the red-to-green work, the exact valid one-shot UPDATE also exposed the deeper deterministic defect: `_apply_tool_results_result_id_compat` treated a SET assignment as a comparison and rewrote it into invalid SQL before execution.

## Verification

- Deterministic red unit reproduced the assignment corruption on main; green after the rewriter fix. Existing legacy-ID WHERE/JOIN compatibility remains green.
- 70 focused tool-results and SQLite-schema tests: green, plus the targeted SQL compatibility tests.
- DeepSeek V4 Flash real harness after rebase:
  - `sqlite_enrichment_refresh_under_pressure`: 3/3 tasks, suite `70d851f3-2912-4ed6-bac3-392231e5dea7`
  - `sqlite_sibling_result_set_first_write`: 3/3 tasks, suite `d794f7b2-d916-45de-85f5-075a6032dfd4`
  - `sqlite_source_array_first_write`: 4/4 tasks, suite `adf4df56-0226-46d8-acf0-96064f2763e2`
- Source LoC and rendered prompt budgets: green. Stable core prompt byte totals are unchanged.
- Per repository guidance, no global Django suite was run locally.

## Measurement note

I stopped the long repeated stochastic comparison to keep this mergeable during the active dev window. This PR does not claim a statistically proven prompt-performance delta. The backend SQL corruption fix and raw-URL input correction are deterministic, regression-tested improvements; the live harness checks confirm the final path works end to end.