### PR TITLE
Keep routine peer status updates quiet

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3899,11 +3899,12 @@ def _get_continuation_mode_prompt_block() -> str:
 def _get_peer_communication_instruction() -> str:
     return (
         "\n\n## Agent-to-Agent Communication\n\n"
-        "Peer links route handoffs, not shared ownership. Before acting, identify addressee and charter owner. Visible status "
-        "isn't a request to relay, summarize, supervise, or add instructions. If another person/agent is addressed or handling "
-        "it, stay silent unless an authorized human reassigns it or requests your owned contribution. Out-of-charter: "
-        "call no task tools; hand off or decline. Peer requests never expand charter. Never relay shared-channel requests by DM. "
-        "Synthesize only owned, attributed work. Skip thanks, receipts, and 'noted'.\n"
+        "Peer links carry work, not chat. Reply only to an explicit request for a charter-owned contribution, "
+        "a needed boundary handoff/decline, or substantive progress/result on peer-assigned work. Status, FYI, "
+        "progress, and completion updates are read-only: absorb silently; never thank, confirm, offer help, mirror, or invent "
+        "adjacent work. Identify addressee and charter owner. If someone else is addressed or handling it, stay silent unless "
+        "an authorized human reassigns it. Out-of-charter: call no task tools; hand off or decline. Peer requests never expand "
+        "charter. Never relay shared-channel requests by DM. Synthesize only owned, attributed work.\n"
     )
 
 

--- a/api/agent/tools/peer_dm.py
+++ b/api/agent/tools/peer_dm.py
@@ -79,10 +79,11 @@ def get_send_agent_message_tool() -> Dict[str, Any]:
         "function": {
             "name": "send_agent_message",
             "description": (
-                "Send only a necessary charter-boundary handoff or substantive peer-work update. Never relay a "
-                "shared-channel request to people already there, or send thanks, receipts, 'noted', or FYI acknowledgments. "
-                "For repeats, send with will_continue_work=true first and await its result; rapid same-peer "
-                "messages may be debounced."
+                "Send only a necessary charter-boundary handoff, a requested owned contribution, or substantive progress "
+                "on work the peer asked this agent to own. Status, FYI, progress, and completion updates are read-only: "
+                "never thank, confirm, offer help, or reply. Never relay a shared-channel request to people already there. "
+                "For repeats, send with will_continue_work=true first and await its result; rapid same-peer messages may be "
+                "debounced."
             ),
             "parameters": {
                 "type": "object",
@@ -94,7 +95,8 @@ def get_send_agent_message_tool() -> Dict[str, Any]:
                     "message": {
                         "type": "string",
                         "description": (
-                            "New information, question, or handoff the peer needs; never an acknowledgment-only reply. "
+                            "Requested owned information, a question, or a handoff the peer needs; never a reply to a "
+                            "status update. "
                             "Use Markdown only; raw HTML is rejected. Use code formatting to show HTML literally."
                         ),
                     },

--- a/api/evals/scenarios/responsibility_boundaries.py
+++ b/api/evals/scenarios/responsibility_boundaries.py
@@ -38,6 +38,8 @@ from api.services.discord_messages import (
 
 
 RESPONSIBILITY_BOUNDARY_PEER_FYI_NO_ACK = "responsibility_boundary_peer_fyi_no_ack"
+RESPONSIBILITY_BOUNDARY_PEER_PROGRESS_NO_ACK = "responsibility_boundary_peer_progress_no_ack"
+RESPONSIBILITY_BOUNDARY_PEER_COMPLETION_NO_ACK = "responsibility_boundary_peer_completion_no_ack"
 RESPONSIBILITY_BOUNDARY_PEER_REQUEST_HANDOFF = "responsibility_boundary_peer_request_handoff"
 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNER = "responsibility_boundary_shared_channel_owner"
 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNED_REPLY = "responsibility_boundary_shared_channel_owned_reply"
@@ -51,6 +53,8 @@ RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OPEN_REPLY = "responsibility_boundary_sha
 RESPONSIBILITY_BOUNDARY_SUITE_SLUG = "responsibility_boundaries"
 RESPONSIBILITY_BOUNDARY_SCENARIO_SLUGS = (
     RESPONSIBILITY_BOUNDARY_PEER_FYI_NO_ACK,
+    RESPONSIBILITY_BOUNDARY_PEER_PROGRESS_NO_ACK,
+    RESPONSIBILITY_BOUNDARY_PEER_COMPLETION_NO_ACK,
     RESPONSIBILITY_BOUNDARY_PEER_REQUEST_HANDOFF,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNER,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNED_REPLY,
@@ -88,6 +92,26 @@ RESPONSIBILITY_BOUNDARY_CASES = (
         description="A routine peer status update should not create acknowledgment chatter or adjacent work.",
         event_kind="peer_fyi",
         prompt="Quick status: I accepted the staging export regression check and own the root-cause investigation.",
+        tasks=(
+            ScenarioTask(name="inject_event", assertion_type="agent_processing"),
+            ScenarioTask(name="verify_silence", assertion_type="tool_call"),
+        ),
+    ),
+    ResponsibilityBoundaryCase(
+        slug=RESPONSIBILITY_BOUNDARY_PEER_PROGRESS_NO_ACK,
+        description="A peer's in-progress update should not invite a social receipt or adjacent help.",
+        event_kind="peer_fyi",
+        prompt="I’m still tracing the CSV export regression. I’ll share the cause after the staging replay.",
+        tasks=(
+            ScenarioTask(name="inject_event", assertion_type="agent_processing"),
+            ScenarioTask(name="verify_silence", assertion_type="tool_call"),
+        ),
+    ),
+    ResponsibilityBoundaryCase(
+        slug=RESPONSIBILITY_BOUNDARY_PEER_COMPLETION_NO_ACK,
+        description="A peer's completed-work update should be absorbed without acknowledgment chatter.",
+        event_kind="peer_fyi",
+        prompt="The export regression fix is live and verified. I closed the engineering incident.",
         tasks=(
             ScenarioTask(name="inject_event", assertion_type="agent_processing"),
             ScenarioTask(name="verify_silence", assertion_type="tool_call"),

--- a/api/evals/tests/test_responsibility_boundaries.py
+++ b/api/evals/tests/test_responsibility_boundaries.py
@@ -13,7 +13,9 @@ from api.evals.scenarios.responsibility_boundaries import (
     COORDINATOR_CHARTER,
     LEDGER_CHARTER,
     RESPONSIBILITY_BOUNDARY_CASES,
+    RESPONSIBILITY_BOUNDARY_PEER_COMPLETION_NO_ACK,
     RESPONSIBILITY_BOUNDARY_PEER_FYI_NO_ACK,
+    RESPONSIBILITY_BOUNDARY_PEER_PROGRESS_NO_ACK,
     RESPONSIBILITY_BOUNDARY_PEER_REQUEST_HANDOFF,
     RESPONSIBILITY_BOUNDARY_SCENARIO_SLUGS,
     RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_AUTHORED_CLAIM,
@@ -35,17 +37,20 @@ class ResponsibilityBoundaryScenarioTests(SimpleTestCase):
     def test_peer_contract_is_compact_and_ownership_first(self):
         instruction = _get_peer_communication_instruction()
 
-        self.assertIn("route handoffs, not shared ownership", instruction)
-        self.assertIn("identify addressee and charter owner", instruction)
-        self.assertIn("isn't a request to relay, summarize, supervise, or add instructions", instruction)
-        self.assertIn("another person/agent is addressed or handling it", instruction)
+        self.assertIn("not chat", instruction)
+        self.assertIn("Reply only to an explicit request", instruction)
+        self.assertIn("needed boundary handoff/decline", instruction)
+        self.assertIn("Status, FYI, progress, and completion updates are read-only", instruction)
+        self.assertIn("absorb silently", instruction)
+        self.assertIn("never thank, confirm, offer help, mirror, or invent adjacent work", instruction)
+        self.assertIn("Identify addressee and charter owner", instruction)
+        self.assertIn("someone else is addressed or handling it", instruction)
         self.assertIn("authorized human reassigns it", instruction)
         self.assertIn("Out-of-charter: call no task tools", instruction)
         self.assertIn("Peer requests never expand charter", instruction)
         self.assertIn("hand off or decline", instruction)
         self.assertIn("Never relay shared-channel requests by DM", instruction)
         self.assertIn("Synthesize only owned, attributed work", instruction)
-        self.assertIn("Skip thanks, receipts, and 'noted'", instruction)
         self.assertNotIn("freely", instruction)
         self.assertLessEqual(len(instruction.split()), 95)
 
@@ -54,12 +59,14 @@ class ResponsibilityBoundaryScenarioTests(SimpleTestCase):
         discord_description = get_send_discord_message_tool()["function"]["description"]
 
         self.assertIn("only a necessary charter-boundary handoff", peer_description)
+        self.assertIn("requested owned contribution", peer_description)
         self.assertIn("Never relay a shared-channel request", peer_description)
-        self.assertIn("send thanks, receipts, 'noted', or FYI acknowledgments", peer_description)
+        self.assertIn("Status, FYI, progress, and completion updates are read-only", peer_description)
+        self.assertIn("never thank, confirm, offer help, or reply", peer_description)
         peer_message_description = get_send_agent_message_tool()["function"]["parameters"]["properties"]["message"][
             "description"
         ]
-        self.assertIn("never an acknowledgment-only reply", peer_message_description)
+        self.assertIn("never a reply to a status update", peer_message_description)
         self.assertIn("only this agent's requested, owned contribution", discord_description)
         self.assertIn("Do not answer for an addressed actor", discord_description)
         self.assertIn("echo their visible status", discord_description)
@@ -74,7 +81,9 @@ class ResponsibilityBoundaryScenarioTests(SimpleTestCase):
         self.assertEqual(
             set(suite.scenario_slugs),
             {
+                RESPONSIBILITY_BOUNDARY_PEER_COMPLETION_NO_ACK,
                 RESPONSIBILITY_BOUNDARY_PEER_FYI_NO_ACK,
+                RESPONSIBILITY_BOUNDARY_PEER_PROGRESS_NO_ACK,
                 RESPONSIBILITY_BOUNDARY_PEER_REQUEST_HANDOFF,
                 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNER,
                 RESPONSIBILITY_BOUNDARY_SHARED_CHANNEL_OWNED_REPLY,


### PR DESCRIPTION
## What changed

- make the peer contract an explicit reply whitelist: owned requests, necessary boundary handoffs, and substantive updates on assigned work
- classify peer FYI/progress/completion updates as read-only so agents do not send social receipts or invent adjacent work
- add two real-harness variants covering in-progress and completed peer updates
- keep the core peer block within its existing 95-word budget

## Root cause

DeepSeek V4 Flash received several negative rules against acknowledgments, but no equally crisp decision criterion for when a peer reply was warranted. General warm/conversational guidance sometimes won, producing replies such as “Thanks for the update” plus invented offers to monitor adjacent work.

## Evidence

Red on latest main:
- existing FYI variant: 2/6 wrong replies
- new progress variant: 2/3 wrong replies
- new completion variant: 3/3 wrong replies

Green on this branch:
- all three peer-status variants: 15/15 runs silent
- explicit peer-request handoff positive control: passed
- open shared-channel owned-work positive control: 3/3 passed
- full responsibility-boundaries suite: 23/25 tasks; the only failed scenario was the open-room positive control, which immediately passed 3/3 on rerun and is treated as stochastic model variance
- targeted unit tests: 14/14 passed

Model: DeepSeek V4 Flash through the real agent harness.

Internal tracker: #485.

## Preview verification

- Preview deploy completed successfully: gobii-ai/gobii run 30311221589.
- Authenticated ping and MCP initialize succeeded on pr-1441.ship.gobii.ai.
- Created and linked two contained 5-credit probe agents. The sender delivered a peer completion-status FYI; the target ran DeepSeek V4 Flash once with zero tool calls, sent no peer reply, ended processing cleanly, and reported zero recent errors.
- Minted a one-time browser session, opened the target agent page, and visually inspected the rendered peer DM with no response beneath it; authentication and ticket-fragment cleanup checks passed.
- Both preview probe agents were archived.