### PR TITLE
Ground SQLite work in live schemas

### DIFF
--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -2385,7 +2385,9 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
         "function": {
             "name": "sqlite_batch",
             "description": (
-                "Durable world model and exact logic: per source shape, one keyed DDL call, one set-wise upsert, "
+                "Durable world model and exact logic. Unknown table: sqlite_master gives names, not columns. "
+                "For unknown columns, run PRAGMA table_info(table) alone; use its output. "
+                "Per source shape: keyed DDL + set-wise upsert; "
                 "and decision-ready SELECTs. Derive fields across is_current_batch=1 plus "
                 "tool_name from result_json/item.value; provenance: t.result_id/t.source_url. Multi-source prose "
                 "modeling first uses the bounded set-wide inspection shown beside results; top-level rows join by "
@@ -2395,8 +2397,7 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
                 "into SQL, import per result_id, mix historical generic-tool results, or rebuild durable tables on "
                 "refresh. Evolve normalized entities/relations; query counts, joins, coverage, gaps, and ranks. "
                 "Return all supporting fields/URLs in the same batch; after decision rows return, deliver without "
-                "rereading. Unknown schema: targeted sqlite_master, then "
-                "PRAGMA alone in its own call, then query only returned columns. Bind messy text via :name; never "
+                "rereading. Bind messy text via :name; never "
                 "backslash-escape SQLite strings. Separate statements with semicolons. ON CONFLICT(cols) requires "
                 "those exact columns to be PRIMARY KEY or UNIQUE. bindings is an object; rows is an array. No ATTACH"
             ),

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -53,6 +53,7 @@ SQLITE_BOUNDED_PORTFOLIO_REPORT = "sqlite_tool_results_bounded_portfolio_report"
 SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY = "sqlite_domain_truth_over_stale_history"
 SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES = "sqlite_domain_model_refreshes_and_evolves"
 SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE = "sqlite_schema_grounded_existing_table"
+SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE_WRITE = "sqlite_schema_grounded_existing_table_write"
 SQLITE_SOURCE_ARRAY_FIRST_WRITE = "sqlite_source_array_first_write"
 SQLITE_SIBLING_RESULT_SET_FIRST_WRITE = "sqlite_sibling_result_set_first_write"
 SQLITE_UNSTRUCTURED_BINDINGS_FIRST_WRITE = "sqlite_unstructured_bindings_first_write"
@@ -71,6 +72,7 @@ SQLITE_TOOL_RESULT_SCENARIO_SLUGS = [
     SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY,
     SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES,
     SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE,
+    SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE_WRITE,
     SQLITE_SOURCE_ARRAY_FIRST_WRITE,
     SQLITE_SIBLING_RESULT_SET_FIRST_WRITE,
     SQLITE_UNSTRUCTURED_BINDINGS_FIRST_WRITE,
@@ -2100,6 +2102,92 @@ class SqliteSchemaGroundedExistingTableScenario(SqliteDomainModelScenario):
             task_name="verify_unresolved_handoff_answer",
             source_urls=(),
             required_terms=("agent-red", "2", "agent-blue", "1"),
+            min_sources=0,
+        )
+
+
+@register_scenario
+class SqliteSchemaGroundedExistingTableWriteScenario(SqliteDomainModelScenario):
+    slug = SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE_WRITE
+    description = "Existing database writes should inspect unavailable columns before mutating or reading the table."
+    expected_runtime = "short"
+    tags = (*SqliteToolResultScenario.tags, "schema_discovery", "trajectory_regression", "first_time_correctness")
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_schema_grounded_write", assertion_type="tool_call"),
+        ScenarioTask(name="verify_updated_handoff_answer", assertion_type="manual"),
+    ]
+    prompt = (
+        "Mark handoff-02 resolved in the existing handoff ledger. Then tell me who still has unfinished work "
+        "and the count for each. Use the ledger as the source of truth."
+    )
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._ready_agent(agent_id)
+        PersistentAgent.objects.filter(id=agent_id).update(
+            charter="Maintain internal operating ledgers precisely and report their current state."
+        )
+        _seed_hidden_handoff_ledger(agent_id)
+        inbound = self._inject_and_wait(
+            run_id,
+            agent_id,
+            self.prompt,
+            {},
+            allowed_tool_names={"sqlite_batch", "send_chat_message"},
+            max_relevant_tool_calls=7,
+        )
+        calls = list(
+            _tool_calls_for_run(
+                run_id,
+                after=inbound.timestamp,
+                tool_names={"sqlite_batch"},
+            )
+        )
+        failures = _schema_grounded_read_failures(calls)
+        schema_indexes = []
+        update_indexes = []
+        for call_index, call in enumerate(calls):
+            sql = str((call.tool_params or {}).get("sql") or "")
+            schema_evidence = json.dumps(_result_payload(call) or {}).casefold()
+            if (
+                HANDOFF_LEDGER_TABLE.casefold() in sql.casefold()
+                and all(field in schema_evidence for field in ("handoff_key", "worker_ref", "resolution_code"))
+            ):
+                schema_indexes.append(call_index)
+            if re.search(rf"\bupdate\s+{re.escape(HANDOFF_LEDGER_TABLE)}\b", _structural_sql(sql), re.I):
+                update_indexes.append(call_index)
+
+        if not update_indexes:
+            failures.append("existing ledger was not updated")
+        if schema_indexes and update_indexes and min(update_indexes) <= min(schema_indexes):
+            failures.append("ledger was mutated before schema inspection completed")
+
+        with agent_sqlite_db(str(agent_id)) as db_path:
+            conn = open_guarded_sqlite_connection(db_path)
+            try:
+                resolution = conn.execute(
+                    f"SELECT resolution_code FROM {HANDOFF_LEDGER_TABLE} WHERE handoff_key=?;",
+                    ("handoff-02",),
+                ).fetchone()
+            finally:
+                clear_guarded_connection(conn)
+                conn.close()
+        if resolution != ("resolved",):
+            failures.append(f"handoff-02 persisted state was {resolution!r}")
+
+        self._record_check(
+            run_id,
+            "verify_schema_grounded_write",
+            failures,
+            "Inspected the live schema before one successful update and follow-up query.",
+        )
+        self._record_sourced_answer(
+            run_id,
+            agent_id=agent_id,
+            after=inbound.timestamp,
+            task_name="verify_updated_handoff_answer",
+            source_urls=(),
+            required_terms=("agent-red", "1", "agent-blue", "1"),
             min_sources=0,
         )
 

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -155,6 +155,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertIn(sqlite_evals.SQLITE_DOMAIN_TRUTH_OVER_STALE_HISTORY, suite.scenario_slugs)
         self.assertIn(sqlite_evals.SQLITE_DOMAIN_MODEL_REFRESHES_AND_EVOLVES, suite.scenario_slugs)
         self.assertIn(SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE, suite.scenario_slugs)
+        self.assertIn(sqlite_evals.SQLITE_SCHEMA_GROUNDED_EXISTING_TABLE_WRITE, suite.scenario_slugs)
         self.assertIn(sqlite_evals.SQLITE_PROSPECT_PIPELINE_COMPLETES, suite.scenario_slugs)
 
     def test_trajectory_regression_prompts_do_not_prescribe_tools_or_format(self):
@@ -163,6 +164,7 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
             SqliteNaturalResultAccessScenario.prompt,
             SqliteBoundedPortfolioReportScenario.prompt,
             sqlite_evals.SqliteSchemaGroundedExistingTableScenario.prompt,
+            sqlite_evals.SqliteSchemaGroundedExistingTableWriteScenario.prompt,
             sqlite_evals.SqliteProspectPipelineCompletesScenario.prompt,
         )
 

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -795,6 +795,9 @@ class SqliteBatchCoreTests(SqliteBatchTestCase):
 
         for expected in (
             "Durable world model and exact logic",
+            "Unknown table: sqlite_master gives names, not columns",
+            "For unknown columns, run PRAGMA table_info(table) alone",
+            "use its output",
             "keyed DDL",
             "set-wise upsert",
             "is_current_batch=1 plus tool_name",
@@ -815,9 +818,6 @@ class SqliteBatchCoreTests(SqliteBatchTestCase):
             "counts, joins, coverage, gaps, and ranks",
             "Return all supporting fields/URLs in the same batch",
             "after decision rows return, deliver without rereading",
-            "targeted sqlite_master",
-            "PRAGMA alone in its own call",
-            "query only returned columns",
         ):
             self.assertIn(expected, description)
         continuation_description = (


### PR DESCRIPTION
## Why

A production agent discovered an existing table name, guessed a nonexistent column, and rolled back an otherwise valid SQLite batch. The existing regression scenario reproduced the same failure on current main: table discovery via `sqlite_master` was treated as sufficient schema knowledge.

## What changed

- state the schema contract at the start of `sqlite_batch`: `sqlite_master` discovers names; `PRAGMA table_info` discovers columns
- require unknown existing columns to be inspected before use
- add a real-harness write regression that verifies schema inspection, the persisted mutation, and the decision-ready answer
- keep the tool prompt within the existing complexity budget (no baseline increase)

## Evidence

- RED on current main: `sqlite_schema_grounded_existing_table` suite `3dcc61f6-06de-47c1-9f4e-77d4de3e6ec0`, run `bac66a56-7f22-4134-be0c-c23973a41d8c` (guessed `record_key`; rollback; 2/3)
- GREEN on DeepSeek V4 Flash after fix: schema-discovery suite `904ce2bb-7532-4c12-8687-a4a6978b7ded` (18/18 across 6 runs)
- GREEN after final prompt tightening: suite `2db77777-4cbb-4f8b-814b-1b9f8bda23e5` (6/6 across read + write)
- focused Django tests: 3/3
- SQLite stale-tool lifecycle guards: 4/4
- complexity budgets: pass; tool prompt is 1 byte under the existing limit
- `git diff --check`: pass

## Scope

One input-contract fix plus focused regression coverage. No SQL recovery loop, output rewriting, heuristic guard, or budget increase.