### PR TITLE
Preserve filespace attachments across peer delivery

### DIFF
--- a/api/agent/tools/tests/test_attachment_guidance.py
+++ b/api/agent/tools/tests/test_attachment_guidance.py
@@ -9,6 +9,7 @@ from api.agent.tools.email_sender import get_send_email_tool
 from api.agent.tools.peer_dm import get_send_agent_message_tool
 from api.agent.tools.send_discord_message import get_send_discord_message_tool
 from api.agent.tools.sms_sender import get_send_sms_tool
+from api.agent.tools.tool_manager import should_skip_auto_substitution
 from api.agent.tools.web_chat_sender import get_send_chat_tool
 from api.agent.core.prompt_context import _get_formatting_guidance
 
@@ -68,6 +69,18 @@ class AttachmentGuidanceTests(SimpleTestCase):
         self.assertIn("<img src='cid:filename'>", html_description)
         self.assertIn("exact file-tool `attach` value", description)
         self.assertIn("body text never attaches files", description)
+
+    def test_attachment_send_tools_preserve_opaque_file_tokens_for_their_resolvers(self):
+        for tool_name in (
+            "send_email",
+            "send_sms",
+            "send_chat_message",
+            "send_mcp_message",
+            "send_agent_message",
+            "send_discord_message",
+        ):
+            with self.subTest(tool_name=tool_name):
+                self.assertTrue(should_skip_auto_substitution(tool_name))
 
     def test_report_message_guidance_names_visual_quality_without_eval_prompting(self):
         email_tool = get_send_email_tool()

--- a/api/agent/tools/tool_manager.py
+++ b/api/agent/tools/tool_manager.py
@@ -180,6 +180,8 @@ SKIP_AUTO_SUBSTITUTION_TOOL_NAMES = {
     "send_sms",
     "send_chat_message",
     "send_mcp_message",
+    "send_agent_message",
+    "send_discord_message",
     "read_file",
     "create_image",
 }

--- a/api/evals/scenarios/structured_peer_handoffs.py
+++ b/api/evals/scenarios/structured_peer_handoffs.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from django.contrib.auth import get_user_model
 
+from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
 from api.evals.base import EvalScenario, ScenarioTask
 from api.evals.execution import ScenarioExecutionTools
 from api.evals.registry import ScenarioRegistry
@@ -25,6 +26,7 @@ from api.models import (
 STRUCTURED_PEER_SINGLE_RECORD = "structured_peer_single_record"
 STRUCTURED_PEER_RECORD_BATCH = "structured_peer_record_batch"
 STRUCTURED_PEER_PLAIN_QUESTION = "structured_peer_plain_question"
+STRUCTURED_PEER_FILE_HANDOFF = "structured_peer_file_handoff"
 STRUCTURED_PEER_NEGATIVE_DECISION = "structured_peer_negative_decision"
 STRUCTURED_PEER_MIXED_DECISIONS = "structured_peer_mixed_decisions"
 STRUCTURED_PEER_HANDOFF_SUITE_SLUG = "structured_peer_handoffs"
@@ -32,6 +34,7 @@ STRUCTURED_PEER_HANDOFF_SCENARIO_SLUGS = (
     STRUCTURED_PEER_SINGLE_RECORD,
     STRUCTURED_PEER_RECORD_BATCH,
     STRUCTURED_PEER_PLAIN_QUESTION,
+    STRUCTURED_PEER_FILE_HANDOFF,
     STRUCTURED_PEER_NEGATIVE_DECISION,
     STRUCTURED_PEER_MIXED_DECISIONS,
 )
@@ -49,6 +52,7 @@ class StructuredPeerHandoffCase:
     prompt: str
     expected_record: dict[str, Any] | None = None
     expected_records: tuple[dict[str, Any], ...] = ()
+    expects_attachment: bool = False
 
 
 STRUCTURED_PEER_HANDOFF_CASES = (
@@ -100,6 +104,16 @@ STRUCTURED_PEER_HANDOFF_CASES = (
             "and have them reply when they know."
         ),
     ),
+    StructuredPeerHandoffCase(
+        slug=STRUCTURED_PEER_FILE_HANDOFF,
+        description="A generated file reaches the explicitly named peer on the first send attempt.",
+        prompt=(
+            "Prepare a plain-text handoff note for Ledger Agent with release Northstar, 18 records, "
+            "status ready_for_review, and no blockers. Save it as /exports/northstar-handoff.txt, "
+            "then deliver that file to Ledger Agent."
+        ),
+        expects_attachment=True,
+    ),
 )
 
 
@@ -134,6 +148,35 @@ class StructuredPeerHandoffScenario(EvalScenario, ScenarioExecutionTools):
             code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
         )
 
+    @staticmethod
+    def _create_linked_peer(
+        agent: PersistentAgent,
+        run_id: str,
+        *,
+        role: str,
+        charter: str,
+    ) -> PersistentAgent:
+        slug = role.lower().replace(" ", "-")
+        peer_username = f"structured-{slug}-{run_id}@eval.local"
+        peer_user = get_user_model().objects.create_user(
+            username=peer_username,
+            email=peer_username,
+        )
+        peer = PersistentAgent.objects.create(
+            user=peer_user,
+            organization=agent.organization,
+            name=f"{role} {str(run_id)[:8]}",
+            charter=charter,
+            browser_use_agent=BrowserUseAgent.objects.create(
+                user=peer_user,
+                name=f"Structured {role} Eval {str(run_id)[:8]}",
+            ),
+            planning_state=PersistentAgent.PlanningState.SKIPPED,
+            is_active=False,
+        )
+        AgentPeerLink.objects.create(agent_a=agent, agent_b=peer, created_by=agent.user)
+        return peer
+
     def _prepare_agents(self, agent_id: str, run_id: str) -> tuple[PersistentAgent, PersistentAgent]:
         PersistentAgent.objects.filter(id=agent_id).update(
             name=f"Handoff Coordinator {str(agent_id)[:8]}",
@@ -143,25 +186,20 @@ class StructuredPeerHandoffScenario(EvalScenario, ScenarioExecutionTools):
         )
         self._seed_prior_run(agent_id)
         agent = PersistentAgent.objects.select_related("user", "organization").get(id=agent_id)
-
-        peer_username = f"structured-ledger-{run_id}@eval.local"
-        peer_user = get_user_model().objects.create_user(
-            username=peer_username,
-            email=peer_username,
-        )
-        peer = PersistentAgent.objects.create(
-            user=peer_user,
-            organization=agent.organization,
-            name=f"Ledger Agent {str(run_id)[:8]}",
+        peer = self._create_linked_peer(
+            agent,
+            run_id,
+            role="Ledger Agent",
             charter="Maintain finalized operational records and answer reconciliation questions.",
-            browser_use_agent=BrowserUseAgent.objects.create(
-                user=peer_user,
-                name=f"Structured Ledger Eval {str(run_id)[:8]}",
-            ),
-            planning_state=PersistentAgent.PlanningState.SKIPPED,
-            is_active=False,
         )
-        AgentPeerLink.objects.create(agent_a=agent, agent_b=peer, created_by=agent.user)
+        if self.case.expects_attachment:
+            self._create_linked_peer(
+                agent,
+                run_id,
+                role="Archive Agent",
+                charter="Maintain long-term archival records when explicitly assigned.",
+            )
+            mark_tool_enabled_without_discovery(agent, "create_file")
         return agent, peer
 
     @staticmethod
@@ -232,7 +270,7 @@ class StructuredPeerHandoffScenario(EvalScenario, ScenarioExecutionTools):
                 eval_stop_policy={
                     "ignored_tool_names": ["sleep_until_next_trigger", "update_plan", "sqlite_batch"],
                     "stop_on_tool_names_after_finish": ["send_agent_message"],
-                    "max_relevant_tool_calls": 2,
+                    "max_relevant_tool_calls": 4 if self.case.expects_attachment else 2,
                 },
             )
         self.record_task_result(
@@ -277,7 +315,24 @@ class StructuredPeerHandoffScenario(EvalScenario, ScenarioExecutionTools):
             received_payload = (received[0].raw_payload or {}).get("structured_payload")
             payloads_match = tool_payload == outbound_payload == received_payload
 
-            if self.case.expected_record is not None:
+            if self.case.expects_attachment:
+                attachment_paths = params.get("attachments") or []
+                outbound_attachments = list(outbound[0].attachments.all())
+                received_attachments = list(received[0].attachments.all())
+                passed = (
+                    tool_payload is None
+                    and len(attachment_paths) == 1
+                    and len(outbound_attachments) == 1
+                    and len(received_attachments) == 1
+                    and outbound_attachments[0].filespace_node.path == "/exports/northstar-handoff.txt"
+                    and received_attachments[0].filename == "northstar-handoff.txt"
+                )
+                observed = (
+                    "The generated file reached the named peer on the first send attempt."
+                    if passed
+                    else "The file send failed, targeted another peer, or lost the attachment."
+                )
+            elif self.case.expected_record is not None:
                 passed = (
                     payloads_match
                     and self._contains_record(tool_payload, self.case.expected_record)

--- a/api/evals/tests/test_structured_peer_handoffs.py
+++ b/api/evals/tests/test_structured_peer_handoffs.py
@@ -6,6 +6,7 @@ from api.agent.tools.peer_dm import get_send_agent_message_tool
 from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.structured_peer_handoffs import (
     STRUCTURED_PEER_HANDOFF_CASES,
+    STRUCTURED_PEER_FILE_HANDOFF,
     STRUCTURED_PEER_HANDOFF_SCENARIO_SLUGS,
     STRUCTURED_PEER_HANDOFF_SUITE_SLUG,
 )
@@ -53,3 +54,12 @@ class StructuredPeerHandoffEvalTests(SimpleTestCase):
         self.assertNotIn("structured_payload", prompts)
         self.assertNotIn("structured payload", prompts)
         self.assertNotIn("json", prompts)
+
+    def test_file_handoff_uses_a_named_peer_and_natural_file_request(self):
+        case = next(case for case in STRUCTURED_PEER_HANDOFF_CASES if case.expects_attachment)
+
+        self.assertEqual(case.slug, STRUCTURED_PEER_FILE_HANDOFF)
+        self.assertIn("ledger agent", case.prompt.lower())
+        self.assertIn("/exports/northstar-handoff.txt", case.prompt)
+        self.assertNotIn("peer_agent_id", case.prompt)
+        self.assertNotIn("$[", case.prompt)


### PR DESCRIPTION
## What changed

- preserve opaque filespace attachment tokens until peer and Discord delivery executors resolve them
- add a real-harness two-peer file handoff regression that requires the named peer, generated file, and first-attempt persisted delivery
- cover every attachment-capable send tool with the same substitution contract

## Root cause

The send tool contract correctly tells agents to pass the exact file token returned by file creation. Generic pre-execution variable substitution converted that token into a signed download URL for peer and Discord sends before their attachment resolvers ran. The resolver then treated the URL as a filespace path and rejected it. Email, SMS, chat, and MCP already skipped that generic substitution; peer and Discord did not.

## Evidence

- Red, DeepSeek V4 Flash: suite a90d9515-473b-49ba-b822-7e831b7c128d, run 27e9afb2-f2c2-494f-9ede-bb43b1d65051 — 1/2; correct named peer and exact token, runtime produced /https://...
- Green, DeepSeek V4 Flash: suite ffb46229-5e0c-48a3-8fba-19933714a9f6, run 4889311e-d43a-471b-87f7-9df34f5b9ea2 — 2/2
- Full structured peer suite: 2efad364-de56-44b5-aaeb-c955e04b0046 — 12/12
- Managed peer routing: ac5ee4ec-92e6-4017-9b30-6043754bfee0 — 5/5
- Owned Discord channel: 112f88c4-5626-4284-b3e8-51d00a8cec11 — 3/3
- Interleaved near-limit channel pressure: 77c71579-1785-45d8-afba-ca34141ea2fd — 5/5
- Focused Django tests: 62/62
- Complexity budgets: pass

Fixes #358