### PR TITLE
Bound stalled model streams so agent queues recover

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -59,7 +59,13 @@ from .processing_flags import (
     processing_lock_storage_keys,
     set_processing_heartbeat,
 )
-from .llm_utils import EmptyLiteLLMResponseError, raise_if_empty_litellm_response, raise_if_invalid_litellm_response, run_completion
+from .llm_utils import (
+    EmptyLiteLLMResponseError,
+    StreamIdleTimeout,
+    raise_if_empty_litellm_response,
+    raise_if_invalid_litellm_response,
+    run_completion,
+)
 from .multimodal_context import collect_fresh_read_file_image_attachments, prepare_multimodal_read_file_request
 from .llm_streaming import StreamAccumulator
 from .tool_arg_streaming import ChatBodyStreamExtractor
@@ -4791,6 +4797,10 @@ def _completion_with_failover(
                             defer_stream_finish=defer_stream_finish,
                         )
                     except OrchestratorPromptStale:
+                        raise
+                    except StreamIdleTimeout:
+                        active_stream_broadcaster.cancel()
+                        active_stream_broadcaster = None
                         raise
                     except Exception:
                         if stale_prompt_checker and stale_prompt_checker():

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -59,13 +59,7 @@ from .processing_flags import (
     processing_lock_storage_keys,
     set_processing_heartbeat,
 )
-from .llm_utils import (
-    EmptyLiteLLMResponseError,
-    StreamIdleTimeout,
-    raise_if_empty_litellm_response,
-    raise_if_invalid_litellm_response,
-    run_completion,
-)
+from .llm_utils import EmptyLiteLLMResponseError, StreamIdleTimeout, raise_if_empty_litellm_response, raise_if_invalid_litellm_response, run_completion
 from .multimodal_context import collect_fresh_read_file_image_attachments, prepare_multimodal_read_file_request
 from .llm_streaming import StreamAccumulator
 from .tool_arg_streaming import ChatBodyStreamExtractor

--- a/api/agent/core/llm_utils.py
+++ b/api/agent/core/llm_utils.py
@@ -57,6 +57,10 @@ class InvalidLiteLLMResponseError(LiteLLMResponseError):
     """Raised when LiteLLM returns a response containing forbidden markers."""
 
 
+class StreamIdleTimeout(litellm.Timeout):
+    """Raised when a streamed completion stops producing chunks."""
+
+
 _RETRYABLE_ERRORS = (
     litellm.Timeout,
     litellm.APIConnectionError,
@@ -67,10 +71,13 @@ _RETRYABLE_ERRORS = (
 )
 
 
-class _FirstDataTimeoutStream:
+class _StreamIdleTimeoutIterator:
     class _StreamError:
         def __init__(self, exc: Exception) -> None:
             self.exc = exc
+
+    class _StreamEnd:
+        pass
 
     def __init__(
         self,
@@ -94,26 +101,27 @@ class _FirstDataTimeoutStream:
         self._backoff_seconds = backoff_seconds
         self._received_first_chunk = False
         self._timed_out = False
+        self._result_queue: queue.Queue[Any] | None = None
 
-    def __iter__(self) -> "_FirstDataTimeoutStream":
+    def __iter__(self) -> "_StreamIdleTimeoutIterator":
         return self
 
     def __next__(self) -> Any:
         if self._timed_out:
             raise StopIteration
-        if self._received_first_chunk:
-            return next(self._stream)
 
         while True:
             try:
-                result = self._read_first_chunk()
+                result = self._read_next_chunk()
             except _RETRYABLE_ERRORS as exc:
-                self._retry_or_raise(exc)
+                if self._received_first_chunk:
+                    raise
+                self._replace_stream_or_raise(exc)
                 continue
             self._received_first_chunk = True
             return result
 
-    def _retry_or_raise(self, exc: Exception) -> None:
+    def _replace_stream_or_raise(self, exc: Exception) -> None:
         while True:
             if self._attempt >= self._max_attempts:
                 raise exc
@@ -129,34 +137,48 @@ class _FirstDataTimeoutStream:
             self._attempt += 1
             try:
                 self._stream = self._create_stream()
+                self._result_queue = None
+                self._timed_out = False
                 return
             except _RETRYABLE_ERRORS as retry_exc:
                 exc = retry_exc
 
-    def _read_first_chunk(self) -> Any:
-        result_queue: queue.Queue[Any] = queue.Queue(maxsize=1)
+    def _start_reader(self) -> queue.Queue[Any]:
+        result_queue: queue.Queue[Any] = queue.Queue()
+        stream = self._stream
 
-        def _read_first_chunk() -> None:
+        def _read_stream() -> None:
             try:
-                result_queue.put(next(self._stream))
+                for chunk in stream:
+                    result_queue.put(chunk)
             except Exception as exc:
                 result_queue.put(self._StreamError(exc))
+            else:
+                result_queue.put(self._StreamEnd())
 
-        thread = threading.Thread(target=_read_first_chunk, daemon=True)
+        thread = threading.Thread(target=_read_stream, daemon=True)
         thread.start()
+        self._result_queue = result_queue
+        return result_queue
+
+    def _read_next_chunk(self) -> Any:
+        result_queue = self._result_queue or self._start_reader()
         try:
             result = result_queue.get(timeout=self._timeout_seconds)
         except queue.Empty:
             self._timed_out = True
             self.close()
-            raise litellm.Timeout(
-                message=f"LLM stream produced no data within {self._timeout_seconds} seconds",
+            timeout_scope = "no data" if not self._received_first_chunk else "no additional data"
+            raise StreamIdleTimeout(
+                message=f"LLM stream produced {timeout_scope} within {self._timeout_seconds} seconds",
                 model=self._model,
                 llm_provider=self._provider or "unknown",
             )
 
         if isinstance(result, self._StreamError):
             raise result.exc
+        if isinstance(result, self._StreamEnd):
+            raise StopIteration
         return result
 
     def __getattr__(self, name: str) -> Any:
@@ -193,7 +215,7 @@ def _attach_response_duration(response: Any, duration_ms: int | None) -> None:
             model_extra["request_duration_ms"] = duration_ms
 
 
-def _wrap_stream_with_first_data_timeout(
+def _wrap_stream_with_idle_timeout(
     stream: Any,
     *,
     create_stream: Callable[[], Any],
@@ -202,8 +224,8 @@ def _wrap_stream_with_first_data_timeout(
     initial_attempt: int,
     max_attempts: int,
     backoff_seconds: float,
-) -> _FirstDataTimeoutStream:
-    return _FirstDataTimeoutStream(
+) -> _StreamIdleTimeoutIterator:
+    return _StreamIdleTimeoutIterator(
         stream,
         create_stream=create_stream,
         timeout_seconds=get_litellm_first_data_timeout_seconds(),
@@ -530,7 +552,7 @@ def run_completion(
                 duration_ms = int(round((time.monotonic() - start_time) * 1000))
             else:
                 response = litellm.completion(**kwargs)
-                response = _wrap_stream_with_first_data_timeout(
+                response = _wrap_stream_with_idle_timeout(
                     response,
                     create_stream=lambda: litellm.completion(**kwargs),
                     model=model,
@@ -606,6 +628,7 @@ def _litellm_responses_bridge_tool_choice(tool_choice: Any) -> Any:
 __all__ = [
     "EmptyLiteLLMResponseError",
     "InvalidLiteLLMResponseError",
+    "StreamIdleTimeout",
     "is_empty_litellm_response",
     "raise_if_empty_litellm_response",
     "raise_if_invalid_litellm_response",

--- a/api/services/system_settings.py
+++ b/api/services/system_settings.py
@@ -107,8 +107,8 @@ SYSTEM_SETTING_DEFINITIONS = (
     ),
     SystemSettingDefinition(
         key="LITELLM_FIRST_DATA_TIMEOUT_SECONDS",
-        label="LiteLLM first data timeout",
-        description="Timeout for streamed LiteLLM requests to produce their first chunk.",
+        label="LiteLLM stream idle timeout",
+        description="Timeout for streamed LiteLLM requests to produce each next chunk.",
         value_type=VALUE_TYPE_INT,
         env_var="LITELLM_FIRST_DATA_TIMEOUT_SECONDS",
         default_getter=lambda: settings.LITELLM_FIRST_DATA_TIMEOUT_SECONDS,

--- a/config/settings.py
+++ b/config/settings.py
@@ -177,7 +177,7 @@ SOLUTIONS_PARTNER_BILLING_ACCESS = env.bool("SOLUTIONS_PARTNER_BILLING_ACCESS", 
 MAX_PREFERRED_PROVIDER_STREAK = env.int("MAX_PREFERRED_PROVIDER_STREAK", default=3)
 # Default timeout (seconds) for LiteLLM requests
 LITELLM_TIMEOUT_SECONDS = env.int("LITELLM_TIMEOUT_SECONDS", default=300)
-# Timeout (seconds) for streamed LiteLLM requests to produce their first chunk
+# Timeout (seconds) for streamed LiteLLM requests to produce each next chunk
 LITELLM_FIRST_DATA_TIMEOUT_SECONDS = env.int(
     "LITELLM_FIRST_DATA_TIMEOUT_SECONDS",
     default=30,

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "0d16de14ad4cdba42d8ea8721fcf237bb6c1815b",
+  "baseline_sha": "775f98cce0a311db853e414d5cf3ec30a9f2e58a",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9256,
+        "fitted_tokens": 9246,
         "system_bytes": 32463,
         "tools_bytes": 23453,
         "total_bytes": 67625,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8629,
+        "fitted_tokens": 8644,
         "system_bytes": 29354,
         "tools_bytes": 23453,
         "total_bytes": 64549,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8841,
+        "fitted_tokens": 8834,
         "system_bytes": 29991,
         "tools_bytes": 23453,
         "total_bytes": 65189,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 262063
+    "limit": 262057
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,18 +1,18 @@
 {
-  "baseline_sha": "3b3231f023f0ae85d5555d7a8d828ecc3ce58fb8",
+  "baseline_sha": "0d16de14ad4cdba42d8ea8721fcf237bb6c1815b",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9261,
+        "fitted_tokens": 9256,
         "system_bytes": 32463,
         "tools_bytes": 23453,
         "total_bytes": 67625,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8624,
+        "fitted_tokens": 8629,
         "system_bytes": 29354,
         "tools_bytes": 23453,
         "total_bytes": 64549,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 262034
+    "limit": 262063
   }
 }

--- a/tests/unit/test_event_processing_llm_selection.py
+++ b/tests/unit/test_event_processing_llm_selection.py
@@ -12,6 +12,7 @@ from api.agent.core.event_processing import (
     _filter_preferred_config_for_low_latency,
     _get_recent_preferred_config,
 )
+from api.agent.core.llm_utils import StreamIdleTimeout
 from api.models import PersistentAgent, BrowserUseAgent, PersistentAgentCompletion
 from tests.utils.token_usage import make_completion_response
 
@@ -175,6 +176,40 @@ class TestEventProcessingLLMSelection(TestCase):
         broadcaster.push_delta.assert_any_call("Thinking", None)
         for call in broadcaster.push_delta.call_args_list:
             self.assertNotIn("Hidden reply", call.args)
+
+    @patch('api.agent.core.event_processing.run_completion')
+    def test_stream_idle_timeout_fails_over_without_replaying_same_provider(self, mock_run_completion):
+        fallback_response = make_completion_response(content="recovered")
+        mock_run_completion.side_effect = [
+            StreamIdleTimeout(
+                "LLM stream produced no additional data",
+                model="model-stalled",
+                llm_provider="provider-stalled",
+            ),
+            fallback_response,
+        ]
+        broadcaster = Mock()
+
+        response, token_usage = _completion_with_failover(
+            [{"role": "user", "content": "hello"}],
+            [],
+            failover_configs=[
+                ("provider-stalled", "model-stalled", {}),
+                ("provider-fallback", "model-fallback", {}),
+            ],
+            agent_id="agent-1",
+            stream_broadcaster=broadcaster,
+            defer_stream_finish=True,
+        )
+
+        self.assertIs(response, fallback_response)
+        self.assertEqual(mock_run_completion.call_count, 2)
+        self.assertTrue(mock_run_completion.call_args_list[0].kwargs["stream"])
+        self.assertNotIn("stream", mock_run_completion.call_args_list[1].kwargs)
+        self.assertEqual(mock_run_completion.call_args_list[1].kwargs["model"], "model-fallback")
+        self.assertEqual(token_usage["provider"], "provider-fallback")
+        broadcaster.cancel.assert_called_once()
+        broadcaster.finish.assert_not_called()
 
     @patch('api.agent.core.event_processing.run_completion')
     def test_completion_with_failover_prefers_explicit_provider(self, mock_run_completion):

--- a/tests/unit/test_event_processing_pending_followup.py
+++ b/tests/unit/test_event_processing_pending_followup.py
@@ -7,10 +7,13 @@ from django.test import TestCase, tag
 from api.agent.core import event_processing as ep
 from api.agent.core.budget import AgentBudgetManager, BudgetContext
 from api.agent.core.event_processing import _attempt_cycle_close_for_sleep
+from api.agent.core.llm_utils import StreamIdleTimeout
 from api.agent.core.processing_flags import (
     bump_human_inbound_generation,
     claim_pending_agent,
     enqueue_pending_agent,
+    get_processing_heartbeat,
+    get_processing_locked_agent_ids,
     mark_human_inbound_generation_consumed,
     pending_set_key,
     remove_pending_agent,
@@ -128,6 +131,56 @@ class PendingFollowUpClosureTests(TestCase):
         pending_work = mock_enqueue_followup.call_args.args[0]
         self.assertEqual(pending_work.inbound_generation, accepted_generation + 1)
         self.assertEqual(pending_work.queue, AGENT_INTERACTIVE_PROCESSING_QUEUE)
+        self.assertIsNone(claim_pending_agent(self.agent.id, client=self.redis))
+
+    @patch("api.agent.tasks.process_events.enqueue_claimed_pending_work")
+    @patch("api.agent.core.event_processing._process_agent_events_locked")
+    @patch("api.agent.core.event_processing.Redlock")
+    def test_stream_timeout_releases_processing_and_queues_one_pending_followup(
+        self,
+        mock_redlock,
+        mock_process_locked,
+        mock_enqueue_followup,
+    ) -> None:
+        accepted_generation = bump_human_inbound_generation(self.agent.id, client=self.redis)
+        lock = MagicMock()
+        lock.acquire.return_value = True
+        lock.release.return_value = True
+        mock_redlock.return_value = lock
+
+        def _timeout_with_pending_work(*_args, **_kwargs):
+            newer_generation = bump_human_inbound_generation(self.agent.id, client=self.redis)
+            enqueue_pending_agent(
+                self.agent.id,
+                inbound_generation=newer_generation,
+                queue=AGENT_INTERACTIVE_PROCESSING_QUEUE,
+                client=self.redis,
+            )
+            raise StreamIdleTimeout(
+                "LLM stream produced no additional data",
+                model="mock-model",
+                llm_provider="mock-provider",
+            )
+
+        mock_process_locked.side_effect = _timeout_with_pending_work
+
+        with self.assertRaises(StreamIdleTimeout):
+            ep.process_agent_events(
+                self.agent.id,
+                inbound_generation=accepted_generation,
+                processing_queue=AGENT_INTERACTIVE_PROCESSING_QUEUE,
+            )
+
+        lock.release.assert_called_once()
+        mock_enqueue_followup.assert_called_once()
+        pending_work = mock_enqueue_followup.call_args.args[0]
+        self.assertEqual(pending_work.inbound_generation, accepted_generation + 1)
+        self.assertEqual(pending_work.queue, AGENT_INTERACTIVE_PROCESSING_QUEUE)
+        self.assertNotIn(
+            str(self.agent.id),
+            get_processing_locked_agent_ids(client=self.redis),
+        )
+        self.assertIsNone(get_processing_heartbeat(self.agent.id, client=self.redis))
         self.assertIsNone(claim_pending_agent(self.agent.id, client=self.redis))
 
     @patch("api.agent.tasks.process_events.enqueue_claimed_pending_work")

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -51,6 +51,31 @@ class _AsyncClosableBlockingFirstChunkStream(_BlockingFirstChunkStream):
         self.released.set()
 
 
+class _BlockingSecondChunkStream:
+    def __init__(self):
+        self.closed = False
+        self.started = threading.Event()
+        self.released = threading.Event()
+        self.chunk_index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.chunk_index += 1
+        if self.chunk_index == 1:
+            return "first-chunk"
+        self.started.set()
+        self.released.wait(timeout=0.2)
+        if self.closed:
+            raise StopIteration
+        return "late-chunk"
+
+    def close(self):
+        self.closed = True
+        self.released.set()
+
+
 class RunCompletionReasoningTests(TestCase):
     @tag("batch_event_llm")
     @patch("api.agent.core.llm_utils.litellm.completion")
@@ -449,7 +474,7 @@ class RunCompletionReasoningTests(TestCase):
         _mock_first_data_timeout,
     ):
         stalled_stream = _BlockingFirstChunkStream()
-        retry_stream = _ClosableStream(["retry-chunk"])
+        retry_stream = _ClosableStream(["retry-chunk", "retry-second-chunk"])
         mock_completion.side_effect = [stalled_stream, retry_stream]
 
         result = run_completion(
@@ -460,6 +485,7 @@ class RunCompletionReasoningTests(TestCase):
         )
 
         self.assertEqual(next(result), "retry-chunk")
+        self.assertEqual(next(result), "retry-second-chunk")
         self.assertTrue(stalled_stream.closed)
         self.assertEqual(mock_completion.call_count, 2)
 
@@ -536,6 +562,32 @@ class RunCompletionReasoningTests(TestCase):
         with self.assertRaises(litellm.Timeout):
             next(result)
         self.assertTrue(stream.closed)
+
+    @tag("batch_event_llm")
+    @override_settings(LITELLM_MAX_RETRIES=2)
+    @patch("api.agent.core.llm_utils.get_litellm_first_data_timeout_seconds", return_value=0.01)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_streaming_second_chunk_timeout_closes_underlying_stream(
+        self,
+        mock_completion,
+        _mock_first_data_timeout,
+    ):
+        stream = _BlockingSecondChunkStream()
+        mock_completion.return_value = stream
+
+        result = run_completion(
+            model="mock-model",
+            messages=[],
+            params={},
+            stream=True,
+        )
+
+        self.assertEqual(next(result), "first-chunk")
+        with self.assertRaises(litellm.Timeout):
+            next(result)
+        self.assertTrue(stream.started.wait(timeout=1))
+        self.assertTrue(stream.closed)
+        mock_completion.assert_called_once()
 
     @tag("batch_event_llm")
     @override_settings(LITELLM_MAX_RETRIES=2, LITELLM_RETRY_BACKOFF_SECONDS=0)


### PR DESCRIPTION
## Summary

- Enforce the existing 30-second stream idle bound between every LLM chunk, not only before the first chunk.
- Fail over immediately after a stalled stream instead of replaying the same provider non-streaming.
- Preserve existing lease finalization: if providers fail, release processing state and enqueue exactly one coalesced pending turn.

## Production evidence

Three independent production agents reproduced one mechanism behind internal bugs #488 and #455. Each persisted a tool result, rebuilt its prompt, began a streamed completion, then held the per-agent processing lock while schedules and inbound messages queued. The Keith incident had no next provider chunk for 8m44s; the stale-generation check ran and the lock released only when another chunk finally arrived. Megan and Sophie showed the same first-chunk-then-silence signature on separate routes. `planning_state=skipped` was correlation, not the cause.

## Tests

- Red before fix: the second-chunk timeout regression failed because no timeout was raised.
- `uv run python manage.py test --tag=batch_event_llm --settings=config.test_settings` — 99 passed.
- `uv run python manage.py test tests.unit.test_event_processing_locking tests.unit.test_event_processing_pending_drain tests.unit.test_event_processing_pending_followup --settings=config.test_settings` — 18 passed.
- Complexity budget passes. Counted source grows by 23 lines, 262034 to 262057; explicit baseline bump included.

No LLM eval was added: this is a deterministic transport/lifecycle defect, and a stochastic real-model eval cannot inject or prove an inter-chunk network stall.

## Scope

Root-cause fix at the LLM streaming transport boundary, plus verification of existing queue finalization. Internal #409 (outbound metadata) and #490 (peer-DM tool choice) are unrelated and intentionally excluded.