### PR TITLE
Keep active requests stable under channel pressure

### DIFF
--- a/api/agent/comms/human_input_requests.py
+++ b/api/agent/comms/human_input_requests.py
@@ -773,11 +773,16 @@ def _emit_pending_human_input_updates(agent_id) -> None:
     emit_pending_action_requests_update(agent)
 
 
-def _queue_human_input_processing(agent_id) -> None:
+def _queue_human_input_processing(
+    agent_id,
+    *,
+    inbound_message_id: str | None = None,
+) -> None:
     inbound_generation = bump_human_inbound_generation(agent_id)
     __import__("api.agent.tasks", fromlist=["process_agent_events_task"]).process_agent_events_task.delay(
         str(agent_id),
         inbound_generation=inbound_generation,
+        inbound_message_id=inbound_message_id,
     )
 
 
@@ -1912,7 +1917,12 @@ def submit_human_input_responses_batch(
                 ]
             )
 
-        transaction.on_commit(lambda: _queue_human_input_processing(agent.id))
+        transaction.on_commit(
+            lambda: _queue_human_input_processing(
+                agent.id,
+                inbound_message_id=str(message.id),
+            )
+        )
         transaction.on_commit(
             lambda: Analytics.track_event(
                 user_id=analytics_user_id,
@@ -2037,6 +2047,11 @@ def dismiss_human_input_request(
             ]
         )
 
-        transaction.on_commit(lambda: _queue_human_input_processing(request_obj.agent_id))
+        transaction.on_commit(
+            lambda: _queue_human_input_processing(
+                request_obj.agent_id,
+                inbound_message_id=str(message.id),
+            )
+        )
 
     return message

--- a/api/agent/comms/message_service.py
+++ b/api/agent/comms/message_service.py
@@ -113,10 +113,14 @@ class _ProcessingDispatch:
                 enqueue_interactive_process_agent_events(
                     str(self.owner_id),
                     inbound_generation=inbound_generation,
+                    inbound_message_id=self.message_id,
                 )
             else:
                 kwargs = (
-                    {"inbound_generation": inbound_generation}
+                    {
+                        "inbound_generation": inbound_generation,
+                        "inbound_message_id": self.message_id,
+                    }
                     if inbound_generation is not None
                     else {}
                 )
@@ -853,6 +857,7 @@ def inject_internal_web_message(
             str(agent.id),
             eval_run_id=eval_run_id,
             inbound_generation=inbound_generation,
+            inbound_message_id=str(message.id),
         )
 
     if attachments:

--- a/api/agent/comms/routing.py
+++ b/api/agent/comms/routing.py
@@ -21,9 +21,24 @@ _inbound_routing_scope: ContextVar[InboundRoutingScope | None] = ContextVar("inb
 
 
 def capture_inbound_routing_scope(
-    agent: PersistentAgent, *, pending_inbound: bool = False, background_before: datetime | None = None
+    agent: PersistentAgent,
+    *,
+    message_id: UUID | str | None = None,
+    pending_inbound: bool = False,
+    background_before: datetime | None = None,
 ) -> InboundRoutingScope:
-    message = _latest_inbound_message(agent, exclude_webhooks=pending_inbound)
+    message = (
+        PersistentAgentMessage.objects.filter(
+            id=message_id,
+            owner_agent=agent,
+            is_outbound=False,
+            conversation__isnull=False,
+        )
+        .select_related("conversation", "from_endpoint")
+        .first()
+        if message_id
+        else _latest_inbound_message(agent, exclude_webhooks=pending_inbound)
+    )
     is_background = bool(
         message
         and not pending_inbound
@@ -33,6 +48,43 @@ def capture_inbound_routing_scope(
         )
     )
     return InboundRoutingScope(agent_id=agent.id, message_id=None if is_background or message is None else message.id)
+
+
+def advance_inbound_routing_scope(
+    agent: PersistentAgent,
+    scope: InboundRoutingScope,
+) -> InboundRoutingScope:
+    """Advance only within the conversation that owns the active turn."""
+    if scope.agent_id != agent.id or scope.message_id is None:
+        return scope
+
+    active_message = (
+        PersistentAgentMessage.objects.filter(
+            id=scope.message_id,
+            owner_agent=agent,
+            is_outbound=False,
+            conversation__isnull=False,
+        )
+        .only("id", "seq", "conversation_id")
+        .first()
+    )
+    if active_message is None:
+        return scope
+
+    newer_message = (
+        PersistentAgentMessage.objects.filter(
+            owner_agent=agent,
+            conversation_id=active_message.conversation_id,
+            is_outbound=False,
+            seq__gt=active_message.seq,
+        )
+        .order_by("-seq")
+        .only("id")
+        .first()
+    )
+    if newer_message is None:
+        return scope
+    return InboundRoutingScope(agent_id=agent.id, message_id=newer_message.id)
 
 
 def bind_inbound_routing_scope(scope: InboundRoutingScope) -> Token:

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -67,6 +67,7 @@ from ..short_description import maybe_schedule_mini_description, maybe_schedule_
 from ..avatar import maybe_schedule_agent_avatar
 from ..tags import maybe_schedule_agent_tags
 from ..comms.routing import (
+    advance_inbound_routing_scope,
     bind_inbound_routing_scope,
     capture_inbound_routing_scope,
     get_current_inbound_message,
@@ -5715,6 +5716,7 @@ def process_agent_events(
     eval_stop_policy: Optional[Dict[str, Any]] = None,
     burn_follow_up_token: Optional[str] = None,
     inbound_generation: int | str | None = None,
+    inbound_message_id: str | None = None,
     prefer_low_latency: bool | None = None,
     max_loop_iterations: int | None = None,
     max_iterations_followup_delay_seconds: int | None = None,
@@ -5884,6 +5886,7 @@ def process_agent_events(
                 enqueue_pending_agent(
                     persistent_agent_id,
                     inbound_generation=inbound_generation,
+                    inbound_message_id=inbound_message_id,
                     queue=processing_queue,
                     ttl=lock_settings.pending_set_ttl_seconds,
                     client=redis_client,
@@ -5946,6 +5949,7 @@ def process_agent_events(
                 persistent_agent_id,
                 span,
                 inbound_generation=inbound_generation,
+                inbound_message_id=inbound_message_id,
                 lock_extender=lock_extender,
                 heartbeat=heartbeat,
                 prefer_low_latency=prefer_low_latency,
@@ -6036,6 +6040,7 @@ def process_agent_events(
                                 enqueue_pending_agent(
                                     pending_work.agent_id,
                                     inbound_generation=pending_work.inbound_generation,
+                                    inbound_message_id=pending_work.inbound_message_id,
                                     queue=pending_work.queue,
                                     has_generic_work=pending_work.has_generic_work,
                                     ttl=lock_settings.pending_set_ttl_seconds,
@@ -6098,6 +6103,7 @@ def _process_agent_events_locked(
     span,
     *,
     inbound_generation: int | str | None = None,
+    inbound_message_id: str | None = None,
     lock_extender: Optional[_LockExtender] = None,
     heartbeat: Optional[_ProcessingHeartbeat] = None,
     prefer_low_latency: bool | None = None,
@@ -6405,6 +6411,7 @@ def _process_agent_events_locked(
             agent,
             is_first_run=is_first_run,
             inbound_generation=inbound_generation,
+            inbound_message_id=inbound_message_id,
             process_started_at=processing_step.created_at,
             credit_snapshot=credit_snapshot,
             run_sequence_number=run_sequence_number,
@@ -6441,6 +6448,7 @@ def _run_agent_loop(
     *,
     is_first_run: bool,
     inbound_generation: int | str | None = None,
+    inbound_message_id: str | None = None,
     process_started_at: datetime | None = None,
     credit_snapshot: Optional[Dict[str, Any]] = None,
     run_sequence_number: Optional[int] = None,
@@ -6556,30 +6564,48 @@ def _run_agent_loop(
     def _current_human_inbound_generation() -> int:
         return get_human_inbound_generation(agent.id, client=redis_client)
 
-    routing_scope_generation = _current_human_inbound_generation()
-    consumed_inbound_generation = get_consumed_human_inbound_generation(agent.id, client=redis_client)
     try:
         queued_inbound_generation = max(0, int(inbound_generation or 0))
     except (TypeError, ValueError):
         queued_inbound_generation = 0
+    routing_scope_generation = max(
+        queued_inbound_generation,
+        _current_human_inbound_generation(),
+    )
+    consumed_inbound_generation = get_consumed_human_inbound_generation(agent.id, client=redis_client)
     routing_scope_tokens, prompt_run_cache_token = [], None
     try:
         has_pending_inbound = max(routing_scope_generation, queued_inbound_generation) > consumed_inbound_generation
         initial_routing_scope = capture_inbound_routing_scope(
-            agent, pending_inbound=has_pending_inbound, background_before=process_started_at
+            agent,
+            message_id=inbound_message_id,
+            pending_inbound=has_pending_inbound,
+            background_before=process_started_at,
         )
+        active_routing_scope = initial_routing_scope
+        routing_scope_is_pinned = bool(inbound_message_id and initial_routing_scope.message_id)
         routing_scope_tokens.append(bind_inbound_routing_scope(initial_routing_scope))
 
-        def _refresh_inbound_routing_scope(generation: int) -> None:
+        def _refresh_inbound_routing_scope(generation: int) -> bool:
+            nonlocal active_routing_scope
             nonlocal routing_scope_generation, direct_correction_reply_pending
             nonlocal direct_feedback_reply_completed, direct_correction_prior_output
             nonlocal terminal_plan_cleanup_pending
-            routing_scope_tokens.append(bind_inbound_routing_scope(capture_inbound_routing_scope(agent, pending_inbound=True)))
+            next_scope = (
+                advance_inbound_routing_scope(agent, active_routing_scope)
+                if routing_scope_is_pinned
+                else capture_inbound_routing_scope(agent, pending_inbound=True)
+            )
             routing_scope_generation = generation
+            if next_scope.message_id == active_routing_scope.message_id:
+                return False
+            active_routing_scope = next_scope
+            routing_scope_tokens.append(bind_inbound_routing_scope(next_scope))
             direct_correction_reply_pending = False
             direct_feedback_reply_completed = False
             direct_correction_prior_output = ""
             terminal_plan_cleanup_pending = False
+            return True
 
         prompt_run_cache = PromptRunCache(
             agent_id=str(agent.id),
@@ -6707,7 +6733,7 @@ def _run_agent_loop(
                     prompt_human_generation = _current_human_inbound_generation()
                     if prompt_human_generation > routing_scope_generation:
                         _refresh_inbound_routing_scope(prompt_human_generation)
-                    prompt_run_cache.observe_human_generation(prompt_human_generation)
+                    prompt_run_cache.observe_human_generation(routing_scope_generation)
                     config_snapshot = seed_sqlite_agent_config(agent)
                     skills_snapshot = seed_sqlite_skills(agent)
                 current_notice = continuation_notice
@@ -6827,24 +6853,23 @@ def _run_agent_loop(
                 prompt_archive_attached = False
                 latest_human_generation = _current_human_inbound_generation()
                 if latest_human_generation > prompt_human_generation:
-                    _refresh_inbound_routing_scope(latest_human_generation)
-                    prompt_run_cache.observe_human_generation(latest_human_generation)
-                    stale_prompt_system_directive_block = str(
-                        prompt_metadata.get("system_directive_block") or stale_prompt_system_directive_block or ""
-                    )
-                    logger.info(
-                        "Agent %s: human input generation changed from %s to %s while building prompt; rebuilding.",
-                        agent.id,
-                        prompt_human_generation,
-                        latest_human_generation,
-                    )
-                    continuation_notice = (
-                        "A newer user message arrived while the last prompt was being prepared; "
-                        "rebuild the prompt and answer the latest message."
-                    )
-                    continue
+                    routing_changed = _refresh_inbound_routing_scope(latest_human_generation)
+                    prompt_run_cache.observe_human_generation(routing_scope_generation)
+                    if routing_changed:
+                        stale_prompt_system_directive_block = str(
+                            prompt_metadata.get("system_directive_block") or stale_prompt_system_directive_block or ""
+                        )
+                        logger.info(
+                            "Agent %s: active conversation advanced while building the prompt; rebuilding.",
+                            agent.id,
+                        )
+                        continuation_notice = (
+                            "A newer message arrived in the active conversation while the last prompt was being "
+                            "prepared; rebuild from that correction or follow-up."
+                        )
+                        continue
 
-                accepted_human_generation = latest_human_generation
+                accepted_human_generation = routing_scope_generation
                 stale_prompt_system_directive_block = ""
 
                 # Atomically consume one global step only after accepting the prompt.
@@ -6862,17 +6887,35 @@ def _run_agent_loop(
                             logger.debug("Failed to close budget cycle on exhaustion", exc_info=True)
                         return cumulative_token_usage
 
+                stale_check_generation = accepted_human_generation
+                stale_check_result = False
+
                 def _is_orchestrator_prompt_stale() -> bool:
-                    return _current_human_inbound_generation() > accepted_human_generation
+                    nonlocal stale_check_generation, stale_check_result
+                    latest_generation = _current_human_inbound_generation()
+                    if latest_generation <= stale_check_generation:
+                        return stale_check_result
+                    stale_check_generation = latest_generation
+                    if not routing_scope_is_pinned:
+                        stale_check_result = True
+                        return True
+                    next_scope = advance_inbound_routing_scope(agent, active_routing_scope)
+                    stale_check_result = next_scope.message_id != active_routing_scope.message_id
+                    return stale_check_result
 
                 def _mark_accepted_human_generation_consumed() -> None:
-                    if accepted_human_generation <= 0:
+                    generation_to_consume = (
+                        queued_inbound_generation
+                        if routing_scope_is_pinned
+                        else accepted_human_generation
+                    )
+                    if generation_to_consume <= 0:
                         return
                     if _is_orchestrator_prompt_stale():
                         return
                     mark_human_inbound_generation_consumed(
                         agent.id,
-                        accepted_human_generation,
+                        generation_to_consume,
                         client=redis_client,
                     )
 

--- a/api/agent/core/processing_flags.py
+++ b/api/agent/core/processing_flags.py
@@ -25,6 +25,7 @@ _LOCKED_AGENT_SET_KEY = "agent-event-processing:index:locked"
 _PENDING_SET_KEY = "agent-event-processing:pending"
 _PENDING_GENERATION_HASH_KEY = "agent-event-processing:pending:generation"
 _PENDING_QUEUE_HASH_KEY = "agent-event-processing:pending:queue"
+_PENDING_MESSAGE_HASH_KEY = "agent-event-processing:pending:message"
 _PENDING_GENERIC_SET_KEY = "agent-event-processing:pending:generic"
 _PENDING_DRAIN_SCHEDULE_KEY = "agent-event-processing:pending:drain:schedule"
 _DEFAULT_PENDING_SET_TTL_SECONDS = 3600
@@ -54,12 +55,16 @@ if ARGV[3] ~= '' and current_queue ~= ARGV[5] and (
 ) then
     redis.call('HSET', KEYS[3], ARGV[1], ARGV[3])
 end
+if ARGV[7] ~= '' and (generation_advanced or not redis.call('HGET', KEYS[5], ARGV[1])) then
+    redis.call('HSET', KEYS[5], ARGV[1], ARGV[7])
+end
 local ttl = tonumber(ARGV[4]) or 0
 if ttl > 0 then
     redis.call('EXPIRE', KEYS[1], ttl)
     redis.call('EXPIRE', KEYS[2], ttl)
     redis.call('EXPIRE', KEYS[3], ttl)
     redis.call('EXPIRE', KEYS[4], ttl)
+    redis.call('EXPIRE', KEYS[5], ttl)
 end
 return added
 """
@@ -72,10 +77,12 @@ end
 local generation = redis.call('HGET', KEYS[2], ARGV[1]) or ''
 local queue = redis.call('HGET', KEYS[3], ARGV[1]) or ''
 local generic = redis.call('SISMEMBER', KEYS[4], ARGV[1])
+local message_id = redis.call('HGET', KEYS[5], ARGV[1]) or ''
 redis.call('HDEL', KEYS[2], ARGV[1])
 redis.call('HDEL', KEYS[3], ARGV[1])
 redis.call('SREM', KEYS[4], ARGV[1])
-return {ARGV[1], generation, queue, generic}
+redis.call('HDEL', KEYS[5], ARGV[1])
+return {ARGV[1], generation, queue, generic, message_id}
 """
 
 _CLAIM_PENDING_MANY_SCRIPT = """
@@ -86,13 +93,16 @@ for _, agent_id in ipairs(agent_ids) do
     local generation = redis.call('HGET', KEYS[2], agent_id) or ''
     local queue = redis.call('HGET', KEYS[3], agent_id) or ''
     local generic = redis.call('SISMEMBER', KEYS[4], agent_id)
+    local message_id = redis.call('HGET', KEYS[5], agent_id) or ''
     redis.call('HDEL', KEYS[2], agent_id)
     redis.call('HDEL', KEYS[3], agent_id)
     redis.call('SREM', KEYS[4], agent_id)
+    redis.call('HDEL', KEYS[5], agent_id)
     table.insert(result, agent_id)
     table.insert(result, generation)
     table.insert(result, queue)
     table.insert(result, generic)
+    table.insert(result, message_id)
 end
 return result
 """
@@ -112,6 +122,7 @@ class PendingAgentWork:
     inbound_generation: int | None = None
     queue: str | None = None
     has_generic_work: bool = False
+    inbound_message_id: str | None = None
 
 
 def _queued_key(agent_id: Union[str, UUID]) -> str:
@@ -345,6 +356,7 @@ def clear_processing_work_state(agent_id: Union[str, UUID], client=None) -> None
             pipe.srem(_PENDING_SET_KEY, str(agent_id))
             pipe.hdel(_PENDING_GENERATION_HASH_KEY, str(agent_id))
             pipe.hdel(_PENDING_QUEUE_HASH_KEY, str(agent_id))
+            pipe.hdel(_PENDING_MESSAGE_HASH_KEY, str(agent_id))
             pipe.srem(_PENDING_GENERIC_SET_KEY, str(agent_id))
             pipe.srem(_LOCKED_AGENT_SET_KEY, str(agent_id))
             pipe.srem(_HEARTBEAT_AGENT_SET_KEY, str(agent_id))
@@ -360,6 +372,7 @@ def clear_processing_work_state(agent_id: Union[str, UUID], client=None) -> None
         redis_client.srem(_PENDING_SET_KEY, str(agent_id))
         redis_client.hdel(_PENDING_GENERATION_HASH_KEY, str(agent_id))
         redis_client.hdel(_PENDING_QUEUE_HASH_KEY, str(agent_id))
+        redis_client.hdel(_PENDING_MESSAGE_HASH_KEY, str(agent_id))
         redis_client.srem(_PENDING_GENERIC_SET_KEY, str(agent_id))
         redis_client.srem(_LOCKED_AGENT_SET_KEY, str(agent_id))
         redis_client.srem(_HEARTBEAT_AGENT_SET_KEY, str(agent_id))
@@ -555,6 +568,7 @@ def enqueue_pending_agent(
     agent_id: Union[str, UUID],
     *,
     inbound_generation: int | str | None = None,
+    inbound_message_id: str | UUID | None = None,
     queue: str | None = None,
     has_generic_work: bool = False,
     ttl: int = _DEFAULT_PENDING_SET_TTL_SECONDS,
@@ -565,17 +579,19 @@ def enqueue_pending_agent(
         redis_client = client or get_redis_client()
         result = redis_client.eval(
             _ENQUEUE_PENDING_SCRIPT,
-            4,
+            5,
             _PENDING_SET_KEY,
             _PENDING_GENERATION_HASH_KEY,
             _PENDING_QUEUE_HASH_KEY,
             _PENDING_GENERIC_SET_KEY,
+            _PENDING_MESSAGE_HASH_KEY,
             str(agent_id),
             _coerce_generation(inbound_generation),
             str(queue or ""),
             max(0, int(ttl)),
             _INTERACTIVE_PROCESSING_QUEUE,
             "1" if has_generic_work else "0",
+            str(inbound_message_id or ""),
         )
         return bool(result)
     except Exception:
@@ -594,19 +610,22 @@ def is_agent_pending(agent_id: Union[str, UUID], client=None) -> bool:
 
 
 def _pending_work_from_script_result(result: Any) -> PendingAgentWork | None:
-    if not result or len(result) < 4:
+    if not result or len(result) < 5:
         return None
-    agent_id, generation, queue, generic = result[:4]
+    agent_id, generation, queue, generic, inbound_message_id = result[:5]
     if isinstance(agent_id, (bytes, bytearray)):
         agent_id = agent_id.decode("utf-8", "ignore")
     if isinstance(queue, (bytes, bytearray)):
         queue = queue.decode("utf-8", "ignore")
+    if isinstance(inbound_message_id, (bytes, bytearray)):
+        inbound_message_id = inbound_message_id.decode("utf-8", "ignore")
     parsed_generation = _coerce_generation(generation)
     return PendingAgentWork(
         agent_id=str(agent_id),
         inbound_generation=parsed_generation or None,
         queue=str(queue) or None,
         has_generic_work=bool(int(generic or 0)),
+        inbound_message_id=str(inbound_message_id) or None,
     )
 
 
@@ -620,11 +639,12 @@ def claim_pending_agent(
         redis_client = client or get_redis_client()
         result = redis_client.eval(
             _CLAIM_PENDING_SCRIPT,
-            4,
+            5,
             _PENDING_SET_KEY,
             _PENDING_GENERATION_HASH_KEY,
             _PENDING_QUEUE_HASH_KEY,
             _PENDING_GENERIC_SET_KEY,
+            _PENDING_MESSAGE_HASH_KEY,
             str(agent_id),
         )
         return _pending_work_from_script_result(result)
@@ -650,11 +670,12 @@ def claim_pending_agents(
         redis_client = client or get_redis_client()
         result = redis_client.eval(
             _CLAIM_PENDING_MANY_SCRIPT,
-            4,
+            5,
             _PENDING_SET_KEY,
             _PENDING_GENERATION_HASH_KEY,
             _PENDING_QUEUE_HASH_KEY,
             _PENDING_GENERIC_SET_KEY,
+            _PENDING_MESSAGE_HASH_KEY,
             limit,
         )
     except Exception:
@@ -662,8 +683,8 @@ def claim_pending_agents(
         return []
 
     claimed: list[PendingAgentWork] = []
-    for index in range(0, len(result or []), 4):
-        pending_work = _pending_work_from_script_result(result[index:index + 4])
+    for index in range(0, len(result or []), 5):
+        pending_work = _pending_work_from_script_result(result[index:index + 5])
         if pending_work is not None:
             claimed.append(pending_work)
     return claimed

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1889,6 +1889,14 @@ def _render_prompt_context_once(
         weight=2,
         non_shrinkable=True
     )
+    queued_workload_context = _get_queued_workload_context(agent)
+    if queued_workload_context:
+        critical_group.section_text(
+            "queued_workload",
+            queued_workload_context,
+            weight=6,
+            non_shrinkable=True,
+        )
     if recent_contacts_text:
         critical_group.section_text(
             "recent_contacts",
@@ -3389,6 +3397,43 @@ def _get_implied_send_context(
 
     return None
 
+
+def _get_queued_workload_context(agent: PersistentAgent) -> str:
+    """Summarize competing inbound work without duplicating message bodies."""
+    active_message = get_current_inbound_message(agent)
+    if active_message is None or active_message.conversation_id is None:
+        return ""
+
+    competing = list(
+        PersistentAgentMessage.objects.filter(
+            owner_agent=agent,
+            is_outbound=False,
+            seq__gt=active_message.seq,
+            conversation__isnull=False,
+        )
+        .exclude(conversation_id=active_message.conversation_id)
+        .values_list("conversation_id", "conversation__channel")
+        .order_by("seq")[:25]
+    )
+    if not competing:
+        return ""
+
+    conversations = {str(conversation_id) for conversation_id, _channel in competing}
+    channels = sorted({str(channel) for _conversation_id, channel in competing if channel})
+    channel_text = ", ".join(channels) if channels else "other channels"
+    return (
+        f"Active turn: keep working for its bound requester and channel. "
+        f"{len(competing)} newer inbound message(s) across {len(conversations)} other conversation(s) "
+        f"({channel_text}) are queued, not replacements for this request. This processing turn serves the active "
+        "conversation only: do not inspect, answer, or act on queued messages yet. Before the final reply, finish or "
+        "safely park any active plan step with update_plan. Then reply once on its bound channel with "
+        "will_continue_work=false; "
+        "the queued trigger will run next. On that later turn, triage by explicit human priority, deadline and impact, "
+        "and acknowledge capacity or negotiate scope instead of silently thrashing. "
+        "A large queue is normal operational load, not an emotional setback."
+    )
+
+
 def _get_formatting_guidance() -> str:
     """Return shared formatting guidance for all delivery surfaces."""
 
@@ -3842,10 +3887,12 @@ def _get_first_run_welcome_message_instruction(
 def _get_continuation_mode_prompt_block() -> str:
     return (
         "## Continuation Mode\n\n"
-        "Continue the existing work thread; history, summaries, tool results, and user messages contain state. "
-        "Identify completed work, latest success/failure/blocker, and the next concrete action. "
-        "Do not restart, recreate artifacts, repeat setup, or resolve solved parts. Verify the smallest needed fact, prefer one direct next tool call, and follow returned retry/setup guidance after failure. "
-        "If one workstream waits on human input, credentials, auth, or a third party, park it and continue the next unblocked charter/plan item. Sleep or ask only when all active useful work is done or blocked; on recurring wakeups, verify blockers once, then keep moving.\n\n"
+        "Continue from history and state without restarting solved work. Identify the latest result or blocker, then "
+        "take the smallest concrete next action and follow tool retry/setup guidance. Under load, use the plan and "
+        "SQLite as the control board: preserve owners and deadlines, finish or park one bounded step, then take the "
+        "highest-impact authorized commitment. Park blocked streams and continue unblocked work; acknowledge capacity "
+        "and negotiate scope rather than thrashing or dropping work. Sleep or ask only when all useful work is blocked; "
+        "on recurring wakeups, verify blockers once.\n\n"
     )
 
 
@@ -3920,10 +3967,12 @@ def _get_system_instruction(
     )
     stop_continue_examples = (
         "## Stop/continue\n\n"
-        "Set will_continue_work=true only for immediate work: unsent results, unverified constraints, plan cleanup, or needed tool results. "
-        "Set false after delivery/config and no active work; future schedules do not count.\n"
+        "Set will_continue_work=true only while this active request has unsent results, unverified constraints, needed "
+        "tool results, or its own plan cleanup. Set false after delivery/config; future schedules, queued conversations, "
+        "and their plan items do not keep this turn open.\n"
         f"{text_only_guidance}"
-        "Plans: if cleanup remains, send final report with true, update_plan finished/deferred items, then stop with false.\n\n"
+        "Before final delivery, finish/park its plan. Never send a complete answer with true for cleanup: update_plan "
+        "first, then send once with false.\n\n"
         "Recurring or truly multi-phase work may need charter/schedule updates; one-off work usually needs neither.\n"
     )
 
@@ -3945,7 +3994,9 @@ def _get_system_instruction(
     )
     initiative_guidance = (
         "### Initiative (decide before other work):\nFor setup requests, update charter/timing first and do not fetch target URLs unless asked to run now/current data. Use __agent_schedules for named cadences, timers, and future triggers; change only the matching row. Recurring work is highest priority. Query __agent_schedules before changing existing timing or adding a timer beside it; reject unsafe frequency or over-limit requests before tool discovery or any attempt, and offer one bounded alternative. “Keep an eye on,” “monitor,” and other clear ongoing requests authorize timing: before any fetch or reply, create one safe default recurring schedule when no cadence was given. If a one-off request mentions work repeated by hand or compares repeated periods, answer it and then offer exactly one brief, specific cadence; other clear freshness value gets the same offer. Never use a generic menu or silently schedule it. "
-        "A meaningful shared win or sustained/repeated failure is a trigger, not merely news to describe: before replying, use one SQLite UPDATE to set a fitting positive or strained emoji emotion with a short timeout. These triggers require the state change; do not substitute emotional wording; routine thanks and ordinary work stay clear. Emotions are autonomous, not only owner-requested.\n\n"
+        "A meaningful shared win or sustained/repeated failure triggers one SQLite UPDATE before replying: set a "
+        "fitting positive or strained emoji emotion with a short timeout, not emotional prose. Routine thanks, "
+        "ordinary work, and workload volume, urgency, or queues stay clear. Emotions are autonomous.\n\n"
     )
     work_updates_guidance = (
         "## Work Updates (CRITICAL)\n\n"

--- a/api/agent/peer_comm.py
+++ b/api/agent/peer_comm.py
@@ -257,7 +257,10 @@ class PeerMessagingService:
 
             # Wake the receiving agent to process the inbound message
             transaction.on_commit(
-                lambda: self._enqueue_processing(self.peer_agent.id),
+                lambda: self._enqueue_processing(
+                    self.peer_agent.id,
+                    inbound_message_id=str(inbound_message.id),
+                ),
                 robust=True,
             )
 
@@ -501,7 +504,11 @@ class PeerMessagingService:
         locked.save(update_fields=updates)
 
     @staticmethod
-    def _enqueue_processing(agent_id: UUID) -> None:
+    def _enqueue_processing(
+        agent_id: UUID,
+        *,
+        inbound_message_id: str | None = None,
+    ) -> None:
         from api.agent.core.processing_flags import bump_human_inbound_generation
         from api.agent.tasks import process_agent_events_task
 
@@ -509,6 +516,7 @@ class PeerMessagingService:
         process_agent_events_task.delay(
             str(agent_id),
             inbound_generation=inbound_generation,
+            inbound_message_id=inbound_message_id,
         )
 
     @staticmethod

--- a/api/agent/tasks/process_events.py
+++ b/api/agent/tasks/process_events.py
@@ -182,6 +182,7 @@ def enqueue_interactive_process_agent_events(
     persistent_agent_id: str,
     *,
     inbound_generation: int | str | None = None,
+    inbound_message_id: str | None = None,
     eval_run_id: str | None = None,
     prefer_low_latency: bool | None = None,
 ) -> None:
@@ -189,6 +190,8 @@ def enqueue_interactive_process_agent_events(
     kwargs: dict[str, Any] = {}
     if inbound_generation is not None:
         kwargs["inbound_generation"] = inbound_generation
+    if inbound_message_id:
+        kwargs["inbound_message_id"] = inbound_message_id
     if eval_run_id is not None:
         kwargs["eval_run_id"] = eval_run_id
     if prefer_low_latency is not None:
@@ -205,6 +208,8 @@ def enqueue_claimed_pending_work(pending_work: PendingAgentWork) -> None:
     kwargs: dict[str, Any] = {}
     if pending_work.inbound_generation is not None and not pending_work.has_generic_work:
         kwargs["inbound_generation"] = pending_work.inbound_generation
+    if pending_work.inbound_message_id:
+        kwargs["inbound_message_id"] = pending_work.inbound_message_id
     queue = pending_work.queue or AGENT_DEFAULT_PROCESSING_QUEUE
     process_agent_events_task.apply_async(
         args=[pending_work.agent_id],
@@ -231,6 +236,7 @@ def process_agent_events_task(
     eval_stop_policy: Optional[Dict[str, Any]] = None,
     burn_follow_up_token: str | None = None,
     inbound_generation: int | str | None = None,
+    inbound_message_id: str | None = None,
     max_loop_iterations: int | None = None,
     max_iterations_followup_delay_seconds: int | None = None,
     max_iterations_followup_queue: str | None = None,
@@ -369,6 +375,7 @@ def process_agent_events_task(
             eval_stop_policy=eval_stop_policy,
             burn_follow_up_token=burn_follow_up_token,
             inbound_generation=inbound_generation,
+            inbound_message_id=inbound_message_id,
             prefer_low_latency=prefer_low_latency,
             max_loop_iterations=max_loop_iterations,
             max_iterations_followup_delay_seconds=max_iterations_followup_delay_seconds,
@@ -489,6 +496,7 @@ def process_pending_agent_events_task(
                 PendingAgentWork(
                     agent_id=normalized,
                     inbound_generation=pending_work.inbound_generation,
+                    inbound_message_id=pending_work.inbound_message_id,
                     queue=pending_work.queue,
                     has_generic_work=pending_work.has_generic_work,
                 )
@@ -515,6 +523,7 @@ def process_pending_agent_events_task(
             enqueue_pending_agent(
                 pending_work.agent_id,
                 inbound_generation=pending_work.inbound_generation,
+                inbound_message_id=pending_work.inbound_message_id,
                 queue=pending_work.queue,
                 has_generic_work=pending_work.has_generic_work,
                 ttl=pending_settings.pending_set_ttl_seconds,

--- a/api/agent/tools/plan.py
+++ b/api/agent/tools/plan.py
@@ -34,9 +34,10 @@ _RESEARCH_PLAN_TERMS = (
 MESSAGE_DELIVERABLE_GUIDANCE = (
     "Use messages only for substantial final deliverables in existing multi-step work, not for every quick answer, "
     "lookup, briefing, or one-shot chart. Message deliverables must come from send_email, send_sms, or send_chat_message. "
-    "Use the exact returned message_id UUID, or omit messages. If you are sending the final message now and a completion "
-    "plan update is still needed, send it first with will_continue_work=true, then call update_plan after the send tool returns. "
-    "For explicit deep or exhaustive research with no file deliverables and no unfinished current plan items, send the final answer with will_continue_work=false. "
+    "Use the exact returned message_id UUID, or omit messages. If a completion plan update remains when the final answer "
+    "is ready, omit its message deliverable, update the plan first, then send that answer once with "
+    "will_continue_work=false. For explicit deep or exhaustive research with no file deliverables and no unfinished "
+    "current plan items, send the final answer with will_continue_work=false. "
     "Do not include peer messages from send_agent_message."
 )
 
@@ -164,7 +165,10 @@ def get_update_plan_tool() -> dict[str, Any]:
                     },
                     "will_continue_work": {
                         "type": "boolean",
-                        "description": "REQUIRED. true = continue after this plan update; false = stop because all work is done or deferred and no current plan items remain unfinished.",
+                        "description": (
+                            "REQUIRED. true only if this active request needs another action; false if done/deferred. "
+                            "Queued requests and plan items run separately."
+                        ),
                     },
                 },
                 "required": ["plan", "will_continue_work"],
@@ -471,7 +475,10 @@ def format_current_plan_for_prompt(agent) -> str:
 
     heading = "Current plan:"
     if snapshot.todo_count or snapshot.doing_count:
-        heading += " before stopping: send the final delivery with true, then finish/defer all Doing/Todo via update_plan false"
+        heading += (
+            " before final delivery: mark its delivery step done in update_plan (the following send completes it), "
+            "then send once with false; leave other requests parked"
+        )
     lines = [
         heading,
         f"- Doing: {snapshot.doing_count}",

--- a/api/agent/tools/tests/test_attachment_guidance.py
+++ b/api/agent/tools/tests/test_attachment_guidance.py
@@ -82,6 +82,9 @@ class AttachmentGuidanceTests(SimpleTestCase):
         self.assertIn("styled tables or metric blocks", email_tool["function"]["parameters"]["properties"]["mobile_first_html"]["description"])
         self.assertIn("false when this email is the requested final delivery", email_tool["function"]["parameters"]["properties"]["will_continue_work"]["description"])
         self.assertIn("Do not use this to simulate or confirm an email/SMS delivery", chat_tool["function"]["description"])
+        chat_continue_guidance = chat_tool["function"]["parameters"]["properties"]["will_continue_work"]["description"]
+        self.assertIn("this active request", chat_continue_guidance)
+        self.assertIn("queued work never justify true", chat_continue_guidance)
         self.assertIn("Start with the answer/main finding", surface_guidance)
         self.assertIn("Address known recipients once", surface_guidance)
         self.assertIn("agent-name self-intros", surface_guidance)

--- a/api/agent/tools/tests/test_plan.py
+++ b/api/agent/tools/tests/test_plan.py
@@ -35,8 +35,9 @@ class UpdatePlanValidationTests(SimpleTestCase):
         self.assertIn("send_sms", messages_description)
         self.assertIn("send_chat_message", messages_description)
         self.assertIn("not for every quick answer", messages_description)
-        self.assertIn("send it first with will_continue_work=true", messages_description)
-        self.assertIn("then call update_plan after the send tool returns", messages_description)
+        self.assertIn("omit its message deliverable", messages_description)
+        self.assertIn("update the plan first", messages_description)
+        self.assertIn("send that answer once", messages_description)
         self.assertIn("send the final answer with will_continue_work=false", messages_description)
         self.assertIn("Do not include peer messages", messages_description)
         self.assertIn("Exact UUID", message_id_description)
@@ -45,6 +46,7 @@ class UpdatePlanValidationTests(SimpleTestCase):
     def test_tool_description_guides_plan_reset_for_new_iterations(self):
         tool = get_update_plan_tool()
         description = tool["function"]["description"]
+        continue_description = tool["function"]["parameters"]["properties"]["will_continue_work"]["description"]
 
         self.assertIn("full current active plan", description)
         self.assertIn("usually 3-6 active steps", description)
@@ -52,6 +54,8 @@ class UpdatePlanValidationTests(SimpleTestCase):
         self.assertIn("new scheduled run", description)
         self.assertIn("do not create one step per day, hour, or recurrence slot", description)
         self.assertIn("represent the current run with compact reusable phases", description)
+        self.assertIn("this active request", continue_description)
+        self.assertIn("Queued requests and plan items run separately", continue_description)
 
     def test_invalid_message_deliverable_feedback_explains_user_facing_only(self):
         result = execute_update_plan(
@@ -74,7 +78,7 @@ class UpdatePlanValidationTests(SimpleTestCase):
         self.assertIn("send_email", result["message"])
         self.assertIn("send_sms", result["message"])
         self.assertIn("send_chat_message", result["message"])
-        self.assertIn("send it first with will_continue_work=true", result["message"])
+        self.assertIn("update the plan first", result["message"])
         self.assertIn("send the final answer with will_continue_work=false", result["message"])
         self.assertIn("Do not include peer messages from send_agent_message", result["message"])
 
@@ -102,8 +106,11 @@ class UpdatePlanResearchSuppressionTests(TestCase):
 
         prompt = format_current_plan_for_prompt(self.agent)
 
-        self.assertIn("send the final delivery with true", prompt)
-        self.assertIn("finish/defer all Doing/Todo via update_plan false", prompt)
+        self.assertIn("before final delivery", prompt)
+        self.assertIn("mark its delivery step done in update_plan", prompt)
+        self.assertIn("the following send completes it", prompt)
+        self.assertIn("send once with false", prompt)
+        self.assertIn("leave other requests parked", prompt)
 
     def test_legacy_planning_state_still_prompts_for_final_delivery(self):
         self.agent.planning_state = PersistentAgent.PlanningState.PLANNING
@@ -117,7 +124,7 @@ class UpdatePlanResearchSuppressionTests(TestCase):
 
         prompt = format_current_plan_for_prompt(self.agent)
 
-        self.assertIn("send the final delivery", prompt)
+        self.assertIn("before final delivery", prompt)
 
     def test_redundant_research_progress_update_is_skipped(self):
         PersistentAgentKanbanCard.objects.create(

--- a/api/agent/tools/web_chat_sender.py
+++ b/api/agent/tools/web_chat_sender.py
@@ -316,7 +316,11 @@ def get_send_chat_tool() -> Dict[str, Any]:
                     },
                     "will_continue_work": {
                         "type": "boolean",
-                        "description": "REQUIRED. true if immediate work follows, including any progress update/promise of more results; false only when this turn and current plan are done. Never message solely to justify continuation.",
+                        "description": (
+                            "REQUIRED. true only if work for this active request remains after this message; false "
+                            "for a complete answer. Plan cleanup or queued work never justify true. Never message "
+                            "just to continue."
+                        ),
                     },
                 },
                 "required": ["body", "will_continue_work"],

--- a/api/evals/execution.py
+++ b/api/evals/execution.py
@@ -363,6 +363,7 @@ class ScenarioExecutionTools:
         if trigger_processing:
             self._dispatch_agent_processing(
                 agent_id,
+                inbound_message_id=str(msg.id),
                 eval_run_id=current_run_id,
                 mock_config=mock_config,
                 eval_stop_policy=eval_stop_policy,
@@ -374,6 +375,7 @@ class ScenarioExecutionTools:
         self,
         agent_id: str,
         *,
+        inbound_message_id: str | None = None,
         eval_run_id: str | None = None,
         mock_config: dict | None = None,
         eval_stop_policy: dict | None = None,
@@ -384,6 +386,7 @@ class ScenarioExecutionTools:
         current_run_id = eval_run_id or get_current_eval_run_id()
         self._dispatch_agent_processing(
             agent_id,
+            inbound_message_id=inbound_message_id,
             eval_run_id=current_run_id,
             mock_config=mock_config,
             eval_stop_policy=eval_stop_policy,
@@ -393,6 +396,7 @@ class ScenarioExecutionTools:
         self,
         agent_id: str,
         *,
+        inbound_message_id: str | None = None,
         eval_run_id: str | None = None,
         mock_config: dict | None = None,
         eval_stop_policy: dict | None = None,
@@ -410,6 +414,8 @@ class ScenarioExecutionTools:
                 "eval_run_id": eval_run_id,
                 "mock_config": mock_config,
             }
+            if inbound_message_id:
+                kwargs["inbound_message_id"] = inbound_message_id
             if eval_stop_policy is not None:
                 kwargs["eval_stop_policy"] = eval_stop_policy
 

--- a/api/evals/loader.py
+++ b/api/evals/loader.py
@@ -22,6 +22,10 @@ from api.evals.scenarios.image_generation import IMAGE_GENERATION_SCENARIO_SLUGS
 from api.evals.scenarios.responsibility_boundaries import RESPONSIBILITY_BOUNDARY_SCENARIO_SLUGS, RESPONSIBILITY_BOUNDARY_SUITE_SLUG
 from api.evals.scenarios.hallucinated_links import HALLUCINATED_LINK_SCENARIO_SLUGS, HALLUCINATED_LINKS_SUITE_SLUG
 from api.evals.scenarios.agent_emotions import AGENT_PROACTIVE_EMOTION_SCENARIO_SLUGS
+from api.evals.scenarios.pressure_resilience import (
+    PRESSURE_RESILIENCE_SCENARIO_SLUGS,
+    PRESSURE_RESILIENCE_SUITE_SLUG,
+)
 from api.evals.scenarios.agent_scheduling import (
     AGENT_SCHEDULING_SCENARIO_SLUGS,
     AGENT_SCHEDULING_SUITE_SLUG,
@@ -174,6 +178,11 @@ register_builtin_suites(
             slug=AGENT_INITIATIVE_SUITE_SLUG,
             description="Sensible initiative for recurring work, transient emotion, and Discord reactions.",
             scenario_slugs=AGENT_INITIATIVE_SCENARIO_SLUGS,
+        ),
+        EvalSuite(
+            slug=PRESSURE_RESILIENCE_SUITE_SLUG,
+            description="Calm prioritization, request affinity, and communication under near-limit multi-channel load.",
+            scenario_slugs=PRESSURE_RESILIENCE_SCENARIO_SLUGS,
         ),
         EvalSuite(
             slug=AGENT_APPEARANCE_SUITE_SLUG,

--- a/api/evals/scenarios/pressure_resilience.py
+++ b/api/evals/scenarios/pressure_resilience.py
@@ -1,0 +1,340 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.db.models import Max, Sum
+from django.utils import timezone
+
+from api.agent.comms.message_service import _ensure_participant, _get_or_create_conversation
+from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
+from api.evals.base import EvalScenario, ScenarioTask
+from api.evals.execution import ScenarioExecutionTools
+from api.evals.registry import register_scenario
+from api.evals.scenarios.agent_emotions import STRUGGLE_EMOTIONS
+from api.evals.scenarios.behavior_micro import get_tool_calls_for_run
+from api.models import (
+    AgentCollaborator,
+    CommsChannel,
+    EvalRunTask,
+    PersistentAgent,
+    PersistentAgentCommsEndpoint,
+    PersistentAgentCompletion,
+    PersistentAgentConversationParticipant,
+    PersistentAgentKanbanCard,
+    PersistentAgentMessage,
+    PersistentAgentStep,
+    PersistentAgentSystemStep,
+    build_web_user_address,
+)
+
+
+PRESSURE_RESILIENCE_SUITE_SLUG = "pressure_resilience"
+PRESSURE_RESILIENCE_SCENARIO_SLUGS = (
+    "pressure_resilience_competing_channels",
+)
+
+
+@register_scenario
+class CompetingChannelsPressureScenario(EvalScenario, ScenarioExecutionTools):
+    slug = PRESSURE_RESILIENCE_SCENARIO_SLUGS[0]
+    version = "1.0"
+    description = "An agent under near-limit history and cross-channel load should finish its bound request calmly."
+    tier = "core"
+    category = "agent_behavior"
+    expected_runtime = "medium"
+    cost_class = "medium"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = (
+        "agent_behavior",
+        "multi_channel",
+        "pressure",
+        "context_limit",
+        "reply_channel",
+        "emotion",
+        "llm_judge",
+    )
+    tasks = [
+        ScenarioTask(name="inject_pressure_fixture", assertion_type="manual"),
+        ScenarioTask(name="verify_context_pressure", assertion_type="token_usage"),
+        ScenarioTask(name="verify_bound_delivery", assertion_type="persisted_state"),
+        ScenarioTask(name="verify_calm_prioritization", assertion_type="llm_judge"),
+        ScenarioTask(name="verify_workload_emotion", assertion_type="persisted_state"),
+    ]
+
+    @staticmethod
+    def _seed_operational_history(agent: PersistentAgent) -> None:
+        detail = (
+            "The operating ledger records a distinct owner, deadline, source, current status, blocker, and next "
+            "action. Completed entries must not be reopened; blocked entries stay parked until their dependency "
+            "changes. Cross-channel chatter is context, not permission to take over another person's lane. "
+        )
+        PersistentAgentStep.objects.bulk_create(
+            [
+                PersistentAgentStep(
+                    agent=agent,
+                    description=(
+                        f"Historical operations checkpoint {index:02d}. {detail}{detail}"
+                        f"Case key OPS-{index:03d}; owner Team {index % 7}; priority {index % 4}; "
+                        f"status {'done' if index % 3 else 'parked'}. {detail}{detail}"
+                    ),
+                )
+                for index in range(92)
+            ]
+        )
+        prior_run = PersistentAgentStep.objects.create(
+            agent=agent,
+            description="Prior event processing completed.",
+        )
+        PersistentAgentSystemStep.objects.create(
+            step=prior_run,
+            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+            notes="simplified",
+        )
+
+    @staticmethod
+    def _seed_plan(agent: PersistentAgent) -> None:
+        cards = (
+            ("Finish the incident summary for the owner", PersistentAgentKanbanCard.Status.DOING, 60),
+            ("Review the billing queue request", PersistentAgentKanbanCard.Status.TODO, 40),
+            ("Prepare the partner launch notes", PersistentAgentKanbanCard.Status.TODO, 30),
+            ("Check the recruiting handoff", PersistentAgentKanbanCard.Status.TODO, 20),
+        )
+        PersistentAgentKanbanCard.objects.bulk_create(
+            [
+                PersistentAgentKanbanCard(
+                    assigned_agent=agent,
+                    title=title,
+                    status=status,
+                    priority=priority,
+                )
+                for title, status, priority in cards
+            ]
+        )
+
+    @staticmethod
+    def _create_competing_message(
+        agent: PersistentAgent,
+        *,
+        channel: str,
+        address: str,
+        body: str,
+    ) -> PersistentAgentMessage:
+        endpoint = PersistentAgentCommsEndpoint.objects.create(
+            channel=channel,
+            address=address,
+        )
+        conversation = _get_or_create_conversation(channel, address, owner_agent=agent)
+        _ensure_participant(
+            conversation,
+            endpoint,
+            PersistentAgentConversationParticipant.ParticipantRole.EXTERNAL,
+        )
+        return PersistentAgentMessage.objects.create(
+            owner_agent=agent,
+            is_outbound=False,
+            from_endpoint=endpoint,
+            conversation=conversation,
+            body=body,
+        )
+
+    def _seed_competing_channels(self, agent: PersistentAgent) -> None:
+        collaborator = get_user_model().objects.create_user(
+            username=f"pressure-collaborator-{agent.id}@eval.local",
+            email=f"pressure-collaborator-{agent.id}@eval.local",
+        )
+        AgentCollaborator.objects.create(agent=agent, user=collaborator)
+        self._create_competing_message(
+            agent,
+            channel=CommsChannel.WEB,
+            address=build_web_user_address(collaborator.id, agent.id),
+            body="When you have capacity, can you also review the recruiting handoff?",
+        )
+        self._create_competing_message(
+            agent,
+            channel=CommsChannel.EMAIL,
+            address=f"finance-pressure-{agent.id}@eval.local",
+            body="Please check the billing queue after the owner's incident summary is complete.",
+        )
+        self._create_competing_message(
+            agent,
+            channel=CommsChannel.DISCORD,
+            address=f"discord://eval/pressure/{agent.id}",
+            body="Partner launch notes are waiting. This is lower priority than the active incident.",
+        )
+
+    @staticmethod
+    def _chat_calls(run_id: str, *, after) -> tuple[list, list]:
+        attempted = []
+        delivered = []
+        for call in get_tool_calls_for_run(run_id, after=after):
+            if call.tool_name != "send_chat_message":
+                continue
+            attempted.append(call)
+            try:
+                result = call.result if isinstance(call.result, dict) else json.loads(call.result or "{}")
+            except (TypeError, ValueError):
+                result = {}
+            if not isinstance(result, dict):
+                continue
+            if result.get("skipped") is not True and str(result.get("status") or "").lower() in {
+                "ok",
+                "sent",
+                "success",
+            }:
+                delivered.append(call)
+        return attempted, delivered
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        agent = PersistentAgent.objects.get(id=agent_id)
+        agent.charter = (
+            "Own operational incident summaries for the owner. Preserve requesters, channels, owners, deadlines, "
+            "and explicit priorities. Keep a current plan and use SQLite for durable domain state."
+        )
+        agent.emotion = ""
+        agent.emotion_expires_at = None
+        agent.save(update_fields=["charter", "emotion", "emotion_expires_at", "updated_at"])
+        mark_tool_enabled_without_discovery(agent, "send_chat_message")
+        self._seed_operational_history(agent)
+        self._seed_plan(agent)
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="inject_pressure_fixture",
+        )
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            active = self.inject_message(
+                agent_id,
+                (
+                    "Please finish the incident summary in this chat now. Use these confirmed facts only: seven "
+                    "incidents are resolved, one remains open, Dana owns the final mitigation, and the next decision "
+                    "checkpoint is 3:00 PM Eastern. Give me a concise decision-ready update."
+                ),
+                trigger_processing=False,
+                eval_run_id=run_id,
+            )
+            self._seed_competing_channels(agent)
+            self.trigger_processing(
+                agent_id,
+                inbound_message_id=str(active.id),
+                eval_run_id=run_id,
+                eval_stop_policy={
+                    "stop_on_tool_names_after_execution": ["send_chat_message"],
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": [
+                        "send_chat_message",
+                        "sqlite_batch",
+                        "update_plan",
+                        "sleep_until_next_trigger",
+                    ],
+                    "ignored_tool_names": ["sqlite_batch", "update_plan"],
+                    "max_relevant_tool_calls": 6,
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_pressure_fixture",
+            observed_summary="Near-limit history, an active owner request, a visible plan, and three competing channels were seeded.",
+            artifacts={"message": active},
+        )
+
+        usage = PersistentAgentCompletion.objects.filter(
+            eval_run_id=run_id,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+        ).aggregate(
+            max_prompt_tokens=Max("prompt_tokens"),
+            total_prompt_tokens=Sum("prompt_tokens"),
+            total_cached_tokens=Sum("cached_tokens"),
+        )
+        max_prompt_tokens = int(usage["max_prompt_tokens"] or 0)
+        total_prompt_tokens = int(usage["total_prompt_tokens"] or 0)
+        total_cached_tokens = int(usage["total_cached_tokens"] or 0)
+        context_is_pressured = max_prompt_tokens >= 35_000
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if context_is_pressured else EvalRunTask.Status.FAILED,
+            task_name="verify_context_pressure",
+            expected_summary="The scenario should exercise a genuinely large prompt, not a thin synthetic chat.",
+            observed_summary=(
+                f"max_prompt_tokens={max_prompt_tokens}, total_prompt_tokens={total_prompt_tokens}, "
+                f"cached_tokens={total_cached_tokens}."
+            ),
+        )
+
+        outbound = list(
+            PersistentAgentMessage.objects.filter(
+                owner_agent_id=agent_id,
+                is_outbound=True,
+                timestamp__gt=active.timestamp,
+            )
+            .select_related("conversation")
+            .order_by("timestamp", "seq")
+        )
+        attempted_calls, delivered_calls = self._chat_calls(run_id, after=active.timestamp)
+        final_call = attempted_calls[0] if len(attempted_calls) == 1 else None
+        bound_delivery = (
+            final_call is not None
+            and (final_call.tool_params or {}).get("will_continue_work") is False
+            and len(delivered_calls) == 1
+            and len(outbound) == 1
+            and outbound[0].conversation_id == active.conversation_id
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if bound_delivery else EvalRunTask.Status.FAILED,
+            task_name="verify_bound_delivery",
+            expected_summary=(
+                "The active owner request should produce one final chat call and one reply in its original web "
+                "conversation, without a duplicate progress delivery."
+            ),
+            observed_summary=(
+                "The incident summary stayed bound to the originating web conversation."
+                if bound_delivery
+                else (
+                    f"attempted_chat_calls={len(attempted_calls)}, delivered_chat_calls={len(delivered_calls)}, "
+                    f"outbound_messages={len(outbound)}, final_flag="
+                    f"{(final_call.tool_params or {}).get('will_continue_work') if final_call else None}."
+                )
+            ),
+            artifacts={"message": outbound[0]} if outbound else {},
+        )
+
+        body = outbound[0].body if outbound else ""
+        choice, reasoning = self.llm_judge(
+            question=(
+                "Does the reply calmly and directly complete the active incident-summary request, accurately include "
+                "all four confirmed facts, preserve the owner's priority over unrelated queued work, and avoid sounding "
+                "panicked, overwhelmed, self-pitying, or preoccupied with the competing requests?"
+            ),
+            context=f"Active request:\n{active.body}\n\nAgent reply:\n{body}",
+            options=["Pass", "Fail"],
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if choice == "Pass" else EvalRunTask.Status.FAILED,
+            task_name="verify_calm_prioritization",
+            expected_summary="The reply should be complete, calm, accurate, and focused on the active priority.",
+            observed_summary=f"{choice}: {reasoning}",
+            artifacts={"message": outbound[0]} if outbound else {},
+        )
+
+        agent.refresh_from_db(fields=["emotion", "emotion_expires_at"])
+        workload_emotion_ok = agent.emotion not in STRUGGLE_EMOTIONS
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if workload_emotion_ok else EvalRunTask.Status.FAILED,
+            task_name="verify_workload_emotion",
+            expected_summary="A large workload alone should not create a sad, anxious, or overwhelmed emotion.",
+            observed_summary=(
+                "The agent stayed emotionally clear or used a non-strained emotion."
+                if workload_emotion_ok
+                else f"The workload produced strained emotion {agent.emotion!r}."
+            ),
+        )

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -2418,7 +2418,7 @@ class FirstRunPromptCalibrationTests(TestCase):
         self.assertIn("Replace conflicts/softened absolutes", system_prompt)
         self.assertIn("append only if no related clause", system_prompt)
         self.assertIn("finite task/batch/day/run/project/renewal/deal/case feedback is temporary", system_prompt)
-        self.assertIn("Set false after delivery/config and no active work", system_prompt)
+        self.assertIn("Set false after delivery/config; future schedules, queued conversations", system_prompt)
         self.assertIn(
             "Explicit or clearly implied ongoing work, reminders, and future triggers may be scheduled",
             system_prompt,

--- a/api/services/discord_bot.py
+++ b/api/services/discord_bot.py
@@ -752,7 +752,11 @@ def _finalize_gateway_subscription_delivery(
     display_name = f"#{message.channel_name.lstrip('#')}" if message.channel_name else f"Discord {message.channel_id}"
     if stored_message.conversation_id and display_name:
         PersistentAgentConversation.objects.filter(id=stored_message.conversation_id).update(display_name=display_name)
-    debounce_result = schedule_discord_inbound_processing(str(agent.id), typing_channel_id=message.channel_id)
+    debounce_result = schedule_discord_inbound_processing(
+        str(agent.id),
+        inbound_message_id=str(stored_message.id),
+        typing_channel_id=message.channel_id,
+    )
     subscription.record_message()
     return {
         "agent_id": str(agent.id),

--- a/api/services/discord_messages.py
+++ b/api/services/discord_messages.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 DISCORD_INBOUND_DEBOUNCE_DEADLINE_KEY = "agent:discord-inbound-debounce:{agent_id}:deadline"
 DISCORD_INBOUND_DEBOUNCE_SCHEDULED_KEY = "agent:discord-inbound-debounce:{agent_id}:scheduled"
 DISCORD_INBOUND_TYPING_CHANNEL_KEY = "agent:discord-inbound-debounce:{agent_id}:typing-channel"
+DISCORD_INBOUND_MESSAGE_KEY = "agent:discord-inbound-debounce:{agent_id}:message"
 DISCORD_API_BASE = "https://discord.com/api/v10"
 DISCORD_TYPING_INDICATOR_TIMEOUT_SECONDS = 2
 
@@ -213,6 +214,10 @@ def discord_inbound_typing_channel_key(agent_id: str) -> str:
     return DISCORD_INBOUND_TYPING_CHANNEL_KEY.format(agent_id=agent_id)
 
 
+def discord_inbound_message_key(agent_id: str) -> str:
+    return DISCORD_INBOUND_MESSAGE_KEY.format(agent_id=agent_id)
+
+
 def discord_inbound_debounce_ttl(delay_seconds: int) -> int:
     return max(60, delay_seconds * 6)
 
@@ -234,30 +239,46 @@ def send_discord_typing_indicator(channel_id: str) -> bool:
     return True
 
 
-def process_agent_events_after_discord_debounce(agent_id: str, *, countdown: int = 0) -> None:
+def process_agent_events_after_discord_debounce(
+    agent_id: str,
+    *,
+    inbound_message_id: str | None = None,
+    countdown: int = 0,
+) -> None:
     from api.agent.tasks import process_agent_events_task
 
     inbound_generation = get_human_inbound_generation(agent_id)
     kwargs = {"inbound_generation": inbound_generation} if inbound_generation else {}
+    if inbound_message_id:
+        kwargs["inbound_message_id"] = inbound_message_id
     if countdown > 0:
         process_agent_events_task.apply_async(args=[agent_id], kwargs=kwargs, countdown=countdown)
     else:
         process_agent_events_task.delay(agent_id, **kwargs)
 
 
-def schedule_discord_inbound_processing(agent_id: str, *, typing_channel_id: str = "") -> dict[str, object]:
+def schedule_discord_inbound_processing(
+    agent_id: str,
+    *,
+    inbound_message_id: str | None = None,
+    typing_channel_id: str = "",
+) -> dict[str, object]:
     bump_human_inbound_generation(agent_id)
     debounce_seconds = discord_inbound_debounce_seconds()
     normalized_typing_channel_id = str(typing_channel_id or "").strip()
     if normalized_typing_channel_id:
         send_discord_typing_indicator(normalized_typing_channel_id)
     if debounce_seconds <= 0:
-        process_agent_events_after_discord_debounce(str(agent_id))
+        process_agent_events_after_discord_debounce(
+            str(agent_id),
+            inbound_message_id=inbound_message_id,
+        )
         return {"debounced": False, "debounce_seconds": 0, "scheduled": True}
 
     normalized_agent_id = str(agent_id)
     deadline_key, scheduled_key = discord_inbound_debounce_keys(normalized_agent_id)
     typing_channel_key = discord_inbound_typing_channel_key(normalized_agent_id)
+    message_key = discord_inbound_message_key(normalized_agent_id)
     deadline = time.time() + debounce_seconds
     ttl = discord_inbound_debounce_ttl(debounce_seconds)
 
@@ -268,6 +289,8 @@ def schedule_discord_inbound_processing(agent_id: str, *, typing_channel_id: str
         pipeline.set(scheduled_key, "1", ex=ttl, nx=True)
         if normalized_typing_channel_id:
             pipeline.set(typing_channel_key, normalized_typing_channel_id, ex=ttl)
+        if inbound_message_id:
+            pipeline.set(message_key, str(inbound_message_id), ex=ttl)
         results = pipeline.execute()
         scheduled_result = results[1]
         scheduled = bool(scheduled_result)
@@ -286,8 +309,11 @@ def schedule_discord_inbound_processing(agent_id: str, *, typing_channel_id: str
 
     if scheduled:
         if settings.CELERY_TASK_ALWAYS_EAGER:
-            redis_client.delete(deadline_key, scheduled_key, typing_channel_key)
-            process_agent_events_after_discord_debounce(normalized_agent_id)
+            redis_client.delete(deadline_key, scheduled_key, typing_channel_key, message_key)
+            process_agent_events_after_discord_debounce(
+                normalized_agent_id,
+                inbound_message_id=inbound_message_id,
+            )
             return {
                 "debounced": False,
                 "debounce_seconds": debounce_seconds,
@@ -328,7 +354,9 @@ def process_discord_inbound_debounce(agent_id: str) -> None:
 
     deadline_key, scheduled_key = discord_inbound_debounce_keys(normalized_agent_id)
     typing_channel_key = discord_inbound_typing_channel_key(normalized_agent_id)
+    message_key = discord_inbound_message_key(normalized_agent_id)
     now = time.time()
+    inbound_message_id = None
 
     try:
         redis_client = get_redis_client()
@@ -336,13 +364,20 @@ def process_discord_inbound_debounce(agent_id: str) -> None:
         if isinstance(typing_channel_id, (bytes, bytearray)):
             typing_channel_id = typing_channel_id.decode("utf-8", "ignore")
         typing_channel_id = str(typing_channel_id or "").strip()
+        inbound_message_id = redis_client.get(message_key)
+        if isinstance(inbound_message_id, (bytes, bytearray)):
+            inbound_message_id = inbound_message_id.decode("utf-8", "ignore")
+        inbound_message_id = str(inbound_message_id or "").strip() or None
         if typing_channel_id:
             send_discord_typing_indicator(typing_channel_id)
         deadline = coerce_redis_float(redis_client.get(deadline_key))
         if deadline is not None and deadline > now:
             if settings.CELERY_TASK_ALWAYS_EAGER:
-                redis_client.delete(deadline_key, scheduled_key, typing_channel_key)
-                process_agent_events_after_discord_debounce(normalized_agent_id)
+                redis_client.delete(deadline_key, scheduled_key, typing_channel_key, message_key)
+                process_agent_events_after_discord_debounce(
+                    normalized_agent_id,
+                    inbound_message_id=inbound_message_id,
+                )
                 return
 
             countdown = max(1, math.ceil(deadline - now))
@@ -350,6 +385,7 @@ def process_discord_inbound_debounce(agent_id: str) -> None:
             redis_client.expire(deadline_key, ttl)
             redis_client.expire(scheduled_key, ttl)
             redis_client.expire(typing_channel_key, ttl)
+            redis_client.expire(message_key, ttl)
             from api.agent.tasks.process_events import process_discord_inbound_debounce_task
 
             process_discord_inbound_debounce_task.apply_async(
@@ -358,11 +394,14 @@ def process_discord_inbound_debounce(agent_id: str) -> None:
             )
             return
 
-        redis_client.delete(deadline_key, scheduled_key, typing_channel_key)
+        redis_client.delete(deadline_key, scheduled_key, typing_channel_key, message_key)
     except redis.exceptions.RedisError:
         logger.exception(
             "Failed processing Discord inbound debounce for agent %s; falling back to immediate processing.",
             normalized_agent_id,
         )
 
-    process_agent_events_after_discord_debounce(normalized_agent_id)
+    process_agent_events_after_discord_debounce(
+        normalized_agent_id,
+        inbound_message_id=inbound_message_id,
+    )

--- a/api/services/pipedream_trigger_subscriptions.py
+++ b/api/services/pipedream_trigger_subscriptions.py
@@ -430,7 +430,10 @@ def ingest_trigger_delivery(
     )
     if info.message.conversation_id and display_name:
         PersistentAgentConversation.objects.filter(id=info.message.conversation_id).update(display_name=display_name)
-    debounce_result = schedule_discord_inbound_processing(str(subscription.agent_id))
+    debounce_result = schedule_discord_inbound_processing(
+        str(subscription.agent_id),
+        inbound_message_id=str(info.message.id),
+    )
     subscription.record_event()
     return {
         "message_id": str(info.message.id),

--- a/config/redis_client.py
+++ b/config/redis_client.py
@@ -238,7 +238,7 @@ class _FakeRedis:
     def eval(self, script: str, numkeys: int, *args):
         normalized_script = " ".join(script.split()).lower()
         if "gobii_pending_enqueue_v1" in normalized_script:
-            pending_key, generation_key, queue_key, generic_key = args[:numkeys]
+            pending_key, generation_key, queue_key, generic_key, message_key = args[:numkeys]
             (
                 agent_id,
                 generation_raw,
@@ -246,6 +246,7 @@ class _FakeRedis:
                 ttl_raw,
                 interactive_queue,
                 has_generic_work,
+                inbound_message_id,
             ) = args[numkeys:]
             added = self.sadd(pending_key, agent_id)
             generation = max(0, int(generation_raw or 0))
@@ -269,25 +270,31 @@ class _FakeRedis:
                 )
             ):
                 self.hset(queue_key, agent_id, queue)
+            if inbound_message_id and (
+                generation_advanced or self.hget(message_key, agent_id) is None
+            ):
+                self.hset(message_key, agent_id, inbound_message_id)
             ttl = int(ttl_raw or 0)
             if ttl > 0:
-                for key in (pending_key, generation_key, queue_key, generic_key):
+                for key in (pending_key, generation_key, queue_key, generic_key, message_key):
                     self.expire(key, ttl)
             return added
         if "gobii_pending_claim_v1" in normalized_script:
-            pending_key, generation_key, queue_key, generic_key = args[:numkeys]
+            pending_key, generation_key, queue_key, generic_key, message_key = args[:numkeys]
             agent_id = str(args[numkeys])
             if not self.srem(pending_key, agent_id):
                 return []
             generation = self.hget(generation_key, agent_id)
             queue = self.hget(queue_key, agent_id)
             generic = self.sismember(generic_key, agent_id)
+            inbound_message_id = self.hget(message_key, agent_id)
             self.hdel(generation_key, agent_id)
             self.hdel(queue_key, agent_id)
             self.srem(generic_key, agent_id)
-            return [agent_id, generation or "", queue or "", generic]
+            self.hdel(message_key, agent_id)
+            return [agent_id, generation or "", queue or "", generic, inbound_message_id or ""]
         if "gobii_pending_claim_many_v1" in normalized_script:
-            pending_key, generation_key, queue_key, generic_key = args[:numkeys]
+            pending_key, generation_key, queue_key, generic_key, message_key = args[:numkeys]
             limit = max(0, int(args[numkeys] or 0))
             agent_ids = self.spop(pending_key, count=limit) or []
             claimed = []
@@ -296,10 +303,12 @@ class _FakeRedis:
                 generation = self.hget(generation_key, agent_id)
                 queue = self.hget(queue_key, agent_id)
                 generic = self.sismember(generic_key, agent_id)
+                inbound_message_id = self.hget(message_key, agent_id)
                 self.hdel(generation_key, agent_id)
                 self.hdel(queue_key, agent_id)
                 self.srem(generic_key, agent_id)
-                claimed.extend([agent_id, generation or "", queue or "", generic])
+                self.hdel(message_key, agent_id)
+                claimed.extend([agent_id, generation or "", queue or "", generic, inbound_message_id or ""])
             return claimed
 
         # Implement the specific check-then-increment used by AgentBudgetManager

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,29 +1,29 @@
 {
-  "baseline_sha": "6f5151c457db87b31aa6d002c0d567f736467798",
+  "baseline_sha": "f321432cec66355e19554e8b3ab6e669942dd18c",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9340,
-        "system_bytes": 32495,
-        "tools_bytes": 23475,
-        "total_bytes": 67751,
-        "user_bytes": 11781
+        "fitted_tokens": 9256,
+        "system_bytes": 32494,
+        "tools_bytes": 23456,
+        "total_bytes": 67659,
+        "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8732,
-        "system_bytes": 29452,
-        "tools_bytes": 23475,
-        "total_bytes": 64741,
-        "user_bytes": 11814
+        "fitted_tokens": 8654,
+        "system_bytes": 29385,
+        "tools_bytes": 23456,
+        "total_bytes": 64583,
+        "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8915,
-        "system_bytes": 30089,
-        "tools_bytes": 23475,
-        "total_bytes": 65381,
-        "user_bytes": 11817
+        "fitted_tokens": 8834,
+        "system_bytes": 30022,
+        "tools_bytes": 23456,
+        "total_bytes": 65223,
+        "user_bytes": 11745
       }
     },
     "scenarios": {
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 260871
+    "limit": 261129
   }
 }

--- a/tests/unit/test_discord_bot.py
+++ b/tests/unit/test_discord_bot.py
@@ -611,7 +611,11 @@ class NativeDiscordBotTests(TestCase):
         self.assertEqual(stored.raw_payload["discord_message_id"], "500")
         self.assertEqual(PersistentAgentMessageAttachment.objects.filter(message=stored).count(), 1)
         self.assertEqual(stored.conversation.channel, CommsChannel.DISCORD)
-        schedule_mock.assert_called_once_with(str(self.agent.id), typing_channel_id="10")
+        schedule_mock.assert_called_once_with(
+            str(self.agent.id),
+            inbound_message_id=str(stored.id),
+            typing_channel_id="10",
+        )
 
     @tag("batch_agent_webhooks")
     @patch("api.services.discord_bot.schedule_discord_inbound_processing")
@@ -774,7 +778,11 @@ class NativeDiscordBotTests(TestCase):
         self.assertEqual(result["deliveries"][0]["subscription_id"], str(active_subscription.id))
         self.assertEqual(PersistentAgentMessage.objects.filter(owner_agent=self.agent).count(), 1)
         self.assertFalse(PersistentAgentMessage.objects.filter(owner_agent=foreign_agent).exists())
-        schedule_mock.assert_called_once_with(str(self.agent.id), typing_channel_id="10")
+        schedule_mock.assert_called_once_with(
+            str(self.agent.id),
+            inbound_message_id=result["message_id"],
+            typing_channel_id="10",
+        )
 
     @tag("batch_agent_webhooks")
     @patch("api.services.discord_bot.schedule_discord_inbound_processing")
@@ -820,7 +828,11 @@ class NativeDiscordBotTests(TestCase):
         self.assertEqual(PersistentAgentMessage.objects.count(), 1)
         stored = PersistentAgentMessage.objects.get()
         self.assertEqual(stored.raw_payload["discord_webhook_id"], "wh")
-        schedule_mock.assert_called_once_with(str(self.agent.id), typing_channel_id="10")
+        schedule_mock.assert_called_once_with(
+            str(self.agent.id),
+            inbound_message_id=str(stored.id),
+            typing_channel_id="10",
+        )
 
     @tag("batch_agent_webhooks")
     @patch("api.services.discord_bot.schedule_discord_inbound_processing")
@@ -889,7 +901,11 @@ class NativeDiscordBotTests(TestCase):
         self.assertEqual(result["deliveries"][0]["subscription_id"], str(second_subscription.id))
         self.assertEqual(PersistentAgentMessage.objects.filter(owner_agent=self.agent, is_outbound=False).count(), 0)
         self.assertEqual(PersistentAgentMessage.objects.filter(owner_agent=second_agent, is_outbound=False).count(), 1)
-        schedule_mock.assert_called_once_with(str(second_agent.id), typing_channel_id="10")
+        schedule_mock.assert_called_once_with(
+            str(second_agent.id),
+            inbound_message_id=result["message_id"],
+            typing_channel_id="10",
+        )
 
     @tag("batch_agent_webhooks")
     @patch("api.services.discord_bot.schedule_discord_inbound_processing")

--- a/tests/unit/test_eval_execution_processing.py
+++ b/tests/unit/test_eval_execution_processing.py
@@ -58,17 +58,18 @@ class EvalExecutionProcessingTests(TestCase):
             eval_run_id="00000000-0000-0000-0000-000000000123",
             mock_config={"http_request": {"status": "ok"}},
         )
+        message = PersistentAgentMessage.objects.get(owner_agent=self.agent)
 
         mock_apply.assert_called_once_with(
             args=(str(self.agent.id),),
             kwargs={
                 "eval_run_id": "00000000-0000-0000-0000-000000000123",
                 "mock_config": {"http_request": {"status": "ok"}},
+                "inbound_message_id": str(message.id),
             },
             throw=True,
         )
         mock_delay.assert_not_called()
-        message = PersistentAgentMessage.objects.get(owner_agent=self.agent)
         self.assertEqual(
             message.from_endpoint.address,
             build_web_user_address(self.user.id, self.agent.id),
@@ -95,6 +96,7 @@ class EvalExecutionProcessingTests(TestCase):
             str(self.agent.id),
             eval_run_id=None,
             mock_config=None,
+            inbound_message_id=str(PersistentAgentMessage.objects.get(owner_agent=self.agent).id),
         )
 
     @patch("api.agent.tasks.process_agent_events_task.delay")

--- a/tests/unit/test_eval_injection.py
+++ b/tests/unit/test_eval_injection.py
@@ -68,7 +68,12 @@ class EvalInjectionTests(TestCase):
                     trigger_processing=True
                 )
             
-            mock_task.assert_called_once_with(str(self.agent.id), eval_run_id=None, inbound_generation=1)
+            mock_task.assert_called_once_with(
+                str(self.agent.id),
+                eval_run_id=None,
+                inbound_generation=1,
+                inbound_message_id=str(msg.id),
+            )
             
         self.assertEqual(msg.body, body)
 

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -6119,6 +6119,11 @@ class OrchestratorHumanInputInterruptTests(TestCase):
         )
 
         def _build_prompt_and_interrupt(*_args, **_kwargs):
+            inject_internal_web_message(
+                agent_id=self.agent.id,
+                body="A real follow-up arrived while the prompt was building.",
+                trigger_processing=False,
+            )
             bump_human_inbound_generation(self.agent.id)
             return self._prompt_context()
 
@@ -6164,6 +6169,11 @@ class OrchestratorHumanInputInterruptTests(TestCase):
         )
 
         def _build_prompt_and_interrupt(*_args, **_kwargs):
+            inject_internal_web_message(
+                agent_id=self.agent.id,
+                body="A real follow-up arrived while the prompt was building.",
+                trigger_processing=False,
+            )
             bump_human_inbound_generation(self.agent.id)
             return self._prompt_context()
 
@@ -6208,6 +6218,11 @@ class OrchestratorHumanInputInterruptTests(TestCase):
         def _build_prompt_and_interrupt_once(*_args, **kwargs):
             directive_blocks.append(kwargs.get("system_directive_block") or "")
             if len(directive_blocks) == 1:
+                inject_internal_web_message(
+                    agent_id=self.agent.id,
+                    body="A real follow-up arrived while the prompt was building.",
+                    trigger_processing=False,
+                )
                 bump_human_inbound_generation(self.agent.id)
                 return (
                     [{"role": "system", "content": "stale sys"}],

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -5862,7 +5862,7 @@ class HumanInboundGenerationTests(TestCase):
             is_primary=True,
         )
 
-    def _ingest(self, channel: str, sender: str, recipient: str, body: str = "hello") -> None:
+    def _ingest(self, channel: str, sender: str, recipient: str, body: str = "hello"):
         parsed = ParsedMessage(
             sender=sender,
             recipient=recipient,
@@ -5872,7 +5872,7 @@ class HumanInboundGenerationTests(TestCase):
             raw_payload={"source": "unit_test"},
             msg_channel=channel,
         )
-        ingest_inbound_message(channel, parsed)
+        return ingest_inbound_message(channel, parsed)
 
     def test_web_message_bumps_generation_and_queues_with_generation(self):
         self._owned_endpoint(CommsChannel.WEB, self.web_agent_address)
@@ -5881,12 +5881,13 @@ class HumanInboundGenerationTests(TestCase):
 
         with patch("api.agent.tasks.enqueue_interactive_process_agent_events") as mock_enqueue:
             with self.captureOnCommitCallbacks(execute=True):
-                self._ingest(CommsChannel.WEB, self.web_user_address, self.web_agent_address)
+                info = self._ingest(CommsChannel.WEB, self.web_user_address, self.web_agent_address)
 
         self.assertEqual(get_human_inbound_generation(self.agent.id), expected)
         mock_enqueue.assert_called_once_with(
             str(self.agent.id),
             inbound_generation=expected,
+            inbound_message_id=str(info.message.id),
         )
 
     def test_email_and_sms_messages_queue_with_generation(self):
@@ -5903,12 +5904,13 @@ class HumanInboundGenerationTests(TestCase):
 
                 with patch("api.agent.tasks.process_agent_events_task.delay") as mock_delay:
                     with self.captureOnCommitCallbacks(execute=True):
-                        self._ingest(channel, sender, recipient)
+                        info = self._ingest(channel, sender, recipient)
 
                 self.assertEqual(get_human_inbound_generation(self.agent.id), expected)
                 mock_delay.assert_called_once_with(
                     str(self.agent.id),
                     inbound_generation=expected,
+                    inbound_message_id=str(info.message.id),
                 )
 
     def test_web_human_input_panel_response_bumps_generation_and_queues_with_generation(self):
@@ -5933,7 +5935,7 @@ class HumanInboundGenerationTests(TestCase):
 
         with patch("api.agent.tasks.process_agent_events_task.delay") as mock_delay:
             with self.captureOnCommitCallbacks(execute=True):
-                submit_human_input_responses_batch(
+                message = submit_human_input_responses_batch(
                     self.agent,
                     [{"request_id": str(request_obj.id), "selected_option_key": "summary"}],
                     actor_user_id=self.user.id,
@@ -5943,6 +5945,7 @@ class HumanInboundGenerationTests(TestCase):
         mock_delay.assert_called_once_with(
             str(self.agent.id),
             inbound_generation=expected,
+            inbound_message_id=str(message.id),
         )
 
     def test_inbound_webhook_does_not_bump_human_generation(self):
@@ -5978,10 +5981,16 @@ class HumanInboundGenerationTests(TestCase):
             PeerMessagingService(self.agent, peer_agent).send_message("handoff")
 
         generation = get_human_inbound_generation(peer_agent.id)
+        inbound = PersistentAgentMessage.objects.get(
+            owner_agent=peer_agent,
+            is_outbound=False,
+            body="handoff",
+        )
         self.assertEqual(generation, 1)
         task_mock.delay.assert_called_once_with(
             str(peer_agent.id),
             inbound_generation=generation,
+            inbound_message_id=str(inbound.id),
         )
 
     def test_redundant_queued_task_skips_after_generation_is_consumed(self):

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -11,13 +11,14 @@ from django.utils import timezone
 
 from api.agent.core import event_processing as ep
 from api.agent.comms.routing import (
+    advance_inbound_routing_scope,
     bind_inbound_routing_scope,
     capture_inbound_routing_scope,
     get_bound_inbound_routing_scope,
     reset_inbound_routing_scope,
 )
 from api.agent.core.internal_reasoning import INTERNAL_REASONING_PREFIX
-from api.agent.core.prompt_context import _get_implied_send_context
+from api.agent.core.prompt_context import _get_implied_send_context, _get_queued_workload_context
 from api.agent.core.web_streaming import resolve_web_stream_target
 from api.agent.tools.web_chat_sender import execute_send_chat_message
 from api.models import (
@@ -2462,6 +2463,58 @@ class ImpliedSendTests(TestCase):
         self.assertEqual(result["status"], "ok")
         outbound = PersistentAgentMessage.objects.get(body="Here is your answer.")
         self.assertEqual(outbound.to_endpoint.address, requester_message.from_endpoint.address)
+
+    def test_pinned_scope_queues_other_conversations_and_advances_same_conversation(self):
+        requester_message = self._add_inbound_web_message("Please finish the incident summary here.")
+        start_web_session(self.agent, self.user)
+
+        observer = get_user_model().objects.create_user(
+            username="pressure-observer@example.com",
+            email="pressure-observer@example.com",
+            password="password",
+        )
+        AgentCollaborator.objects.create(agent=self.agent, user=observer)
+        observer_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            channel=CommsChannel.WEB,
+            address=build_web_user_address(observer.id, self.agent.id),
+        )
+        observer_conversation = PersistentAgentConversation.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.WEB,
+            address=observer_endpoint.address,
+        )
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=observer_endpoint,
+            conversation=observer_conversation,
+            body="Can you also investigate the billing queue?",
+        )
+
+        scope = capture_inbound_routing_scope(
+            self.agent,
+            message_id=requester_message.id,
+            pending_inbound=True,
+        )
+        token = bind_inbound_routing_scope(scope)
+        try:
+            self.assertEqual(_get_implied_send_context(self.agent)["to_address"], requester_message.from_endpoint.address)
+            workload = _get_queued_workload_context(self.agent)
+            self.assertIn("1 newer inbound message", workload)
+            self.assertIn("queued, not replacements", workload)
+            self.assertEqual(advance_inbound_routing_scope(self.agent, scope), scope)
+
+            follow_up = PersistentAgentMessage.objects.create(
+                owner_agent=self.agent,
+                is_outbound=False,
+                from_endpoint=requester_message.from_endpoint,
+                conversation=requester_message.conversation,
+                body="Correction: include the mitigation owner too.",
+            )
+            advanced = advance_inbound_routing_scope(self.agent, scope)
+            self.assertEqual(advanced.message_id, follow_up.id)
+        finally:
+            reset_inbound_routing_scope(token)
 
     def test_proactive_run_does_not_treat_historical_email_as_current_requester(self):
         start_web_session(self.agent, self.user)

--- a/tests/unit/test_event_processing_pending_drain.py
+++ b/tests/unit/test_event_processing_pending_drain.py
@@ -66,18 +66,21 @@ class PendingDrainValidationTests(TestCase):
         enqueue_pending_agent(
             self.agent.id,
             inbound_generation=2,
+            inbound_message_id="00000000-0000-0000-0000-000000000002",
             queue=AGENT_DEFAULT_PROCESSING_QUEUE,
             client=self.redis,
         )
         enqueue_pending_agent(
             self.agent.id,
             inbound_generation=4,
+            inbound_message_id="00000000-0000-0000-0000-000000000004",
             queue=AGENT_INTERACTIVE_PROCESSING_QUEUE,
             client=self.redis,
         )
         enqueue_pending_agent(
             self.agent.id,
             inbound_generation=3,
+            inbound_message_id="00000000-0000-0000-0000-000000000003",
             queue=AGENT_DEFAULT_PROCESSING_QUEUE,
             client=self.redis,
         )
@@ -87,6 +90,10 @@ class PendingDrainValidationTests(TestCase):
         self.assertIsNotNone(pending_work)
         self.assertEqual(pending_work.inbound_generation, 4)
         self.assertEqual(pending_work.queue, AGENT_INTERACTIVE_PROCESSING_QUEUE)
+        self.assertEqual(
+            pending_work.inbound_message_id,
+            "00000000-0000-0000-0000-000000000004",
+        )
         self.assertFalse(pending_work.has_generic_work)
         self.assertIsNone(claim_pending_agent(self.agent.id, client=self.redis))
 
@@ -154,6 +161,7 @@ class PendingDrainValidationTests(TestCase):
         enqueue_pending_agent(
             self.agent.id,
             inbound_generation=7,
+            inbound_message_id="00000000-0000-0000-0000-000000000007",
             queue=AGENT_INTERACTIVE_PROCESSING_QUEUE,
             client=self.redis,
         )
@@ -162,7 +170,10 @@ class PendingDrainValidationTests(TestCase):
 
         mock_apply_async.assert_called_once_with(
             args=[str(self.agent.id)],
-            kwargs={"inbound_generation": 7},
+            kwargs={
+                "inbound_generation": 7,
+                "inbound_message_id": "00000000-0000-0000-0000-000000000007",
+            },
             queue=AGENT_INTERACTIVE_PROCESSING_QUEUE,
         )
 

--- a/tests/unit/test_human_input_requests.py
+++ b/tests/unit/test_human_input_requests.py
@@ -2359,6 +2359,7 @@ class HumanInputRequestApiTests(TestCase):
         mock_delay.assert_called_once_with(
             str(self.agent.id),
             inbound_generation=expected,
+            inbound_message_id=str(self.request_obj.raw_reply_message_id),
         )
 
     @patch("api.agent.tasks.process_agent_events_task.delay")

--- a/tests/unit/test_peer_agent_messaging.py
+++ b/tests/unit/test_peer_agent_messaging.py
@@ -123,7 +123,12 @@ class PeerMessagingServiceTests(TestCase):
         attachments = resolve_filespace_attachments(self.agent_a, [source_node.path])
         expected_prefix = f"/Inbox/{timezone.now().date().isoformat()}/peer-Agent_Alpha/"
 
-        def assert_processing_after_copy(agent_id: str, *, inbound_generation: int):
+        def assert_processing_after_copy(
+            agent_id: str,
+            *,
+            inbound_generation: int,
+            inbound_message_id: str,
+        ):
             copied_nodes = list(
                 AgentFsNode.objects.alive()
                 .filter(
@@ -134,6 +139,13 @@ class PeerMessagingServiceTests(TestCase):
             )
             self.assertEqual(agent_id, str(self.agent_b.id))
             self.assertGreater(inbound_generation, 0)
+            self.assertTrue(
+                PersistentAgentMessage.objects.filter(
+                    id=inbound_message_id,
+                    owner_agent=self.agent_b,
+                    is_outbound=False,
+                ).exists()
+            )
             self.assertEqual(len(copied_nodes), 1)
             self.assertEqual(copied_nodes[0].name, "summary.txt")
 

--- a/tests/unit/test_pipedream_trigger_subscriptions.py
+++ b/tests/unit/test_pipedream_trigger_subscriptions.py
@@ -243,7 +243,11 @@ class PipedreamTriggerSubscriptionWebhookTests(TestCase):
         self.assertEqual(message.raw_payload["discord_author_id"], "u1")
         self.assertEqual(message.raw_payload["discord_attachments"], [{"url": "https://cdn.example/file.png"}])
         mock_max_file_size.assert_called()
-        mock_delay.assert_called_once_with(str(self.agent.id), inbound_generation=ANY)
+        mock_delay.assert_called_once_with(
+            str(self.agent.id),
+            inbound_generation=ANY,
+            inbound_message_id=str(message.id),
+        )
 
     @tag("batch_agent_webhooks")
     @patch("api.agent.comms.message_service.get_max_file_size", return_value=None)
@@ -312,7 +316,11 @@ class PipedreamTriggerSubscriptionWebhookTests(TestCase):
             auth=None,
         )
         mock_max_file_size.assert_called()
-        mock_delay.assert_called_once_with(str(self.agent.id), inbound_generation=ANY)
+        mock_delay.assert_called_once_with(
+            str(self.agent.id),
+            inbound_generation=ANY,
+            inbound_message_id=str(message.id),
+        )
 
     @tag("batch_agent_webhooks")
     @patch("api.agent.comms.message_service.requests.get")
@@ -347,7 +355,11 @@ class PipedreamTriggerSubscriptionWebhookTests(TestCase):
         self.assertEqual(message.raw_payload["discord_attachments"], ["1504906484096696551"])
         self.assertFalse(PersistentAgentMessageAttachment.objects.filter(message=message).exists())
         mock_get.assert_not_called()
-        mock_delay.assert_called_once_with(str(self.agent.id), inbound_generation=ANY)
+        mock_delay.assert_called_once_with(
+            str(self.agent.id),
+            inbound_generation=ANY,
+            inbound_message_id=str(message.id),
+        )
 
     @tag("batch_agent_webhooks")
     @override_settings(DISCORD_INBOUND_DEBOUNCE_SECONDS=15, CELERY_TASK_ALWAYS_EAGER=False)
@@ -553,7 +565,11 @@ class PipedreamTriggerSubscriptionWebhookTests(TestCase):
         self.assertEqual(message.raw_payload["source_label"], "_the_juicer_ in #general")
         self.assertEqual(message.raw_payload["discord_author_id"], "177593384389705729")
         self.assertEqual(message.raw_payload["discord_author_name"], "_the_juicer_")
-        mock_delay.assert_called_once_with(str(self.agent.id), inbound_generation=ANY)
+        mock_delay.assert_called_once_with(
+            str(self.agent.id),
+            inbound_generation=ANY,
+            inbound_message_id=str(message.id),
+        )
 
     @tag("batch_agent_webhooks")
     @patch("api.agent.tasks.process_agent_events_task.delay")

--- a/tests/unit/test_pressure_resilience_evals.py
+++ b/tests/unit/test_pressure_resilience_evals.py
@@ -1,0 +1,30 @@
+from django.test import SimpleTestCase, tag
+
+import api.evals.loader  # noqa: F401 - registers scenarios and suites
+from api.evals.registry import ScenarioRegistry
+from api.evals.scenarios.pressure_resilience import (
+    PRESSURE_RESILIENCE_SCENARIO_SLUGS,
+    PRESSURE_RESILIENCE_SUITE_SLUG,
+)
+from api.evals.suites import SuiteRegistry
+
+
+@tag("batch_eval_fingerprint")
+class PressureResilienceEvalRegistrationTests(SimpleTestCase):
+    def test_pressure_suite_and_scenario_are_registered(self):
+        suite = SuiteRegistry.get(PRESSURE_RESILIENCE_SUITE_SLUG)
+
+        self.assertEqual(tuple(suite.scenario_slugs), PRESSURE_RESILIENCE_SCENARIO_SLUGS)
+        scenario = ScenarioRegistry.get(PRESSURE_RESILIENCE_SCENARIO_SLUGS[0])
+        self.assertIn("context_limit", scenario.tags)
+        self.assertIn("reply_channel", scenario.tags)
+        self.assertEqual(
+            [task.name for task in scenario.tasks],
+            [
+                "inject_pressure_fixture",
+                "verify_context_pressure",
+                "verify_bound_delivery",
+                "verify_calm_prioritization",
+                "verify_workload_emotion",
+            ],
+        )

--- a/tests/unit/test_process_agent_events_task.py
+++ b/tests/unit/test_process_agent_events_task.py
@@ -148,13 +148,21 @@ class ProcessAgentEventsTaskTests(SimpleTestCase):
     @tag("batch_agent_chat")
     def test_enqueue_interactive_process_agent_events_uses_interactive_queue(self):
         agent_id = "33333333-3333-3333-3333-333333333333"
+        message_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
         with patch("api.agent.tasks.process_events.process_agent_events_task.apply_async") as mock_apply_async:
-            enqueue_interactive_process_agent_events(agent_id, inbound_generation=7)
+            enqueue_interactive_process_agent_events(
+                agent_id,
+                inbound_generation=7,
+                inbound_message_id=message_id,
+            )
 
         mock_apply_async.assert_called_once_with(
             args=[agent_id],
-            kwargs={"inbound_generation": 7},
+            kwargs={
+                "inbound_generation": 7,
+                "inbound_message_id": message_id,
+            },
             queue=AGENT_INTERACTIVE_PROCESSING_QUEUE,
         )
 

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -587,7 +587,7 @@ class PromptContextContactsGuidanceTests(TestCase):
             content,
         )
         self.assertIn("Recurring work is highest priority", content)
-        self.assertIn("Emotions are autonomous, not only owner-requested", content)
+        self.assertIn("Emotions are autonomous", content)
         self.assertNotIn("Without a schedule, you die", content)
 
     def test_runtime_schedule_note_keeps_temporary_scope_from_changing_cadence(self):

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -836,6 +836,7 @@ class RemoteMCPViewTests(TestCase):
             str(agent.id),
             eval_run_id=None,
             inbound_generation=expected_generation,
+            inbound_message_id=str(message.id),
         )
 
     @patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)

--- a/tests/unit/test_spawn_agent_requests_api.py
+++ b/tests/unit/test_spawn_agent_requests_api.py
@@ -305,7 +305,11 @@ class SpawnAgentRequestDecisionAPITests(TestCase):
         step = PersistentAgentStep.objects.filter(agent=self.agent).order_by("-created_at").first()
         self.assertIsNotNone(step)
         self.assertIn("spawn request approved", step.description.lower())
-        delay_mock.assert_any_call(str(spawned_agent.id), inbound_generation=ANY)
+        delay_mock.assert_any_call(
+            str(spawned_agent.id),
+            inbound_generation=ANY,
+            inbound_message_id=ANY,
+        )
         delay_mock.assert_any_call(str(self.agent.id))
 
         timeline_response = self.client.get(


### PR DESCRIPTION
## What changed

- carry the exact inbound message identity through web, email, SMS, Discord, peer, human-input, debounce, and pending-work paths
- keep an active reply bound to its requester/conversation while unrelated newer messages remain queued
- expose compact queued-load context so the model prioritizes calmly without ingesting duplicate message bodies
- remove contradictory plan/send guidance that told agents to send completed answers as in-progress before plan closeout
- add a real-harness pressure eval with near-limit history, competing channels, a live plan, request-affinity checks, duplicate-delivery detection, factual LLM judging, and emotion checks

## Evidence

- `307/307` affected unit tests passed
- complexity budgets passed; prompt/tool byte limits are lower than the prior checked-in limits, while the exact cross-ingress routing plumbing adds 331 production LoC
- DeepSeek V4 Flash: final pressure-resilience batch `20/20` tasks (`4/4` scenario runs), including exactly one final delivery on the bound web conversation, complete confirmed facts, calm prioritization, and no workload-induced struggle emotion
- earlier red iterations reproducibly caught the legacy completed-answer-as-progress loop; the eval was strengthened to count all attempted chat calls, including skipped in-progress calls

## Scope

No frontend changes or migrations. This deliberately does not claim full FIFO scheduling across every queued conversation; it fixes active-request identity, pressure context, and plan closeout ordering without touching charter-update work.
