### PR TITLE
Message-surface swath 2: notifications, email envelopes, bootstrap recovery (#491 #495 #472 #427 #492 #247)

### DIFF
--- a/api/agent/comms/message_service.py
+++ b/api/agent/comms/message_service.py
@@ -544,6 +544,9 @@ def ingest_inbound_message(
             message = PersistentAgentMessage.objects.create(
                 is_outbound=False,
                 from_endpoint=from_ep,
+                # The receiving endpoint was always resolved but never persisted, leaving
+                # inbound cards unable to name the mailbox that received the message (#495).
+                to_endpoint=to_ep,
                 conversation=conv,
                 body=parsed.body,
                 raw_payload=parsed.raw_payload,

--- a/console/agent_chat/signals.py
+++ b/console/agent_chat/signals.py
@@ -33,7 +33,14 @@ from api.services.signup_preview import transition_agent_to_signup_preview_waiti
 from console.agent_chat.realtime import send_developer_update, send_user_group_event, user_profile_group_name
 from console.insight_views import build_usage_metadata_for_agent
 from util.text_sanitizer import sanitize_notification_preview_text
-from api.agent.comms.message_reads import build_agent_message_read_state_for_users, is_peer_dm_message, serialize_latest_agent_message_read_state
+from api.agent.comms.message_reads import (
+    _resolve_unique_user_for_email,
+    _resolve_unique_user_for_phone,
+    build_agent_message_read_state_for_users,
+    is_peer_dm_message,
+    serialize_latest_agent_message_read_state,
+)
+from api.models import CommsChannel
 
 from .access import user_can_manage_agent_settings
 from .plan_events import persist_plan_event
@@ -151,7 +158,16 @@ def emit_message_notification(message: PersistentAgentMessage) -> None:
             "channel": channel,
         },
     }
+    # The audience must be who the message was addressed to, not who owns the agent:
+    # an email an agent sends to an external lead is not a message *to* the owner, and
+    # notifying every workspace member leaked the email body preview as a browser
+    # notification on each send (#491).
+    recipient_user_ids = _notification_recipient_user_ids(message, agent, channel)
     listener_user_ids = _resolve_profile_listener_user_ids(agent)
+    if recipient_user_ids is not None:
+        listener_user_ids &= recipient_user_ids
+        if not listener_user_ids:
+            return
     read_state_by_user_id = build_agent_message_read_state_for_users(agent, listener_user_ids)
     for user_id in listener_user_ids:
         payload = {
@@ -194,6 +210,46 @@ def _emit_processing_profile_update_if_changed(agent: PersistentAgent, processin
     if previous_processing_active is not None and previous_processing_active == normalized_processing_active:
         return
     emit_agent_profile_update(agent, processing_active=normalized_processing_active)
+
+
+def _notification_recipient_user_ids(
+    message: PersistentAgentMessage,
+    agent: PersistentAgent,
+    channel: str | None,
+) -> set[int] | None:
+    """Workspace user ids the outbound message was actually addressed to.
+
+    Only channels whose addresses map to verifiable workspace identities filter the
+    audience: email (verified allauth address) and SMS (verified phone). Returns None
+    for other channels — web chat is by definition addressed to console viewers, and
+    Discord identities have no workspace mapping — leaving their behavior unchanged.
+    """
+    channel_key = (channel or "").lower()
+    conversation_address = (
+        (message.conversation.address or "").strip() if message.conversation_id else ""
+    )
+    to_address = (
+        (message.to_endpoint.address or "").strip() if message.to_endpoint_id else ""
+    )
+    if channel_key == CommsChannel.EMAIL:
+        addresses = [address for address in {to_address or conversation_address} if address]
+        addresses.extend(
+            address
+            for address in (
+                (endpoint.address or "").strip() for endpoint in message.cc_endpoints.all()
+            )
+            if address
+        )
+        matched: set[int] = set()
+        for address in addresses:
+            user = _resolve_unique_user_for_email(agent, address)
+            if user is not None:
+                matched.add(user.id)
+        return matched
+    if channel_key == CommsChannel.SMS:
+        user = _resolve_unique_user_for_phone(agent, to_address or conversation_address)
+        return {user.id} if user is not None else set()
+    return None
 
 
 def _resolve_profile_listener_user_ids(agent: PersistentAgent) -> set[int]:

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -221,11 +221,44 @@ def _message_body_html(message: PersistentAgentMessage, channel: str | None, att
     )
 
 
+def _inbound_email_header(message: PersistentAgentMessage, name: str) -> str | None:
+    """Read an address header from an inbound email's provider payload.
+
+    Inbound payloads are stored verbatim: Postmark capitalises keys ("To", "Cc"),
+    Mailgun uses lowercase (plus "recipient"), and IMAP nests them in a headers map.
+    """
+    payload = message.raw_payload if isinstance(message.raw_payload, dict) else {}
+    wanted = {name.lower()}
+    if name.lower() == "to":
+        wanted.add("recipient")
+    for key, value in payload.items():
+        if isinstance(key, str) and key.lower() in wanted and isinstance(value, str) and value.strip():
+            return value.strip()
+    headers = payload.get("headers")
+    if isinstance(headers, dict):
+        for key, value in headers.items():
+            if isinstance(key, str) and key.lower() == name.lower() and isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
 def _message_subject(message: PersistentAgentMessage, channel: str | None) -> str | None:
     if not channel or channel.lower() != "email":
         return None
     payload = message.raw_payload if isinstance(message.raw_payload, dict) else {}
+    # Outbound writes lowercase "subject"; inbound payloads are stored verbatim from the
+    # provider — Postmark uses "Subject" and IMAP only has headers["Subject"] — so a
+    # lowercase-only read silently dropped inbound subjects for those providers (#495).
     subject = payload.get("subject")
+    if not isinstance(subject, str):
+        subject = payload.get("Subject")
+    if not isinstance(subject, str):
+        headers = payload.get("headers")
+        if isinstance(headers, dict):
+            for key, value in headers.items():
+                if isinstance(key, str) and key.lower() == "subject" and isinstance(value, str):
+                    subject = value
+                    break
     if not isinstance(subject, str):
         return None
     return subject.strip() or None
@@ -551,23 +584,30 @@ def _serialize_message(
     recipient_address: str | None = None
     recipient_name: str | None = None
     cc_addresses: list[str] = []
-    if message.is_outbound and channel.lower() == CommsChannel.EMAIL:
-        # The message's own to_endpoint records who this email actually went to; the conversation
-        # only records the thread's original counterparty. When they diverge the card must follow
-        # the message — labelling the send with the thread's counterparty misattributes it, and
-        # the thread's display name must never be attached to a different address (bug #419).
+    if channel.lower() == CommsChannel.EMAIL:
         to_endpoint_address = (
             (message.to_endpoint.address or "").strip()
             if message.to_endpoint_id and message.to_endpoint.channel == CommsChannel.EMAIL
             else ""
         )
-        conversation_address = ((conversation.address or "").strip() if conversation else "")
-        recipient_address = to_endpoint_address or conversation_address or None
-        if recipient_address and (
-            not to_endpoint_address
-            or to_endpoint_address.lower() == conversation_address.lower()
-        ):
-            recipient_name = ((conversation.display_name or "").strip() if conversation else "") or None
+        if message.is_outbound:
+            # The message's own to_endpoint records who this email actually went to; the
+            # conversation only records the thread's original counterparty. When they diverge the
+            # card must follow the message — labelling the send with the thread's counterparty
+            # misattributes it, and the thread's display name must never be attached to a
+            # different address (bug #419).
+            conversation_address = ((conversation.address or "").strip() if conversation else "")
+            recipient_address = to_endpoint_address or conversation_address or None
+            if recipient_address and (
+                not to_endpoint_address
+                or to_endpoint_address.lower() == conversation_address.lower()
+            ):
+                recipient_name = ((conversation.display_name or "").strip() if conversation else "") or None
+        else:
+            # Inbound: the recipient is the agent's own mailbox — meaningful because agents
+            # receive on several aliases. Endpoints were historically not persisted inbound,
+            # so fall back to the provider envelope stored verbatim in raw_payload (#495).
+            recipient_address = to_endpoint_address or _inbound_email_header(message, "to") or None
     if channel.lower() == CommsChannel.EMAIL:
         # Who else received it. Bcc is deliberately absent: it is never persisted on the message,
         # so the card cannot claim to show a complete recipient list.
@@ -579,6 +619,10 @@ def _serialize_message(
             )
             if address
         ]
+        if not cc_addresses and not message.is_outbound:
+            cc_header = _inbound_email_header(message, "cc")
+            if cc_header:
+                cc_addresses = [part.strip() for part in cc_header.split(",") if part.strip()]
     if not is_mcp and channel.lower() == "web" and sender_address:
         user_id, agent_id = parse_web_user_address(sender_address)
         if user_id is not None and (not agent_id or not message.owner_agent_id or str(message.owner_agent_id) == agent_id):

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -173,10 +173,21 @@ async function jsonFetchInternal<T>(
   const appliedContextHeaders = shouldApplyConsoleContextHeaders(input) ? applyConsoleContextHeaders(headers) : false
   applyStaffViewContextHeaders(headers)
 
+  // A stalled connection must reject rather than hang forever: bootstrap queries have
+  // no other way to fail into their error/retry paths, and an unbounded initial
+  // timeline fetch pinned the chat on "Loading conversation…" (bug #472). Callers may
+  // pass their own signal, which wins.
+  const signal = restInit.signal ?? (
+    typeof AbortSignal !== 'undefined' && 'timeout' in AbortSignal
+      ? AbortSignal.timeout(45_000)
+      : undefined
+  )
+
   const response = await fetch(input, {
     credentials: 'same-origin',
     ...restInit,
     headers,
+    signal,
   })
 
   maybeRedirectToLogin(response)

--- a/frontend/src/components/agentChat/MessageEventCard.test.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.test.tsx
@@ -54,7 +54,14 @@ describe('MessageEventCard email recipient', () => {
     expect(screen.getByText('To')).toBeInTheDocument()
   })
 
-  it('does not label a received email with a recipient', () => {
+  it('labels a received email with the mailbox that received it (#495)', () => {
+    renderCard(emailMessage({ isOutbound: false, recipientAddress: 'scout@my.gobii.ai' }))
+
+    expect(screen.getByText('To')).toBeInTheDocument()
+    expect(screen.getByText('scout@my.gobii.ai')).toBeInTheDocument()
+  })
+
+  it('stays quiet on a received email with no recipient data', () => {
     renderCard(emailMessage({ isOutbound: false, recipientAddress: null }))
 
     expect(screen.queryByText('To')).not.toBeInTheDocument()

--- a/frontend/src/components/agentChat/MessageEventCard.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.tsx
@@ -211,8 +211,9 @@ export const MessageEventCard = memo(function MessageEventCard({
       : null,
   ].filter(Boolean)
   const emailSubject = channel === 'email' ? message.subject?.trim() : ''
-  // A sent email otherwise names its recipient only inside the body, which is not an audit trail.
-  const emailRecipient = channel === 'email' && message.isOutbound
+  // A sent email otherwise names its recipient only inside the body, which is not an audit
+  // trail; an inbound email's To is the agent's own alias, worth showing too (#495).
+  const emailRecipient = channel === 'email'
     ? message.recipientAddress?.trim() || ''
     : ''
   const emailRecipientName = message.recipientName?.trim() || ''
@@ -221,8 +222,8 @@ export const MessageEventCard = memo(function MessageEventCard({
     ? `${emailRecipientName} <${emailRecipient}>`
     : emailRecipient
   // Which mailbox actually sent it. Agents send from several custom domains, so "who sent this"
-  // is not answerable from the agent name alone.
-  const emailSender = channel === 'email' && message.isOutbound
+  // is not answerable from the agent name alone; inbound, it is the counterparty's address (#495).
+  const emailSender = channel === 'email'
     ? message.senderAddress?.trim() || ''
     : ''
   const emailCc = channel === 'email'

--- a/frontend/src/components/agentChat/toolDetails/details/schedule.tsx
+++ b/frontend/src/components/agentChat/toolDetails/details/schedule.tsx
@@ -5,7 +5,7 @@ import { CalendarClock, Clock, Repeat } from 'lucide-react'
 import { describeSchedule } from '../../../../util/schedule'
 import type { ScheduleDescription } from '../../../../util/schedule'
 import type { ToolDetailProps } from '../../tooling/types'
-import type { AgentConfigCharterChange } from '../../../tooling/agentConfigSql'
+import { parseCharterLiteralForDisplay, type AgentConfigCharterChange } from '../../../tooling/agentConfigSql'
 import { KeyValueList, Section, TruncatedMarkdown } from '../shared'
 import { useAppSelector } from '../../../../store/hooks'
 import { selectImmersiveShellViewer } from '../../../../store/immersiveShellSlice'
@@ -216,7 +216,13 @@ function CharterChangeDetail({ change }: { change: AgentConfigCharterChange }) {
 
 export function AgentConfigUpdateDetail({ entry }: ToolDetailProps) {
   const timeZone = useAppSelector(selectImmersiveShellViewer).timeZone
-  const charterText = entry.charterText ?? null
+  // Historical events predate the display-metadata snapshot and often wrote the charter
+  // as a direct literal rather than patch_text; recover the text from the SQL rather
+  // than rendering "not available" (bug #247).
+  const literalCharterText = entry.charterText == null && !entry.agentConfigCharterChange
+    ? parseCharterLiteralForDisplay(entry.sqlStatements ?? [])
+    : null
+  const charterText = entry.charterText ?? literalCharterText
   const charterChange = entry.agentConfigCharterChange ?? null
   const charterConfirmation = entry.agentConfigConfirmation?.charter ?? null
   const hasCharterText = charterText !== null

--- a/frontend/src/components/tooling/agentConfigSql.test.ts
+++ b/frontend/src/components/tooling/agentConfigSql.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseAgentConfigCharterChange } from './agentConfigSql'
+import { parseAgentConfigCharterChange, parseCharterLiteralForDisplay } from './agentConfigSql'
 
 describe('parseAgentConfigCharterChange', () => {
   it('parses patch_text clauses containing escaped quotes, commas, and parentheses', () => {
@@ -37,5 +37,33 @@ describe('parseAgentConfigCharterChange', () => {
     ])
 
     expect(parsed).toBeNull()
+  })
+})
+
+// #247: the historical detail card needs the assignment text even when it was written as
+// a direct literal (pre-snapshot rows) — display-only, never fed to the confirmation flow.
+describe('parseCharterLiteralForDisplay', () => {
+  it('recovers a direct literal assignment with escaped quotes', () => {
+    const text = parseCharterLiteralForDisplay([
+      "UPDATE __agent_config SET charter='Track ''priority'' leads daily' WHERE id=1",
+    ])
+
+    expect(text).toBe("Track 'priority' leads daily")
+  })
+
+  it('ignores charter predicates and patch_text calls', () => {
+    expect(parseCharterLiteralForDisplay([
+      "UPDATE __agent_config SET schedule='0 9 * * *' WHERE charter='Unchanged'",
+    ])).toBeNull()
+    expect(parseCharterLiteralForDisplay([
+      "UPDATE __agent_config SET charter=patch_text(charter, 'a', 'b') WHERE id=1",
+    ])).toBeNull()
+  })
+
+  it('uses the last literal when several statements write the charter', () => {
+    expect(parseCharterLiteralForDisplay([
+      "UPDATE __agent_config SET charter='First' WHERE id=1",
+      "UPDATE __agent_config SET charter='Second' WHERE id=1",
+    ])).toBe('Second')
   })
 })

--- a/frontend/src/components/tooling/agentConfigSql.ts
+++ b/frontend/src/components/tooling/agentConfigSql.ts
@@ -447,3 +447,31 @@ export function parseAgentConfigCharterChange(statements: string[]): AgentConfig
   }
   return charterChange
 }
+
+/**
+ * Display-only fallback for the historical detail card (bug #247): recover the new
+ * assignment text from a direct `charter = '<literal>'` write when neither the
+ * display-metadata snapshot nor a patch_text clause is available. Deliberately NOT part
+ * of parseAgentConfigCharterChange — the confirmation flow must keep ignoring literal
+ * assignments (a literal rewrite is not a verified delta).
+ */
+export function parseCharterLiteralForDisplay(statements: string[]): string | null {
+  let replacement: string | null = null
+  for (const statement of expandSqlStatements(statements)) {
+    const updateAssignments = extractUpdateAssignments(statement)
+    if (!updateAssignments) {
+      continue
+    }
+    const match = updateAssignments.match(
+      /\bcharter\b\s*=\s*('(?:[^']|'')*'|"(?:[^"]|"")*")(?!\s*\()/i,
+    )
+    if (!match) {
+      continue
+    }
+    const decoded = decodeSqlLiteral(match[1] ?? '')
+    if (decoded !== undefined && decoded !== null) {
+      replacement = normalizeEscapedNewlinesForDisplay(decoded)
+    }
+  }
+  return replacement
+}

--- a/frontend/src/hooks/useConsoleContextSwitcher.ts
+++ b/frontend/src/hooks/useConsoleContextSwitcher.ts
@@ -61,7 +61,12 @@ export function useConsoleContextSwitcher({
     queryFn: () => fetchConsoleContext({ forAgentId, staffContext }),
     enabled,
     staleTime: 60_000,
-    refetchOnWindowFocus: false,
+    // Everything downstream — timeline, subscriptions, web session — is gated on this
+    // query, and a cold-session failure used to wedge the whole chat with no retry
+    // path (bug #472). Keep retrying on focus/reconnect so the wedge self-heals.
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    retry: 3,
   })
   const { data: queryData, error: queryError, isLoading, refetch } = contextQuery
   const data = queryData ?? null

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -1038,6 +1038,7 @@ export function AgentChatPage({
     error: contextError,
     switchContext,
     createOrganizationContext,
+    refresh: refreshContext,
   } = useConsoleContextSwitcher({
     enabled: true,
     forAgentId: contextLookupAgentId,
@@ -4298,7 +4299,11 @@ export function AgentChatPage({
   const timelineErrorMessage = timelineQuery.error && !messageAnchorUnavailable
     ? safeErrorMessage(timelineQuery.error, 'Unable to load agent timeline right now.')
     : null
-  const topLevelError = timelineErrorMessage || (sessionStatus === 'error' ? sessionError : null)
+  // A failed context load previously rendered as an endless empty/loading state with no
+  // recovery path — the whole bootstrap is gated on it (bug #472).
+  const topLevelError = timelineErrorMessage
+    || (sessionStatus === 'error' ? sessionError : null)
+    || contextError
 
   if (isSelectionView) {
     if (!contextReady || rosterLoading) {
@@ -4364,7 +4369,18 @@ export function AgentChatPage({
       style={agentChatPageStyle}
     >
       {topLevelError ? (
-        <div className="mx-auto w-full max-w-3xl px-4 py-2 text-sm text-rose-600">{topLevelError}</div>
+        <div className="mx-auto flex w-full max-w-3xl items-center gap-3 px-4 py-2 text-sm text-rose-600">
+          <span>{topLevelError}</span>
+          {contextError ? (
+            <button
+              type="button"
+              className="rounded border border-rose-300 px-2 py-0.5 text-xs font-semibold text-rose-600 hover:bg-rose-50"
+              onClick={() => { void refreshContext() }}
+            >
+              Retry
+            </button>
+          ) : null}
+        </div>
       ) : null}
       {messageAnchorUnavailable ? (
         <div className="mx-auto w-full max-w-3xl px-4 py-2 text-sm text-amber-700">Message unavailable. Showing the latest conversation.</div>

--- a/frontend/src/screens/outbox/ImmersiveOutboxPage.test.tsx
+++ b/frontend/src/screens/outbox/ImmersiveOutboxPage.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * #427 (frontend contributor): "Save & send" approved an edited body that had never been
+ * rendered — the reviewer saw a raw textarea, not the HTML that would ship. Editing must
+ * be saved (which refreshes the rendered preview) before approve becomes available.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ImmersiveOutboxPage } from './ImmersiveOutboxPage'
+
+const outboxItem = {
+  id: 'item-1',
+  version: 3,
+  status: 'needs_review',
+  sender: 'agent@my.gobii.ai',
+  to: 'lead@example.com',
+  cc: [],
+  subject: 'Pricing follow-up',
+  body: 'Plain text body',
+  bodyHtml: '<html><body>Plain text body</body></html>',
+  bodyPreview: 'Plain text body',
+  createdAt: '2026-07-28T00:00:00Z',
+  agent: { id: 'agent-1', name: 'Scout' },
+  attachments: [],
+  threadChanged: false,
+  reviewStatus: 'pending',
+  queuedAt: '2026-07-28T00:00:00Z',
+  warnings: [],
+  allowedActions: { edit: true, approve: true, discard: true, retry: false },
+}
+
+vi.mock('../../api/outbox', () => ({
+  fetchOutbox: vi.fn(async () => ({
+    featureEnabled: true,
+    available: true,
+    items: [outboxItem],
+    counts: { needs_review: 1, sending: 0, failed: 0, sent: 0, discarded: 0, expired: 0 },
+  })),
+  fetchOutboxItem: vi.fn(async () => outboxItem),
+  fetchOutboxAgentFiles: vi.fn(async () => []),
+  updateOutboxItem: vi.fn(async () => outboxItem),
+  decideOutboxItem: vi.fn(async () => outboxItem),
+  bulkDiscardOutbox: vi.fn(async () => ({ discardedIds: [] })),
+  fetchEmailSendingPolicy: vi.fn(async () => ({ enabled: true, mode: 'review_all' })),
+  updateEmailSendingPolicy: vi.fn(async () => ({ enabled: true, mode: 'review_all' })),
+}))
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <ImmersiveOutboxPage />
+    </QueryClientProvider>,
+  )
+}
+
+describe('outbox review edit flow', () => {
+  it('hides approve while editing so unrendered bodies cannot be sent', async () => {
+    renderPage()
+    fireEvent.click(await screen.findByText('Pricing follow-up'))
+    await screen.findByTitle('Email preview')
+    expect(screen.getByText('Approve & send')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Edit'))
+
+    expect(screen.queryByText('Approve & send')).not.toBeInTheDocument()
+    expect(screen.queryByText('Save & send')).not.toBeInTheDocument()
+    expect(screen.getByText('Save changes')).toBeInTheDocument()
+
+    // Saving exits edit mode and restores the rendered preview + approve.
+    fireEvent.click(screen.getByText('Save changes'))
+    await waitFor(() => expect(screen.getByText('Approve & send')).toBeInTheDocument())
+    expect(screen.getByTitle('Email preview')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/screens/outbox/ImmersiveOutboxPage.tsx
+++ b/frontend/src/screens/outbox/ImmersiveOutboxPage.tsx
@@ -144,10 +144,11 @@ function ReviewDetail({ itemId, onClose }: { itemId: string; onClose: () => void
       if (editing && attachmentsChanged) edits.attachmentNodeIds = draft.attachmentNodeIds
       if (saveOnly) return updateOutboxItem(item.id, { expectedVersion: item.version, ...edits })
       if (!action) throw new Error('Missing action.')
+      // Approve never carries edits: an edited body must be saved first so the reviewer
+      // sees the rendered preview of what will actually ship before approving (#427).
       return decideOutboxItem(item.id, action, {
         expectedVersion: item.version,
         acknowledgeThreadChanged: threadAcknowledged,
-        ...(action === 'approve' ? edits : {}),
       })
     },
     onSuccess: async (updated) => {
@@ -237,7 +238,7 @@ function ReviewDetail({ itemId, onClose }: { itemId: string; onClose: () => void
       <div className="mt-5 flex flex-wrap gap-2">
         {item.allowedActions.edit ? <button type="button" onClick={() => setEditing((value) => !value)} className="inline-flex items-center gap-2 rounded-lg border border-slate-600 px-3 py-2 text-sm font-semibold hover:bg-slate-800"><Pencil className="size-4" />{editing ? 'Cancel edit' : 'Edit'}</button> : null}
         {editing ? <button type="button" disabled={mutation.isPending} onClick={() => mutation.mutate({ saveOnly: true })} className="rounded-lg border border-blue-400/50 px-3 py-2 text-sm font-semibold text-blue-200 hover:bg-blue-500/10">Save changes</button> : null}
-        {item.allowedActions.approve ? <button type="button" disabled={mutation.isPending || (threadChanged && !threadAcknowledged)} onClick={() => mutation.mutate({ action: 'approve' })} className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:opacity-50"><Send className="size-4" />{editing ? 'Save & send' : 'Approve & send'}</button> : null}
+        {!editing && item.allowedActions.approve ? <button type="button" disabled={mutation.isPending || (threadChanged && !threadAcknowledged)} onClick={() => mutation.mutate({ action: 'approve' })} className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:opacity-50"><Send className="size-4" />Approve & send</button> : null}
         {item.allowedActions.discard ? <button type="button" disabled={mutation.isPending} onClick={() => mutation.mutate({ action: 'discard' })} className="inline-flex items-center gap-2 rounded-lg border border-rose-400/50 px-3 py-2 text-sm font-semibold text-rose-200 hover:bg-rose-500/10"><Trash2 className="size-4" />Discard</button> : null}
         {item.allowedActions.retry ? <button type="button" disabled={mutation.isPending} onClick={() => mutation.mutate({ action: 'retry' })} className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"><RotateCcw className="size-4" />Retry unchanged email</button> : null}
       </div>

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -8023,7 +8023,9 @@
     justify-content: flex-start;
     gap: 0.85rem;
     min-height: 5.6rem;
-    padding: 1rem 1rem 0.8rem;
+    /* Right padding reserves the absolutely-positioned star's gutter (0.7rem offset +
+       1.9rem button) — long names pushed the mood emoji underneath it (bug #492). */
+    padding: 1rem 2.85rem 0.8rem 1rem;
     overflow: hidden;
     background: rgba(30, 41, 59, 0.88);
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "b35d4730edab7269762483dcc6cdbc25d8074e21",
+  "baseline_sha": "9785d06fd401de86f2bcb2a4e2b3508dbed29427",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9253,
+        "fitted_tokens": 9268,
         "system_bytes": 32484,
         "tools_bytes": 23607,
         "total_bytes": 67800,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8646,
+        "fitted_tokens": 8651,
         "system_bytes": 29375,
         "tools_bytes": 23607,
         "total_bytes": 64724,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8841,
+        "fitted_tokens": 8827,
         "system_bytes": 30012,
         "tools_bytes": 23607,
         "total_bytes": 65364,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 262444
+    "limit": 262609
   }
 }

--- a/tests/unit/test_agent_chat_signals.py
+++ b/tests/unit/test_agent_chat_signals.py
@@ -410,6 +410,74 @@ class AgentChatSignalTests(TestCase):
 
     @tag("batch_agent_chat")
     @patch("console.agent_chat.signals.transition_agent_to_signup_preview_waiting", return_value=False)
+    def test_outbound_email_to_external_recipient_notifies_nobody(self, _mock_transition):
+        """#491: an agent's email to a third party is not a message to the workspace —
+        broadcasting it leaked the email body as a browser notification on every send."""
+        conversation = PersistentAgentConversation.objects.create(
+            channel=CommsChannel.EMAIL,
+            address="lead@external-company.example",
+            owner_agent=self.agent,
+        )
+        email_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="agent@my.gobii.ai",
+        )
+        with self.captureOnCommitCallbacks(execute=True):
+            PersistentAgentMessage.objects.create(
+                owner_agent=self.agent,
+                is_outbound=True,
+                from_endpoint=email_endpoint,
+                conversation=conversation,
+                body="Hi lead, following up on pricing.",
+                raw_payload={"subject": "Pricing"},
+            )
+
+        owner_events = [
+            event for event in self._drain_channel_events(self.owner_profile_channel_name)
+            if event.get("type") == "message_notification_event"
+        ]
+        collaborator_events = [
+            event for event in self._drain_channel_events(self.collaborator_profile_channel_name)
+            if event.get("type") == "message_notification_event"
+        ]
+        self.assertEqual(owner_events, [])
+        self.assertEqual(collaborator_events, [])
+
+    @tag("batch_agent_chat")
+    @patch("console.agent_chat.signals.transition_agent_to_signup_preview_waiting", return_value=False)
+    def test_outbound_email_to_owner_notifies_only_the_owner(self, _mock_transition):
+        """#491: an email actually addressed to a workspace member still notifies them."""
+        conversation = PersistentAgentConversation.objects.create(
+            channel=CommsChannel.EMAIL,
+            address=self.user.email,
+            owner_agent=self.agent,
+        )
+        email_endpoint = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address="agent@my.gobii.ai",
+        )
+        with self.captureOnCommitCallbacks(execute=True):
+            PersistentAgentMessage.objects.create(
+                owner_agent=self.agent,
+                is_outbound=True,
+                from_endpoint=email_endpoint,
+                conversation=conversation,
+                body="Here is your weekly report.",
+                raw_payload={"subject": "Weekly report"},
+            )
+
+        owner_notification = self._receive_with_timeout(self.owner_profile_channel_name)
+        self.assertEqual(owner_notification.get("type"), "message_notification_event")
+        collaborator_events = [
+            event for event in self._drain_channel_events(self.collaborator_profile_channel_name)
+            if event.get("type") == "message_notification_event"
+        ]
+        self.assertEqual(collaborator_events, [])
+
+    @tag("batch_agent_chat")
+    @patch("console.agent_chat.signals.transition_agent_to_signup_preview_waiting", return_value=False)
     def test_visible_outbound_message_emits_message_notification_event(self, _mock_transition):
         with self.captureOnCommitCallbacks(execute=True):
             message = PersistentAgentMessage.objects.create(

--- a/tests/unit/test_timeline_email_recipient.py
+++ b/tests/unit/test_timeline_email_recipient.py
@@ -71,14 +71,44 @@ class TimelineEmailRecipientTests(TestCase):
         self.assertEqual(payload["recipientName"], "Derraleigh Vance")
         self.assertEqual(payload["recipientAddress"], "derraleigh@example.com")
 
-    def test_inbound_email_has_no_recipient(self):
-        """The counterparty address is the sender there, so labelling it "to" would be wrong."""
+    def test_inbound_email_reports_the_receiving_mailbox(self):
+        """Inbound, the To is the agent's own alias — meaningful because agents receive on
+        several custom-domain aliases (#495). Resolved from the provider envelope when the
+        endpoint was not persisted."""
         message = self._email_message(is_outbound=False, address="cantey@example.com")
+        message.raw_payload = {"Subject": "loved this", "To": "alpha.scout@my.gobii.ai"}
+        message.save(update_fields=["raw_payload"])
 
         payload = serialize_message_event(message)["message"]
 
-        self.assertIsNone(payload["recipientAddress"])
+        self.assertEqual(payload["recipientAddress"], "alpha.scout@my.gobii.ai")
         self.assertIsNone(payload["recipientName"])
+
+    def test_inbound_postmark_payload_yields_subject_and_cc(self):
+        """Postmark stores capitalised keys verbatim; the serializer must read them (#495)."""
+        message = self._email_message(is_outbound=False, address="cantey@example.com")
+        message.raw_payload = {
+            "Subject": "Q3 numbers",
+            "To": "alpha.scout@my.gobii.ai",
+            "Cc": "ops@example.com, boss@example.com",
+        }
+        message.save(update_fields=["raw_payload"])
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertEqual(payload["subject"], "Q3 numbers")
+        self.assertEqual(payload["ccAddresses"], ["ops@example.com", "boss@example.com"])
+
+    def test_inbound_imap_headers_yield_subject(self):
+        """IMAP payloads only carry headers; the subject must come from there (#495)."""
+        message = self._email_message(is_outbound=False, address="cantey@example.com")
+        message.raw_payload = {"headers": {"Subject": "Re: contract", "To": "alpha.scout@my.gobii.ai"}}
+        message.save(update_fields=["raw_payload"])
+
+        payload = serialize_message_event(message)["message"]
+
+        self.assertEqual(payload["subject"], "Re: contract")
+        self.assertEqual(payload["recipientAddress"], "alpha.scout@my.gobii.ai")
 
     def test_to_endpoint_wins_over_the_conversation_label(self):
         """The conversation is keyed by its original counterparty, but a message records who it


### PR DESCRIPTION
Second swath of verified frontend/UI bugs, each at its root cause with red→green tests.

## Fixes

**#491 — email body previews leaked as browser notifications (major).** The notification audience was derived from agent ownership alone: an agent emailing an external lead pushed the email body preview as a browser notification to every owner and collaborator. The audience now intersects with the message's actual recipients (verified allauth email / verified phone for SMS); web chat unchanged, Discord unchanged (no workspace identity mapping). Red test: an external email notifies nobody; a report emailed to the owner notifies exactly the owner.

**#495 — inbound email cards omitted sender, recipient, subject, Cc.** Four separate causes: the card discarded `senderAddress` inbound; the serializer never resolved To/Cc inbound (the receiving alias is meaningful — agents receive on several custom domains); ingest never persisted `to_endpoint`; and the subject was read only from lowercase `"subject"` — a key only outbound writes, while Postmark stores `"Subject"` and IMAP nests `headers["Subject"]`, so their inbound subjects silently vanished (invisible to the old suite because fixtures used the lowercase key). Serializer now reads the provider envelope verbatim with raw_payload fallback for history; ingest persists `to_endpoint`; the card renders the same envelope block both directions.

**#472 — cold-session chat bootstrap wedged unrecoverably (major).** The console context query gates the entire bootstrap (timeline, subscriptions, web session) but had no retry and rendered its error nowhere — one failed request on a cold session meant an empty chat and "Loading workspace…" forever. It now retries, refetches on focus/reconnect, and surfaces in the error banner with a Retry button. Separately, app fetches had no timeout, so a stalled initial timeline request pinned "Loading conversation…" indefinitely; fetches now abort at 45s into the existing error/retry paths.

**#427 (frontend contributor) — "Save & send" approved an email the reviewer never saw rendered.** In edit mode the rendered preview is replaced by a raw textarea, and approve bundled the edits — the styled HTML that ships was generated only after approval. Approve is now unavailable while editing: save first (which refreshes the rendered preview), then approve what is shown. The deeper send-time divergences (free-plan footer and inline-image rewriting applied only at dispatch) are backend, RCA'd and handed off on the ticket.

**#492 — mood emoji overlapped the star badge on gallery cards.** The star is absolutely positioned but the hero reserved no gutter for it, so long names pushed the emoji underneath. The hero's right padding now reserves the star's band.

**#247 — assignment history showed "not available".** Pre-snapshot charter updates wrote the text as a direct SQL literal, which the detail card could not read. A display-only parser recovers it; the confirmation flow's parser deliberately still ignores literals (a rewrite is not a verified delta — preserving the #1432-era contract).

## Verified on preview (pr-1453, authenticated browser + MCP)
- **#495**: real forked inbound emails (will@gobii.ai → Zoe Leibniz, Postmark payloads) now serialize subject, sender, the agent's receiving alias, and a Cc recovered from the envelope — all previously null. Live DOM shows the full From/To/subject envelope block on both directions (8 rows sampled).
- **Smoke**: chat bootstrap clean — timeline loads, no stuck "Loading conversation…", no error banner, zero page errors.
- **Honest limits**: the outbox review feature is disabled on preview deployments, so #427's edit flow is pinned by its unit test rather than exercised live; #492 is a deterministic padding-only change (the gallery-card layout didn't occur in the validation account's sidebar state); #472 is intermittent by nature — its fixes are covered by config/code inspection and the existing error-path tests, not a live repro.
- **#491** is backend signal fan-out — proven by the red→green test pair (external email notifies nobody; owner-addressed email notifies exactly the owner).

## Handoffs on tracker
#376 (BCC absent end-to-end — full backend spec attached), #427 backend (freeze rendered HTML at approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
