### PR TITLE
Shell swath 3: dead right column, anonymous socket storm, native webhooks discoverability

### DIFF
--- a/frontend/src/components/mcp/WorkspaceAppsManager.test.ts
+++ b/frontend/src/components/mcp/WorkspaceAppsManager.test.ts
@@ -1,0 +1,22 @@
+/**
+ * #243 (frontend half): a search for "webhook" on the integrations page returned only
+ * Pipedream catalog apps — the native inbound-webhook feature was invisible on this
+ * surface, steering users toward Pipedream.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { searchSuggestsWebhooks } from './WorkspaceAppsManager'
+
+describe('searchSuggestsWebhooks', () => {
+  it('matches webhook-intent searches', () => {
+    for (const term of ['webhook', 'webhooks', 'inbound webhook', 'web hook', 'callback url']) {
+      expect(searchSuggestsWebhooks(term)).toBe(true)
+    }
+  })
+
+  it('stays quiet for unrelated searches', () => {
+    for (const term of ['slack', 'hubspot', 'web scraping', 'hooks for react']) {
+      expect(searchSuggestsWebhooks(term)).toBe(false)
+    }
+  })
+})

--- a/frontend/src/components/mcp/WorkspaceAppsManager.tsx
+++ b/frontend/src/components/mcp/WorkspaceAppsManager.tsx
@@ -669,10 +669,10 @@ function AppListScreen({
 
 function WebhooksHintRowItem() {
   return (
-    <div className="flex items-start justify-between gap-3 border-b border-slate-200/60 px-4 py-3">
+    <div className="flex items-start justify-between gap-3 border-b border-slate-600/40 px-4 py-3">
       <div className="min-w-0">
-        <p className="text-sm font-semibold text-slate-800">Webhooks — built into Gobii</p>
-        <p className="mt-0.5 text-xs text-slate-500">
+        <p className="text-sm font-semibold text-slate-100">Webhooks — built into Gobii</p>
+        <p className="mt-0.5 text-xs text-slate-400">
           Every agent can receive inbound webhooks natively — no app needed. Add one under the
           agent&apos;s Settings → Integrations.
         </p>
@@ -681,7 +681,7 @@ function WebhooksHintRowItem() {
         href="https://docs.gobii.ai/console-guides/agent-settings"
         target="_blank"
         rel="noopener noreferrer"
-        className="shrink-0 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+        className="shrink-0 rounded-lg border border-slate-500 px-3 py-1.5 text-xs font-semibold text-slate-200 hover:bg-slate-700/40"
       >
         Learn more
       </a>

--- a/frontend/src/components/mcp/WorkspaceAppsManager.tsx
+++ b/frontend/src/components/mcp/WorkspaceAppsManager.tsx
@@ -75,6 +75,14 @@ type WorkspaceAppRow =
   | (WorkspacePipedreamAppRow & { kind: 'pipedream' })
   | (NativeIntegrationProvider & { kind: 'native' })
   | (NativeIntegrationProvider & { kind: 'discord' })
+  | { kind: 'webhooks-hint' }
+
+// Native inbound webhooks live in each agent's settings, not in this catalog — so a
+// search for "webhook" here used to return only Pipedream apps and steered users away
+// from the built-in feature entirely (bug #243's frontend half).
+export function searchSuggestsWebhooks(normalizedSearch: string): boolean {
+  return /webhook|web hook|callback|inbound event/.test(normalizedSearch)
+}
 
 type PendingAppAction = {
   slug: string
@@ -241,7 +249,10 @@ export function WorkspaceAppsManager({
         source,
       }
     })
-    return [...nativeRows, ...pipedreamRows]
+    const hintRows: WorkspaceAppRow[] = normalizedSearch && searchSuggestsWebhooks(normalizedSearch)
+      ? [{ kind: 'webhooks-hint' as const }]
+      : []
+    return [...hintRows, ...nativeRows, ...pipedreamRows]
   }, [
     debouncedSearchTerm,
     discordConnected,
@@ -619,7 +630,9 @@ function AppListScreen({
         <PipedreamEmptyState label="No apps matched your search." />
       ) : (
         <PipedreamListFrame isMobile={isMobile} constrainHeight={false}>
-          {apps.map((app) => app.kind === 'native' ? (
+          {apps.map((app) => app.kind === 'webhooks-hint' ? (
+            <WebhooksHintRowItem key="webhooks-hint" />
+          ) : app.kind === 'native' ? (
             <NativeAppRowItem
               key={`native-${app.providerKey}`}
               provider={app}
@@ -650,6 +663,28 @@ function AppListScreen({
           ))}
         </PipedreamListFrame>
       )}
+    </div>
+  )
+}
+
+function WebhooksHintRowItem() {
+  return (
+    <div className="flex items-start justify-between gap-3 border-b border-slate-200/60 px-4 py-3">
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-slate-800">Webhooks — built into Gobii</p>
+        <p className="mt-0.5 text-xs text-slate-500">
+          Every agent can receive inbound webhooks natively — no app needed. Add one under the
+          agent&apos;s Settings → Integrations.
+        </p>
+      </div>
+      <a
+        href="https://docs.gobii.ai/console-guides/agent-settings"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+      >
+        Learn more
+      </a>
     </div>
   )
 }

--- a/frontend/src/hooks/useAgentChatSocket.ts
+++ b/frontend/src/hooks/useAgentChatSocket.ts
@@ -85,6 +85,10 @@ function useLatestRef<T>(value: T) {
 export function useAgentChatSocket(
   desiredSubscriptionsInput: AgentChatSocketSubscription[],
   options: {
+    /** Gate the connection entirely — e.g. until an authenticated console context
+     *  exists. An unauthenticated handshake closes pre-accept, surfaces as a 403 the
+     *  client cannot distinguish from an outage, and retried forever. */
+    enabled?: boolean
     contextOverride?: AgentChatSocketContextOverride
     staffContextOverride?: StaffViewContext | null
     developerMode?: boolean
@@ -178,6 +182,8 @@ export function useAgentChatSocket(
   })
 
   const retryRef = useRef(0)
+  const hasConnectedOnceRef = useRef(false)
+  const enabled = options.enabled !== false
   const socketRef = useRef<WebSocket | null>(null)
   const timeoutRef = useRef<number | null>(null)
   const syncIntervalRef = useRef<number | null>(null)
@@ -187,7 +193,7 @@ export function useAgentChatSocket(
   const scheduleConnectRef = useRef<(delay: number) => void>(() => undefined)
   const closeSocketRef = useRef<() => void>(() => undefined)
   const closingSocketRef = useRef<WebSocket | null>(null)
-  const pauseReasonRef = useRef<'offline' | null>(null)
+  const pauseReasonRef = useRef<'offline' | 'disabled' | null>(null)
   const lastSyncAtRef = useRef(0)
   const lastActivityAtRef = useRef(0)
   const requestedSubscriptionsRef = useRef<Map<string, AgentChatSocketSubscription['mode']>>(new Map())
@@ -446,6 +452,7 @@ export function useAgentChatSocket(
       }, CONNECT_TIMEOUT_MS)
 
       socket.onopen = () => {
+        hasConnectedOnceRef.current = true
         if (socketRef.current !== socketInstance) {
           return
         }
@@ -552,6 +559,15 @@ export function useAgentChatSocket(
           })
           return
         }
+        // A handshake refusal (close 1006 before any successful open) is not an
+        // outage worth hammering: after a few attempts, stop and surface it.
+        if (event.code === 1006 && !hasConnectedOnceRef.current && retryRef.current >= 4) {
+          updateSnapshot({
+            status: 'error',
+            lastError: errorMessage || 'Unable to establish realtime connection.',
+          })
+          return
+        }
         updateSnapshot({
           status: 'reconnecting',
           lastError: errorMessage,
@@ -575,7 +591,9 @@ export function useAgentChatSocket(
     }
 
     pauseReasonRef.current = null
-    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    if (enabled === false) {
+      pauseReasonRef.current = 'disabled'
+    } else if (typeof navigator !== 'undefined' && navigator.onLine === false) {
       pauseReasonRef.current = 'offline'
     } else if (pauseReasonRef.current === null) {
       scheduleConnect(0)
@@ -609,6 +627,7 @@ export function useAgentChatSocket(
   }, [
     clearConnectTimeout,
     currentRef,
+    enabled,
     handlersRef,
     markActivity,
     queryClient,

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -1956,6 +1956,9 @@ export function AgentChatPage({
     rosterAgents,
   })
   const socketSnapshot = useAgentChatSocket(desiredSocketSubscriptions, {
+    // No connection until an authenticated console context exists — an anonymous
+    // handshake is refused pre-accept and used to retry forever from every route.
+    enabled: contextReady,
     contextOverride: contextReady ? effectiveContext : null,
     staffContextOverride: staffContext,
     developerMode: developerModeEnabled,
@@ -4370,22 +4373,65 @@ export function AgentChatPage({
     || contextError
 
   if (isSelectionView) {
-    if (!contextReady || rosterLoading) {
-      return renderSelectionLayout(
-        <div className="flex min-h-[60vh] items-center justify-center">
-          <p className="text-sm font-medium text-slate-500">Loading workspace…</p>
-        </div>,
-      )
-    }
+    // Shell pages (billing, integrations, secrets, profile, …) fetch their own data and
+    // must not wait on the chat context/roster: gating them behind it rendered
+    // "Loading workspace…" forever whenever that load wedged, and the desktop column
+    // showed a blank pane because only mobile consumed selectionMainPanel. The column
+    // now always has a body — the same select-a-conversation state /app/agents shows —
+    // plus any recoverable context error.
     if (selectionPage !== 'agents') {
       return renderSelectionLayout(
-        selectionMainPanel ? (
-          <div className="flex min-h-full w-full flex-1 md:hidden">
-            {selectionMainPanel}
+        <>
+          {selectionMainPanel ? (
+            <div className="flex min-h-full w-full flex-1 md:hidden">
+              {selectionMainPanel}
+            </div>
+          ) : null}
+          <div className={`min-h-full w-full flex-1 flex-col items-center justify-center gap-3 px-4 ${selectionMainPanel ? 'hidden md:flex' : 'flex'}`}>
+            {topLevelError ? (
+              <div className="flex items-center gap-3 text-sm text-rose-600">
+                <span>{topLevelError}</span>
+                {contextError ? (
+                  <button
+                    type="button"
+                    className="rounded border border-rose-300 px-2 py-0.5 text-xs font-semibold text-rose-600 hover:bg-rose-50"
+                    onClick={() => { void refreshContext() }}
+                  >
+                    Retry
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+            <AgentSelectState
+              hasAgents={rosterAgents.length > 0}
+              onCreateAgent={handleCreateAgent}
+              createAgentDisabledReason={createAgentDisabledReason}
+              onBlockedCreateAgent={previewCreateAgentBlocked ? () => handleBlockedCreateAgent('empty_state') : undefined}
+            />
           </div>
-        ) : (
-          <div className="flex min-h-full w-full flex-1" />
-        ),
+        </>,
+      )
+    }
+    if (!contextReady || rosterLoading) {
+      return renderSelectionLayout(
+        <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3">
+          {topLevelError ? (
+            <div className="flex items-center gap-3 text-sm text-rose-600">
+              <span>{topLevelError}</span>
+              {contextError ? (
+                <button
+                  type="button"
+                  className="rounded border border-rose-300 px-2 py-0.5 text-xs font-semibold text-rose-600 hover:bg-rose-50"
+                  onClick={() => { void refreshContext() }}
+                >
+                  Retry
+                </button>
+              ) : null}
+            </div>
+          ) : (
+            <p className="text-sm font-medium text-slate-500">Loading workspace…</p>
+          )}
+        </div>,
       )
     }
     return renderSelectionLayout(

--- a/middleware/app_shell.py
+++ b/middleware/app_shell.py
@@ -28,6 +28,7 @@ APP_PROFILE_PATH_PREFIX = f"{APP_PATH_PREFIX}/profile"
 APP_SECRETS_PATH_PREFIX = f"{APP_PATH_PREFIX}/secrets"
 APP_USAGE_PATH_PREFIX = f"{APP_PATH_PREFIX}/usage"
 APP_INTEGRATIONS_PATH_PREFIX = f"{APP_PATH_PREFIX}/integrations"
+APP_OUTBOX_PATH_PREFIX = f"{APP_PATH_PREFIX}/outbox"
 APP_LOGIN_REQUIRED_PATH_PREFIXES = (
     APP_PROTECTED_PATH_PREFIX,
     APP_BILLING_PATH_PREFIX,
@@ -40,6 +41,9 @@ APP_LOGIN_REQUIRED_PATH_PREFIXES = (
     APP_SECRETS_PATH_PREFIX,
     APP_USAGE_PATH_PREFIX,
     APP_INTEGRATIONS_PATH_PREFIX,
+    # Outbox was the one shell route served to anonymous sessions, which then hit the
+    # chat socket and console APIs unauthenticated (403 handshake + 401 storm).
+    APP_OUTBOX_PATH_PREFIX,
 )
 APP_LOGIN_REQUIRED_SUBPATH_PREFIXES = tuple(f"{prefix}/" for prefix in APP_LOGIN_REQUIRED_PATH_PREFIXES)
 APP_SHELL_CACHE_CONTROL = "no-cache, must-revalidate"

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "9785d06fd401de86f2bcb2a4e2b3508dbed29427",
+  "baseline_sha": "ae8395209e705f12657ea2b11033ec6156413574",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9268,
-        "system_bytes": 32484,
-        "tools_bytes": 23607,
-        "total_bytes": 67800,
+        "fitted_tokens": 9258,
+        "system_bytes": 32481,
+        "tools_bytes": 23606,
+        "total_bytes": 67796,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8651,
-        "system_bytes": 29375,
-        "tools_bytes": 23607,
-        "total_bytes": 64724,
+        "fitted_tokens": 8649,
+        "system_bytes": 29362,
+        "tools_bytes": 23606,
+        "total_bytes": 64710,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8827,
-        "system_bytes": 30012,
-        "tools_bytes": 23607,
-        "total_bytes": 65364,
+        "fitted_tokens": 8844,
+        "system_bytes": 29999,
+        "tools_bytes": 23606,
+        "total_bytes": 65350,
         "user_bytes": 11745
       }
     },
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 930,
+    "file_count": 934,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 280000
+    "limit": 263554
   }
 }

--- a/tests/unit/test_vite_assets.py
+++ b/tests/unit/test_vite_assets.py
@@ -144,6 +144,7 @@ class AppShellAuthenticationTests(TestCase):
             "/app/secrets",
             "/app/usage",
             "/app/integrations",
+            "/app/outbox",
             f"/app/agents/{uuid.uuid4()}/settings",
             f"/app/agents/{uuid.uuid4()}/secrets",
             f"/app/agents/{uuid.uuid4()}/email",


### PR DESCRIPTION
Three root-cause fixes from an authenticated QA crawl over current main, all validated on the pr-1463 preview with screenshots.

**Dead right column on shell routes.** Billing/integrations/secrets/profile gated their right column behind chat context/roster they never use — a wedged load meant 'Loading workspace…' forever, and even when loaded, desktop rendered a literally empty div (only mobile consumed the panel). Shell pages skip the gate, the desktop column shows the standard select-a-conversation state, and context errors surface with Retry. **Preview:** all three routes render the workspace state; zero 'Loading workspace' occurrences.

**Anonymous socket storm via /app/outbox.** Outbox was the one shell route missing from the app shell's login-required prefixes — anonymous sessions got the SPA, then hammered the chat socket (pre-accept close = opaque 403, retried forever) and console APIs (401s). Prefix added (red→green tested: anonymous /app/outbox now 302s to login), the socket gained an `enabled: contextReady` gate, and handshake refusals with no prior successful open stop after 4 attempts. **Residual noted:** one WS handshake failure still observed on authenticated preview outbox — storm bounded, single failure under investigation separately.

**#243 (frontend half): native webhooks invisible in integrations search.** Searching 'webhook' returned only Pipedream apps. Webhook-intent searches now show a 'Webhooks — built into Gobii' hint row pointing at agent Settings → Integrations with a docs link. **Preview:** renders above Pipedream results, dark-theme styled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)