### PR TITLE
Fix external action completion lifecycle

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3981,10 +3981,10 @@ def _get_system_instruction(
         f"{response_structure}\n\n"
         f"{tool_calls_note}"
         f"{stop_explicit_note}"
-        "Missing recipient or required content for an email/SMS/outbound send is a blocker: use request_human_input with will_continue_work=false, not chat-only questions. "
-        "Ask one compact tracked request; use options for a decision and free text for details the user must supply. "
+        "Missing email/SMS fields: request_human_input(will_continue_work=false), not chat. Ask once; options for decisions, free text for details. "
         "Use the requested recipient/channel; otherwise reply to the latest inbound requester on that same channel, never an older/preferred contact. A skipped web send never permits switching. "
-        "Scheduled/background exact feed/API fetches without implied send still need send_chat_message(body=brief sourced report, will_continue_work=false).\n\n"
+        "External state follows evidence: act first, then persist returned status/ID. Approved/prepared is not sent; sent/provider-accepted is not delivered. "
+        "Scheduled feed/API pulls without implied send still need send_chat_message(body=brief sourced report, will_continue_work=false).\n\n"
         f"{stop_continue_examples}"
     )
 
@@ -5057,7 +5057,7 @@ def _get_unified_history_prompt(
                     header = f'[{m.timestamp.isoformat()}] Inbound webhook "{label}" triggered:'
                 elif is_mcp:
                     label = str(source_label).strip() if isinstance(source_label, str) and str(source_label).strip() else "Gobii MCP"
-                    header = f'[{m.timestamp.isoformat()}] Inbound MCP message from "{label}":'
+                    header = f'[{m.timestamp.isoformat()}] Inbound MCP message from "{label}" (reply in this web conversation; tool results are not replies):'
                 elif source_label:
                     header = f"[{m.timestamp.isoformat()}] On {channel}, you received a message from {source_label}:"
                 else:

--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -172,16 +172,15 @@ def _resolve_reply_target(
 
 
 def get_send_email_tool() -> Dict[str, Any]:
-    """Return the send_email tool definition for the LLM."""
     return {
         "type": "function",
         "function": {
             "name": "send_email",
             "description": (
-                "Body-only HTML: omit <html>/<head>/<body>, Markdown, and em/en/double dashes. "
-                "No <style> blocks/classes; inline CSS only. "
-                "A successful call may return pending_approval. When it does, the recipient has not received the email: tell the user it is awaiting human approval and never retry the send. "
-                "Report emails need distinct styled sections/tables and highlighted values, plus a tasteful icon marker and obvious inline-styled badge for key status/value. Never leave metrics in plain lists or use Markdown pipe tables."
+                "Body-only HTML; omit document tags, Markdown, and em/en/double dashes. No <style> blocks/classes; inline CSS only. "
+                "Approval or preparation is not sent: send first, then record returned delivery_status; never infer delivered. "
+                "pending_approval is not received: tell user it awaits approval; never retry. "
+                "Reports need distinct styled sections/tables and highlighted values, plus a tasteful icon marker and obvious inline-styled badge for status/value. Never leave metrics in plain lists or use Markdown pipe tables."
             ),
             "parameters": {
                 "type": "object",
@@ -459,7 +458,8 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
 
         return {
             "status": "ok",
-            "message": f"Email sent to {to_address}.",
+            "delivery_status": message.latest_status,
+            "message": f"Email send completed for {to_address} with delivery_status={message.latest_status}. Use that status exactly; do not claim recipient delivery unless it is delivered.",
             "message_id": str(message.id),
             "auto_sleep_ok": not will_continue,
         }

--- a/api/evals/scenarios/message_quality.py
+++ b/api/evals/scenarios/message_quality.py
@@ -8,7 +8,13 @@ from uuid import UUID
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
-from api.agent.comms.message_service import _ensure_participant, _get_or_create_conversation
+from api.agent.comms.message_service import (
+    _ensure_participant,
+    _get_or_create_conversation,
+    inject_internal_web_message,
+)
+from api.agent.tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
+from api.agent.tools.sqlite_state import agent_sqlite_db
 from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
 from api.agent.tools.web_chat_sender import WEB_CHAT_UNAVAILABLE_MESSAGE
 from api.evals.base import EvalScenario, ScenarioTask
@@ -38,6 +44,8 @@ REPLY_CHANNEL_CONTINUITY_SLUG = "message_quality_reply_stays_in_web_chat"
 UNAVAILABLE_WEB_CHANNEL_CONTINUITY_SLUG = "message_quality_unavailable_web_does_not_switch_channels"
 FAILED_EMAIL_DELIVERY_RECOVERY_SLUG = "message_quality_failed_email_reports_failure"
 EMAIL_REVIEW_OUTBOX_COMMUNICATION_SLUG = "message_quality_email_review_outbox_communication"
+REMOTE_MCP_RESULT_DELIVERY_SLUG = "message_quality_remote_mcp_result_is_delivered"
+EMAIL_SENT_STATE_SEQUENCING_SLUG = "message_quality_email_sent_state_after_provider_acceptance"
 
 
 @dataclass(frozen=True)
@@ -284,6 +292,8 @@ MESSAGE_QUALITY_SCENARIO_SLUGS = (
     UNAVAILABLE_WEB_CHANNEL_CONTINUITY_SLUG,
     FAILED_EMAIL_DELIVERY_RECOVERY_SLUG,
     EMAIL_REVIEW_OUTBOX_COMMUNICATION_SLUG,
+    REMOTE_MCP_RESULT_DELIVERY_SLUG,
+    EMAIL_SENT_STATE_SEQUENCING_SLUG,
 )
 
 
@@ -1469,6 +1479,334 @@ class UnavailableWebChannelContinuityScenario(EvalScenario, ScenarioExecutionToo
                 else f"Agent changed channels via {[call.tool_name for call in cross_channel_calls]}."
             ),
             artifacts={"step": cross_channel_calls[0].step} if cross_channel_calls else {},
+        )
+
+
+def _seed_lifecycle_eval_table(agent_id: str, statements: tuple[str, ...]) -> None:
+    with agent_sqlite_db(str(agent_id)) as db_path:
+        connection = open_guarded_sqlite_connection(db_path)
+        try:
+            for statement in statements:
+                connection.execute(statement)
+            connection.commit()
+        finally:
+            clear_guarded_connection(connection)
+            connection.close()
+
+
+def _sqlite_call_text(call: PersistentAgentToolCall) -> str:
+    params = MessageQualityScenario._tool_params(call)
+    raw_sql = params.get("queries", params.get("sql") or "")
+    if isinstance(raw_sql, list):
+        return "\n".join(str(query) for query in raw_sql)
+    return str(raw_sql)
+
+
+@register_scenario
+class RemoteMcpResultDeliveryScenario(EvalScenario, ScenarioExecutionTools):
+    slug = REMOTE_MCP_RESULT_DELIVERY_SLUG
+    version = "1.0"
+    description = "A remote MCP request should receive the decision-ready result after internal SQLite work."
+    tier = "core"
+    category = "message_quality"
+    expected_runtime = "short"
+    cost_class = "low"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = ("message_quality", "remote_mcp", "sqlite_batch", "send_chat_message")
+    tasks = [
+        ScenarioTask(name="inject_remote_mcp_request", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_internal_result_queried", assertion_type="tool_call"),
+        ScenarioTask(name="verify_requester_received_result", assertion_type="persisted_state"),
+    ]
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        agent = PersistentAgent.objects.get(id=agent_id)
+        mark_tool_enabled_without_discovery(agent, "sqlite_batch")
+        mark_tool_enabled_without_discovery(agent, "send_chat_message")
+        _seed_lifecycle_eval_table(
+            agent_id,
+            (
+                "CREATE TABLE current_office_snapshot ("
+                "snapshot_key TEXT PRIMARY KEY, total_open_cases INTEGER NOT NULL, "
+                "busiest_region TEXT NOT NULL, busiest_region_open_cases INTEGER NOT NULL);",
+                "INSERT INTO current_office_snapshot VALUES ('latest', 16, 'South', 7);",
+            ),
+        )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="inject_remote_mcp_request",
+        )
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            inbound, _ = inject_internal_web_message(
+                agent_id,
+                (
+                    "Return one concise office-hours snapshot with the total open case count and the busiest "
+                    "region. Use the current modeled operations state rather than memory."
+                ),
+                sender_user_id=agent.user_id,
+                trigger_processing=False,
+                eval_run_id=run_id,
+                source="remote_mcp",
+                source_kind="mcp",
+                source_label="Gobii MCP",
+            )
+            CommsAllowlistEntry.objects.update_or_create(
+                agent=agent,
+                channel=CommsChannel.WEB,
+                address=inbound.from_endpoint.address,
+                defaults={"is_active": True, "allow_inbound": True, "allow_outbound": True},
+            )
+            agent.preferred_contact_endpoint = inbound.from_endpoint
+            agent.save(update_fields=["preferred_contact_endpoint"])
+            self.trigger_processing(
+                agent_id,
+                inbound_message_id=str(inbound.id),
+                eval_run_id=run_id,
+                eval_stop_policy={
+                    "stop_on_tool_names_after_execution": ["send_chat_message"],
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": [
+                        "sqlite_batch",
+                        "send_chat_message",
+                        "update_plan",
+                        "sleep_until_next_trigger",
+                    ],
+                    "ignored_tool_names": ["update_plan"],
+                    "max_relevant_tool_calls": 5,
+                },
+            )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_remote_mcp_request",
+            observed_summary="Remote MCP request processed through the real agent harness.",
+            artifacts={"message": inbound},
+        )
+        calls = MessageQualityScenario._tool_calls_for_run(run_id, after=inbound.timestamp)
+        sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch" and call.status == "complete"]
+        queried_state = any("current_office_snapshot" in _sqlite_call_text(call).lower() for call in sqlite_calls)
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if queried_state else EvalRunTask.Status.FAILED,
+            task_name="verify_internal_result_queried",
+            expected_summary="Agent should query the modeled operations state before answering.",
+            observed_summary=(
+                "Agent queried current_office_snapshot."
+                if queried_state
+                else f"No successful current_office_snapshot query; tool sequence was {[call.tool_name for call in calls]}."
+            ),
+            artifacts={"step": sqlite_calls[0].step} if sqlite_calls else {},
+        )
+
+        delivered = [
+            call
+            for call in calls
+            if call.tool_name == "send_chat_message"
+            and str(MessageQualityScenario._tool_result(call).get("status") or "").lower()
+            in {"ok", "sent", "success"}
+            and MessageQualityScenario._tool_result(call).get("skipped") is not True
+        ]
+        body = str(MessageQualityScenario._tool_params(delivered[0]).get("body") or "") if delivered else ""
+        exact_answer = len(delivered) == 1 and "16" in body and "south" in body.casefold()
+        outbound = list(
+            PersistentAgentMessage.objects.filter(
+                owner_agent_id=agent_id,
+                conversation_id=inbound.conversation_id,
+                is_outbound=True,
+                timestamp__gt=inbound.timestamp,
+            )
+        )
+        requester_received = exact_answer and len(outbound) == 1
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if requester_received else EvalRunTask.Status.FAILED,
+            task_name="verify_requester_received_result",
+            expected_summary="The MCP requester should receive one concise snapshot after the SQLite result.",
+            observed_summary=(
+                "Requester received one correct snapshot."
+                if requester_received
+                else (
+                    f"Saw {len(delivered)} successful chat delivery call(s), {len(outbound)} persisted reply/replies, "
+                    f"and body={body[:300]!r}."
+                )
+            ),
+            artifacts={"message": outbound[0]} if outbound else {},
+        )
+
+
+@register_scenario
+class EmailSentStateSequencingScenario(EvalScenario, ScenarioExecutionTools):
+    slug = EMAIL_SENT_STATE_SEQUENCING_SLUG
+    version = "1.0"
+    description = "An agent should send first, then record the provider's exact sent state without claiming delivery."
+    tier = "core"
+    category = "message_quality"
+    expected_runtime = "short"
+    cost_class = "low"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = ("message_quality", "send_email", "sqlite_batch", "delivery_state")
+    tasks = [
+        ScenarioTask(name="inject_approved_send", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_send_precedes_sent_state", assertion_type="tool_call"),
+        ScenarioTask(name="verify_exact_provider_state", assertion_type="persisted_state"),
+    ]
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        agent = PersistentAgent.objects.get(id=agent_id)
+        mark_tool_enabled_without_discovery(agent, "sqlite_batch")
+        mark_tool_enabled_without_discovery(agent, "send_email")
+        mark_tool_enabled_without_discovery(agent, "send_chat_message")
+        CommsAllowlistEntry.objects.update_or_create(
+            agent=agent,
+            channel=CommsChannel.EMAIL,
+            address="finance@example.test",
+            defaults={
+                "is_active": True,
+                "allow_inbound": True,
+                "allow_outbound": True,
+                "verified": True,
+            },
+        )
+        _seed_lifecycle_eval_table(
+            agent_id,
+            (
+                "CREATE TABLE outbound_actions ("
+                "action_key TEXT PRIMARY KEY, approval_status TEXT NOT NULL, "
+                "delivery_status TEXT NOT NULL, recipient TEXT NOT NULL, "
+                "subject TEXT NOT NULL, body TEXT NOT NULL, provider_message_id TEXT);",
+                "INSERT INTO outbound_actions VALUES ("
+                "'forecast-q3', 'approved', 'not_sent', 'finance@example.test', 'Q3 forecast ready', "
+                "'The approved Q3 forecast is ready for review.', NULL);",
+            ),
+        )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="inject_approved_send",
+        )
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            inbound = self.inject_message(
+                agent_id,
+                "Send the approved Q3 forecast note to finance and keep the outbound tracker accurate.",
+                trigger_processing=True,
+                eval_run_id=run_id,
+                mock_config={
+                    "send_email": {
+                        "status": "ok",
+                        "delivery_status": "sent",
+                        "message": (
+                            "Email send completed for finance@example.test with delivery_status=sent. "
+                            "Use that status exactly; do not claim recipient delivery unless it is delivered."
+                        ),
+                        "message_id": "eval-provider-message-301",
+                        "auto_sleep_ok": False,
+                    },
+                },
+                eval_stop_policy={
+                    "stop_on_tool_names_after_execution": ["send_chat_message"],
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": [
+                        "sqlite_batch",
+                        "send_email",
+                        "send_chat_message",
+                        "update_plan",
+                        "sleep_until_next_trigger",
+                    ],
+                    "ignored_tool_names": ["update_plan", "sleep_until_next_trigger"],
+                    "max_relevant_tool_calls": 7,
+                },
+            )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_approved_send",
+            observed_summary="Approved send processed through the real agent harness.",
+            artifacts={"message": inbound},
+        )
+        calls = MessageQualityScenario._tool_calls_for_run(run_id, after=inbound.timestamp)
+        email_calls = [call for call in calls if call.tool_name == "send_email"]
+        sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch"]
+        email_index = calls.index(email_calls[0]) if len(email_calls) == 1 else -1
+        premature_writes = [
+            call
+            for call in sqlite_calls
+            if calls.index(call) < email_index
+            and re.search(r"\b(?:insert|update|replace)\b", _sqlite_call_text(call), re.I)
+            and re.search(r"\b(?:sent|delivered)\b", _sqlite_call_text(call), re.I)
+        ]
+        send_precedes_state = len(email_calls) == 1 and not premature_writes
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if send_precedes_state else EvalRunTask.Status.FAILED,
+            task_name="verify_send_precedes_sent_state",
+            expected_summary="No sent or delivered tracker state should be written before send_email succeeds.",
+            observed_summary=(
+                "The provider call preceded any sent-state write."
+                if send_precedes_state
+                else (
+                    f"Saw {len(email_calls)} email call(s) and {len(premature_writes)} premature state write(s); "
+                    f"tool sequence was {[call.tool_name for call in calls]}."
+                )
+            ),
+            artifacts={"step": (premature_writes or email_calls)[0].step} if premature_writes or email_calls else {},
+        )
+
+        with agent_sqlite_db(str(agent_id)) as db_path:
+            connection = open_guarded_sqlite_connection(db_path)
+            try:
+                row = connection.execute(
+                    "SELECT approval_status, delivery_status, provider_message_id "
+                    "FROM outbound_actions WHERE action_key = ?",
+                    ("forecast-q3",),
+                ).fetchone()
+            finally:
+                clear_guarded_connection(connection)
+                connection.close()
+        chat_bodies = [
+            str(MessageQualityScenario._tool_params(call).get("body") or "")
+            for call in calls
+            if call.tool_name == "send_chat_message"
+        ]
+        inflated_delivery_claim = any(
+            re.search(
+                r"\bdelivered\b|\bdelivery (?:confirmed|complete|successful)\b|"
+                r"\brecipient (?:received|has received)\b",
+                body,
+                re.I,
+            )
+            for body in chat_bodies
+        )
+        exact_state = (
+            row is not None
+            and tuple(row) == ("approved", "sent", "eval-provider-message-301")
+            and not inflated_delivery_claim
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if exact_state else EvalRunTask.Status.FAILED,
+            task_name="verify_exact_provider_state",
+            expected_summary="Tracker should record sent plus the provider message id, without inflating it to delivered.",
+            observed_summary=(
+                "Tracker preserved the provider's exact sent state."
+                if exact_state
+                else f"Tracker row was {tuple(row) if row is not None else None}; chat bodies were {chat_bodies!r}."
+            ),
+            artifacts={"step": sqlite_calls[-1].step} if sqlite_calls else {},
         )
 
 

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -2414,7 +2414,7 @@ class FirstRunPromptCalibrationTests(TestCase):
             system_prompt,
         )
         self.assertIn("A skipped web send never permits switching", system_prompt)
-        self.assertIn("one compact tracked request; use options for a decision and free text", system_prompt)
+        self.assertIn("Ask once; options for decisions, free text for details", system_prompt)
         self.assertIn("Replace conflicts/softened absolutes", system_prompt)
         self.assertIn("append only if no related clause", system_prompt)
         self.assertIn("finite task/batch/day/run/project/renewal/deal/case feedback is temporary", system_prompt)

--- a/api/evals/tests/test_message_quality.py
+++ b/api/evals/tests/test_message_quality.py
@@ -6,6 +6,7 @@ from django.test import SimpleTestCase, tag
 import api.evals.loader  # noqa: F401 - registers scenarios and suites
 from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.message_quality import (
+    EMAIL_SENT_STATE_SEQUENCING_SLUG,
     EMAIL_REVIEW_OUTBOX_COMMUNICATION_SLUG,
     EmailReviewOutboxCommunicationScenario,
     FAILED_EMAIL_DELIVERY_RECOVERY_SLUG,
@@ -15,6 +16,7 @@ from api.evals.scenarios.message_quality import (
     MESSAGE_QUALITY_SUITE_SLUG,
     OWNER_UPDATE_QUALITY_CASES,
     PORTFOLIO_REPORT_QUALITY_CASES,
+    REMOTE_MCP_RESULT_DELIVERY_SLUG,
     REPLY_CHANNEL_CONTINUITY_SLUG,
     REPORT_MESSAGE_QUALITY_CASES,
     SIMPLE_EMAIL_QUALITY_CASES,
@@ -32,11 +34,13 @@ class MessageQualityScenarioTests(SimpleTestCase):
 
         self.assertIsNotNone(suite)
         self.assertEqual(tuple(suite.scenario_slugs), MESSAGE_QUALITY_SCENARIO_SLUGS)
-        self.assertEqual(len(suite.scenario_slugs), 20)
+        self.assertEqual(len(suite.scenario_slugs), 22)
         self.assertIn(REPLY_CHANNEL_CONTINUITY_SLUG, suite.scenario_slugs)
         self.assertIn(UNAVAILABLE_WEB_CHANNEL_CONTINUITY_SLUG, suite.scenario_slugs)
         self.assertIn(FAILED_EMAIL_DELIVERY_RECOVERY_SLUG, suite.scenario_slugs)
         self.assertIn(EMAIL_REVIEW_OUTBOX_COMMUNICATION_SLUG, suite.scenario_slugs)
+        self.assertIn(REMOTE_MCP_RESULT_DELIVERY_SLUG, suite.scenario_slugs)
+        self.assertIn(EMAIL_SENT_STATE_SEQUENCING_SLUG, suite.scenario_slugs)
 
     def test_generated_cases_cover_email_and_chat_for_each_real_world_domain(self):
         channels_by_brief = {}

--- a/tests/unit/test_email_sender_db_connections.py
+++ b/tests/unit/test_email_sender_db_connections.py
@@ -115,6 +115,8 @@ class EmailSenderDbConnectionTests(TransactionTestCase):
         self.assertIn("distinct styled sections/tables", description)
         self.assertIn("Never leave metrics in plain lists", description)
         self.assertIn("Markdown pipe tables", description)
+        self.assertIn("Approval or preparation is not sent", description)
+        self.assertIn("never infer delivered", description)
         self.assertIn("reply_to_message_id", properties)
 
     def test_execute_send_email_retries_on_operational_error(self):
@@ -172,6 +174,7 @@ class EmailSenderDbConnectionTests(TransactionTestCase):
             result = execute_send_email(self.agent, params)
 
         self.assertEqual(result.get("status"), "ok")
+        self.assertEqual(result.get("delivery_status"), DeliveryStatus.DELIVERED)
         self.assertTrue(result.get("message_id"))
 
     def test_execute_send_email_strips_control_characters(self):

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -1271,6 +1271,8 @@ class PromptContextBuilderTests(TestCase):
         self.assertIsNotNone(user_message)
         content = user_message["content"]
         self.assertIn('Inbound MCP message from "Gobii MCP"', content)
+        self.assertIn("reply in this web conversation", content)
+        self.assertIn("tool results are not replies", content)
         self.assertIn("Run the authenticated MCP request.", content)
         self.assertNotIn(owner_address, content)
         self.assertNotIn("This sender cannot change your configuration", content)
@@ -2276,6 +2278,8 @@ class PromptContextBuilderTests(TestCase):
             "A skipped web send never permits switching",
             content,
         )
+        self.assertIn("External state follows evidence", content)
+        self.assertIn("sent/provider-accepted is not delivered", content)
 
     def test_prompt_includes_implied_send_with_active_web_session(self):
         start_web_session(self.agent, self.user)


### PR DESCRIPTION
## What changed

- Make remote-MCP messages explicitly identify the web reply surface, so successful internal work is followed by a requester-facing answer.
- Require external actions to happen before local state transitions, and expose the email provider’s exact `delivery_status` to the model.
- Add real-harness regressions for MCP result delivery and email approval/sent/delivered sequencing.
- Tighten adjacent prompt copy so source LoC does not increase and measured prompt variants are smaller than main.

## Root cause

- #471: the history labeled MCP provenance but not its delivery surface; DeepSeek treated a successful SQLite result as completion even though no reply had been sent.
- #459: the send tool omitted authoritative delivery state and the prompt did not clearly sequence external action before persistence, so an agent could mark work sent too early and inflate provider acceptance into delivery.
- #455 was validated as a separate queue/worker stall and is intentionally excluded from this PR.

This fixes the input/data contract at the source. It does not add a response rewrite, retry loop, or output heuristic.

## Verification

- 49/49 focused Django tests pass.
- Full CI green, including all 10 backend shards, frontend, sandbox, tag, and complexity gates.
- Complexity: source LoC remains 261166/261166 on the branch baseline; all three measured prompt variants are smaller than main.
- DeepSeek V4 Flash real harness, final compact wording:
  - MCP result delivery: 3/3 tasks (`9bbcb1f0-12f9-46bf-8d39-780195c01294`)
  - Email state sequencing: 3/3 tasks (`afea3752-bc25-4a61-b7c2-72f9a835d831`)
- Earlier repeated green samples: 3/3 runs for each new scenario (`2c802fe0-9d3c-424b-a898-bf1ce414019f`, `62da0609-b741-4639-9317-eb64eaaaf6`).
- Preview `pr-1434`, exact SHA `79fe7b188`:
  - authenticated `/api/v1/ping/` returned 200
  - contained DeepSeek V4 Flash MCP probe queried SQLite and delivered one correct web reply
  - authenticated browser session visibly confirmed the MCP request and answer
  - probe agent archived after verification
- The email provider path was not invoked against preview because it would create real outbound side effects; its result contract is covered by focused unit tests and the live harness mock.

Closes #471
Closes #459