### PR TITLE
Wait for custom-tool results before outbound sends

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -126,7 +126,7 @@ from ..tools.sqlite_config_statements import (
     sqlite_statement_assigns_agent_config_field,
 )
 from ..tools.sqlite_skills import apply_sqlite_skill_updates, refresh_skills_for_tool, seed_sqlite_skills
-from ..tools.custom_tools import execute_create_custom_tool
+from ..tools.custom_tools import CUSTOM_TOOL_PREFIX, execute_create_custom_tool
 from ..tools.custom_tool_names import CREATE_CUSTOM_TOOL_NAME
 from ..tools.plan import build_plan_snapshot, build_redundant_research_plan_skip_result, execute_update_plan
 from ..tools.planning import execute_end_planning
@@ -1528,6 +1528,24 @@ def _tool_call_field(call: Any, field: str, *, skip_empty: bool = False) -> Any:
 def _get_tool_call_name(call: Any) -> Optional[str]:
     name = _tool_call_field(call, "name", skip_empty=True)
     return _sanitize_tool_name(name) if name else None
+
+
+def _partition_unresolved_custom_tool_sends(
+    tool_calls: list[Any],
+) -> tuple[list[Any], list[Any]]:
+    """Hold sends whose necessity cannot be known until a custom tool returns."""
+    executable: list[Any] = []
+    deferred: list[Any] = []
+    custom_result_pending = False
+    for call in tool_calls:
+        tool_name = _get_tool_call_name(call) or ""
+        if custom_result_pending and tool_name in MESSAGE_TOOL_NAMES:
+            deferred.append(call)
+            continue
+        executable.append(call)
+        if tool_name.startswith(CUSTOM_TOOL_PREFIX):
+            custom_result_pending = True
+    return executable, deferred
 
 
 def _sanitize_tool_name(name: str) -> str:
@@ -3433,6 +3451,7 @@ def _prepare_tool_batch(
             stale_cancellation=True,
         )
 
+    tool_calls, deferred_sends = _partition_unresolved_custom_tool_sends(tool_calls)
     rate_limit_batch = (
         _build_tool_rate_limit_batch(
             agent,
@@ -3442,11 +3461,30 @@ def _prepare_tool_batch(
         else None
     )
     prepared_calls: list[_PreparedToolExecution] = []
-    followup_required = False
+    followup_required = bool(deferred_sends)
     all_calls_sleep = not has_non_sleep_calls
     abort_after_execution = False
     cancel_prepared_calls = False
     stale_cancellation = False
+    if deferred_sends:
+        deferred_names = ", ".join(
+            name
+            for call in deferred_sends
+            if (name := _get_tool_call_name(call))
+        )
+        _record_policy_step(
+            agent,
+            "Tool dependency: held outbound send planned after a custom tool because its result was not available "
+            "when the send was planned. Read the completed result, obey its side_effects/status/next_action, and "
+            f"send only work it proves remains. Held: {deferred_names or 'unknown send'}.",
+            attach_completion=attach_completion,
+            attach_prompt_archive=attach_prompt_archive,
+        )
+        logger.info(
+            "Agent %s: held %d outbound send(s) until the preceding custom-tool result is available.",
+            agent.id,
+            len(deferred_sends),
+        )
     deep_work_update_reason = _deep_work_update_gate_context(agent, tool_calls)
     if deep_work_update_reason:
         _record_deep_work_update_correction(

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -4122,6 +4122,7 @@ def _get_system_instruction(
 
         "## Tool Rules\n\n```\nopaque identifiers -> supplied endpoints/paths/IDs/placeholders character-for-character; tool names exactly; never shorten/normalize\nevidence -> exact IDs/statuses/counts/associations; sent != delivered; no padding/mixing/promotion. Clean/final need ledger; fresh wins conflicts. Approved action -> exact recipient/content from ledger\n"
         "unrelated small result -> answer; build/create custom tool -> create_custom_tool first; supplied URLs -> opaque runtime inputs, no prefetch/inspect/browser\n"
+        "custom result governs later sends -> call custom tool alone; WAIT; obey side_effects/next_action\n"
         "credential-returning API -> search_tools('secure credential delegation') first; never HTTP/browser/SQLite\n"
         "named model + explicit fresh non-secret source/URL -> http_request only, no text/send/plan; WAIT; next completion exactly one reconcile+SELECT sqlite_batch; then report\n"
         "exact docs/blog/changelog/release-notes URL -> scrape_as_markdown or http_request first; never spawn_web_task first just because it is a webpage or app URL\n"
@@ -4144,7 +4145,7 @@ def _get_system_instruction(
         "```\n"
 
         "For MCP tools, call the matching tool; do not list/open first unless required. "
-        "Obey returned status, retryable, and next_action. For retryable=false, never repeat unchanged: repair from context, fetch one missing input, then change path or stop. Held/skipped/rejected means not run: apply the correction next; never bypass it or claim success. If auth/setup is blocked, give the requester the returned setup action, park that workstream, and continue only independent work. Correct a retryable request-shape error once. "
+        "Obey returned side_effects, status, retryable, and next_action. For retryable=false, never repeat unchanged: repair from context, fetch one missing input, then change path or stop. Held/skipped/rejected means not run: apply the correction next; never bypass it or claim success. If auth/setup is blocked, give the requester the returned setup action, park that workstream, and continue only independent work. Correct a retryable request-shape error once. "
         "Email/SMS imperatives map directly to send_email/send_sms. For a specific new number when send_sms is absent, call request_contact_permission directly; never search for messaging tools. "
         "Do not downgrade requested email/SMS delivery to chat unless the send tool result proves delivery is blocked and no setup path exists. "
         "Never ask for passwords or 2FA codes for OAuth services. Avoid 2FA/MFA unless the user explicitly asks for it, because those flows may hit system limitations; prefer non-2FA paths when available. "

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -28,6 +28,7 @@ from api.agent.core.event_processing import (
     _normalize_error_result,
     _normalize_tool_params,
     _parse_tool_call_params,
+    _partition_unresolved_custom_tool_sends,
     _PreparedToolExecution,
     _sanitize_tool_name,
     _should_infer_message_tool_continuation,
@@ -71,6 +72,47 @@ class _DummySpan:
 
     def set_attribute(self, *_args, **_kwargs):
         return None
+
+
+@tag('batch_event_processing')
+class CustomToolSendDependencyTests(SimpleTestCase):
+    @staticmethod
+    def _call(name):
+        return {"function": {"name": name, "arguments": "{}"}}
+
+    def test_defers_outbound_sends_planned_after_custom_tool_result(self):
+        custom = self._call("custom_publish_incident")
+        discord = self._call("send_discord_message")
+        email = self._call("send_email")
+
+        executable, deferred = _partition_unresolved_custom_tool_sends(
+            [custom, discord, email]
+        )
+
+        self.assertEqual(executable, [custom])
+        self.assertEqual(deferred, [discord, email])
+
+    def test_preserves_kickoff_before_custom_tool_and_independent_work_after_it(self):
+        kickoff = self._call("send_chat_message")
+        custom = self._call("custom_collect_results")
+        sqlite = self._call("sqlite_batch")
+        final = self._call("send_chat_message")
+
+        executable, deferred = _partition_unresolved_custom_tool_sends(
+            [kickoff, custom, sqlite, final]
+        )
+
+        self.assertEqual(executable, [kickoff, custom, sqlite])
+        self.assertEqual(deferred, [final])
+
+    def test_does_not_treat_create_custom_tool_as_an_invocation(self):
+        create = self._call("create_custom_tool")
+        send = self._call("send_email")
+
+        executable, deferred = _partition_unresolved_custom_tool_sends([create, send])
+
+        self.assertEqual(executable, [create, send])
+        self.assertEqual(deferred, [])
 
 
 @tag('batch_event_processing')

--- a/api/agent/tools/eval_synthetic_tools.py
+++ b/api/agent/tools/eval_synthetic_tools.py
@@ -235,6 +235,18 @@ EVAL_SYNTHETIC_TOOL_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         ),
         "parameters": _GENERIC_BATCH_WORK_SCHEMA,
     },
+    "custom_eval_incident_workflow": {
+        "description": (
+            "Run the configured incident workflow. Depending on policy, it may only update the ledger or may also "
+            "send the configured notifications. Its returned side_effects and next_action are authoritative."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {"incident_id": {"type": "string"}},
+            "required": ["incident_id"],
+            "additionalProperties": False,
+        },
+    },
     **{
         tool_name: {
             "description": (

--- a/api/agent/tools/tool_manager.py
+++ b/api/agent/tools/tool_manager.py
@@ -63,7 +63,13 @@ from .create_pdf import get_create_pdf_tool, execute_create_pdf
 from .create_chart import get_create_chart_tool, execute_create_chart
 from .create_image import get_create_image_tool, execute_create_image, is_image_generation_available_for_agent
 from .create_video import get_create_video_tool, execute_create_video, is_video_generation_available_for_agent
-from .custom_tools import execute_create_custom_tool, execute_custom_tool, get_create_custom_tool_tool, is_custom_tools_available_for_agent
+from .custom_tools import (
+    CUSTOM_TOOL_PREFIX,
+    execute_create_custom_tool,
+    execute_custom_tool,
+    get_create_custom_tool_tool,
+    is_custom_tools_available_for_agent,
+)
 from .custom_tool_names import CREATE_CUSTOM_TOOL_NAME, CUSTOM_TOOL_DEVELOPMENT_SYSTEM_SKILL_KEY
 from .eval_synthetic_tools import EVAL_SYNTHETIC_TOOL_DEFINITIONS, EVAL_SYNTHETIC_TOOL_SERVER, get_eval_synthetic_tool_definition, get_eval_synthetic_tool_fallback_result, is_eval_synthetic_tool_name
 from .python_exec import get_python_exec_tool
@@ -99,6 +105,18 @@ DISCORD_CHANNEL_SUBSCRIPTIONS_TOOL_NAME = "discord_channel_subscriptions"
 DISCORD_ADD_REACTION_TOOL_NAME = "add_discord_reaction"
 DISCORD_SEND_MESSAGE_TOOL_NAME = "send_discord_message"
 PIPEDREAM_TOOL_SERVER_NAME = "pipedream"
+CUSTOM_TOOL_RESULT_CONTRACT = (
+    " Call alone when this result governs later sends. Treat returned side_effects and next_action as authoritative; "
+    "if requested delivery is already sent and remaining_work is zero, stop without a recap or receipt."
+)
+
+
+def _custom_tool_description_for_llm(tool_name: str, description: str) -> str:
+    if not tool_name.startswith(CUSTOM_TOOL_PREFIX):
+        return description
+    return f"{description.rstrip()}{CUSTOM_TOOL_RESULT_CONTRACT}"
+
+
 DEFAULT_BUILTIN_TOOLS = {
     READ_FILE_TOOL_NAME,
     SQLITE_TOOL_NAME,
@@ -492,7 +510,7 @@ def get_available_custom_tool_entries(
         catalog[tool.tool_name] = ToolCatalogEntry(
             provider="custom",
             full_name=tool.tool_name,
-            description=tool.description,
+            description=_custom_tool_description_for_llm(tool.tool_name, tool.description),
             parameters=_custom_tool_parameters_for_llm(tool.parameters_schema),
             tool_server="custom",
             tool_name=tool.tool_name,
@@ -1230,7 +1248,10 @@ def get_enabled_tool_definitions(agent: PersistentAgent) -> List[Dict[str, Any]]
                     "type": "function",
                     "function": {
                         "name": tool.tool_name,
-                        "description": tool.description,
+                        "description": _custom_tool_description_for_llm(
+                            tool.tool_name,
+                            tool.description,
+                        ),
                         "parameters": _custom_tool_parameters_for_llm(tool.parameters_schema),
                     },
                 }
@@ -1243,6 +1264,12 @@ def get_enabled_tool_definitions(agent: PersistentAgent) -> List[Dict[str, Any]]
         tool_def = get_eval_synthetic_tool_definition(agent, tool_name)
         if not tool_def:
             continue
+        function = tool_def.get("function")
+        if isinstance(function, dict):
+            function["description"] = _custom_tool_description_for_llm(
+                tool_name,
+                str(function.get("description") or ""),
+            )
         definitions.append(_sanitize_tool_definition_for_llm(tool_def))
         existing_names.add(tool_name)
 

--- a/api/evals/loader.py
+++ b/api/evals/loader.py
@@ -5,6 +5,10 @@ from api.evals.scenarios import * # noqa
 from api.evals.scenarios.behavior_micro import BEHAVIOR_MICRO_SCENARIO_SLUGS, CHARTER_MEMORY_MICRO_SCENARIO_SLUGS, GUIDED_PLANNING_MICRO_SCENARIO_SLUGS, TOOL_CHOICE_MICRO_SCENARIO_SLUGS
 from api.evals.scenarios.effort_calibration import EFFORT_CALIBRATION_SCENARIO_SLUGS
 from api.evals.scenarios.custom_tool_result_contract import CUSTOM_TOOL_RESULT_CONTRACT_SCENARIO_SLUGS, CUSTOM_TOOL_RESULT_CONTRACT_SUITE_SLUG
+from api.evals.scenarios.notification_terminality import (
+    NOTIFICATION_TERMINALITY_SCENARIO_SLUGS,
+    NOTIFICATION_TERMINALITY_SUITE_SLUG,
+)
 from api.evals.scenarios.daily_credit_prompt import DAILY_CREDIT_PROMPT_SCENARIO_SLUGS, DAILY_CREDIT_PROMPT_SUITE_SLUG
 from api.evals.scenarios.sqlite_tool_results import SQLITE_TOOL_RESULT_SCENARIO_SLUGS, SQLITE_TOOL_RESULT_SUITE_SLUG
 from api.evals.scenarios.message_quality import MESSAGE_QUALITY_SCENARIO_SLUGS, MESSAGE_QUALITY_SUITE_SLUG
@@ -117,6 +121,11 @@ register_builtin_suites(
             slug=CUSTOM_TOOL_RESULT_CONTRACT_SUITE_SLUG,
             description="Small custom-tool result contract evals based on real agent trajectory failures.",
             scenario_slugs=CUSTOM_TOOL_RESULT_CONTRACT_SCENARIO_SLUGS,
+        ),
+        EvalSuite(
+            slug=NOTIFICATION_TERMINALITY_SUITE_SLUG,
+            description="Custom-tool side-effect terminality and required-notification sequencing.",
+            scenario_slugs=NOTIFICATION_TERMINALITY_SCENARIO_SLUGS,
         ),
         EvalSuite(
             slug=DAILY_CREDIT_PROMPT_SUITE_SLUG,

--- a/api/evals/scenarios/__init__.py
+++ b/api/evals/scenarios/__init__.py
@@ -55,6 +55,11 @@ from .effort_calibration import (
     EffortExplicitDeepResearchRemainsCapableScenario,
 )
 from .custom_tool_result_contract import CUSTOM_TOOL_RESULT_CONTRACT_SCENARIO_SLUGS, CUSTOM_TOOL_RESULT_CONTRACT_SUITE_SLUG, CustomToolResultContractScenario
+from .notification_terminality import (
+    NOTIFICATION_TERMINALITY_SCENARIO_SLUGS,
+    NOTIFICATION_TERMINALITY_SUITE_SLUG,
+    NotificationTerminalityScenario,
+)
 from .daily_credit_prompt import (
     DAILY_CREDIT_PROMPT_SCENARIO_SLUGS,
     DAILY_CREDIT_PROMPT_SUITE_SLUG,

--- a/api/evals/scenarios/notification_terminality.py
+++ b/api/evals/scenarios/notification_terminality.py
@@ -1,0 +1,334 @@
+import json
+from dataclasses import dataclass
+
+from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
+from api.evals.base import EvalScenario, ScenarioTask
+from api.evals.execution import ScenarioExecutionTools
+from api.evals.registry import ScenarioRegistry
+from api.evals.scenarios.behavior_micro import get_tool_calls_for_run
+from api.models import (
+    CommsAllowlistEntry,
+    CommsChannel,
+    EvalRunTask,
+    PersistentAgent,
+    PersistentAgentStep,
+    PersistentAgentSystemStep,
+)
+
+
+NOTIFICATION_TERMINALITY_SUITE_SLUG = "notification_terminality"
+NOTIFICATION_TERMINALITY_COMPLETED = "notification_terminality_completed_side_effects"
+NOTIFICATION_TERMINALITY_REMAINING = "notification_terminality_remaining_side_effects"
+NOTIFICATION_TERMINALITY_SCENARIO_SLUGS = (
+    NOTIFICATION_TERMINALITY_COMPLETED,
+    NOTIFICATION_TERMINALITY_REMAINING,
+)
+_WORKFLOW_TOOL = "custom_eval_incident_workflow"
+_NOTIFICATION_TOOLS = ("send_email",)
+_DEPENDENCY_HOLD_MARKER = "Tool dependency: held outbound send"
+
+
+@dataclass(frozen=True)
+class NotificationTerminalityCase:
+    slug: str
+    custom_tool_name: str
+    custom_result: dict
+    notifications_remain: bool
+
+
+_CASES = (
+    NotificationTerminalityCase(
+        slug=NOTIFICATION_TERMINALITY_COMPLETED,
+        custom_tool_name=_WORKFLOW_TOOL,
+        custom_result={
+            "status": "ok",
+            "result": {
+                "incident_id": "INC-472",
+                "side_effects": [
+                    {
+                        "action": "send_email",
+                        "status": "sent",
+                        "recipient": "engineering@example.test",
+                        "message_id": "email-inc-472",
+                    },
+                ],
+                "email_sent": True,
+                "remaining_work": 0,
+                "next_action": "Do not repeat notifications; work is complete.",
+            },
+        },
+        notifications_remain=False,
+    ),
+    NotificationTerminalityCase(
+        slug=NOTIFICATION_TERMINALITY_REMAINING,
+        custom_tool_name=_WORKFLOW_TOOL,
+        custom_result={
+            "status": "ok",
+            "result": {
+                "incident_id": "INC-472",
+                "side_effects": [
+                    {"action": "update_incident_ledger", "status": "complete"},
+                ],
+                "email_sent": False,
+                "remaining_work": 1,
+                "next_action": "Send one email notification.",
+            },
+        },
+        notifications_remain=True,
+    ),
+)
+
+
+class NotificationTerminalityScenario(EvalScenario, ScenarioExecutionTools):
+    version = "1.0"
+    description = "Custom-tool side effects must govern later outbound notifications without suppressing required sends."
+    tier = "core"
+    category = "agent_behavior"
+    expected_runtime = "medium"
+    cost_class = "medium"
+    owner = "agent-platform"
+    area = "tool_execution"
+    tags = (
+        "agent_behavior",
+        "custom_tools",
+        "notifications",
+        "pressure",
+        "side_effects",
+        "real_harness",
+    )
+    tasks = [
+        ScenarioTask(name="inject_incident", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_custom_workflow", assertion_type="tool_call"),
+        ScenarioTask(name="verify_notification_integrity", assertion_type="tool_call"),
+    ]
+    case: NotificationTerminalityCase | None = None
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        if self.case is None:
+            raise ValueError("Notification terminality eval is missing case metadata.")
+        case = self.case
+        agent = PersistentAgent.objects.get(id=agent_id)
+        agent.charter = (
+            "Own the engineering incident ledger. Use the configured incident workflow, preserve exact incident "
+            "identity, and notify the requested internal channels without duplicate deliveries."
+        )
+        agent.planning_state = PersistentAgent.PlanningState.SKIPPED
+        agent.save(update_fields=["charter", "planning_state", "updated_at"])
+        self._seed_prior_run(agent, pressured=not case.notifications_remain)
+        for tool_name in (case.custom_tool_name, *_NOTIFICATION_TOOLS):
+            mark_tool_enabled_without_discovery(agent, tool_name)
+        CommsAllowlistEntry.objects.get_or_create(
+            agent=agent,
+            channel=CommsChannel.EMAIL,
+            address="engineering@example.test",
+            defaults={"is_active": True},
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="inject_incident",
+        )
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            inbound = self.inject_message(
+                agent_id,
+                (
+                    "Handle incident INC-472 with the enabled `custom_eval_incident_workflow`, email "
+                    "`engineering@example.test`, then stop. The incident details are already complete in the "
+                    "workflow input."
+                ),
+                trigger_processing=True,
+                eval_run_id=run_id,
+                mock_config=self._mock_config(case),
+                eval_stop_policy=self._stop_policy(case),
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_incident",
+            observed_summary="Incident request was processed through the real agent loop.",
+            artifacts={"message": inbound},
+        )
+
+        calls = get_tool_calls_for_run(run_id, after=inbound.timestamp)
+        workflow_calls = [call for call in calls if call.tool_name == case.custom_tool_name]
+        workflow_ok = len(workflow_calls) == 1 and self._result_ok(workflow_calls[0].result)
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if workflow_ok else EvalRunTask.Status.FAILED,
+            task_name="verify_custom_workflow",
+            observed_summary=(
+                "Configured incident workflow ran exactly once."
+                if workflow_ok
+                else f"Expected one successful {case.custom_tool_name} call; found {len(workflow_calls)}."
+            ),
+            artifacts={"tool_calls": workflow_calls},
+        )
+
+        notification_calls = {
+            tool_name: [call for call in calls if call.tool_name == tool_name]
+            for tool_name in _NOTIFICATION_TOOLS
+        }
+        held_steps = list(
+            PersistentAgentStep.objects.filter(
+                agent_id=agent_id,
+                created_at__gte=inbound.timestamp,
+                description__startswith=_DEPENDENCY_HOLD_MARKER,
+            )
+        )
+        notification_ok, summary = self._notification_score(
+            case,
+            workflow_calls,
+            notification_calls,
+            held_steps,
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if notification_ok else EvalRunTask.Status.FAILED,
+            task_name="verify_notification_integrity",
+            observed_summary=summary,
+            artifacts={
+                "notification_calls": notification_calls,
+                "dependency_holds": held_steps,
+            },
+        )
+
+    @staticmethod
+    def _seed_prior_run(agent: PersistentAgent, *, pressured: bool) -> None:
+        if PersistentAgentSystemStep.objects.filter(
+            step__agent=agent,
+            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+        ).exists():
+            return
+        if pressured:
+            detail = (
+                "The incident ledger preserves a distinct owner, channel, severity, source, current status, "
+                "notification state, and next action. Completed notifications must not be reopened or repeated. "
+            )
+            PersistentAgentStep.objects.bulk_create(
+                [
+                    PersistentAgentStep(
+                        agent=agent,
+                        description=(
+                            f"Historical incident checkpoint {index:02d}. {detail}{detail}"
+                            f"Case key INC-{300 + index}; owner Team {index % 7}; priority {index % 4}; "
+                            f"status {'closed' if index % 3 else 'monitoring'}. {detail}{detail}"
+                        ),
+                    )
+                    for index in range(92)
+                ]
+            )
+        step = PersistentAgentStep.objects.create(agent=agent, description="Process events")
+        PersistentAgentSystemStep.objects.create(
+            step=step,
+            code=PersistentAgentSystemStep.Code.PROCESS_EVENTS,
+        )
+
+    @staticmethod
+    def _mock_config(case: NotificationTerminalityCase) -> dict:
+        return {
+            case.custom_tool_name: case.custom_result,
+            "send_email": {
+                "status": "ok",
+                "message": "Email sent.",
+                "message_id": "email-direct-inc-472",
+            },
+        }
+
+    @staticmethod
+    def _stop_policy(case: NotificationTerminalityCase) -> dict:
+        policy = {
+            "ignored_tool_names": ["update_plan", "sqlite_batch"],
+            "max_relevant_tool_calls": 8,
+        }
+        if case.notifications_remain:
+            policy["stop_when_all_seen"] = [
+                {"tool_name": case.custom_tool_name, "after_execution": True},
+                {"tool_name": "send_email", "after_execution": True},
+            ]
+        return policy
+
+    @staticmethod
+    def _result_ok(value) -> bool:
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                return False
+        return isinstance(value, dict) and str(value.get("status") or "").lower() in {"ok", "success"}
+
+    @staticmethod
+    def _completion_id(call) -> str:
+        return str(getattr(getattr(call, "step", None), "completion_id", "") or "")
+
+    @staticmethod
+    def _created_at(call):
+        return getattr(getattr(call, "step", None), "created_at", None)
+
+    @classmethod
+    def _notification_score(
+        cls,
+        case: NotificationTerminalityCase,
+        workflow_calls: list,
+        notification_calls: dict[str, list],
+        held_steps: list,
+    ) -> tuple[bool, str]:
+        if held_steps:
+            return False, f"Model preplanned {len(held_steps)} outbound send(s) before the custom result was available."
+        workflow_at = cls._created_at(workflow_calls[0]) if len(workflow_calls) == 1 else None
+        post_workflow_calls = {
+            name: [
+                call
+                for call in calls
+                if workflow_at is None
+                or cls._created_at(call) is None
+                or cls._created_at(call) >= workflow_at
+            ]
+            for name, calls in notification_calls.items()
+        }
+        counts = {name: len(calls) for name, calls in post_workflow_calls.items()}
+        if not case.notifications_remain:
+            passed = all(count == 0 for count in counts.values())
+            return (
+                passed,
+                (
+                    "Completed custom-tool notifications were not repeated."
+                    if passed
+                    else f"Completed notifications were repeated: {counts}."
+                ),
+            )
+
+        if len(workflow_calls) != 1 or any(counts[name] != 1 for name in _NOTIFICATION_TOOLS):
+            return False, f"Expected one workflow call and one required send per channel; found {counts}."
+        workflow_completion = cls._completion_id(workflow_calls[0])
+        send_completions = {
+            cls._completion_id(call)
+            for calls in post_workflow_calls.values()
+            for call in calls
+        }
+        separated = bool(workflow_completion) and workflow_completion not in send_completions
+        return (
+            separated,
+            (
+                "Required notifications were sent once after the custom-tool result."
+                if separated
+                else "Required notifications were preplanned in the same completion as the unresolved custom tool."
+            ),
+        )
+
+
+def _scenario_class(case: NotificationTerminalityCase):
+    class _CaseScenario(NotificationTerminalityScenario):
+        slug = case.slug
+
+    _CaseScenario.__name__ = "".join(part.title() for part in case.slug.split("_")) + "Scenario"
+    _CaseScenario.__qualname__ = _CaseScenario.__name__
+    _CaseScenario.case = case
+    return _CaseScenario
+
+
+for notification_terminality_case in _CASES:
+    ScenarioRegistry.register(_scenario_class(notification_terminality_case)())

--- a/api/evals/tests/test_notification_terminality.py
+++ b/api/evals/tests/test_notification_terminality.py
@@ -1,0 +1,105 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase, tag
+
+import api.evals.loader  # noqa: F401
+from api.evals.scenarios.notification_terminality import (
+    NOTIFICATION_TERMINALITY_COMPLETED,
+    NOTIFICATION_TERMINALITY_REMAINING,
+    NOTIFICATION_TERMINALITY_SCENARIO_SLUGS,
+    NOTIFICATION_TERMINALITY_SUITE_SLUG,
+    NotificationTerminalityScenario,
+    _CASES,
+)
+from api.evals.suites import SuiteRegistry
+
+
+@tag("batch_event_processing")
+class NotificationTerminalityEvalTests(SimpleTestCase):
+    @staticmethod
+    def _call(name, completion_id, created_at=2):
+        return SimpleNamespace(
+            tool_name=name,
+            step=SimpleNamespace(completion_id=completion_id, created_at=created_at),
+        )
+
+    def test_suite_registers_both_regressions(self):
+        suite = SuiteRegistry.get(NOTIFICATION_TERMINALITY_SUITE_SLUG)
+
+        self.assertIsNotNone(suite)
+        self.assertEqual(tuple(suite.scenario_slugs), NOTIFICATION_TERMINALITY_SCENARIO_SLUGS)
+
+    def test_completed_side_effects_reject_direct_notification_repeats(self):
+        case = next(case for case in _CASES if case.slug == NOTIFICATION_TERMINALITY_COMPLETED)
+        workflow = [self._call(case.custom_tool_name, "completion-1")]
+        notifications = {
+            "send_email": [self._call("send_email", "completion-1")],
+        }
+
+        passed, _summary = NotificationTerminalityScenario._notification_score(
+            case, workflow, notifications, []
+        )
+
+        self.assertFalse(passed)
+
+    def test_completed_side_effects_accept_no_direct_repeats(self):
+        case = next(case for case in _CASES if case.slug == NOTIFICATION_TERMINALITY_COMPLETED)
+
+        passed, _summary = NotificationTerminalityScenario._notification_score(
+            case,
+            [self._call(case.custom_tool_name, "completion-1")],
+            {"send_email": []},
+            [],
+        )
+
+        self.assertTrue(passed)
+
+    def test_completed_side_effects_allow_kickoff_before_workflow(self):
+        case = next(case for case in _CASES if case.slug == NOTIFICATION_TERMINALITY_COMPLETED)
+
+        passed, _summary = NotificationTerminalityScenario._notification_score(
+            case,
+            [self._call(case.custom_tool_name, "completion-2", created_at=2)],
+            {
+                "send_email": [
+                    self._call("send_email", "completion-1", created_at=1)
+                ],
+            },
+            [],
+        )
+
+        self.assertTrue(passed)
+
+    def test_remaining_side_effects_require_later_completion(self):
+        case = next(case for case in _CASES if case.slug == NOTIFICATION_TERMINALITY_REMAINING)
+        workflow = [self._call(case.custom_tool_name, "completion-1")]
+        same_completion = {
+            "send_email": [self._call("send_email", "completion-1")],
+        }
+        later_completion = {
+            "send_email": [self._call("send_email", "completion-2")],
+        }
+
+        same_passed, _summary = NotificationTerminalityScenario._notification_score(
+            case, workflow, same_completion, []
+        )
+        later_passed, _summary = NotificationTerminalityScenario._notification_score(
+            case, workflow, later_completion, []
+        )
+
+        self.assertFalse(same_passed)
+        self.assertTrue(later_passed)
+
+    def test_dependency_hold_is_a_first_shot_failure(self):
+        case = next(case for case in _CASES if case.slug == NOTIFICATION_TERMINALITY_REMAINING)
+
+        passed, _summary = NotificationTerminalityScenario._notification_score(
+            case,
+            [self._call(case.custom_tool_name, "completion-1")],
+            {
+                "send_email": [self._call("send_email", "completion-2")],
+            },
+            [SimpleNamespace(description="Tool dependency: held outbound send")],
+        )
+
+        self.assertFalse(passed)

--- a/tests/unit/test_custom_tools.py
+++ b/tests/unit/test_custom_tools.py
@@ -46,6 +46,7 @@ from api.agent.tools.run_command import execute_run_command
 from api.agent.tools.sqlite_batch import execute_sqlite_batch
 from api.agent.tools.sqlite_state import agent_sqlite_db
 from api.agent.tools.tool_manager import (
+    _custom_tool_description_for_llm,
     enable_tools,
     execute_enabled_tool,
     get_available_tool_ids,
@@ -88,13 +89,25 @@ class CustomToolsTests(TestCase):
         quota, _ = UserQuota.objects.get_or_create(user=cls.user)
         quota.agent_limit = 100
         quota.save(update_fields=["agent_limit"])
-
         cls.browser_agent = BrowserUseAgent.objects.create(user=cls.user, name="Custom Tools Browser")
         cls.agent = PersistentAgent.objects.create(
             user=cls.user,
             name="Custom Tools Agent",
             charter="Build sandbox tools",
             browser_use_agent=cls.browser_agent,
+        )
+
+    def test_custom_tool_descriptions_expose_terminal_result_contract(self):
+        description = _custom_tool_description_for_llm(
+            "custom_publish_incident",
+            "Publish an incident.",
+        )
+
+        self.assertIn("side_effects and next_action as authoritative", description)
+        self.assertIn("stop without a recap or receipt", description)
+        self.assertEqual(
+            _custom_tool_description_for_llm("send_email", "Send email."),
+            "Send email.",
         )
 
     def _create_env_var_secret(self, key: str, value: str) -> PersistentAgentSecret:


### PR DESCRIPTION
## What changed

- Hold outbound sends planned after an unresolved custom-tool call until its result is available.
- Keep kickoff sends before the custom tool and independent non-message work unchanged.
- Put the terminal side-effect contract next to each custom tool definition and add one compact core rule.
- Add real-harness regressions for both terminal and still-required notification outcomes.

## Root cause

Production traces for #414 and #295 show `custom_routine_bug_updater`, Discord, and email emitted in one completion. Serial execution did not help: the later sends were already committed before the custom result reported both deliveries complete and said not to repeat them.

## Verification

- RED → GREEN: exact unit reproduction failed before `_partition_unresolved_custom_tool_sends` existed; 10 focused dependency/eval tests now pass.
- 37 affected unit/eval-contract tests pass after rebasing onto current main.
- DeepSeek V4 Flash: new suite passed 10/10 scenarios (30/30 tasks), then 2/2 scenarios (6/6 tasks) again on the rebased SHA.
- Prompt-size and source-LoC complexity budgets pass without budget changes.

## Honest caveat

The older `custom_tool_result_contract` authoring suite currently cannot discover `create_custom_tool` in its eval-agent catalog; the failure reproduced before this PRs changed result-description path is exercised. I did not widen this PR into that separate harness/setup defect.