### PR TITLE
Timeline: stream message bodies, stop reflow re-pins, coalesce stream renders (#314 #267 #422)

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -62,6 +62,7 @@ from .processing_flags import (
 from .llm_utils import EmptyLiteLLMResponseError, raise_if_empty_litellm_response, raise_if_invalid_litellm_response, run_completion
 from .multimodal_context import collect_fresh_read_file_image_attachments, prepare_multimodal_read_file_request
 from .llm_streaming import StreamAccumulator
+from .tool_arg_streaming import ChatBodyStreamExtractor
 from .token_usage import completion_kwargs_from_usage, extract_reasoning_content, extract_token_usage, set_usage_span_attributes
 from ..short_description import maybe_schedule_mini_description, maybe_schedule_short_description
 from ..avatar import maybe_schedule_agent_avatar
@@ -4470,6 +4471,7 @@ def _stream_completion_with_broadcast(
         stream_broadcaster.start()
 
     content_filter = _CanonicalContinuationStreamFilter() if stream_broadcaster else None
+    tool_body_extractor = ChatBodyStreamExtractor() if stream_broadcaster else None
     accumulator = StreamAccumulator()
     start_time = time.monotonic()
     time_to_first_token_ms = None
@@ -4508,11 +4510,18 @@ def _stream_completion_with_broadcast(
                 if stream_broadcaster:
                     stream_broadcaster.cancel()
                 raise OrchestratorPromptStale("Prompt became stale during streaming completion.")
-            reasoning_delta, content_delta = accumulator.ingest_chunk(chunk)
+            reasoning_delta, content_delta, tool_calls_delta = accumulator.ingest_chunk(chunk)
             if stream_broadcaster:
                 filtered_delta = None
                 if stream_content:
                     filtered_delta = content_filter.ingest(content_delta) if content_filter else content_delta
+                # A web reply written through send_chat_message streams its body from the
+                # tool-call arguments — otherwise only the thinking ever streams and the message
+                # itself pops in whole when the tool executes. Plain assistant content wins if a
+                # completion somehow produces both; interleaving them would garble the card.
+                body_delta = tool_body_extractor.ingest(tool_calls_delta) if tool_body_extractor else None
+                if body_delta and not accumulator.content_parts:
+                    filtered_delta = f"{filtered_delta}{body_delta}" if filtered_delta else body_delta
                 stream_broadcaster.push_delta(reasoning_delta, filtered_delta)
     finally:
         if stream_broadcaster and not canceled:

--- a/api/agent/core/llm_streaming.py
+++ b/api/agent/core/llm_streaming.py
@@ -82,7 +82,9 @@ class StreamAccumulator:
 
         self._capture_usage(chunk)
 
-        return reasoning_delta, content_delta
+        # The raw tool-call delta travels back so the caller can stream tool-argument text
+        # (a web reply's body lives there); accumulation above is unaffected.
+        return reasoning_delta, content_delta, tool_calls_delta
 
     def _capture_usage(self, chunk: Any) -> None:
         usage = _read_attr(chunk, "usage")

--- a/api/agent/core/llm_streaming.py
+++ b/api/agent/core/llm_streaming.py
@@ -57,12 +57,12 @@ class StreamAccumulator:
         choices = _read_attr(chunk, "choices") or []
         if not choices:
             self._capture_usage(chunk)
-            return None, None
+            return None, None, None
 
         choice = choices[0]
         delta = _read_attr(choice, "delta")
         if delta is None:
-            return None, None
+            return None, None, None
 
         reasoning_delta = _coerce_stream_text(_read_attr(delta, "reasoning_content"))
         content_delta = _coerce_stream_text(_read_attr(delta, "content"))

--- a/api/agent/core/tool_arg_streaming.py
+++ b/api/agent/core/tool_arg_streaming.py
@@ -1,0 +1,197 @@
+"""Stream the body of a send_chat_message tool call as the model writes it.
+
+A web reply is a tool call, so its text arrives token by token inside the JSON ``arguments``
+fragments of the tool-call delta — invisible to the content stream. Thinking streams because it
+is ``reasoning_content``; without this extractor the message itself only appears when the tool
+executes, which reads as "streaming is broken" to anyone watching the chat.
+
+The extractor is a minimal incremental JSON lexer: it walks argument fragments character by
+character, tracks string/escape/depth state across fragment boundaries (including ``\\uXXXX``
+escapes and surrogate pairs split mid-escape), and emits the decoded value of the top-level
+``body`` key of the first send_chat_message call. Everything else is ignored.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+_CHAT_TOOL_NAME = "send_chat_message"
+
+_ESCAPE_MAP = {
+    '"': '"',
+    "\\": "\\",
+    "/": "/",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+}
+
+
+class _ArgLexer:
+    """Incremental scan of one tool call's arguments for the top-level "body" string value."""
+
+    def __init__(self) -> None:
+        self._depth = 0
+        self._in_string = False
+        self._escape = False
+        self._unicode_pending: str | None = None
+        self._high_surrogate: int | None = None
+        self._expecting_key = False
+        self._current_is_key = False
+        self._current_key_chars: list[str] = []
+        self._streaming_body = False
+        self._body_next_value = False
+        self._done = False
+
+    @property
+    def done(self) -> bool:
+        return self._done
+
+    def feed(self, fragment: str) -> str:
+        if self._done or not fragment:
+            return ""
+        out: list[str] = []
+        for ch in fragment:
+            self._feed_char(ch, out)
+            if self._done:
+                break
+        return "".join(out)
+
+    def _emit(self, ch: str, out: list[str]) -> None:
+        if self._current_is_key:
+            self._current_key_chars.append(ch)
+        elif self._streaming_body:
+            out.append(ch)
+
+    def _emit_codepoint(self, code: int, out: list[str]) -> None:
+        if self._high_surrogate is not None:
+            high = self._high_surrogate
+            self._high_surrogate = None
+            if 0xDC00 <= code <= 0xDFFF:
+                combined = 0x10000 + ((high - 0xD800) << 10) + (code - 0xDC00)
+                self._emit(chr(combined), out)
+                return
+            self._emit("�", out)
+            # fall through to handle `code` on its own
+        if 0xD800 <= code <= 0xDBFF:
+            self._high_surrogate = code
+            return
+        if 0xDC00 <= code <= 0xDFFF:
+            self._emit("�", out)
+            return
+        self._emit(chr(code), out)
+
+    def _feed_char(self, ch: str, out: list[str]) -> None:
+        if self._in_string:
+            if self._unicode_pending is not None:
+                self._unicode_pending += ch
+                if len(self._unicode_pending) == 4:
+                    try:
+                        code = int(self._unicode_pending, 16)
+                    except ValueError:
+                        self._emit("�", out)
+                    else:
+                        self._emit_codepoint(code, out)
+                    self._unicode_pending = None
+                return
+            if self._escape:
+                self._escape = False
+                if ch == "u":
+                    self._unicode_pending = ""
+                    return
+                self._emit(_ESCAPE_MAP.get(ch, ch), out)
+                return
+            if ch == "\\":
+                self._escape = True
+                return
+            if ch == '"':
+                self._in_string = False
+                if self._current_is_key:
+                    key = "".join(self._current_key_chars)
+                    self._current_key_chars = []
+                    self._current_is_key = False
+                    self._body_next_value = self._depth == 1 and key == "body"
+                elif self._streaming_body:
+                    self._streaming_body = False
+                    self._done = True
+                return
+            self._emit(ch, out)
+            return
+
+        if ch == '"':
+            self._in_string = True
+            if self._expecting_key:
+                self._current_is_key = True
+                self._current_key_chars = []
+                self._expecting_key = False
+            elif self._body_next_value:
+                self._streaming_body = True
+                self._body_next_value = False
+            return
+        if ch == "{":
+            self._depth += 1
+            self._expecting_key = True
+            return
+        if ch == "[":
+            self._depth += 1
+            self._expecting_key = False
+            self._body_next_value = False
+            return
+        if ch in "}]":
+            self._depth -= 1
+            self._expecting_key = False
+            return
+        if ch == ",":
+            # In an object the next string is a key; keys only matter at depth 1.
+            self._expecting_key = True
+            self._body_next_value = False
+            return
+        if ch == ":":
+            self._expecting_key = False
+            return
+        # whitespace / literals / numbers: a non-string value after "body": means no string body
+        if self._body_next_value and not ch.isspace():
+            self._body_next_value = False
+
+
+class ChatBodyStreamExtractor:
+    """Surface the body of the first send_chat_message call across streamed tool-call deltas."""
+
+    def __init__(self) -> None:
+        self._names: dict[int, list[str]] = {}
+        self._chosen_index: int | None = None
+        self._rejected: set[int] = set()
+        self._lexer = _ArgLexer()
+
+    def ingest(self, tool_calls_delta: Optional[Iterable[Any]]) -> Optional[str]:
+        if not tool_calls_delta:
+            return None
+        out: list[str] = []
+        for entry in tool_calls_delta:
+            index = _read(entry, "index")
+            index = int(index) if index is not None else 0
+            function = _read(entry, "function") or {}
+            name_fragment = _read(function, "name")
+            args_fragment = _read(function, "arguments")
+
+            if self._chosen_index is None and index not in self._rejected:
+                name = self._names.setdefault(index, [])
+                if name_fragment:
+                    name.append(str(name_fragment))
+                joined = "".join(name)
+                if joined == _CHAT_TOOL_NAME:
+                    self._chosen_index = index
+                elif not _CHAT_TOOL_NAME.startswith(joined):
+                    self._rejected.add(index)
+
+            if index == self._chosen_index and args_fragment and not self._lexer.done:
+                out.append(self._lexer.feed(str(args_fragment)))
+        text = "".join(out)
+        return text or None
+
+
+def _read(obj: Any, key: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, type Ref } from 'react'
+import { memo, useCallback, useMemo, type Ref } from 'react'
 import { Loader2 } from 'lucide-react'
 import { TimelineEventItem } from './TimelineEventItem'
 import { StreamingReplyCard } from './StreamingReplyCard'
@@ -91,7 +91,9 @@ type AgentTimelinePaneProps = {
   typingStatusText: string
 }
 
-export function AgentTimelinePane({
+// Memoized: the chat page re-renders on every stream flush and near-bottom flip, and
+// re-running the full event map each time is the render-storm half of bug #267.
+export const AgentTimelinePane = memo(function AgentTimelinePane({
   composerDisabled = false,
   contactCapOpenPacks,
   contactCapShowUpgrade = false,
@@ -346,4 +348,4 @@ export function AgentTimelinePane({
       </button>
     </>
   )
-}
+})

--- a/frontend/src/components/agentChat/useTimelineScrollController.test.tsx
+++ b/frontend/src/components/agentChat/useTimelineScrollController.test.tsx
@@ -152,6 +152,9 @@ describe('useTimelineScrollController', () => {
     flushAnimationFrames()
     expect(viewport.scrollTop).toBe(300)
 
+    // Scrolling back to the live edge only re-pins when a real gesture drove it; a bare scroll
+    // event could just as well be a reflow moving the content under the reader.
+    fireEvent.wheel(viewport, { deltaY: 120 })
     viewport.scrollTop = 550
     fireEvent.scroll(viewport)
     expect(result.current.pinned).toBe(true)
@@ -159,5 +162,30 @@ describe('useTimelineScrollController', () => {
     rerender({ contentVersion: 'reply:1' })
     flushAnimationFrames()
     expect(viewport.scrollTop).toBe(600)
+  })
+
+  it('does not re-pin a parked reader when a reflow lands them near the bottom', () => {
+    const { result } = renderHook(
+      ({ contentVersion }: HarnessProps) => useScrollHarness({ contentVersion }),
+      { initialProps: { contentVersion: 'thinking:1' } },
+    )
+    const viewport = createScrollViewport()
+
+    act(() => result.current.controller.timelineRef(viewport))
+    flushNextAnimationFrame()
+
+    // The reader scrolls up and parks.
+    fireEvent.wheel(viewport, { deltaY: -120 })
+    viewport.scrollTop = 300
+    fireEvent.scroll(viewport)
+    expect(result.current.pinned).toBe(false)
+
+    // Time passes with no further input. A layout change — a stream card collapsing — fires a
+    // scroll event that leaves them near the bottom through no action of their own.
+    vi.spyOn(Date, 'now').mockReturnValue(60_000)
+    viewport.scrollTop = 560
+    fireEvent.scroll(viewport)
+
+    expect(result.current.pinned).toBe(false)
   })
 })

--- a/frontend/src/components/agentChat/useTimelineScrollController.ts
+++ b/frontend/src/components/agentChat/useTimelineScrollController.ts
@@ -15,6 +15,11 @@ const PROGRAMMATIC_SCROLL_MS = 180
 const SCROLLABLE_EPSILON_PX = 1
 const PREPEND_RESTORE_GUARD_MS = 250
 const USER_SCROLL_DELTA_PX = 2
+// A downward scroll may only re-engage bottom-follow this soon after a real gesture. Scroll
+// events fired by reflow or browser scroll anchoring carry no user intent; long enough for
+// wheel momentum and scrollbar drags to keep counting, short enough that a reflow minutes into
+// reading cannot re-pin.
+const USER_INPUT_REPIN_WINDOW_MS = 1500
 // How long the anchored row is held in place after older history is inserted. It covers the late
 // measurement of prepended cards -- highlighting, JSON viewers, images, charts -- which lands after
 // the commit that inserted them. Any reader input ends the hold immediately.
@@ -117,6 +122,7 @@ export function useTimelineScrollController({
   const ignorePinUntilRef = useRef(0)
   const lastScrollTopRef = useRef(0)
   const pointerActiveRef = useRef(false)
+  const lastUserInputAtRef = useRef(0)
   const touchYRef = useRef<number | null>(null)
 
   const [timelineNode, setTimelineNode] = useState<HTMLDivElement | null>(null)
@@ -440,8 +446,13 @@ export function useTimelineScrollController({
       return
     }
 
+    const markUserInput = () => {
+      lastUserInputAtRef.current = Date.now()
+    }
+
     const handleWheel = (event: WheelEvent) => {
       // The reader is driving again; never move the viewport out from under them.
+      markUserInput()
       stopAnchorHold()
       if (event.deltaY < 0 && canScrollUp(container)) {
         suspendAutoFollow()
@@ -449,11 +460,13 @@ export function useTimelineScrollController({
     }
 
     const handleTouchStart = (event: TouchEvent) => {
+      markUserInput()
       stopAnchorHold()
       touchYRef.current = event.touches[0]?.clientY ?? null
     }
 
     const handleTouchMove = (event: TouchEvent) => {
+      markUserInput()
       const nextTouchY = event.touches[0]?.clientY ?? null
       const previousTouchY = touchYRef.current
       touchYRef.current = nextTouchY
@@ -472,6 +485,7 @@ export function useTimelineScrollController({
     }
 
     const handlePointerDown = () => {
+      markUserInput()
       stopAnchorHold()
       pointerActiveRef.current = true
     }
@@ -481,7 +495,11 @@ export function useTimelineScrollController({
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (isEditableTarget(event.target) || !canScrollUp(container)) {
+      if (isEditableTarget(event.target)) {
+        return
+      }
+      markUserInput()
+      if (!canScrollUp(container)) {
         return
       }
       const scrollsUp = event.key === 'ArrowUp'
@@ -538,7 +556,21 @@ export function useTimelineScrollController({
 
       if (meaningfulScrollUp && !contentLayoutChangingRef.current) {
         suspendAutoFollow()
-      } else if (scrollingDown && distance <= NEAR_BOTTOM_PX && !hasNextPage) {
+      } else if (
+        scrollingDown
+        && distance <= NEAR_BOTTOM_PX
+        && !hasNextPage
+        // Scroll events also come from reflows and browser scroll-anchoring adjustments, not
+        // just people. Content shrinking under a parked reader — a stream card collapsing, a
+        // tool preview folding — can land them "near bottom" without any gesture, and re-pinning
+        // there means the next append yanks them to the live edge (the intermittent
+        // pulled-to-bottom-while-reading bug). Only a recent real input, or a scrollbar drag
+        // still in progress, may re-engage follow.
+        && (
+          pointerActiveRef.current
+          || Date.now() - lastUserInputAtRef.current <= USER_INPUT_REPIN_WINDOW_MS
+        )
+      ) {
         setPinned(true)
       }
 

--- a/frontend/src/hooks/useAgentChatSocket.ts
+++ b/frontend/src/hooks/useAgentChatSocket.ts
@@ -26,6 +26,10 @@ const BACKGROUND_SYNC_INTERVAL_MS = 30000
 const PING_INTERVAL_MS = 20000
 const PONG_TIMEOUT_MS = 8000
 const CONNECT_TIMEOUT_MS = 10000
+// Stream deltas can arrive far faster than frames, and each dispatch renders the whole chat
+// page. Coalescing to this cadence keeps the typewriter visibly smooth while cutting renders
+// during streaming by an order of magnitude (the repaint-storm half of bug #267/#314).
+const STREAM_DELTA_FLUSH_MS = 50
 
 export type AgentChatSocketStatus = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'offline' | 'error'
 
@@ -92,6 +96,49 @@ export function useAgentChatSocket(
 ): AgentChatSocketSnapshot {
   const queryClient = useQueryClient()
   const dispatch = useAppDispatch()
+
+  type BufferedStreamDelta = { agentId: string; payload: Parameters<typeof receiveStreamEvent>[1] }
+  const streamDeltaBufferRef = useRef<BufferedStreamDelta | null>(null)
+  const streamDeltaTimerRef = useRef<number | null>(null)
+  const flushStreamDeltas = useCallback(() => {
+    if (streamDeltaTimerRef.current !== null) {
+      window.clearTimeout(streamDeltaTimerRef.current)
+      streamDeltaTimerRef.current = null
+    }
+    const buffered = streamDeltaBufferRef.current
+    streamDeltaBufferRef.current = null
+    if (buffered) {
+      dispatch(receiveStreamEvent(buffered.agentId, buffered.payload))
+    }
+  }, [dispatch])
+  useEffect(() => () => flushStreamDeltas(), [flushStreamDeltas])
+  const enqueueStreamEvent = useCallback((agentId: string, payload: Parameters<typeof receiveStreamEvent>[1]) => {
+    if (payload.status !== 'delta') {
+      // start/done/canceled are ordering-sensitive; deliver anything buffered first.
+      flushStreamDeltas()
+      dispatch(receiveStreamEvent(agentId, payload))
+      return
+    }
+    const buffered = streamDeltaBufferRef.current
+    if (
+      buffered
+      && buffered.agentId === agentId
+      && buffered.payload.stream_id === payload.stream_id
+    ) {
+      buffered.payload = {
+        ...buffered.payload,
+        reasoning_delta: `${buffered.payload.reasoning_delta ?? ''}${payload.reasoning_delta ?? ''}`,
+        content_delta: `${buffered.payload.content_delta ?? ''}${payload.content_delta ?? ''}`,
+      }
+    } else {
+      flushStreamDeltas()
+      streamDeltaBufferRef.current = { agentId, payload: { ...payload } }
+    }
+    if (streamDeltaTimerRef.current === null) {
+      streamDeltaTimerRef.current = window.setTimeout(flushStreamDeltas, STREAM_DELTA_FLUSH_MS)
+    }
+  }, [dispatch, flushStreamDeltas])
+
   const desiredSubscriptions = useMemo(
     () => normalizeAgentChatSocketSubscriptions(desiredSubscriptionsInput),
     [desiredSubscriptionsInput],
@@ -109,9 +156,7 @@ export function useAgentChatSocket(
     updateUsageInsight: (agentId: string, metadata: Parameters<typeof chatActions.usageInsightUpdated>[0]['metadata']) => {
       dispatch(chatActions.usageInsightUpdated({ agentId, metadata }))
     },
-    receiveStreamEvent: (agentId: string, payload: Parameters<typeof receiveStreamEvent>[1]) => {
-      dispatch(receiveStreamEvent(agentId, payload))
-    },
+    receiveStreamEvent: enqueueStreamEvent,
     replacePendingActions: (
       agentId: string,
       pendingActions: Parameters<typeof chatActions.pendingActionsSnapshotReceived>[0]['pendingActions'],

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "1808b350fb7a7e6a654b8e86f028996a2be7363e",
+  "baseline_sha": "fc3a4b7f36f44f4631a98bca823ba2243f17fc16",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9246,
-        "system_bytes": 32494,
-        "tools_bytes": 23456,
-        "total_bytes": 67659,
+        "fitted_tokens": 9276,
+        "system_bytes": 32488,
+        "tools_bytes": 23453,
+        "total_bytes": 67650,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8644,
-        "system_bytes": 29385,
-        "tools_bytes": 23456,
-        "total_bytes": 64583,
+        "fitted_tokens": 8654,
+        "system_bytes": 29379,
+        "tools_bytes": 23453,
+        "total_bytes": 64574,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8827,
-        "system_bytes": 30022,
-        "tools_bytes": 23456,
-        "total_bytes": 65223,
+        "fitted_tokens": 8830,
+        "system_bytes": 30016,
+        "tools_bytes": 23453,
+        "total_bytes": 65214,
         "user_bytes": 11745
       }
     },
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 927,
+    "file_count": 928,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 270000
+    "limit": 261920
   }
 }

--- a/tests/unit/test_tool_arg_streaming.py
+++ b/tests/unit/test_tool_arg_streaming.py
@@ -1,0 +1,141 @@
+"""The reply an agent writes with send_chat_message must stream like its thinking does.
+
+Web replies are tool calls, so the body arrives token by token inside the JSON `arguments`
+fragment of the tool-call delta — and the streaming loop dropped those on the floor. Thinking
+streamed (it is `reasoning_content`); the message itself appeared only after the tool executed.
+These pin the incremental extractor that surfaces the body as it is generated.
+"""
+from django.test import SimpleTestCase, tag
+
+from api.agent.core.tool_arg_streaming import ChatBodyStreamExtractor
+
+
+def _delta(index: int, name: str | None = None, args: str | None = None) -> list[dict]:
+    function: dict = {}
+    if name is not None:
+        function["name"] = name
+    if args is not None:
+        function["arguments"] = args
+    return [{"index": index, "function": function}]
+
+
+@tag("batch_event_processing")
+class ChatBodyStreamExtractorTests(SimpleTestCase):
+    def test_streams_the_body_of_a_send_chat_message_call(self):
+        ex = ChatBodyStreamExtractor()
+        out = []
+        out.append(ex.ingest(_delta(0, name="send_chat", args="")))
+        out.append(ex.ingest(_delta(0, name="_message", args='{"bo')))
+        out.append(ex.ingest(_delta(0, args='dy": "Hel')))
+        out.append(ex.ingest(_delta(0, args='lo the')))
+        out.append(ex.ingest(_delta(0, args='re!", "will_continue_work": false}')))
+        self.assertEqual("".join(part for part in out if part), "Hello there!")
+
+    def test_json_escapes_decode_across_fragment_boundaries(self):
+        ex = ChatBodyStreamExtractor()
+        out = []
+        out.append(ex.ingest(_delta(0, name="send_chat_message", args='{"body": "line1\\')))
+        out.append(ex.ingest(_delta(0, args='nline2 \\u00e9 and \\')))
+        out.append(ex.ingest(_delta(0, args='"quoted\\""}')))
+        self.assertEqual("".join(part for part in out if part), 'line1\nline2 é and "quoted"')
+
+    def test_surrogate_pair_split_across_fragments(self):
+        ex = ChatBodyStreamExtractor()
+        out = []
+        out.append(ex.ingest(_delta(0, name="send_chat_message", args='{"body": "\\ud83d')))
+        out.append(ex.ingest(_delta(0, args='\\ude00 done"}')))
+        self.assertEqual("".join(part for part in out if part), "\U0001f600 done")
+
+    def test_other_tools_do_not_stream(self):
+        ex = ChatBodyStreamExtractor()
+        out = []
+        out.append(ex.ingest(_delta(0, name="send_email", args='{"body": "external mail text"}')))
+        self.assertEqual("".join(part for part in out if part), "")
+
+    def test_keys_before_body_are_skipped(self):
+        ex = ChatBodyStreamExtractor()
+        out = []
+        out.append(ex.ingest(_delta(0, name="send_chat_message", args='{"will_continue_work": false, "bo')))
+        out.append(ex.ingest(_delta(0, args='dy": "after other keys"}')))
+        self.assertEqual("".join(part for part in out if part), "after other keys")
+
+    def test_a_body_valued_string_inside_another_key_is_not_mistaken(self):
+        """A value containing the text "body": must not open extraction."""
+        ex = ChatBodyStreamExtractor()
+        out = []
+        out.append(ex.ingest(_delta(0, name="send_chat_message", args='{"note": "the \\"body\\": key", "body": "real"}')))
+        self.assertEqual("".join(part for part in out if part), "real")
+
+    def test_only_the_first_chat_send_streams(self):
+        """Two send calls in one completion: streaming both would concatenate two messages."""
+        ex = ChatBodyStreamExtractor()
+        out = []
+        out.append(ex.ingest(_delta(0, name="send_chat_message", args='{"body": "first"}')))
+        out.append(ex.ingest(_delta(1, name="send_chat_message", args='{"body": "second"}')))
+        self.assertEqual("".join(part for part in out if part), "first")
+
+    def test_none_and_empty_deltas_are_harmless(self):
+        ex = ChatBodyStreamExtractor()
+        self.assertIsNone(ex.ingest(None))
+        self.assertIsNone(ex.ingest([]))
+
+
+@tag("batch_event_processing")
+class StreamLoopBodyBroadcastTests(SimpleTestCase):
+    """The loop must push tool-call body text to the web stream even when plain content
+    streaming is disabled — that combination (tool-send models) is exactly the fleet state in
+    which "thinking streams, messages don't" was reported."""
+
+    def test_send_chat_message_body_reaches_the_broadcaster(self):
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from api.agent.core.event_processing import _stream_completion_with_broadcast
+
+        def chunk(args=None, name=None, content=None, reasoning=None, finish=None):
+            function = {}
+            if name is not None:
+                function["name"] = name
+            if args is not None:
+                function["arguments"] = args
+            delta = SimpleNamespace(
+                content=content,
+                reasoning_content=reasoning,
+                tool_calls=[{"index": 0, "id": "call_1", "type": "function", "function": function}] if function else None,
+            )
+            return SimpleNamespace(id="resp", choices=[SimpleNamespace(delta=delta, finish_reason=finish)], usage=None)
+
+        chunks = [
+            chunk(reasoning="thinking..."),
+            chunk(name="send_chat_message", args='{"bo'),
+            chunk(args='dy": "Hi An'),
+            chunk(args='drew!", "will_continue_work": false}', finish="tool_calls"),
+        ]
+
+        pushed: list[tuple] = []
+        broadcaster = SimpleNamespace(
+            start=lambda: None,
+            push_delta=lambda r, c: pushed.append((r, c)),
+            finish=lambda: None,
+            cancel=lambda: None,
+        )
+
+        with patch("api.agent.core.event_processing.run_completion", return_value=iter(chunks)):
+            response = _stream_completion_with_broadcast(
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                params={},
+                tools=None,
+                provider="p",
+                stream_broadcaster=broadcaster,
+                stream_content=False,  # tool-send model: implied-send content disabled
+            )
+
+        body_stream = "".join(c for _r, c in pushed if c)
+        self.assertEqual(body_stream, "Hi Andrew!")
+        reasoning_stream = "".join(r for r, _c in pushed if r)
+        self.assertEqual(reasoning_stream, "thinking...")
+        # accumulation is unaffected: the tool call still materializes whole for execution
+        tool_calls = response.choices[0].message.tool_calls
+        self.assertEqual(len(tool_calls), 1)
+        self.assertIn("Hi Andrew!", str(tool_calls[0]))


### PR DESCRIPTION
## Not for automerge — Andrew human-tests on the preview before merge.

Four root-cause fixes to the chat timeline, one surface.

## 1. Web replies now stream as the model writes them (new ticket, Andrew first-hand)

Thinking streamed but messages didn't: a web reply is a `send_chat_message` **tool call**, so its text arrives token-by-token inside the JSON `arguments` of the tool-call delta — which the streaming loop dropped entirely. On tool-send models (`stream_content=False`, most of the fleet) nothing but reasoning ever streamed. A minimal incremental JSON lexer (`tool_arg_streaming.py`) surfaces the top-level `body` string of the first send_chat_message call across fragment boundaries — escapes and split surrogate pairs included — and the loop pushes it as content deltas. Plain assistant content wins if both appear; accumulation/tool-execution unchanged. 9 unit tests including a full loop integration test.

## 2. Reflow can no longer re-pin a parked reader (#422 / the "pulled to bottom" bug)

Downward-scroll-near-bottom re-engaged bottom-follow on **any** scroll event — including reflow and browser scroll-anchoring adjustments. A stream card collapsing under a parked reader could land them "near bottom" with zero gesture, re-pin them, and the next append yanked them to the live edge. Re-pin now requires real input within 1.5s (or an in-progress scrollbar drag). New contract test: a reflow landing a parked reader near the bottom does NOT re-pin.

## 3. Stream deltas coalesce; the pane is memoized (#267/#314 render storm)

Each stream delta dispatched straight into Redux — a full chat-page render per token batch, faster than frames. Deltas now coalesce on a 50ms cadence (start/done/canceled flush in-order first). `AgentTimelinePane` is memoized so near-bottom flips and stream flushes stop re-running the full event map. Together: order-of-magnitude fewer renders during streaming.

## 4. Stream→final handoff verified atomic (#314)

The outbound message event clears the stream card in the same reducer pass — no gap, no double-render. No change needed; verified by inspection and existing tests.

## Gates

Frontend 286/286, backend streaming + event-processing suites green, build + tsc clean, budgets recorded (+262: extractor + tests).

## Andrew's preview test script

1. Message an agent and watch the reply **stream in live** (not pop in whole) — this is the headline change.
2. While an agent is thinking/streaming, scroll up and read — you should never be yanked down; scrolling back down yourself re-engages follow normally.
3. General feel: scrolling during activity should be visibly smoother (fewer frame drops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Replaces #1440 — that branch received zero GitHub Actions events (same phenomenon as #1430 earlier today).