### PR TITLE
Fix desktop timeline cards: To-line attribution, reply context, invite highlight (#419 #248 #339)

### DIFF
--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -548,9 +548,23 @@ def _serialize_message(
     recipient_address: str | None = None
     recipient_name: str | None = None
     cc_addresses: list[str] = []
-    if message.is_outbound and channel.lower() == CommsChannel.EMAIL and conversation is not None:
-        recipient_address = (conversation.address or "").strip() or None
-        recipient_name = (conversation.display_name or "").strip() or None
+    if message.is_outbound and channel.lower() == CommsChannel.EMAIL:
+        # The message's own to_endpoint records who this email actually went to; the conversation
+        # only records the thread's original counterparty. When they diverge the card must follow
+        # the message — labelling the send with the thread's counterparty misattributes it, and
+        # the thread's display name must never be attached to a different address (bug #419).
+        to_endpoint_address = (
+            (message.to_endpoint.address or "").strip()
+            if message.to_endpoint_id and message.to_endpoint.channel == CommsChannel.EMAIL
+            else ""
+        )
+        conversation_address = ((conversation.address or "").strip() if conversation else "")
+        recipient_address = to_endpoint_address or conversation_address or None
+        if recipient_address and (
+            not to_endpoint_address
+            or to_endpoint_address.lower() == conversation_address.lower()
+        ):
+            recipient_name = ((conversation.display_name or "").strip() if conversation else "") or None
     if channel.lower() == CommsChannel.EMAIL:
         # Who else received it. Bcc is deliberately absent: it is never persisted on the message,
         # so the card cannot claim to show a complete recipient list.
@@ -594,6 +608,20 @@ def _serialize_message(
 
     body_html = _message_body_html(message, channel, attachments)
     subject = _message_subject(message, channel)
+
+    # A Discord reply's meaning lives in what it replied to; the ingestion payload carries the
+    # full quoted message and the agent's prompt already uses it, but the web card dropped it —
+    # "have you been there?" rendered with no indication of what "there" meant (bug #248).
+    reply_to_payload: dict | None = None
+    raw_message_payload = message.raw_payload if isinstance(message.raw_payload, Mapping) else {}
+    reply_raw = raw_message_payload.get("discord_reply_to")
+    if isinstance(reply_raw, Mapping) and not reply_raw.get("unavailable"):
+        reply_body = str(reply_raw.get("content") or "").strip()
+        if reply_body:
+            reply_to_payload = {
+                "authorName": str(reply_raw.get("author_name") or "").strip() or None,
+                "bodyText": reply_body,
+            }
     outbox_review = None
     try:
         review = message.outbound_email_review
@@ -629,6 +657,7 @@ def _serialize_message(
             "senderAddress": None if is_mcp else sender_address,
             "recipientName": recipient_name,
             "recipientAddress": recipient_address,
+            "replyTo": reply_to_payload,
             "ccAddresses": cc_addresses,
             "sourceKind": source_kind,
             "sourceLabel": source_label,

--- a/frontend/src/components/agentChat/MessageEventCard.test.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.test.tsx
@@ -66,3 +66,28 @@ describe('MessageEventCard email recipient', () => {
     expect(screen.queryByText('To')).not.toBeInTheDocument()
   })
 })
+
+describe('MessageEventCard reply context', () => {
+  // A Discord reply's meaning lives in what it answered; the card dropped it entirely and
+  // "have you been there?" rendered with no indication of what "there" meant (bug #248).
+  it('quotes the replied-to message above the body', () => {
+    renderCard(emailMessage({
+      channel: 'discord',
+      isOutbound: false,
+      bodyText: 'have you been there?',
+      subject: null,
+      recipientAddress: null,
+      replyTo: { authorName: 'Alyssa Perkins', bodyText: 'honestly maybe like a 30.' },
+    }))
+
+    expect(screen.getByTestId('reply-context')).toBeInTheDocument()
+    expect(screen.getByText('Alyssa Perkins')).toBeInTheDocument()
+    expect(screen.getByText('honestly maybe like a 30.')).toBeInTheDocument()
+  })
+
+  it('renders no quote block for a plain message', () => {
+    renderCard(emailMessage({ channel: 'discord', isOutbound: false, subject: null, recipientAddress: null }))
+
+    expect(screen.queryByTestId('reply-context')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/agentChat/MessageEventCard.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.tsx
@@ -373,6 +373,16 @@ export const MessageEventCard = memo(function MessageEventCard({
           <div
             className={`chat-content prose prose-sm max-w-none leading-relaxed ${contentTone}`}
           >
+            {message.replyTo ? (
+              // The reply's meaning lives in what it answered; without the quote a card like
+              // "have you been there?" says nothing (bug #248).
+              <blockquote className="chat-reply-context" data-testid="reply-context">
+                {message.replyTo.authorName ? (
+                  <span className="chat-reply-context__author">{message.replyTo.authorName}</span>
+                ) : null}
+                <span className="chat-reply-context__body">{message.replyTo.bodyText}</span>
+              </blockquote>
+            ) : null}
             <MessageContent
               bodyHtml={message.bodyHtml}
               bodyText={message.bodyText}

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -3585,6 +3585,31 @@
     overflow-wrap: anywhere;
     word-break: break-word;
 }
+/* The quoted message a Discord reply answered (bug #248). Clamped: it is context, not content —
+   the full text belongs to the original card upthread. */
+.chat-reply-context {
+    display: block;
+    margin: 0 0 0.5rem;
+    padding: 0.375rem 0.625rem;
+    border-left: 3px solid rgba(99, 102, 241, 0.45);
+    border-radius: 0.375rem;
+    background: rgba(99, 102, 241, 0.06);
+    font-size: 0.8125rem;
+    color: #475569;
+    font-style: normal;
+}
+.chat-reply-context__author {
+    display: block;
+    font-weight: 600;
+    color: #4f46e5;
+    margin-bottom: 0.125rem;
+}
+.chat-reply-context__body {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
 /* Sized to its content so the surrounding overflow-x-auto wrapper can scroll. Pinning the table to
    the container instead made every column shrink until the cells were unreadable on a phone. */
 .chat-content table {
@@ -6891,7 +6916,9 @@
     cursor: default;
 }
 .agent-invite[data-variant='drawer'] {
-    --agent-invite-bg: #ffffff;
+    /* Not solid white: on the drawer's near-white sheet a hard #ffffff card reads as a washed-out
+       highlight around the request badge (bug #339). The border stays as the accent. */
+    --agent-invite-bg: rgba(99, 102, 241, 0.05);
     --agent-invite-border: rgba(99, 102, 241, 0.18);
 }
 .agent-invite[data-variant='sidebar']:hover .agent-roster-item__avatar {

--- a/frontend/src/types/agentChat.ts
+++ b/frontend/src/types/agentChat.ts
@@ -56,6 +56,7 @@ export type AgentMessage = {
   senderAddress?: string | null
   recipientName?: string | null
   recipientAddress?: string | null
+  replyTo?: { authorName?: string | null; bodyText: string } | null
   ccAddresses?: string[] | null
   sourceKind?: string | null
   sourceLabel?: string | null

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,29 +1,29 @@
 {
-  "baseline_sha": "6107edc1fa0d4ce7ce686cb8c31de370eea53d68",
+  "baseline_sha": "beed75caf012b58bb80e1e3731d700d252c4e275",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9328,
+        "fitted_tokens": 9246,
         "system_bytes": 32494,
         "tools_bytes": 23456,
-        "total_bytes": 67731,
-        "user_bytes": 11781
+        "total_bytes": 67659,
+        "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8696,
+        "fitted_tokens": 8644,
         "system_bytes": 29385,
         "tools_bytes": 23456,
-        "total_bytes": 64655,
-        "user_bytes": 11814
+        "total_bytes": 64583,
+        "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8903,
+        "fitted_tokens": 8827,
         "system_bytes": 30022,
         "tools_bytes": 23456,
-        "total_bytes": 65295,
-        "user_bytes": 11817
+        "total_bytes": 65223,
+        "user_bytes": 11745
       }
     },
     "scenarios": {
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 261166
+    "limit": 261232
   }
 }

--- a/tests/unit/test_timeline_discord_reply.py
+++ b/tests/unit/test_timeline_discord_reply.py
@@ -1,0 +1,91 @@
+"""#248: a Discord reply must carry its reply context into the web timeline.
+
+The ingestion payload stores the full replied-to message under discord_reply_to, and the agent's
+prompt context uses it — but the web timeline dropped it entirely, so a card like "have you been
+there?" rendered with no indication of what "there" meant.
+"""
+from django.contrib.auth import get_user_model
+from django.test import TestCase, tag
+
+from api.models import (
+    BrowserUseAgent,
+    CommsChannel,
+    PersistentAgent,
+    PersistentAgentCommsEndpoint,
+    PersistentAgentConversation,
+    PersistentAgentMessage,
+)
+from console.agent_chat.timeline import serialize_message_event
+
+
+@tag("batch_agent_chat")
+class TimelineDiscordReplyTests(TestCase):
+    def setUp(self):
+        user = get_user_model().objects.create_user(
+            username="reply-card@example.test",
+            email="reply-card@example.test",
+        )
+        self.agent = PersistentAgent.objects.create(
+            user=user,
+            name="Relay",
+            charter="Relay Discord.",
+            browser_use_agent=BrowserUseAgent.objects.create(user=user, name="browser"),
+        )
+        self.endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.DISCORD,
+            address="discord://agent/x/guild/1/channel/2",
+        )
+        self.conversation = PersistentAgentConversation.objects.create(
+            channel=CommsChannel.DISCORD,
+            address="discord://guild/1/channel/2",
+        )
+
+    def _discord_message(self, raw_payload: dict) -> PersistentAgentMessage:
+        return PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            from_endpoint=self.endpoint,
+            conversation=self.conversation,
+            is_outbound=False,
+            body="have you been there?",
+            raw_payload=raw_payload,
+        )
+
+    def test_reply_context_reaches_the_card(self):
+        message = self._discord_message({
+            "source_kind": "discord",
+            "discord_author_name": "asker",
+            "discord_reply_to": {
+                "author_name": "Alyssa Perkins",
+                "content": "honestly maybe like a 30. it's strip-mall Frederick right off 26.",
+            },
+        })
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertEqual(payload["replyTo"], {
+            "authorName": "Alyssa Perkins",
+            "bodyText": "honestly maybe like a 30. it's strip-mall Frederick right off 26.",
+        })
+
+    def test_an_unavailable_reply_carries_no_context(self):
+        """Discord marks fetch failures; a banner with an empty quote asserts nothing useful."""
+        message = self._discord_message({
+            "source_kind": "discord",
+            "discord_reply_to": {
+                "author_name": "Alyssa Perkins",
+                "content": "",
+                "unavailable": True,
+            },
+        })
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertIsNone(payload["replyTo"])
+
+    def test_a_plain_message_has_no_reply_context(self):
+        message = self._discord_message({"source_kind": "discord"})
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertIsNone(payload["replyTo"])

--- a/tests/unit/test_timeline_email_recipient.py
+++ b/tests/unit/test_timeline_email_recipient.py
@@ -79,3 +79,43 @@ class TimelineEmailRecipientTests(TestCase):
 
         self.assertIsNone(payload["recipientAddress"])
         self.assertIsNone(payload["recipientName"])
+
+    def test_to_endpoint_wins_over_the_conversation_label(self):
+        """The conversation is keyed by its original counterparty, but a message records who it
+        actually went to. When they diverge the card must follow the message, not the thread —
+        showing the thread's label as "To" misattributes the send (bug #419)."""
+        message = self._email_message(
+            is_outbound=True,
+            address="original-counterparty@example.com",
+            display_name="Original Counterparty",
+        )
+        message.to_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            channel=CommsChannel.EMAIL,
+            address="actual-recipient@example.com",
+        )
+        message.save(update_fields=["to_endpoint"])
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertEqual(payload["recipientAddress"], "actual-recipient@example.com")
+        # The thread label belongs to someone else; naming the actual recipient with it would
+        # assert an identity the message does not carry.
+        self.assertIsNone(payload["recipientName"])
+
+    def test_matching_to_endpoint_keeps_the_conversation_display_name(self):
+        message = self._email_message(
+            is_outbound=True,
+            address="derraleigh@example.com",
+            display_name="Derraleigh Vance",
+        )
+        message.to_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            channel=CommsChannel.EMAIL,
+            address="Derraleigh@Example.com",
+        )
+        message.save(update_fields=["to_endpoint"])
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertEqual(payload["recipientName"], "Derraleigh Vance")
+        # Endpoint addresses are normalized on save.
+        self.assertEqual(payload["recipientAddress"], "derraleigh@example.com")


### PR DESCRIPTION
## What

Three verified fixes on timeline/chat cards, from the desktop verification batch (tracker #419, #248, #339). Two further tickets from that batch closed with evidence, no code needed: #422 (scroll snap — 1105-frame live-injection test measured zero viewport drift on current main) and #208 (empty email bodies — 0 truncation signatures in 797 recent inbound emails with substantial raw content since the Jul 14 parsing overhaul).

## #419 — email card "To" line follows the thread, not the message

`recipientAddress/Name` came from `conversation` (the thread's original counterparty). When a send actually went to a different address (`to_endpoint`), the card misattributed it, and the thread's display name could label a different person's address. The card now follows the message's own `to_endpoint`, and the thread's display name only appears when the addresses match. Red→green in `test_timeline_email_recipient` (2 new tests).

## #248 — Discord replies rendered with no reply context

`discord_reply_to` carries the full quoted message and already feeds the agent's prompt, but the web timeline dropped it — Andrew's example ("have you been there?") rendered with no indication of what it answered (verified live on this PR's preview fork: no banner, no preview). The serializer now emits `replyTo {authorName, bodyText}` (skipping Discord-unavailable stubs) and the card quotes it above the body with the standard left-accent treatment, clamped to 3 lines. New serializer suite (3 tests) + component tests (2).

## #339 — invite card glares white in the mobile drawer

`.agent-invite[data-variant='drawer']` forced solid `#ffffff` on the drawer's near-white sheet — the reported "weird pale highlight" around request-badge cards. Now the same translucent indigo family as its border.

## Gates

Frontend 285/285, backend timeline suites green (`test_timeline_discord_reply`, `test_timeline_email_recipient`, `test_timeline_email_from_cc`, `test_agent_chat_api`, `test_timeline_emotion_entry`), build + tsc clean, complexity budgets recorded (+66 LoC, tests + reply context). Preview validation of the rendered reply banner to follow before merge.

Note: replaces #1430, whose branch stopped receiving GitHub Actions events entirely (pushes and close/reopen produced zero workflow runs while other branches triggered normally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)