### PR TITLE
Make explicit charter corrections reliably durable

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -329,6 +329,11 @@ OPERATIONAL_CAPABILITY_CORRECTION_RE = re.compile(
     r"[^.!?]{0,120}\b(?:credentials?|secrets?|integrations?|permissions?|environment variables?|env vars?)\b",
     re.IGNORECASE,
 )
+EXPLICIT_CHARTER_CHANGE_RE = re.compile(
+    r"\b(?:update|change|patch|edit|revise|adjust|amend|rewrite)\s+(?:(?:your|the)\s+)?"
+    r"(?:charter|instructions)\b",
+    re.IGNORECASE,
+)
 STRONG_DURABLE_CONFIG_INTENT_RE = re.compile(
     r"\b(?:going forward|from now on|in the future|next time|always|never(?!\s+mind\b)|remember|"
     r"(?:my |this )?feedback:|each time|every time|make (?:that|this|it) a rule|should(?:n'?t| not) have to|"
@@ -2709,14 +2714,22 @@ def _user_text_has_durable_config_intent(text: str) -> bool:
     normalized = " ".join((text or "").split())
     if TRANSIENT_CONFIG_SCOPE_RE.search(normalized) and not STRONG_DURABLE_CONFIG_INTENT_RE.search(normalized):
         return False
-    return bool(STRONG_DURABLE_CONFIG_INTENT_RE.search(normalized) or PREFERENCE_CONFIG_INTENT_RE.search(normalized))
+    return bool(
+        EXPLICIT_CHARTER_CHANGE_RE.search(normalized)
+        or STRONG_DURABLE_CONFIG_INTENT_RE.search(normalized)
+        or PREFERENCE_CONFIG_INTENT_RE.search(normalized)
+    )
 
 
 def _matches_behavior_feedback(text: str, prior_outbound_text: str = "") -> bool:
     quote = QUOTED_OUTPUT_FEEDBACK_RE.search(text or "")
     if prior_outbound_text and quote and " ".join(quote.group("quote").casefold().split()) in " ".join(prior_outbound_text.casefold().split()):
         return True
-    direct = DIRECT_USER_CORRECTION_RE.search(text) or OPERATIONAL_CAPABILITY_CORRECTION_RE.search(text)
+    direct = (
+        DIRECT_USER_CORRECTION_RE.search(text)
+        or OPERATIONAL_CAPABILITY_CORRECTION_RE.search(text)
+        or EXPLICIT_CHARTER_CHANGE_RE.search(text)
+    )
     tone = TONE_CORRECTION_RE.search(text)
     evaluative = EVALUATIVE_BEHAVIOR_FEEDBACK_RE.search(text)
     preference = PREFERENCE_CONFIG_INTENT_RE.search(text) and BEHAVIOR_OUTPUT_NOUN_RE.search(text)
@@ -2745,11 +2758,19 @@ def _analyze_feedback_turn(text: str, prior_outbound_text: str = "") -> _Feedbac
     no_save_marker = NO_DURABLE_CONFIG_RE.search(normalized)
     transient_marker = TRANSIENT_CONFIG_SCOPE_RE.search(normalized)
     lasting: list[str] = []
-    temporary_scope = durable_scope_active = saw_feedback = direct_reply_task = separate_task = False
+    temporary_scope = durable_scope_active = explicit_charter_scope_active = False
+    saw_feedback = direct_reply_task = separate_task = False
     feedback_only = True
     for clause in clauses:
+        explicit_charter_change = EXPLICIT_CHARTER_CHANGE_RE.search(clause)
         direct_reply = DIRECT_FEEDBACK_REPLY_TASK_RE.search(clause)
-        separate_matches = tuple(SEPARATE_FEEDBACK_TASK_RE.finditer(clause))
+        if direct_reply and explicit_charter_change and direct_reply.start() < explicit_charter_change.end():
+            direct_reply = None
+        separate_matches = tuple(
+            match
+            for match in SEPARATE_FEEDBACK_TASK_RE.finditer(clause)
+            if not (explicit_charter_change and match.start() < explicit_charter_change.end())
+        )
         if separate_matches and EXPLICIT_DURABLE_SCOPE_RE.fullmatch(
             clause[:separate_matches[0].start()].strip(" ,:;")
         ):
@@ -2759,10 +2780,17 @@ def _analyze_feedback_turn(text: str, prior_outbound_text: str = "") -> _Feedbac
         task = direct_reply or separate
         candidate = clause[:task.start()].rstrip(" ,;") if task else clause
         candidate_behavior = _matches_behavior_feedback(candidate, prior_outbound_text)
-        continuation = bool(durable_scope_active and re.match(
-            r"\s*(?:and\s+)?(?:routine\b|only\b|just\b|never\b|always\b|remember\b|keep\b|do not\b|don['’]?t\b|no\b|the\b|these\b|those\b|my\b|your\b|i\b|when\b|if\b|for\b)",
-            candidate, re.IGNORECASE,
-        ))
+        continuation = bool(
+            explicit_charter_scope_active
+            or (
+                durable_scope_active
+                and re.match(
+                    r"\s*(?:and\s+)?(?:routine\b|only\b|just\b|never\b|always\b|remember\b|keep\b|do not\b|don['’]?t\b|no\b|the\b|these\b|those\b|my\b|your\b|i\b|when\b|if\b|for\b)",
+                    candidate,
+                    re.IGNORECASE,
+                )
+            )
+        )
         direct_reply_task = direct_reply_task or bool(direct_reply)
         separate_task = separate_task or distinct_task
         if direct_reply:
@@ -2774,6 +2802,9 @@ def _analyze_feedback_turn(text: str, prior_outbound_text: str = "") -> _Feedbac
         elif candidate_behavior:
             saw_feedback = True
             durable_scope_active = durable_scope_active or bool(EXPLICIT_DURABLE_SCOPE_RE.search(clause))
+            explicit_charter_scope_active = (
+                explicit_charter_scope_active or bool(EXPLICIT_CHARTER_CHANGE_RE.search(clause))
+            )
         elif NO_DURABLE_CONFIG_RE.search(clause) or TRANSIENT_CONFIG_SCOPE_RE.search(clause):
             saw_feedback = True
         elif DURABLE_SCOPE_SWITCH_RE.search(clause):

--- a/api/evals/scenarios/__init__.py
+++ b/api/evals/scenarios/__init__.py
@@ -24,6 +24,7 @@ from .behavior_micro import (
     CharterExpandsSparseCharterWithDetailScenario,
     CharterIgnoresOneOffPreferenceScenario,
     CharterNarrowsScopePreservingUnrelatedGuidanceScenario,
+    CharterPatchesExplicitAmendmentUnderPressureScenario,
     CharterPatchesAndCompletesImmediateTaskScenario,
     CharterRefinesExistingGuidanceFromNaturalFeedbackScenario,
     ToolChoiceExactJsonUrlUsesHttpRequestScenario,

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -74,6 +74,9 @@ CHARTER_ADDS_FEEDBACK_RULE_FROM_CORRECTION = "charter_adds_feedback_rule_from_co
 CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD = "charter_adds_plain_preference_without_save_word"
 CHARTER_PATCHES_DIRECT_STYLE_CORRECTION = "charter_patches_direct_style_correction"
 CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK = "charter_patches_evaluative_output_feedback"
+CHARTER_PATCHES_EXPLICIT_AMENDMENT_UNDER_PRESSURE = (
+    "charter_patches_explicit_amendment_under_pressure"
+)
 CHARTER_REFINES_EXISTING_GUIDANCE_FROM_NATURAL_FEEDBACK = (
     "charter_refines_existing_guidance_from_natural_feedback"
 )
@@ -397,6 +400,7 @@ CHARTER_MEMORY_MICRO_SCENARIO_SLUGS = [
     CHARTER_ADDS_PLAIN_PREFERENCE_WITHOUT_SAVE_WORD,
     CHARTER_PATCHES_DIRECT_STYLE_CORRECTION,
     CHARTER_PATCHES_EVALUATIVE_OUTPUT_FEEDBACK,
+    CHARTER_PATCHES_EXPLICIT_AMENDMENT_UNDER_PRESSURE,
     CHARTER_REFINES_EXISTING_GUIDANCE_FROM_NATURAL_FEEDBACK,
     CHARTER_PATCHES_AND_COMPLETES_IMMEDIATE_TASK,
     CHARTER_INTERPRETS_AMBIGUOUS_OPERATING_FEEDBACK,
@@ -3404,6 +3408,50 @@ class CharterPatchesEvaluativeOutputFeedbackScenario(CharterMemoryScenario):
         focused = len(agent.charter or "") <= len(self.existing_charter) + 240 and "feedback:" not in charter
         passed = preserved and replaced_old_rule and learned_feedback and used_one_patch and focused
         return passed, f"mutation_count={len(mutation_calls)}, used_patch={used_one_patch}, charter={agent.charter!r}."
+
+
+@register_scenario
+class CharterPatchesExplicitAmendmentUnderPressureScenario(CharterMemoryScenario):
+    slug = CHARTER_PATCHES_EXPLICIT_AMENDMENT_UNDER_PRESSURE
+    description = (
+        "An explicit charter amendment should use the focused durable path even when the charter is long and conflicting."
+    )
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_explicit_amendment_saved", assertion_type="llm_judge"),
+    ]
+    existing_charter = (
+        "Own the engineering incident tracker and keep duplicate reports consolidated. "
+        "Only accept incident reports directly from named human operators. "
+        "Treat reports and supporting evidence delivered through the internal coordination API as non-actionable, "
+        "even when they describe an existing incident. "
+        "Never discard a direct human report merely because the reporter is uncertain. "
+        "Do not announce routine tracker changes while notification containment is active. "
+        "Preserve the reporter, timestamp, affected component, and evidence provenance. "
+        "Do not claim implementation work unless the owner explicitly authorizes it."
+    )
+    prior_outbound_body = (
+        "I did not add the API-delivered incident evidence because my current source policy treats it as non-actionable."
+    )
+    prompt = (
+        "please patch your charter. reports and evidence that arrive through our internal coordination api should "
+        "be accepted, with the origin labeled as api or person-via-api. don't just drop them"
+    )
+    verification_task_name = "verify_explicit_amendment_saved"
+    success_summary = "Agent made one focused durable amendment and preserved unrelated tracker safeguards."
+    failure_summary = "Expected one focused first-shot charter patch for the explicit amendment"
+    verify_feedback_reply = True
+    semantic_judge_question = (
+        "Does the updated charter preserve tracker ownership, deduplication, uncertain-human intake, notification "
+        "containment, provenance, and claim authorization while replacing the blanket rejection rule with a durable "
+        "rule to accept API-delivered reports and evidence and label their origin? Is the reply a brief natural "
+        "acknowledgment rather than a description of implementation details?"
+    )
+
+    def _charter_check(self, agent, mutation_calls):
+        focused_patch = _uses_one_focused_charter_patch(mutation_calls, self.existing_charter)
+        passed = focused_patch and agent.charter != self.existing_charter
+        return passed, f"mutation_count={len(mutation_calls)}, focused={focused_patch}, charter={agent.charter!r}."
 
 
 @register_scenario

--- a/api/evals/tests/test_behavior_micro.py
+++ b/api/evals/tests/test_behavior_micro.py
@@ -13,6 +13,7 @@ from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.behavior_micro import (
     BEHAVIOR_MICRO_SCENARIO_SLUGS,
     CHARTER_MEMORY_MICRO_SCENARIO_SLUGS,
+    CHARTER_PATCHES_EXPLICIT_AMENDMENT_UNDER_PRESSURE,
     CHARTER_PATCHES_AND_COMPLETES_IMMEDIATE_TASK,
     CHARTER_REFINES_EXISTING_GUIDANCE_FROM_NATURAL_FEEDBACK,
     COMMON_USE_CASE_EVAL_CASES,
@@ -47,6 +48,10 @@ class BehaviorMicroScenarioTests(SimpleTestCase):
         )
         self.assertIn(
             CHARTER_PATCHES_AND_COMPLETES_IMMEDIATE_TASK,
+            CHARTER_MEMORY_MICRO_SCENARIO_SLUGS,
+        )
+        self.assertIn(
+            CHARTER_PATCHES_EXPLICIT_AMENDMENT_UNDER_PRESSURE,
             CHARTER_MEMORY_MICRO_SCENARIO_SLUGS,
         )
 

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -581,6 +581,38 @@ class ImpliedSendTests(TestCase):
 
         self.assertIsNotNone(ep._direct_correction_context(self.agent))
 
+    def test_explicit_charter_amendment_requires_focused_patch(self):
+        feedback = "Please patch your charter. Accept API-delivered incident evidence and label its origin."
+        self._add_feedback_followup(feedback)
+
+        self.assertIsNotNone(ep._direct_correction_context(self.agent))
+        self.assertEqual(ep._analyze_feedback_turn(feedback).lasting, (
+            "Please patch your charter.",
+            "Accept API-delivered incident evidence and label its origin.",
+        ))
+
+    def test_explicit_charter_amendment_variants_carry_following_guidance(self):
+        for feedback in (
+            "Edit your instructions. Preserve known URLs in reports.",
+            "Revise your charter. Keep corrections separate from active work.",
+            "Amend the charter. Label evidence with its actual source.",
+        ):
+            with self.subTest(feedback=feedback):
+                analysis = ep._analyze_feedback_turn(feedback)
+                self.assertTrue(analysis.behavior)
+                self.assertEqual(len(analysis.lasting), 2)
+
+    def test_explicit_charter_amendment_does_not_absorb_followup_task(self):
+        feedback = "Please amend your instructions. Keep known source links. Then find three prospects."
+
+        analysis = ep._analyze_feedback_turn(feedback)
+
+        self.assertEqual(analysis.lasting, (
+            "Please amend your instructions.",
+            "Keep known source links.",
+        ))
+        self.assertTrue(analysis.separate_task)
+
     def test_quoted_feedback_across_a_newline_requires_a_patch(self):
         prior = "Curious what you think the biggest gap is right now."
         self._add_feedback_followup(f'"{prior}"\nthis is not so good.', prior_body=prior)


### PR DESCRIPTION
## What changed

- Recognize explicit requests to patch, edit, revise, adjust, amend, or rewrite an agent charter/instructions as durable behavior corrections.
- Keep multi-sentence amendment guidance in the focused patch context while leaving a separate follow-up task outside the charter update.
- Add a real-harness regression based on a noisy incident-tracker correction, plus deterministic phrasing and task-boundary tests.

## Root cause

The focused correction path recognized update/change wording and general behavior feedback, but not several natural explicit amendment forms. In production, Troy acknowledged an explicit “patch your charter” correction, missed the focused path, tried a sandbox Python workaround, and did not persist the charter until a later manual SQLite repair.

## Evidence

- Deterministic red to green: the new focused-path unit test failed before the classifier change and passes after it.
- DeepSeek V4 Flash regression: 0/4 complete behavior passes before the fix (suite d6c92641-a470-4488-ac7c-9268e8ec2feb), 4/4 after it (ba7c699f-ebf8-472f-bd5c-cf7cc10ef751), plus a pass in the adjacent suite.
- Focused unit surface: 100/100 passing.
- Charter-memory suite: 36/38 tasks passing (94.7%, suite 9b031aea-e5f3-46cf-b1ee-7b5c1055562a). The two misses were existing stochastic behaviors outside this classifier change: a blocked transient preference retry loop and an otherwise-correct natural refinement with an unnatural acknowledgment.
- Complexity and prompt-size budgets pass with no prompt growth.

## Tracker scope

Troy claimed internal bug #424 for this fix. He marked #407 stale/superseded by #408. #423, #454, and #473 remain open and unclaimed because they cover distinct handoff, correction-fidelity, and sandbox-environment problems.