### PR TITLE
Normalize exact sleep instructions into tool calls

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -4169,6 +4169,18 @@ def _build_implied_send_tool_call(
         None,
     )
 
+
+def _implied_send_correction_description(message_text: str) -> str:
+    return (
+        "The answer below was not delivered. This mode requires an explicit tool. "
+        "If it is user-facing, send that same content unchanged now with the explicit tool "
+        "for the requester's inbound channel; do not research or call other tools first. "
+        "If it represents silence, completion, or a tool/control instruction, do not send it; "
+        "call sleep_until_next_trigger with empty response content.\n\n"
+        f"UNDELIVERED ANSWER:\n{message_text}"
+    )
+
+
 def _attempt_cycle_close_for_sleep(agent: PersistentAgent, budget_ctx: Optional[BudgetContext]) -> None:
     """Best-effort attempt to close the budget cycle when the agent goes idle."""
 
@@ -7226,6 +7238,26 @@ def _run_agent_loop(
                         )
                         _mark_accepted_human_generation_consumed()
                         continue
+                if not raw_tool_calls and message_text == "sleep_until_next_trigger":
+                    # Some tool-capable models occasionally emit the terminal tool name as
+                    # response text. Consume only the exact token so it cannot be delivered.
+                    raw_tool_calls = [
+                        {
+                            "id": "normalized_sleep_until_next_trigger",
+                            "type": "function",
+                            "function": {
+                                "name": "sleep_until_next_trigger",
+                                "arguments": "{}",
+                            },
+                        }
+                    ]
+                    msg_content = ""
+                    raw_message_text = ""
+                    message_text = ""
+                    logger.info(
+                        "Agent %s: normalized plain-text sleep_until_next_trigger into a tool call.",
+                        agent.id,
+                    )
                 ready_tool_calls = _defer_tool_calls_behind_dependencies(raw_tool_calls)
                 if len(ready_tool_calls) != len(raw_tool_calls):
                     logger.info(
@@ -7291,11 +7323,7 @@ def _run_agent_loop(
                             try:
                                 step_kwargs = {
                                     "agent": agent,
-                                    "description": (
-                                        "The answer below was not delivered. Send that same answer now with the explicit tool "
-                                        "for the requester's inbound channel; do not research or call other tools first.\n\n"
-                                        f"UNDLIVERED ANSWER:\n{message_text}"
-                                    ),
+                                    "description": _implied_send_correction_description(message_text),
                                 }
                                 _persist_attached_step(step_kwargs, _attach_completion, _attach_prompt_archive)
                             except Exception:

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -4169,18 +4169,6 @@ def _build_implied_send_tool_call(
         None,
     )
 
-
-def _implied_send_correction_description(message_text: str) -> str:
-    return (
-        "The answer below was not delivered. This mode requires an explicit tool. "
-        "If it is user-facing, send that same content unchanged now with the explicit tool "
-        "for the requester's inbound channel; do not research or call other tools first. "
-        "If it represents silence, completion, or a tool/control instruction, do not send it; "
-        "call sleep_until_next_trigger with empty response content.\n\n"
-        f"UNDELIVERED ANSWER:\n{message_text}"
-    )
-
-
 def _attempt_cycle_close_for_sleep(agent: PersistentAgent, budget_ctx: Optional[BudgetContext]) -> None:
     """Best-effort attempt to close the budget cycle when the agent goes idle."""
 
@@ -7238,26 +7226,10 @@ def _run_agent_loop(
                         )
                         _mark_accepted_human_generation_consumed()
                         continue
-                if not raw_tool_calls and message_text == "sleep_until_next_trigger":
-                    # Some tool-capable models occasionally emit the terminal tool name as
-                    # response text. Consume only the exact token so it cannot be delivered.
-                    raw_tool_calls = [
-                        {
-                            "id": "normalized_sleep_until_next_trigger",
-                            "type": "function",
-                            "function": {
-                                "name": "sleep_until_next_trigger",
-                                "arguments": "{}",
-                            },
-                        }
-                    ]
-                    msg_content = ""
-                    raw_message_text = ""
-                    message_text = ""
-                    logger.info(
-                        "Agent %s: normalized plain-text sleep_until_next_trigger into a tool call.",
-                        agent.id,
-                    )
+                if not raw_tool_calls and raw_message_text == "sleep_until_next_trigger":
+                    raw_tool_calls = [_coerce_function_call_tool({"name": raw_message_text, "arguments": "{}"})]
+                    msg_content = raw_message_text = message_text = ""
+                    logger.info("Agent %s: normalized plain-text sleep_until_next_trigger into a tool call.", agent.id)
                 ready_tool_calls = _defer_tool_calls_behind_dependencies(raw_tool_calls)
                 if len(ready_tool_calls) != len(raw_tool_calls):
                     logger.info(
@@ -7265,12 +7237,10 @@ def _run_agent_loop(
                         agent.id,
                     )
                     raw_tool_calls = ready_tool_calls
-                raw_tool_names = [_get_tool_call_name(call) for call in raw_tool_calls]
-                has_explicit_send = any(name in MESSAGE_TOOL_NAMES for name in raw_tool_names if name)
-                has_explicit_sleep = any(name == "sleep_until_next_trigger" for name in raw_tool_names if name)
-                has_other_tool_calls = any(
-                    name and name != "sleep_until_next_trigger" for name in raw_tool_names
-                )
+                raw_tool_names = {_get_tool_call_name(call) for call in raw_tool_calls}
+                has_explicit_send = not raw_tool_names.isdisjoint(MESSAGE_TOOL_NAMES)
+                has_explicit_sleep = "sleep_until_next_trigger" in raw_tool_names
+                has_other_tool_calls = bool(raw_tool_names - {None, "sleep_until_next_trigger"})
 
                 implied_send = False
                 tool_calls = list(raw_tool_calls)
@@ -7321,11 +7291,16 @@ def _run_agent_loop(
                         )
                         if implied_error:
                             try:
-                                step_kwargs = {
-                                    "agent": agent,
-                                    "description": _implied_send_correction_description(message_text),
-                                }
-                                _persist_attached_step(step_kwargs, _attach_completion, _attach_prompt_archive)
+                                _record_policy_step(
+                                    agent,
+                                    "The answer below was not delivered. This mode requires an explicit tool. If it is "
+                                    "user-facing, send that same content unchanged now with the explicit tool for the requester's "
+                                    "inbound channel; do not research or call other tools first. If it represents silence, "
+                                    "completion, or a tool/control instruction, do not send it; call sleep_until_next_trigger "
+                                    f"with empty response content.\n\nUNDELIVERED ANSWER:\n{message_text}",
+                                    attach_completion=_attach_completion,
+                                    attach_prompt_archive=_attach_prompt_archive,
+                                )
                             except Exception:
                                 logger.debug("Failed to persist implied-send correction step", exc_info=True)
                         # Don't continue here - still execute any other tool calls that were returned

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -2102,6 +2102,104 @@ class ImpliedSendTests(TestCase):
         return resp
 
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
+    @patch("api.agent.core.event_processing.build_prompt_context")
+    @patch("api.agent.core.event_processing._completion_with_failover")
+    def test_plain_text_sleep_tool_name_is_normalized_without_delivery(
+        self,
+        mock_completion,
+        mock_build_prompt,
+        _mock_credit,
+    ):
+        mock_build_prompt.return_value = ([{"role": "system", "content": "sys"}], 1000, None)
+        mock_completion.return_value = (
+            self._mock_completion("  sleep_until_next_trigger\n"),
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "model": "m",
+                "provider": "p",
+            },
+        )
+
+        with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
+            ep._run_agent_loop(self.agent, is_first_run=False)
+
+        sleep_step = PersistentAgentStep.objects.get(
+            agent=self.agent,
+            description="Decided to sleep until next trigger.",
+        )
+        self.assertIsNotNone(sleep_step.completion_id)
+        self.assertFalse(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description__startswith="The answer below was not delivered.",
+            ).exists()
+        )
+        self.assertFalse(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description__contains="sleep_until_next_trigger",
+            ).exclude(description="Decided to sleep until next trigger.").exists()
+        )
+        self.assertFalse(
+            PersistentAgentToolCall.objects.filter(
+                step__agent=self.agent,
+                tool_name__in=ep.MESSAGE_TOOL_NAMES,
+            ).exists()
+        )
+        self.assertFalse(
+            PersistentAgentMessage.objects.filter(
+                owner_agent=self.agent,
+                is_outbound=True,
+            ).exists()
+        )
+
+    @patch("api.agent.core.event_processing.build_prompt_context")
+    @patch("api.agent.core.event_processing._completion_with_failover")
+    def test_non_exact_sleep_text_uses_branching_delivery_correction(
+        self,
+        mock_completion,
+        mock_build_prompt,
+    ):
+        mock_build_prompt.return_value = ([{"role": "system", "content": "sys"}], 1000, None)
+        response_text = "Use sleep_until_next_trigger when finished."
+        mock_completion.return_value = (
+            self._mock_completion(response_text),
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "model": "m",
+                "provider": "p",
+            },
+        )
+
+        with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
+            ep._run_agent_loop(self.agent, is_first_run=False)
+
+        correction_description = PersistentAgentStep.objects.get(
+            agent=self.agent,
+            description__startswith="The answer below was not delivered.",
+        ).description
+        self.assertIn("send that same content unchanged", correction_description)
+        self.assertIn(
+            "If it represents silence, completion, or a tool/control instruction, do not send it",
+            correction_description,
+        )
+        self.assertIn(
+            "call sleep_until_next_trigger with empty response content",
+            correction_description,
+        )
+        self.assertTrue(correction_description.endswith(response_text))
+        self.assertFalse(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description="Decided to sleep until next trigger.",
+            ).exists()
+        )
+
+    @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.execute_send_chat_message", return_value={"status": "ok", "auto_sleep_ok": True})
     @patch("api.agent.core.event_processing.build_prompt_context")
     @patch("api.agent.core.event_processing._completion_with_failover")

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -2101,6 +2101,7 @@ class ImpliedSendTests(TestCase):
         resp.choices = [choice]
         return resp
 
+    @patch("api.agent.core.event_processing._attempt_cycle_close_for_sleep")
     @patch("api.agent.core.event_processing._ensure_credit_for_tool", return_value={"cost": None, "credit": None})
     @patch("api.agent.core.event_processing.build_prompt_context")
     @patch("api.agent.core.event_processing._completion_with_failover")
@@ -2109,6 +2110,7 @@ class ImpliedSendTests(TestCase):
         mock_completion,
         mock_build_prompt,
         _mock_credit,
+        mock_cycle_close,
     ):
         mock_build_prompt.return_value = ([{"role": "system", "content": "sys"}], 1000, None)
         mock_completion.return_value = (
@@ -2152,6 +2154,42 @@ class ImpliedSendTests(TestCase):
             PersistentAgentMessage.objects.filter(
                 owner_agent=self.agent,
                 is_outbound=True,
+            ).exists()
+        )
+        mock_cycle_close.assert_called_once_with(self.agent, None)
+
+    @patch("api.agent.core.event_processing.build_prompt_context")
+    @patch("api.agent.core.event_processing._completion_with_failover")
+    def test_sleep_text_with_continuation_signal_is_not_normalized(
+        self,
+        mock_completion,
+        mock_build_prompt,
+    ):
+        mock_build_prompt.return_value = ([{"role": "system", "content": "sys"}], 1000, None)
+        mock_completion.return_value = (
+            self._mock_completion("sleep_until_next_trigger CONTINUE_WORK_SIGNAL"),
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "model": "m",
+                "provider": "p",
+            },
+        )
+
+        with patch.object(ep, "MAX_AGENT_LOOP_ITERATIONS", 1):
+            ep._run_agent_loop(self.agent, is_first_run=False)
+
+        self.assertTrue(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description__startswith="The answer below was not delivered.",
+            ).exists()
+        )
+        self.assertFalse(
+            PersistentAgentStep.objects.filter(
+                agent=self.agent,
+                description="Decided to sleep until next trigger.",
             ).exists()
         )
 


### PR DESCRIPTION
## Summary

- Convert an exact plain-text `sleep_until_next_trigger` response into a sleep tool call.
- Preserve delivery correction behavior for non-exact sleep text and continuation signals.
- Simplify tool-call classification using sets and clarify correction guidance.
- Add unit coverage for normalization and edge cases.

## Testing

- Added focused unit tests covering exact, continuation, and non-exact sleep responses.
- Not run (not requested).