### PR TITLE
Fix the mobile chat shell: white gap, back gesture, dead icon, spawn loader (#430 #432 #437 #338)

### DIFF
--- a/frontend/src/components/agentChat/AgentChatLayout.test.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.test.tsx
@@ -396,6 +396,10 @@ describe('AgentChatLayout upgrade modal gating', () => {
 
     expect(screen.queryByTestId('agent-composer')).not.toBeInTheDocument()
     expect(screen.getByText('Preparing your agent…')).toBeInTheDocument()
+    // The loader owns the timeline's space and centers in it; with the empty pane still mounted
+    // it sat pinned to the bottom of a blank phone screen (bug #338).
+    expect(document.querySelector('#timeline-events')).toBeNull()
+    expect(screen.getByText('Preparing your agent…').closest('div[aria-busy]')?.className).toContain('flex-1')
 
     fireEvent.click(screen.getByRole('button', { name: 'Skip Planning' }))
 

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -1517,6 +1517,11 @@ export function AgentChatLayout({
           data-plan-mode={workspacePlanMode}
         >
           <div className="agent-chat-workspace-main">
+          {/* While the spawn intent resolves there is nothing to show in the timeline; leaving
+              the empty pane in place pinned the loader to the bottom of a blank phone screen,
+              where it read as a broken page (bug #338). The loader takes the pane's space and
+              centers instead. */}
+          {spawnIntentLoading ? null : (
           <AgentTimelinePane
             composerDisabled={composerDisabled}
             contactCapOpenPacks={contactPackCanManageBilling ? () => handleAddonsOpen('contacts') : undefined}
@@ -1576,12 +1581,13 @@ export function AgentChatLayout({
             timelineRef={timelineRef}
             typingStatusText={typingStatusText}
           />
+          )}
 
           {/* Composer at bottom of flex layout */}
           {spawnIntentLoading ? (
             <div
               ref={composerShellRef}
-              className="flex items-center justify-center py-10"
+              className="flex flex-1 items-center justify-center py-10"
               aria-live="polite"
               aria-busy="true"
             >

--- a/frontend/src/components/agentChat/ChatSidebar.tsx
+++ b/frontend/src/components/agentChat/ChatSidebar.tsx
@@ -641,8 +641,8 @@ export const ChatSidebar = memo(function ChatSidebar({
               ? embeddedSettingsTitle
               : (drawerViewMode === 'gallery' && galleryShellPage !== 'agents' ? shellTitle : 'Switch agent')
           }
-          {/* Not PanelLeft: that glyph is the interactive expand-sidebar control on desktop, and as
-              inert sheet decoration it reads as a dead button (bug #437). */}
+          // Not PanelLeft: that glyph is the interactive expand-sidebar control on desktop, and
+          // as inert sheet decoration it read as a dead button (bug #437).
           icon={ArrowLeftRight}
           bodyPadding={false}
           headerAccessory={!messageSearchOpen && !showSettingsView && mobileContextSwitcher ? (

--- a/frontend/src/components/agentChat/ChatSidebar.tsx
+++ b/frontend/src/components/agentChat/ChatSidebar.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useCallback, useEffect, useMemo, useRef, type Dispatch, type ReactNode, type SetStateAction } from 'react'
-import { ArrowLeftRight, Bell, BellOff, Check, LayoutGrid, List, PanelLeft, PanelLeftClose, PanelRightClose, Plus, Search, Settings, X } from 'lucide-react'
+import { ArrowLeftRight, Bell, BellOff, Check, LayoutGrid, List, PanelLeftClose, PanelRightClose, Plus, Search, Settings, X } from 'lucide-react'
 
 import type { ConsoleContext } from '../../api/context'
 import { useAppSelector } from '../../store/hooks'
@@ -18,6 +18,7 @@ import { MessageSearchPanel, type MessageSearchState } from './MessageSearchPane
 import { SidebarSettingsMenu, type SidebarSettingsInfo } from './SidebarSettingsMenu'
 import { AgentInviteDetails, AgentInviteSidebarItem, type AgentInviteAction, type AgentInviteDialogState } from './AgentInviteSidebarItem'
 import { getNextAgentChatSidebarMode, getPreviousAgentChatSidebarMode, type AgentChatSidebarMode, SIDEBAR_MOBILE_BREAKPOINT_PX, type AgentDrawerViewMode } from './sidebarMode'
+import { useMobileDrawerHistory } from './useMobileDrawerHistory'
 import { AgentChatAvatar, AgentChatButton } from './uiPrimitives'
 
 type AgentContextMenuState = FixedContextMenuPosition & {
@@ -132,6 +133,8 @@ export const ChatSidebar = memo(function ChatSidebar({
     ))
   }, [updateMessageSearchState])
   const [drawerViewMode, setDrawerViewMode] = useState<AgentDrawerViewMode>('list')
+  const closeDrawerFromHistory = useCallback(() => setDrawerOpen(false), [])
+  useMobileDrawerHistory(drawerOpen, isMobile, closeDrawerFromHistory)
   const [agentContextMenu, setAgentContextMenu] = useState<AgentContextMenuState | null>(null)
   const [inviteDialog, setInviteDialog] = useState<AgentInviteDialogState | null>(null)
   const [inviteBusy, setInviteBusy] = useState(false)
@@ -638,7 +641,9 @@ export const ChatSidebar = memo(function ChatSidebar({
               ? embeddedSettingsTitle
               : (drawerViewMode === 'gallery' && galleryShellPage !== 'agents' ? shellTitle : 'Switch agent')
           }
-          icon={PanelLeft}
+          {/* Not PanelLeft: that glyph is the interactive expand-sidebar control on desktop, and as
+              inert sheet decoration it reads as a dead button (bug #437). */}
+          icon={ArrowLeftRight}
           bodyPadding={false}
           headerAccessory={!messageSearchOpen && !showSettingsView && mobileContextSwitcher ? (
             <AgentChatContextSwitcher {...mobileContextSwitcher} variant="drawer" />

--- a/frontend/src/components/agentChat/useMobileDrawerHistory.test.ts
+++ b/frontend/src/components/agentChat/useMobileDrawerHistory.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The Android back gesture is the reflexive way to dismiss an overlay; with no history entry
+ * for the mobile drawer it navigated the browser instead (bug #432). These pin the marker-entry
+ * contract the hook keeps with the real history stack.
+ */
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMobileDrawerHistory } from './useMobileDrawerHistory'
+
+const KEY = '__gobiiMobileDrawer'
+
+function firePop(state: unknown) {
+  act(() => {
+    window.dispatchEvent(new PopStateEvent('popstate', { state }))
+  })
+}
+
+describe('useMobileDrawerHistory', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '')
+  })
+
+  it('pushes a marker entry when the drawer opens on mobile', () => {
+    const push = vi.spyOn(window.history, 'pushState')
+    const { rerender } = renderHook(
+      ({ open }) => useMobileDrawerHistory(open, true, () => {}),
+      { initialProps: { open: false } },
+    )
+    expect(push).not.toHaveBeenCalled()
+
+    rerender({ open: true })
+
+    expect(push).toHaveBeenCalledTimes(1)
+    expect((push.mock.calls[0][0] as Record<string, unknown>)[KEY]).toBe(true)
+    push.mockRestore()
+  })
+
+  it('closes the drawer when the back gesture lands below the marker', () => {
+    const close = vi.fn()
+    renderHook(() => useMobileDrawerHistory(true, true, close))
+
+    firePop({})
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('steps through a ghost marker left by a UI close instead of eating the back press', () => {
+    const back = vi.spyOn(window.history, 'back').mockImplementation(() => {})
+    renderHook(() => useMobileDrawerHistory(false, true, () => {}))
+
+    firePop({ [KEY]: true })
+
+    expect(back).toHaveBeenCalledTimes(1)
+    back.mockRestore()
+  })
+
+  it('does nothing on desktop', () => {
+    const push = vi.spyOn(window.history, 'pushState')
+    const close = vi.fn()
+    const { rerender } = renderHook(
+      ({ open }) => useMobileDrawerHistory(open, false, close),
+      { initialProps: { open: false } },
+    )
+    rerender({ open: true })
+    firePop({})
+
+    expect(push).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+    push.mockRestore()
+  })
+
+  it('sheds a stale marker left behind by a reload', () => {
+    window.history.replaceState({ [KEY]: true, other: 1 }, '')
+
+    renderHook(() => useMobileDrawerHistory(false, true, () => {}))
+
+    const state = window.history.state as Record<string, unknown>
+    expect(state[KEY]).toBeUndefined()
+    expect(state.other).toBe(1)
+  })
+})

--- a/frontend/src/components/agentChat/useMobileDrawerHistory.ts
+++ b/frontend/src/components/agentChat/useMobileDrawerHistory.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react'
+
+const DRAWER_STATE_KEY = '__gobiiMobileDrawer'
+
+/**
+ * Give the mobile drawer a history entry so the platform back gesture closes it.
+ *
+ * Without one, back-swiping with the drawer open navigates the browser away from the app
+ * entirely (bug #432) -- on Android the swipe is the reflexive way to dismiss any overlay.
+ *
+ * The drawer state stays owned by React; history only carries a marker entry:
+ * - Opening pushes a same-URL entry whose state carries the marker.
+ * - A popstate that lands below the marker means the user backed out of the drawer: close it.
+ * - A popstate that lands ON a marker while the drawer is closed is a ghost left by closing
+ *   through the UI; step back again so the entry is transparent to the user.
+ */
+export function useMobileDrawerHistory(open: boolean, enabled: boolean, close: () => void) {
+  const openRef = useRef(open)
+  openRef.current = open
+  const closeRef = useRef(close)
+  closeRef.current = close
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') {
+      return
+    }
+    // A reload can land on a marker entry from the previous page life; the drawer starts
+    // closed, so shed the marker rather than making the next back press a no-op.
+    const state = window.history.state as Record<string, unknown> | null
+    if (!openRef.current && state && state[DRAWER_STATE_KEY]) {
+      const { [DRAWER_STATE_KEY]: _dropped, ...rest } = state
+      window.history.replaceState(rest, '')
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled || !open || typeof window === 'undefined') {
+      return
+    }
+    const state = window.history.state as Record<string, unknown> | null
+    if (state && state[DRAWER_STATE_KEY]) {
+      return
+    }
+    window.history.pushState({ ...(state ?? {}), [DRAWER_STATE_KEY]: true }, '')
+  }, [enabled, open])
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') {
+      return
+    }
+    const handlePop = (event: PopStateEvent) => {
+      const onMarker = Boolean(
+        event.state && (event.state as Record<string, unknown>)[DRAWER_STATE_KEY],
+      )
+      if (openRef.current && !onMarker) {
+        closeRef.current()
+      } else if (!openRef.current && onMarker) {
+        window.history.back()
+      }
+    }
+    window.addEventListener('popstate', handlePop)
+    return () => window.removeEventListener('popstate', handlePop)
+  }, [enabled])
+}

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -8169,14 +8169,17 @@
 @media (max-width: 767px) {
     .agent-fab {
         display: flex;
+        /* Hug the composer. The 1.625rem hover gap made the covered strip taller than the
+           switcher itself, and the full-width padding band that compensated for it was the
+           white gap of bug #430. */
+        bottom: calc(env(safe-area-inset-bottom, 0px) + var(--composer-height, 6.5rem) + 0.375rem);
     }
-    /* The switcher is fixed over the bottom-right of the timeline, so whatever comes to rest
-       there is covered by it. At the default scroll position that is a suggested-follow-up row,
-       and tapping the row opens the switcher instead of running the prompt. Reserve the strip
-       the switcher occupies -- its own height plus the gap it leaves above the composer -- so
-       content can always scroll clear of it. Keep in step with .agent-fab. */
-    .agent-chat-workspace-main:has(.composer-shell) #timeline-inner {
-        padding-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--composer-height, 6.5rem) + 1.625rem + 2.75rem);
+    /* The switcher floats over the bottom-right corner, so the one interactive row that rests
+       there by default -- a suggested follow-up -- keeps its tap target and chevron clear of it
+       horizontally instead of the timeline reserving a full-width dead band (bug #430; the
+       band was added for bug #334). Keep the clearance in step with .agent-fab's right + width. */
+    .starter-prompts-card__row {
+        padding-right: 5rem;
     }
 }
 .agent-fab:hover {


### PR DESCRIPTION
## What

Four mobile-cluster fixes on the chat shell, each verified baseline-vs-fix on this PR's preview in Pixel 7 emulation.

## #430 — white gap above the composer

The full-width padding band reserved for the agent-switcher FAB (added by #1396 for #334) was the gap: measured exactly 70px of dead space above the composer (padding 327.6px vs composer 257.6px). Now the FAB hugs the composer (6px) and the suggested-follow-up rows — the one interactive element that rests under the FAB by default — keep their tap targets clear horizontally instead. **Measured: dead gap 70px → 12px.** #334's protection is preserved by the row clearance.

## #432 — Android back gesture exits the app instead of closing the drawer

The drawer had no history entry. Reproduced on baseline: back with the drawer open navigated to /app/. New `useMobileDrawerHistory` hook pushes a same-URL marker entry on open; backing below it closes the drawer, ghost markers left by UI closes are stepped through transparently. **Verified: back now closes the drawer with the URL unchanged (asserted on the sheet's `--open` class), and after a UI close the back press does not eat a navigation.** 5 new unit tests.

## #437 — dead "expand" icon on the Switch Agent sheet

The sheet header decorated its title with `PanelLeft` — the glyph that IS the interactive expand-sidebar control on desktop — as inert, button-looking decoration. Swapped to `ArrowLeftRight` (matches "Switch agent", not a control glyph anywhere in the app). Verified rendered glyph on preview.

## #338 — "Preparing your agent…" pinned to the bottom of a blank screen

The spawn-intent loader only replaced the composer slot, so a new mobile user's first screen was 85% blank with a tiny spinner at the very bottom. The empty timeline pane now yields its space and the loader centers. Before/after screenshots captured via a 9s-delayed spawn-intent route so the state held still. Layout test extended to pin the contract.

## Gates

Full frontend suite 283/283, `npm run build` clean, complexity budgets pass (no bump), CI fully green. Probe agents archived. Baseline evidence gathered from this PR's own preview serving unmodified main before the fix commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)