### PR TITLE
Prevent stalled LLM requests from pinning agent work

### DIFF
--- a/api/agent/core/llm_utils.py
+++ b/api/agent/core/llm_utils.py
@@ -265,7 +265,7 @@ def _invoke_completion_with_timeout(
     try:
         succeeded, result = result_queue.get(timeout=timeout_seconds)
     except queue.Empty:
-        raise litellm.Timeout(
+        raise (StreamIdleTimeout if kwargs.get("stream") else litellm.Timeout)(
             message=f"LLM request did not return within {timeout_seconds:g} seconds",
             model=model,
             llm_provider=provider or "unknown",

--- a/api/agent/core/llm_utils.py
+++ b/api/agent/core/llm_utils.py
@@ -4,6 +4,7 @@ import logging
 import queue
 import threading
 import time
+from contextvars import copy_context
 from typing import Any, Callable, Iterable
 
 from asgiref.sync import async_to_sync
@@ -235,6 +236,43 @@ def _wrap_stream_with_idle_timeout(
         max_attempts=max_attempts,
         backoff_seconds=backoff_seconds,
     )
+
+
+def _invoke_completion_with_timeout(
+    kwargs: dict[str, Any],
+    *,
+    model: str,
+    provider: str | None,
+) -> Any:
+    """Enforce the request timeout even when a provider client ignores it."""
+    try:
+        timeout_seconds = float(kwargs.get("timeout"))
+    except (TypeError, ValueError):
+        return litellm.completion(**kwargs)
+    if timeout_seconds <= 0:
+        return litellm.completion(**kwargs)
+
+    result_queue: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
+    context = copy_context()
+
+    def _invoke() -> None:
+        try:
+            result_queue.put((True, context.run(litellm.completion, **kwargs)))
+        except Exception as exc:
+            result_queue.put((False, exc))
+
+    threading.Thread(target=_invoke, daemon=True).start()
+    try:
+        succeeded, result = result_queue.get(timeout=timeout_seconds)
+    except queue.Empty:
+        raise litellm.Timeout(
+            message=f"LLM request did not return within {timeout_seconds:g} seconds",
+            model=model,
+            llm_provider=provider or "unknown",
+        )
+    if not succeeded:
+        raise result
+    return result
 
 
 def _first_message_from_response(response: Any) -> Any:
@@ -548,13 +586,25 @@ def run_completion(
             duration_ms = None
             if not kwargs.get("stream"):
                 start_time = time.monotonic()
-                response = litellm.completion(**kwargs)
+                response = _invoke_completion_with_timeout(
+                    kwargs,
+                    model=model,
+                    provider=provider_hint,
+                )
                 duration_ms = int(round((time.monotonic() - start_time) * 1000))
             else:
-                response = litellm.completion(**kwargs)
+                response = _invoke_completion_with_timeout(
+                    kwargs,
+                    model=model,
+                    provider=provider_hint,
+                )
                 response = _wrap_stream_with_idle_timeout(
                     response,
-                    create_stream=lambda: litellm.completion(**kwargs),
+                    create_stream=lambda: _invoke_completion_with_timeout(
+                        kwargs,
+                        model=model,
+                        provider=provider_hint,
+                    ),
                     model=model,
                     provider=provider_hint,
                     initial_attempt=attempt,

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "55b2ecd8fd9c71addb6d1c89d5449afe16bf18ea",
+  "baseline_sha": "b35d4730edab7269762483dcc6cdbc25d8074e21",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9271,
-        "system_bytes": 32463,
+        "fitted_tokens": 9253,
+        "system_bytes": 32484,
         "tools_bytes": 23607,
-        "total_bytes": 67779,
+        "total_bytes": 67800,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8644,
-        "system_bytes": 29354,
+        "fitted_tokens": 8646,
+        "system_bytes": 29375,
         "tools_bytes": 23607,
-        "total_bytes": 64703,
+        "total_bytes": 64724,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8855,
-        "system_bytes": 29991,
+        "fitted_tokens": 8841,
+        "system_bytes": 30012,
         "tools_bytes": 23607,
-        "total_bytes": 65343,
+        "total_bytes": 65364,
         "user_bytes": 11745
       }
     },
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 929,
+    "file_count": 930,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 280000
+    "limit": 262444
   }
 }

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -77,6 +77,17 @@ class _BlockingSecondChunkStream:
 
 
 class RunCompletionReasoningTests(TestCase):
+    def _blocking_completion(self, result):
+        started = threading.Event()
+        released = threading.Event()
+
+        def invoke(**_kwargs):
+            started.set()
+            released.wait(timeout=0.2)
+            return result
+
+        return invoke, started, released
+
     @tag("batch_event_llm")
     @patch("api.agent.core.llm_utils.litellm.completion")
     def test_reasoning_effort_omitted_when_not_supported(self, mock_completion):
@@ -399,6 +410,47 @@ class RunCompletionReasoningTests(TestCase):
 
         _, kwargs = mock_completion.call_args
         self.assertEqual(kwargs.get("timeout"), 42)
+
+    @tag("batch_event_llm")
+    @override_settings(LITELLM_MAX_RETRIES=1)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_timeout_bounds_non_streaming_request_itself(self, mock_completion):
+        invoke, started, released = self._blocking_completion(make_completion_response())
+        mock_completion.side_effect = invoke
+
+        try:
+            with self.assertRaises(litellm.Timeout):
+                run_completion(
+                    model="mock-model",
+                    messages=[],
+                    params={},
+                    timeout=0.01,
+                )
+        finally:
+            released.set()
+
+        self.assertTrue(started.is_set())
+
+    @tag("batch_event_llm")
+    @override_settings(LITELLM_MAX_RETRIES=1)
+    @patch("api.agent.core.llm_utils.litellm.completion")
+    def test_timeout_bounds_stream_creation(self, mock_completion):
+        invoke, started, released = self._blocking_completion(_ClosableStream(["late-chunk"]))
+        mock_completion.side_effect = invoke
+
+        try:
+            with self.assertRaises(litellm.Timeout):
+                run_completion(
+                    model="mock-model",
+                    messages=[],
+                    params={},
+                    stream=True,
+                    timeout=0.01,
+                )
+        finally:
+            released.set()
+
+        self.assertTrue(started.is_set())
 
     @tag("batch_event_llm")
     @override_settings(LITELLM_TIMEOUT_SECONDS=321)

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 from django.test import TestCase, override_settings, tag
 import litellm
 
-from api.agent.core.llm_utils import InvalidLiteLLMResponseError, run_completion
+from api.agent.core.llm_utils import InvalidLiteLLMResponseError, StreamIdleTimeout, run_completion
 from tests.utils.token_usage import make_completion_response
 
 
@@ -439,7 +439,7 @@ class RunCompletionReasoningTests(TestCase):
         mock_completion.side_effect = invoke
 
         try:
-            with self.assertRaises(litellm.Timeout):
+            with self.assertRaises(StreamIdleTimeout):
                 run_completion(
                     model="mock-model",
                     messages=[],


### PR DESCRIPTION
## Summary
- enforce Gobii's configured request deadline around the LiteLLM call itself, covering both non-streaming compaction and initial stream creation
- preserve context propagation while bounding an uncooperative provider client
- keep the existing retry, provider failover, lock release, and pending-trigger recovery paths intact

## Production evidence
Bug #498: one production agent's last completed tool call finished at 12:39:28 UTC, then no completion or tool execution occurred until a new processing cycle at 13:28 UTC. Direct work and a verified inbound sales event queued during that gap but could not run. The first later compaction took 333,969 ms despite the configured 300-second LiteLLM timeout, proving the client timeout was not a hard application deadline.

Root-cause layer: platform code. The stream-idle guard added in #1446 begins only after `litellm.completion()` returns a stream, and non-streaming calls had no Gobii-enforced deadline. This change fixes that request boundary; it is not a queue-clearing mitigation.

## Tests
- red before fix, green after: 2 request-boundary regressions (stream creation and non-streaming request)
- `tests.unit.test_llm_utils`: 33/33
- pending follow-up, provider selection, locking, and task-wrapper modules: 44/44
- complexity budget: green
- Ruff was unavailable in the repository environment; CI lint remains authoritative

No model eval was added: this is a deterministic execution-state defect below model behavior, reproduced and covered at the shared LLM boundary.

## Complexity
Core source grows by 45 nonblank lines for the hard deadline wrapper; the baseline is updated and prompt bytes are flat/slightly lower. No prompt or agent-behavior guidance changed.
