### PR TITLE
Preserve source truth through agent actions

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -824,7 +824,7 @@ def _get_sqlite_guidance() -> str:
         "`UPDATE __agent_config SET charter=patch_text(charter,:old,:new) WHERE id=1`; put old/new only in bindings, "
         "never SQL literals; never SELECT patch_text or use E'...'. "
         "A browser task completion wakes you and adds its result; do "
-        "not poll snapshots while it runs. Facts and URLs must come from evidence, not search terms."
+        "not poll snapshots while it runs."
     )
 
 
@@ -4081,7 +4081,7 @@ def _get_system_instruction(
         "Do not invent work, results, preferences, or personal experiences.\n\n"
 
         "## Output Rules\n\n"
-        "Keep chat/outreach light. For finite sets, grouped discovery isn't coverage: resolve/source each requested field. Label blockers partial; separate sourced unavailability from research gaps. An owner report on 4+ items is unfinished without `Covered N/N` and every item/requested field in one channel-appropriate structured comparison: a table where supported, headings and bullets where not. Ground facts, numbers, units, and URLs in tool results; when evidence supplies an item URL with an adjacent $[link:...] handle, link the item name once in its result row using that handle copied character-for-character. Do not repeat the destination in a Link/Source column. Never invent, edit, or substitute a destination. Present requested data directly; omit unrelated/unavailable fields and follow-up offers after simple facts, prices, statuses, or lookups. "
+        "Keep chat/outreach light. For finite sets, grouped discovery isn't coverage: resolve/source each requested field. Label blockers partial; separate sourced unavailability from research gaps. An owner report on 4+ items is unfinished without `Covered N/N` and every item/requested field in one channel-appropriate structured comparison: a table where supported, headings and bullets where not. Ground facts, numbers, units, and URLs in evidence. Use an adjacent $[link:...] exactly once on the item name; never invent/edit/substitute destinations or add a Link/Source column. Present requested data directly; omit unrelated/unavailable fields and follow-up offers after simple facts, prices, statuses, or lookups. "
         "Charts: create only when requested/materially useful. "
         "Paste create_chart result.inline/result.inline_html in the message; do not attach/read charts or invent paths, hashes, image tags, or <img> URLs. "
         "Use create_csv for tabular exports, create_pdf for PDFs, and create_file for other text/doc formats; create_file query mode must return exactly one row and one column.\n\n"
@@ -4091,7 +4091,7 @@ def _get_system_instruction(
         f"File uploads are {'' if settings.ALLOW_FILE_UPLOAD else 'not'} supported. "
         "Do not download or upload files unless absolutely necessary or explicitly requested by the user. "
 
-        "## Tool Rules\n\n```\nopaque identifiers -> copy exposed tool names and supplied endpoints/paths/IDs/placeholders character-for-character; never shorten or normalize\n"
+        "## Tool Rules\n\n```\nopaque identifiers -> copy exposed tool names and supplied endpoints/paths/IDs/placeholders character-for-character; never shorten or normalize\nevidence -> keep counts/associations; no padding/mixing or row/result-ID promotion. Fresh evidence updates model; missing locally=unknown. Approved action -> reread/copy recipient/content exactly\n"
         "unrelated small result -> answer; build/create custom tool -> create_custom_tool first; supplied URLs -> opaque runtime inputs, no prefetch/inspect/browser\n"
         "credential-returning API -> search_tools('secure credential delegation') first; never HTTP/browser/SQLite\n"
         "named model + explicit fresh non-secret source/URL -> http_request only, no text/send/plan; WAIT; next completion exactly one reconcile+SELECT sqlite_batch; then report\n"

--- a/api/agent/core/result_analysis.py
+++ b/api/agent/core/result_analysis.py
@@ -1197,11 +1197,11 @@ def _find_all_arrays(
         if isinstance(data[0], dict):
             for key, val in data[0].items():
                 # Use [0] not [*] - SQLite doesn't support wildcards in JSON paths
-                nested = _find_all_arrays(val, f"{current_path}[0].{key}", depth + 1, inside_array=True)
+                nested = _find_all_arrays(val, f"{current_path}[0]{_safe_json_path(str(key))[1:]}", depth + 1, inside_array=True)
                 results.extend(nested)
     elif isinstance(data, dict):
         for key, val in data.items():
-            nested = _find_all_arrays(val, f"{current_path}.{key}", depth + 1, inside_array=inside_array)
+            nested = _find_all_arrays(val, f"{current_path}{_safe_json_path(str(key))[1:]}", depth + 1, inside_array=inside_array)
             results.extend(nested)
 
     return results
@@ -1214,7 +1214,7 @@ def _get_scalar_fields(data: Dict, exclude_keys: set) -> List[str]:
         if key in exclude_keys:
             continue
         if not isinstance(val, (dict, list)):
-            scalars.append(f"$.{key}")
+            scalars.append(_safe_json_path(str(key)))
     return scalars[:20]
 
 

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -134,6 +134,10 @@ def entity_name_stem(value: str) -> str:
     return f"{leaf[:-3]}y" if leaf.endswith("ies") else leaf[:-1] if leaf.endswith("s") else leaf
 
 
+def _array_entity_stem(path: str) -> str:
+    return entity_name_stem(path.rsplit(".", 1)[-1].strip('"'))
+
+
 def _entity_arrays(analysis: ResultAnalysis | None) -> tuple:
     json_analysis = analysis.json_analysis if analysis else None
     if not json_analysis:
@@ -152,9 +156,9 @@ def source_array_entity_groups(result_text: str, tool_name: str) -> tuple[set[st
     _meta, _stored_json, _stored_text, analysis = _summarize_result(result_text, "source", tool_name)
     arrays = _entity_arrays(analysis)
     return (
-        {entity_name_stem(item.path.rsplit(".", 1)[-1]) for item in arrays},
+        {_array_entity_stem(item.path) for item in arrays},
         {
-            entity_name_stem(item.path.rsplit(".", 1)[-1]) for item in arrays
+            _array_entity_stem(item.path) for item in arrays
             if any(_is_entity_key(field) for field in item.item_fields)
         },
     )
@@ -464,7 +468,7 @@ def prepare_tool_results_for_prompt(
             relevant_arrays = tuple(
                 item for item in arrays
                 if any(_is_entity_key(field) for field in item.item_fields)
-                or entity_name_stem(item.path.rsplit(".", 1)[-1]) in model_entities
+                or _array_entity_stem(item.path) in model_entities
             )
             array_specs = tuple(
                 (item, _source_item_key(item.item_fields))
@@ -475,27 +479,27 @@ def prepare_tool_results_for_prompt(
                 + (f"[stable_key={stable_key}]" if stable_key else "[no_stable_key]")
                 for item, stable_key in array_specs
             ]
+            exact_iterators = "; ".join(
+                f"json_each(t.result_json,'{item.path.replace(chr(39), chr(39) * 2)}') AS j{index}"
+                for index, (item, _stable_key) in enumerate(array_specs, start=1)
+            )
             matching_arrays = tuple(
                 item for item in relevant_arrays
-                if entity_name_stem(item.path.rsplit(".", 1)[-1]) in model_entities
+                if _array_entity_stem(item.path) in model_entities
             )
             if schemas and matching_arrays:
                 requires_source_import = True
                 source_import_key = (source_batch_id, record.tool_name)
                 if source_import_key not in emitted_source_import_sets:
                     source_import_prefix = (
-                        f"[SOURCE ARRAYS; paths: {'; '.join(schemas)}. NEXT: one sqlite_batch—no parallel/second call. "
-                        "Pass top-level rows=[]; never invent or inspect result IDs. "
-                        "Create/evolve keyed tables; upsert every sibling set-wise with "
-                        f"INSERT ... SELECT/json_each over is_current_batch=1 AND tool_name='{record.tool_name}' "
-                        "then SELECT bounded task rows. Final SELECTs constrain each entity to the exact stable_key values "
-                        "in its same current source path. Never filter freshness by a mutable name, even one the user named, "
-                        "or by a literal ID/history. "
-                        "With no stable key, use newest observed_at. "
-                        "Current batch plus tool_name is the exact set: add no source_url/result_id predicate. Each item's "
-                        "source ID is its key; t.result_id is row provenance, never item identity. Derive item fields/URLs from "
-                        "j.value, parent fields from t.result_json, and provenance from t.result_id. Never delete/clear the model. "
-                        "No pre-read, refetch, blob inspection, copied literals, or split calls.]\n"
+                        f"[SOURCE ARRAYS; paths: {'; '.join(schemas)}. NEXT: one sqlite_batch only. "
+                        f"Exact iterators: {exact_iterators}; keep every wrapper segment such as $.content. "
+                        f"Use rows=[]. Create/evolve keyed tables; INSERT ... SELECT/json_each all is_current_batch=1 "
+                        f"AND tool_name='{record.tool_name}' siblings, then SELECT bounded task rows. Use stable_key as "
+                        "entity ID; t.result_id is "
+                        "provenance only. Final rows preserve exact source associations. With no stable key, use newest "
+                        "observed_at. No source_url/result_id or mutable-name freshness filters, pre-read, refetch, blob "
+                        "inspection, copied literals, or split calls. Never delete/clear the model.]\n"
                     )
                     emitted_source_import_sets.add(source_import_key)
         if not requires_source_import and hide_literal_result_id:

--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -1,9 +1,4 @@
-"""
-Email sending tool for persistent agents.
-
-This module provides email sending functionality for persistent agents,
-including tool definition and execution logic.
-"""
+"""Email sending tool for persistent agents."""
 
 import logging
 import re
@@ -57,9 +52,10 @@ _ATTACHMENT_CLAIM_PATTERNS = (
     re.compile(r"\battached\s+(?:you(?:'|’)ll|you\s+will)\s+find\b", re.IGNORECASE),
     re.compile(r"\battached\s+(?:is|are)\b", re.IGNORECASE),
 )
-_MISSING_ATTACHMENT_CLAIM_ERROR_MESSAGE = (
-    "Email body claims attachments are included, but send_email.attachments is empty. "
-    "Pass the exact $[/path] values returned by recent file tools in send_email.attachments."
+_MISSING_ATTACHMENT_CLAIM_ERROR_MESSAGE = "Email body claims attachments are included, but send_email.attachments is empty. Pass the exact $[/path] values returned by recent file tools in send_email.attachments."
+_EMBEDDED_TOOL_ARGUMENT_PATTERN = re.compile(
+    r"</[a-z][^>]*>\s*[\"']?\s*,(?=[\s\S]*[\"']will_continue_work[\"']\s*:\s*(?:true|false))[\s\S]*}\s*$",
+    re.IGNORECASE | re.DOTALL,
 )
 
 
@@ -127,12 +123,13 @@ def _strip_quoted_thread_html(html: str) -> str:
     return _QUOTED_THREAD_PATTERN.sub(" ", html)
 
 
-def _email_claims_attachments(html: str) -> bool:
-    """Return True when the email body explicitly claims attachments are included."""
+def _email_body_error(html: str, has_attachments: bool) -> str | None:
+    if _EMBEDDED_TOOL_ARGUMENT_PATTERN.search(html or ""):
+        return "Email body contains serialized sibling tool-call arguments. End mobile_first_html after the email content and pass every tool argument separately."
     plain_text = _strip_html_to_text(_strip_quoted_thread_html(html))
-    if not plain_text:
-        return False
-    return any(pattern.search(plain_text) for pattern in _ATTACHMENT_CLAIM_PATTERNS)
+    if not has_attachments and any(pattern.search(plain_text) for pattern in _ATTACHMENT_CLAIM_PATTERNS):
+        return _MISSING_ATTACHMENT_CLAIM_ERROR_MESSAGE
+    return None
 
 
 def _resolve_reply_target(
@@ -252,8 +249,8 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
     if not all([to_address, subject, mobile_first_html]):
         return {"status": "error", "message": "Missing required parameters: to_address, subject, or mobile_first_html"}
 
-    if _email_claims_attachments(mobile_first_html) and not attachment_paths:
-        return {"status": "error", "message": _MISSING_ATTACHMENT_CLAIM_ERROR_MESSAGE}
+    if body_error := _email_body_error(mobile_first_html, bool(attachment_paths)):
+        return {"status": "error", "message": body_error}
 
     try:
         resolved_attachments = resolve_filespace_attachments(agent, attachment_paths)

--- a/api/evals/scenarios/message_quality.py
+++ b/api/evals/scenarios/message_quality.py
@@ -46,6 +46,7 @@ FAILED_EMAIL_DELIVERY_RECOVERY_SLUG = "message_quality_failed_email_reports_fail
 EMAIL_REVIEW_OUTBOX_COMMUNICATION_SLUG = "message_quality_email_review_outbox_communication"
 REMOTE_MCP_RESULT_DELIVERY_SLUG = "message_quality_remote_mcp_result_is_delivered"
 EMAIL_SENT_STATE_SEQUENCING_SLUG = "message_quality_email_sent_state_after_provider_acceptance"
+EMAIL_APPROVED_ACTION_TUPLE_SLUG = "message_quality_email_approved_action_tuple"
 
 
 @dataclass(frozen=True)
@@ -294,6 +295,7 @@ MESSAGE_QUALITY_SCENARIO_SLUGS = (
     EMAIL_REVIEW_OUTBOX_COMMUNICATION_SLUG,
     REMOTE_MCP_RESULT_DELIVERY_SLUG,
     EMAIL_SENT_STATE_SEQUENCING_SLUG,
+    EMAIL_APPROVED_ACTION_TUPLE_SLUG,
 )
 
 
@@ -1807,6 +1809,124 @@ class EmailSentStateSequencingScenario(EvalScenario, ScenarioExecutionTools):
                 else f"Tracker row was {tuple(row) if row is not None else None}; chat bodies were {chat_bodies!r}."
             ),
             artifacts={"step": sqlite_calls[-1].step} if sqlite_calls else {},
+        )
+
+
+@register_scenario
+class EmailApprovedActionTupleScenario(EvalScenario, ScenarioExecutionTools):
+    slug = EMAIL_APPROVED_ACTION_TUPLE_SLUG
+    version = "1.0"
+    description = "An approved outbound action should preserve its recipient, company, subject, and body as one tuple."
+    tier = "core"
+    category = "message_quality"
+    expected_runtime = "short"
+    cost_class = "low"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = ("message_quality", "send_email", "sqlite_batch", "identity_integrity")
+    tasks = [
+        ScenarioTask(name="inject_approved_action", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_exact_approved_action", assertion_type="tool_call"),
+    ]
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        agent = PersistentAgent.objects.get(id=agent_id)
+        mark_tool_enabled_without_discovery(agent, "sqlite_batch")
+        mark_tool_enabled_without_discovery(agent, "send_email")
+        mark_tool_enabled_without_discovery(agent, "send_chat_message")
+        for address in ("heidi@younger.example.test", "pat@holtlunsford.example.test"):
+            CommsAllowlistEntry.objects.update_or_create(
+                agent=agent,
+                channel=CommsChannel.EMAIL,
+                address=address,
+                defaults={
+                    "is_active": True,
+                    "allow_inbound": True,
+                    "allow_outbound": True,
+                    "verified": True,
+                },
+            )
+        _seed_lifecycle_eval_table(
+            agent_id,
+            (
+                "CREATE TABLE approved_outbound_actions ("
+                "action_key TEXT PRIMARY KEY, company TEXT NOT NULL, recipient TEXT NOT NULL, "
+                "subject TEXT NOT NULL, body_html TEXT NOT NULL, approval_status TEXT NOT NULL);",
+                "INSERT INTO approved_outbound_actions VALUES ("
+                "'aurora-renewal-02', 'Younger Partners', 'heidi@younger.example.test', "
+                "'Aurora renewal next steps', '<p>Heidi, the approved Aurora renewal brief is ready.</p>', "
+                "'approved');",
+                "INSERT INTO approved_outbound_actions VALUES ("
+                "'warehouse-tour-18', 'Holt Lunsford', 'pat@holtlunsford.example.test', "
+                "'Warehouse tour follow-up', '<p>Pat, thanks for the Holt Lunsford warehouse tour.</p>', "
+                "'approved');",
+            ),
+        )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="inject_approved_action",
+        )
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            inbound = self.inject_message(
+                agent_id,
+                (
+                    "Send approved action aurora-renewal-02 now. Use the approved tracker as the source of truth "
+                    "for the recipient and content."
+                ),
+                trigger_processing=True,
+                eval_run_id=run_id,
+                mock_config={
+                    "send_email": {
+                        "status": "ok",
+                        "delivery_status": "sent",
+                        "message_id": "eval-approved-action-402",
+                        "auto_sleep_ok": False,
+                    },
+                },
+                eval_stop_policy={
+                    "stop_on_tool_names_after_execution": ["send_email"],
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": ["sqlite_batch", "send_email", "update_plan"],
+                    "ignored_tool_names": ["update_plan"],
+                    "max_relevant_tool_calls": 4,
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_approved_action",
+            observed_summary="Approved action processed through the real agent harness.",
+            artifacts={"message": inbound},
+        )
+
+        calls = MessageQualityScenario._tool_calls_for_run(run_id, after=inbound.timestamp)
+        email_calls = [call for call in calls if call.tool_name == "send_email"]
+        params = MessageQualityScenario._tool_params(email_calls[0]) if len(email_calls) == 1 else {}
+        exact_tuple = (
+            len(email_calls) == 1
+            and params.get("to_address") == "heidi@younger.example.test"
+            and params.get("subject") == "Aurora renewal next steps"
+            and params.get("mobile_first_html")
+            == "<p>Heidi, the approved Aurora renewal brief is ready.</p>"
+            and "Holt Lunsford" not in json.dumps(params)
+            and "holtlunsford" not in json.dumps(params).casefold()
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if exact_tuple else EvalRunTask.Status.FAILED,
+            task_name="verify_exact_approved_action",
+            expected_summary="The send should copy one approved recipient/content tuple without cross-record mixing.",
+            observed_summary=(
+                "Sent the exact approved Younger Partners action."
+                if exact_tuple
+                else f"Expected one exact aurora-renewal-02 send; params were {params!r}."
+            ),
+            artifacts={"step": email_calls[0].step} if email_calls else {},
         )
 
 

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -59,6 +59,8 @@ SQLITE_UNSTRUCTURED_BINDINGS_FIRST_WRITE = "sqlite_unstructured_bindings_first_w
 SQLITE_INCREMENTAL_DOMAIN_MODEL = "sqlite_incremental_domain_model"
 SQLITE_PROSPECT_PIPELINE_COMPLETES = "sqlite_prospect_pipeline_completes"
 SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE = "sqlite_enrichment_refresh_under_pressure"
+SQLITE_SOURCE_CARDINALITY_AND_IDENTITY = "sqlite_source_cardinality_and_identity"
+SQLITE_FRESH_PEER_FACT_OVER_EMPTY_MODEL = "sqlite_fresh_peer_fact_over_empty_model"
 SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_MULTI_RESULT_WEB_SYNTHESIS,
     SQLITE_INTERMEDIATE_WORKING_TABLE,
@@ -75,6 +77,8 @@ SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_INCREMENTAL_DOMAIN_MODEL,
     SQLITE_PROSPECT_PIPELINE_COMPLETES,
     SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE,
+    SQLITE_SOURCE_CARDINALITY_AND_IDENTITY,
+    SQLITE_FRESH_PEER_FACT_OVER_EMPTY_MODEL,
 ]
 
 
@@ -215,6 +219,23 @@ ENRICHED_CONTACTS = (
     ("contact-301", "Maya Chen", "Umbra Works", "Hana Lee", "maya@umbra.example.test"),
     ("contact-302", "Rowan Kim", "Driftwood Robotics", "Hana Lee", "rowan@driftwood.example.test"),
     ("contact-303", "Avery Cole", "Northstar Systems", "Hana Lee", None),
+)
+CLAIM_INTAKE_URL = "https://api.example.test/intake/claim-batch.json"
+CLAIM_INTAKE_CONTACTS = (
+    (
+        "contact-17",
+        "Mina Patel",
+        "Aster Forge",
+        "mina.o'brien@aster.example.test",
+        "https://profiles.example.test/people/mina-patel",
+    ),
+    (
+        "contact-29",
+        "Jonah Reed",
+        "Bramble Health",
+        "jonah@bramble.example.test",
+        "https://profiles.example.test/people/jonah-reed",
+    ),
 )
 INITIATIVES = (
     ("init-checkout", "Checkout Recovery", "active", "revenue"),
@@ -721,6 +742,38 @@ def _product_mock() -> dict:
         for url, (vendor, plans) in zip(PRODUCT_URLS, PRODUCT_PLAN_ROWS)
     }
     return {"http_request": {"rules": [{"url_contains": url, "result": {"status": "ok", "status_code": 200, "url": url, "content": payload}} for url, payload in payloads.items()], "default": {"status": "error", "message": "Unknown eval URL."}}}
+
+
+def _claim_intake_mock() -> dict:
+    contacts = [
+        {
+            "contact_id": contact_id,
+            "full_name": full_name,
+            "company": company,
+            "email": email,
+            "profile_url": profile_url,
+        }
+        for contact_id, full_name, company, email, profile_url in CLAIM_INTAKE_CONTACTS
+    ]
+    return {
+        "http_request": {
+            "rules": [
+                {
+                    "url_contains": CLAIM_INTAKE_URL,
+                    "result": {
+                        "status": "ok",
+                        "status_code": 200,
+                        "url": CLAIM_INTAKE_URL,
+                        "content": {
+                            "batch_id": "claim-2026-07-28-a",
+                            "contacts": contacts,
+                        },
+                    },
+                },
+            ],
+            "default": {"status": "error", "message": "Unknown eval URL."},
+        },
+    }
 
 
 def _inventory_mock() -> dict:
@@ -1263,6 +1316,36 @@ def _seed_hidden_handoff_ledger(agent_id: str) -> None:
                 f"INSERT INTO {HANDOFF_LEDGER_TABLE} "
                 "(handoff_key, worker_ref, resolution_code) VALUES (?, ?, ?);",
                 HANDOFF_ROWS,
+            )
+            conn.commit()
+        finally:
+            clear_guarded_connection(conn)
+            conn.close()
+
+
+def _seed_claimed_contacts_ledger(agent_id: str) -> None:
+    with agent_sqlite_db(str(agent_id)) as db_path:
+        conn = open_guarded_sqlite_connection(db_path)
+        try:
+            conn.execute(
+                "CREATE TABLE claimed_contacts ("
+                "contact_id TEXT PRIMARY KEY, full_name TEXT NOT NULL, company TEXT NOT NULL, "
+                "email TEXT NOT NULL, profile_url TEXT NOT NULL, source_result_id TEXT NOT NULL);"
+            )
+            conn.commit()
+        finally:
+            clear_guarded_connection(conn)
+            conn.close()
+
+
+def _seed_empty_launch_handoffs(agent_id: str) -> None:
+    with agent_sqlite_db(str(agent_id)) as db_path:
+        conn = open_guarded_sqlite_connection(db_path)
+        try:
+            conn.execute(
+                "CREATE TABLE launch_handoffs ("
+                "work_key TEXT PRIMARY KEY, owner TEXT NOT NULL, due_on TEXT NOT NULL, "
+                "source_kind TEXT NOT NULL, source_ref TEXT NOT NULL);"
             )
             conn.commit()
         finally:
@@ -3352,3 +3435,211 @@ class SqliteBoundedPortfolioReportScenario(SqliteToolResultScenario):
         )
         nondisclosure = re.search(r"\b(?:nondisclos|undisclos|not\s+publicly\s+disclosed)\b", body, re.I)
         return bool(explicit_total or (founder_coverage and (blocker or nondisclosure)))
+
+
+@register_scenario
+class SqliteSourceCardinalityAndIdentityScenario(SqliteDomainModelScenario):
+    slug = SQLITE_SOURCE_CARDINALITY_AND_IDENTITY
+    version = "1.0"
+    description = (
+        "A bounded source batch should produce only real entities while preserving each source record's identity "
+        "and associations."
+    )
+    expected_runtime = "short"
+    tags = (*SqliteToolResultScenario.tags, "trajectory_regression", "identity_integrity")
+    tasks = [
+        ScenarioTask(name="inject_claim_batch", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_exact_source_rows", assertion_type="persisted_state"),
+        ScenarioTask(name="verify_honest_claim_count", assertion_type="manual"),
+    ]
+    prompt = (
+        "The intake batch is ready. Add every real contact in it to the existing claimed-contacts ledger, "
+        "up to five if available, then tell me how many contacts were actually present and claimed. "
+        f"Include the source link: {CLAIM_INTAKE_URL}"
+    )
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._ready_agent(agent_id)
+        PersistentAgent.objects.filter(id=agent_id).update(
+            charter=(
+                "Maintain the sourced contact ledger for outbound operations. Keep contact identity, company, "
+                "email, profile, and provenance accurate."
+            ),
+        )
+        _seed_claimed_contacts_ledger(agent_id)
+        self._enable_tools(agent_id, ("http_request",))
+        inbound = self._inject_and_wait(
+            run_id,
+            agent_id,
+            self.prompt,
+            _claim_intake_mock(),
+            allowed_tool_names={"http_request", "sqlite_batch", "send_chat_message"},
+            max_relevant_tool_calls=6,
+            task_name="inject_claim_batch",
+        )
+        calls = _tool_calls_for_run(run_id, after=inbound.timestamp)
+        http_calls = [call for call in calls if call.tool_name == "http_request"]
+        sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch"]
+        with agent_sqlite_db(str(agent_id)) as db_path:
+            conn = open_guarded_sqlite_connection(db_path)
+            try:
+                rows = conn.execute(
+                    "SELECT contact_id, full_name, company, email, profile_url, source_result_id "
+                    "FROM claimed_contacts ORDER BY contact_id;"
+                ).fetchall()
+            finally:
+                clear_guarded_connection(conn)
+                conn.close()
+
+        expected_result_ids = (
+            set(build_short_result_id_map([str(http_calls[0].step_id)]).values())
+            if len(http_calls) == 1
+            else set()
+        )
+        expected_rows = sorted(CLAIM_INTAKE_CONTACTS)
+        actual_rows = sorted(tuple(row[:5]) for row in rows)
+        actual_result_ids = {str(row[5]) for row in rows}
+        failures = _tool_attempt_failures(http_calls, "Source fetch")
+        failures.extend(_sqlite_attempt_failures(sqlite_calls))
+        failures.extend(
+            message
+            for failed, message in (
+                (len(http_calls) != 1, f"expected one source fetch, found {len(http_calls)}"),
+                (not sqlite_calls, "no SQLite model write observed"),
+                (actual_rows != expected_rows, f"persisted rows were {rows!r}"),
+                (
+                    actual_result_ids != expected_result_ids,
+                    f"source result ids were {sorted(actual_result_ids)!r}; expected {sorted(expected_result_ids)!r}",
+                ),
+            )
+            if failed
+        )
+        self._record_check(
+            run_id,
+            "verify_exact_source_rows",
+            failures,
+            "Persisted exactly the two real contacts with intact identity, associations, and provenance.",
+        )
+
+        outbound = _outbound_messages_after(agent_id, inbound.timestamp)
+        body = outbound[-1].body if outbound else ""
+        honest_count = (
+            len(outbound) == 1
+            and bool(re.search(r"\b(?:2|two)\b", body or "", re.I))
+            and CLAIM_INTAKE_URL in (body or "")
+            and not re.search(r"\b(?:unused|placeholder|unknown[- ]?[345])\b", body or "", re.I)
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if honest_count else EvalRunTask.Status.FAILED,
+            task_name="verify_honest_claim_count",
+            observed_summary=(
+                "Reported the actual two-contact source cardinality."
+                if honest_count
+                else f"Expected one sourced answer reporting two real contacts; body={body!r}."
+            ),
+            artifacts={"message": outbound[-1]} if outbound else {},
+        )
+
+
+@register_scenario
+class SqliteFreshPeerFactOverEmptyModelScenario(SqliteDomainModelScenario):
+    slug = SQLITE_FRESH_PEER_FACT_OVER_EMPTY_MODEL
+    version = "1.0"
+    description = (
+        "Fresh peer evidence should update an empty local model rather than being discounted as absent or false."
+    )
+    expected_runtime = "short"
+    tags = (*SqliteToolResultScenario.tags, "trajectory_regression", "peer_handoff")
+    tasks = [
+        ScenarioTask(name="inject_handoff_request", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_peer_fact_modeled", assertion_type="persisted_state"),
+        ScenarioTask(name="verify_current_handoff_answer", assertion_type="manual"),
+    ]
+    prompt = (
+        "Who currently owns launch readiness, and when is it due? Check the handoff picture you maintain "
+        "and give me the confirmed assignment."
+    )
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        from api.evals.scenarios.responsibility_boundaries import ResponsibilityBoundaryScenario
+
+        self._ready_agent(agent_id)
+        PersistentAgent.objects.filter(id=agent_id).update(
+            charter="Maintain the current launch handoff ledger and report confirmed ownership and due dates.",
+        )
+        _seed_empty_launch_handoffs(agent_id)
+        agent = PersistentAgent.objects.get(id=agent_id)
+        ResponsibilityBoundaryScenario._peer_inbound(
+            agent,
+            run_id,
+            (
+                "Confirmed handoff: work_key=launch-readiness, owner=Maya Chen, due_on=Friday, "
+                "source_ref=peer-note-418. Please keep the operating picture current."
+            ),
+        )
+        inbound = self._inject_and_wait(
+            run_id,
+            agent_id,
+            self.prompt,
+            {},
+            allowed_tool_names={"sqlite_batch", "send_chat_message"},
+            max_relevant_tool_calls=5,
+            task_name="inject_handoff_request",
+        )
+        calls = _tool_calls_for_run(run_id, after=inbound.timestamp)
+        sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch"]
+        with agent_sqlite_db(str(agent_id)) as db_path:
+            conn = open_guarded_sqlite_connection(db_path)
+            try:
+                rows = conn.execute(
+                    "SELECT work_key, owner, due_on, source_kind, source_ref "
+                    "FROM launch_handoffs ORDER BY work_key;"
+                ).fetchall()
+            finally:
+                clear_guarded_connection(conn)
+                conn.close()
+
+        modeled_handoff = (
+            len(rows) == 1
+            and tuple(rows[0][:3]) == ("launch-readiness", "Maya Chen", "Friday")
+            and bool(str(rows[0][3]).strip())
+            and rows[0][4] == "peer-note-418"
+        )
+        failures = _sqlite_attempt_failures(sqlite_calls)
+        failures.extend(
+            message
+            for failed, message in (
+                (not sqlite_calls, "no SQLite handoff reconciliation observed"),
+                (not modeled_handoff, f"persisted handoffs were {rows!r}"),
+            )
+            if failed
+        )
+        self._record_check(
+            run_id,
+            "verify_peer_fact_modeled",
+            failures,
+            "Reconciled the fresh peer handoff into the previously empty local model.",
+        )
+
+        outbound = _outbound_messages_after(agent_id, inbound.timestamp)
+        body = outbound[-1].body if outbound else ""
+        current_answer = (
+            len(outbound) == 1
+            and "maya chen" in (body or "").casefold()
+            and "friday" in (body or "").casefold()
+            and not re.search(r"\b(?:no|not|without)\s+(?:confirmed\s+)?(?:assignment|owner|evidence)\b", body or "", re.I)
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if current_answer else EvalRunTask.Status.FAILED,
+            task_name="verify_current_handoff_answer",
+            observed_summary=(
+                "Reported the fresh confirmed owner and due date."
+                if current_answer
+                else f"Expected one answer naming Maya Chen and Friday; body={body!r}."
+            ),
+            artifacts={"message": outbound[-1]} if outbound else {},
+        )

--- a/api/evals/tests/test_message_quality.py
+++ b/api/evals/tests/test_message_quality.py
@@ -6,6 +6,7 @@ from django.test import SimpleTestCase, tag
 import api.evals.loader  # noqa: F401 - registers scenarios and suites
 from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.message_quality import (
+    EMAIL_APPROVED_ACTION_TUPLE_SLUG,
     EMAIL_SENT_STATE_SEQUENCING_SLUG,
     EMAIL_REVIEW_OUTBOX_COMMUNICATION_SLUG,
     EmailReviewOutboxCommunicationScenario,
@@ -34,13 +35,14 @@ class MessageQualityScenarioTests(SimpleTestCase):
 
         self.assertIsNotNone(suite)
         self.assertEqual(tuple(suite.scenario_slugs), MESSAGE_QUALITY_SCENARIO_SLUGS)
-        self.assertEqual(len(suite.scenario_slugs), 22)
+        self.assertEqual(len(suite.scenario_slugs), 23)
         self.assertIn(REPLY_CHANNEL_CONTINUITY_SLUG, suite.scenario_slugs)
         self.assertIn(UNAVAILABLE_WEB_CHANNEL_CONTINUITY_SLUG, suite.scenario_slugs)
         self.assertIn(FAILED_EMAIL_DELIVERY_RECOVERY_SLUG, suite.scenario_slugs)
         self.assertIn(EMAIL_REVIEW_OUTBOX_COMMUNICATION_SLUG, suite.scenario_slugs)
         self.assertIn(REMOTE_MCP_RESULT_DELIVERY_SLUG, suite.scenario_slugs)
         self.assertIn(EMAIL_SENT_STATE_SEQUENCING_SLUG, suite.scenario_slugs)
+        self.assertIn(EMAIL_APPROVED_ACTION_TUPLE_SLUG, suite.scenario_slugs)
 
     def test_generated_cases_cover_email_and_chat_for_each_real_world_domain(self):
         channels_by_brief = {}

--- a/tests/unit/test_email_sender_db_connections.py
+++ b/tests/unit/test_email_sender_db_connections.py
@@ -310,6 +310,26 @@ class EmailSenderDbConnectionTests(TransactionTestCase):
         self.assertIsNone(message.parent_id)
         self.assertEqual(message.conversation.address, self.user.email)
 
+    def test_execute_send_email_rejects_tool_argument_suffix_in_body(self):
+        result = execute_send_email(
+            self.agent,
+            {
+                "to_address": self.user.email,
+                "subject": "Quick update",
+                "mobile_first_html": (
+                    "<p>The report is ready for review.</p>"
+                    "\", \"will_continue_work\": false}"
+                ),
+                "will_continue_work": False,
+            },
+        )
+
+        self.assertEqual(result.get("status"), "error")
+        self.assertIn("tool-call arguments", result.get("message", ""))
+        self.assertFalse(
+            PersistentAgentMessage.objects.filter(owner_agent=self.agent).exists()
+        )
+
     def test_execute_send_email_rolls_back_message_when_delivery_fails(self):
         params = {
             "to_address": self.user.email,

--- a/tests/unit/test_result_analysis.py
+++ b/tests/unit/test_result_analysis.py
@@ -59,6 +59,14 @@ class JsonAnalysisTests(SimpleTestCase):
         self.assertIn("id", analysis.primary_array.item_fields)
         self.assertIn("title", analysis.primary_array.item_fields)
 
+    def test_array_paths_quote_special_object_keys(self):
+        analysis = analyze_json(
+            {"content": {"v1.items": [{"item_id": "item-1"}]}},
+            "test-id",
+        )
+
+        self.assertEqual(analysis.primary_array.path, '$.content."v1.items"')
+
     def test_analyzes_content_wrapper(self):
         data = {
             "status": "ok",

--- a/tests/unit/test_sqlite_source_array_eval.py
+++ b/tests/unit/test_sqlite_source_array_eval.py
@@ -8,16 +8,20 @@ from api.agent.tools.sqlite_query_quality import summarize_sqlite_tool_result_sq
 from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.sqlite_tool_results import (
     SQLITE_ENRICHMENT_REFRESH_UNDER_PRESSURE,
+    SQLITE_FRESH_PEER_FACT_OVER_EMPTY_MODEL,
     SQLITE_INCREMENTAL_DOMAIN_MODEL,
     SQLITE_SIBLING_RESULT_SET_FIRST_WRITE,
+    SQLITE_SOURCE_CARDINALITY_AND_IDENTITY,
     SQLITE_SOURCE_ARRAY_FIRST_WRITE,
     SQLITE_TOOL_RESULT_SCENARIO_SLUGS,
     SQLITE_TOOL_RESULT_SUITE_SLUG,
     SQLITE_UNSTRUCTURED_BINDINGS_FIRST_WRITE,
     SqliteEnrichmentRefreshUnderPressureScenario,
+    SqliteFreshPeerFactOverEmptyModelScenario,
     SqliteIncrementalDomainModelScenario,
     SqliteIntermediateWorkingTableScenario,
     SqliteSiblingResultSetFirstWriteScenario,
+    SqliteSourceCardinalityAndIdentityScenario,
     SqliteSourceArrayFirstWriteScenario,
     SqliteUnstructuredBindingsFirstWriteScenario,
     _repeated_source_import_tables,
@@ -91,6 +95,28 @@ class SqliteSourceArrayEvalTests(SimpleTestCase):
                 "verify_release_answer",
             ],
         )
+
+    def test_truth_integrity_cases_are_registered_without_teaching_sql(self):
+        suite = SuiteRegistry.get(SQLITE_TOOL_RESULT_SUITE_SLUG)
+        cases = (
+            (
+                SQLITE_SOURCE_CARDINALITY_AND_IDENTITY,
+                SqliteSourceCardinalityAndIdentityScenario,
+            ),
+            (
+                SQLITE_FRESH_PEER_FACT_OVER_EMPTY_MODEL,
+                SqliteFreshPeerFactOverEmptyModelScenario,
+            ),
+        )
+
+        for slug, scenario_class in cases:
+            with self.subTest(slug=slug):
+                self.assertIsNotNone(ScenarioRegistry.get(slug))
+                self.assertIn(slug, SQLITE_TOOL_RESULT_SCENARIO_SLUGS)
+                self.assertIn(slug, suite.scenario_slugs)
+                prompt = scenario_class.prompt.casefold()
+                for leaked_term in ("sqlite", "__tool_results", "json_each", "insert", "select", "table"):
+                    self.assertNotIn(leaked_term, prompt)
 
     def test_prompt_does_not_teach_the_sql_solution(self):
         prompt = SqliteSourceArrayFirstWriteScenario.prompt.casefold()

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -956,14 +956,14 @@ class PreviewByteLimitTests(SimpleTestCase):
         self.assertIn("SOURCE ARRAYS; paths", info.preview_text)
         for expected in (
             "$.content.items", "one sqlite_batch", "keyed tables",
-            "INSERT ... SELECT/json_each", "Derive item fields/URLs from j.value",
-            "parent fields from t.result_json", "provenance from t.result_id",
+            "json_each(t.result_json,'$.content.items') AS j1",
+            "keep every wrapper segment such as $.content",
+            "t.result_id is provenance only",
             "is_current_batch=1",
             "[no_stable_key]",
-            "exact stable_key values",
-            "Never filter freshness by a mutable name, even one the user named",
-            "literal ID/history",
-            "No pre-read, refetch, blob inspection, copied literals",
+            "Final rows preserve exact source associations",
+            "mutable-name freshness filters",
+            "pre-read, refetch, blob inspection",
         ):
             self.assertIn(expected, info.preview_text)
         self.assertEqual(info.preview_text.count("[SOURCE ARRAYS"), 1)
@@ -1057,6 +1057,29 @@ class PreviewByteLimitTests(SimpleTestCase):
         self.assertFalse(large.is_inline)
         self.assertIn("SOURCE ARRAYS", large.preview_text)
         self.assertTrue(large.source_reconciliation_directive)
+
+    def test_exact_source_iterators_quote_json_keys_and_sql_apostrophes(self):
+        payload = {
+            "status": "ok",
+            "content": {
+                "v1.items": [{"item_id": "item-1", "name": "Acme"}],
+                "team's contacts": [{"contact_id": "contact-1", "name": "Mina"}],
+            },
+        }
+        info, _record = self._prepare_http_result(
+            "step-special-keys",
+            payload,
+            named_model_tables={"items"},
+        )
+
+        self.assertIn(
+            "json_each(t.result_json,'$.content.\"v1.items\"') AS j2",
+            info.preview_text,
+        )
+        self.assertIn(
+            "json_each(t.result_json,'$.content.\"team''s contacts\"') AS j1",
+            info.preview_text,
+        )
 
     def test_fresh_source_without_matching_entity_array_does_not_force_import(self):
         cases = (


### PR DESCRIPTION
## Outcome

Preserves source cardinality, identity, associations, and approved action tuples from evidence through SQLite and outbound email. It also rejects the observed malformed-email payload before delivery.

## Root cause and fix

- Reproduced DeepSeek dropping a JSON wrapper segment, importing zero rows, refetching, and entering diagnostics.
- The fresh-source contract now emits exact copyable json_each iterators for every discovered array path, while staying smaller than the prior contract.
- Adds one compact core invariant against padding, cross-record mixing, opaque result-ID promotion, stale-local-fact rejection, and approved-recipient/content drift.
- Adds a narrow send_email boundary rejection for serialized sibling arguments leaking into HTML.

## Evidence

- Red source-cardinality run: suite 2fc23d51-45a2-48a0-8b12-5ef0a93ec23e, 1/3; zero imported rows, two fetches, five SQLite attempts.
- Green DeepSeek V4 Flash run: suite 4ef81bfb-bc8f-467b-b75a-f618d6f25cd3, 3/3; exact two-row import in one batch, no refetch, advisory, or error.
- Green exact approved-action run: suite d32c257b-427a-457b-8eac-0a21e96bc2d1, 2/2.
- Fresh peer evidence was modeled and reported correctly in two DeepSeek trajectories; the evaluator was relaxed only from a literal source_kind spelling to a nonempty provenance type while preserving exact source_ref verification.
- 129 focused unit/registration tests pass; three source-reconciliation context regressions pass.
- Existing prompt complexity budgets pass with tool size unchanged and four-byte prompt headroom.

## Backlog batch

Targets #497, #496, #494, #454, #493, #438, #377, and #349. #406, #444, and #486 were separately proven fixed on current main and closed. #303 lacks an actionable trajectory locator and will be returned rather than falsely claimed fixed.

## Verification

CI and authenticated preview smoke checks are required before merge.