### PR TITLE
Live web-chat streaming: interpolated reveal, flash-free handoff, block-memoized markdown (#510)

### DIFF
--- a/api/agent/core/web_streaming.py
+++ b/api/agent/core/web_streaming.py
@@ -54,6 +54,7 @@ class WebStreamBroadcaster:
     _finished: bool = field(default=False, init=False)
     _reasoning_buffer: list[str] = field(default_factory=list, init=False)
     _content_buffer: list[str] = field(default_factory=list, init=False)
+    _content_flushed: bool = field(default=False, init=False)
 
     def start(self) -> None:
         if self._started or self._finished:
@@ -85,6 +86,7 @@ class WebStreamBroadcaster:
             payload["reasoning_delta"] = "".join(self._reasoning_buffer)
         if self._content_buffer:
             payload["content_delta"] = "".join(self._content_buffer)
+            self._content_flushed = True
 
         self._reasoning_buffer = []
         self._content_buffer = []
@@ -109,6 +111,11 @@ class WebStreamBroadcaster:
     def _should_flush(self) -> bool:
         if not self._reasoning_buffer and not self._content_buffer:
             return False
+        # The first message-content delta flushes immediately: it is the reader's first
+        # visible sign of the reply, and holding it for the batching window just delays
+        # perceived start of streaming (bug #510).
+        if self._content_buffer and not self._content_flushed:
+            return True
         buffered_chars = sum(len(part) for part in self._reasoning_buffer) + sum(len(part) for part in self._content_buffer)
         if buffered_chars >= self.max_buffer_chars:
             return True

--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -888,7 +888,13 @@ export function AgentChatLayout({
   const hasStreamingContent = Boolean(streaming?.content?.trim())
   // Un-suppress the static thinking entry once streaming completes so it appears in its chronological position
   const suppressedThinkingCursor = streaming && !streaming.done ? streaming.cursor ?? null : null
-  const showStreamingSlot = hasStreamingContent && isStreaming
+  // The slot must survive `done`: the reveal animation may still be catching up, and the
+  // card owns the content until the persisted message is rendered (bug #510 — hiding at
+  // done gave the card ~150ms of life when providers burst the whole body at the end).
+  const streamAwaitingHandoff = Boolean(
+    streaming?.done && streaming.source !== 'timeline' && streaming.content?.trim(),
+  )
+  const showStreamingSlot = hasStreamingContent && (isStreaming || streamAwaitingHandoff)
   const showStreamingThinking = Boolean(
     isStreaming && streaming?.reasoning?.trim() && !hasStreamingContent && !hasMoreNewer,
   )

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, type Ref } from 'react'
+import { memo, useCallback, useEffect, useMemo, type Ref } from 'react'
 import { Loader2 } from 'lucide-react'
 import { TimelineEventItem } from './TimelineEventItem'
 import { StreamingReplyCard } from './StreamingReplyCard'
@@ -13,7 +13,7 @@ import type { SimplifiedTimelineItem } from '../../hooks/useSimplifiedTimeline'
 import type { TemplateRecommendation } from '../../api/agentSpawnIntent'
 import type { AgentMessage } from '../../types/agentChat'
 import type { StatusExpansionTargets } from './statusExpansion'
-import { chatActions, selectActiveChatSession } from '../../store/chatSlice'
+import { chatActions, selectActiveChatAgentId, selectActiveChatSession } from '../../store/chatSlice'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
 import { selectImmersiveShellViewer } from '../../store/immersiveShellSlice'
 
@@ -169,6 +169,29 @@ export const AgentTimelinePane = memo(function AgentTimelinePane({
     [dispatch],
   )
   const streaming = activeSession.stream.streaming
+  const activeAgentId = useAppSelector(selectActiveChatAgentId)
+  // The stream card owns the reply until its reveal catches up; the persisted message it
+  // became stays suppressed here so the swap happens in one commit with no double render
+  // and no blank frame (bug #510).
+  const streamHandoffMessageId = streaming?.source !== 'timeline' ? streaming?.handoffMessageId ?? null : null
+  const streamHandoffMessageRendered = useMemo(
+    () => Boolean(streamHandoffMessageId) && events.some(
+      (event) => event.kind === 'message' && event.message?.id === streamHandoffMessageId,
+    ),
+    [events, streamHandoffMessageId],
+  )
+  // A stream that finished but whose send never produced a message (tool failure, missed
+  // socket frame) must not pin the card forever; the refetched timeline is authoritative.
+  useEffect(() => {
+    if (!streaming?.done || streaming.source === 'timeline' || !streaming.content || streaming.handoffMessageId || !activeAgentId) {
+      return
+    }
+    const streamId = streaming.streamId
+    const timer = window.setTimeout(() => {
+      dispatch(chatActions.streamHandedOff({ agentId: activeAgentId, streamId }))
+    }, 10_000)
+    return () => window.clearTimeout(timer)
+  }, [activeAgentId, dispatch, streaming?.content, streaming?.done, streaming?.handoffMessageId, streaming?.source, streaming?.streamId])
   const viewer = useAppSelector(selectImmersiveShellViewer)
   const agentFirstName = deriveAgentFirstName(agentName)
   const viewerEmail = viewer.email
@@ -211,6 +234,9 @@ export const AgentTimelinePane = memo(function AgentTimelinePane({
                 </div>
               ) : events.map((event, index) => {
                 if (event.kind === 'plan' || event.kind === 'kanban') {
+                  return null
+                }
+                if (streamHandoffMessageId && event.kind === 'message' && event.message?.id === streamHandoffMessageId) {
                   return null
                 }
                 return (
@@ -306,6 +332,10 @@ export const AgentTimelinePane = memo(function AgentTimelinePane({
                       agentFirstName={agentFirstName}
                       agentAvatarUrl={agentAvatarUrl}
                       isStreaming={isStreaming}
+                      done={Boolean(streaming?.done)}
+                      streamId={streaming?.streamId ?? null}
+                      agentId={activeAgentId}
+                      handoffReady={streamHandoffMessageRendered}
                       onLinkClick={onMessageLinkClick}
                     />
                   ) : null}

--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -174,6 +174,9 @@ export const AgentTimelinePane = memo(function AgentTimelinePane({
   // became stays suppressed here so the swap happens in one commit with no double render
   // and no blank frame (bug #510).
   const streamHandoffMessageId = streaming?.source !== 'timeline' ? streaming?.handoffMessageId ?? null : null
+  // After the swap, the message this stream became must not replay its fast-reveal
+  // entrance — its content has been on screen for seconds (bug #510 polish).
+  const streamedMessageId = streamHandoffMessageId ?? activeSession.stream.lastHandoffMessageId
   const streamHandoffMessageRendered = useMemo(
     () => Boolean(streamHandoffMessageId) && events.some(
       (event) => event.kind === 'message' && event.message?.id === streamHandoffMessageId,
@@ -251,6 +254,7 @@ export const AgentTimelinePane = memo(function AgentTimelinePane({
                     <TimelineEventItem
                       event={event}
                       isLatestEvent={index === lastRenderedIndex}
+                      streamedMessageId={streamedMessageId}
                       agentFirstName={agentFirstName}
                       agentAvatarUrl={agentAvatarUrl}
                       viewerUserId={viewerUserId ?? null}

--- a/frontend/src/components/agentChat/MessageEventCard.tsx
+++ b/frontend/src/components/agentChat/MessageEventCard.tsx
@@ -58,6 +58,8 @@ type MessageEventCardProps = {
   onMessageLinkClick?: (href: string) => boolean | void
   onReportMessage?: (message: AgentMessage) => void
   onRetryMessage?: (message: AgentMessage) => void | Promise<void>
+  /** Content was already revealed by the stream card; render instantly (bug #510). */
+  disableFastReveal?: boolean
 }
 
 // Only animate messages that arrived recently (within last 3 seconds)
@@ -106,11 +108,12 @@ export const MessageEventCard = memo(function MessageEventCard({
   onMessageLinkClick,
   onReportMessage,
   onRetryMessage,
+  disableFastReveal = false,
 }: MessageEventCardProps) {
   const [copied, setCopied] = useState(false)
   const [retrying, setRetrying] = useState(false)
   const isAgent = Boolean(message.isOutbound)
-  const shouldAnimate = isAgent && isRecentMessage(message.timestamp)
+  const shouldAnimate = isAgent && !disableFastReveal && isRecentMessage(message.timestamp)
   const channel = (message.channel || 'web').toLowerCase()
   const sourceKind = (message.sourceKind || '').toLowerCase()
   const isWebhook = sourceKind === 'webhook'

--- a/frontend/src/components/agentChat/StreamingReplyCard.test.tsx
+++ b/frontend/src/components/agentChat/StreamingReplyCard.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * #510: the card owns the reply until the reveal catches up AND the persisted message is
+ * rendered, then swaps in one commit via streamHandedOff. (Reduced motion is forced so
+ * the reveal completes instantly and the swap conditions are deterministic.)
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StreamingReplyCard } from './StreamingReplyCard'
+import { chatActions, receiveStreamEvent, selectActiveChatSession } from '../../store/chatSlice'
+import { createTestAppStore, StoreProvider } from '../../test/storeTestUtils'
+
+const AGENT = 'agent-510'
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes('prefers-reduced-motion'),
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }))
+})
+
+function renderCard(store: ReturnType<typeof createTestAppStore>, props: Partial<Parameters<typeof StreamingReplyCard>[0]> = {}) {
+  return render(
+    <StoreProvider store={store}>
+      <StreamingReplyCard
+        content="The reply text."
+        agentFirstName="Scout"
+        isStreaming={false}
+        done
+        streamId="s1"
+        agentId={AGENT}
+        handoffReady={false}
+        {...props}
+      />
+    </StoreProvider>,
+  )
+}
+
+function storeWithStream() {
+  const store = createTestAppStore()
+  store.dispatch(chatActions.agentSelected({ agentId: AGENT }))
+  store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'start' }))
+  store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'delta', content_delta: 'The reply text.' }))
+  store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'done' }))
+  return store
+}
+
+describe('StreamingReplyCard handoff (#510)', () => {
+  it('renders the content and holds the stream while the message is not yet rendered', () => {
+    const store = storeWithStream()
+    renderCard(store, { handoffReady: false })
+
+    expect(screen.getByText('The reply text.')).toBeInTheDocument()
+    expect(selectActiveChatSession(store.getState()).stream.streaming).not.toBeNull()
+  })
+
+  it('dispatches the swap once done + reveal complete + message rendered', async () => {
+    const store = storeWithStream()
+    renderCard(store, { handoffReady: true })
+
+    await waitFor(() => {
+      expect(selectActiveChatSession(store.getState()).stream.streaming).toBeNull()
+    })
+  })
+
+  it('does not swap while the stream is still open', () => {
+    const store = createTestAppStore()
+    store.dispatch(chatActions.agentSelected({ agentId: AGENT }))
+    store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'start' }))
+    store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'delta', content_delta: 'The reply text.' }))
+    renderCard(store, { isStreaming: true, done: false, handoffReady: true })
+
+    expect(selectActiveChatSession(store.getState()).stream.streaming).not.toBeNull()
+  })
+})

--- a/frontend/src/components/agentChat/StreamingReplyCard.tsx
+++ b/frontend/src/components/agentChat/StreamingReplyCard.tsx
@@ -4,6 +4,9 @@ import { MarkdownViewer } from '../common/MarkdownViewer'
 import { AgentAvatarBadge } from '../common/AgentAvatarBadge'
 import { looksLikeHtml, sanitizeHtml, stripBlockquoteQuotes } from '../../util/sanitize'
 import { useTypewriter } from '../../hooks/useTypewriter'
+import { chatActions } from '../../store/chatSlice'
+import { useAppDispatch } from '../../store/hooks'
+import { repairUnclosedFence, splitMarkdownBlocks } from './streamingMarkdownBlocks'
 
 const COMMIT_INTERVAL_MS = 150
 
@@ -11,17 +14,25 @@ type StreamingReplyCardProps = {
   content: string
   agentFirstName: string
   agentAvatarUrl?: string | null
+  /** More content may still arrive. */
   isStreaming: boolean
+  /** The stream finished; the card may still be revealing and awaiting handoff. */
+  done?: boolean
+  streamId?: string | null
+  agentId?: string | null
+  /** The persisted message this stream became is rendered (suppressed) in the timeline;
+   *  once the reveal catches up the card dispatches the one-commit swap (bug #510). */
+  handoffReady?: boolean
   onLinkClick?: (href: string) => boolean | void
 }
 
 /**
- * During active streaming, split the content into a "committed" portion
- * (rendered through expensive MarkdownViewer at ~7 Hz) and a plain-text
- * "tail" (rendered as a cheap <span>, updated every frame).
- * This prevents markdown re-parsing on every character arrival.
+ * While text is revealing, split it into markdown "committed" text (re-committed at ~7 Hz)
+ * and a plain-text tail span updated every animation frame — the parser never runs at
+ * frame rate, and committed text is further split into blocks so completed blocks are
+ * never re-parsed at all.
  */
-function useThrottledMarkdown(content: string, isStreaming: boolean) {
+function useThrottledMarkdown(content: string, revealing: boolean) {
   const [committedMarkdown, setCommittedMarkdown] = useState(content)
   const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const contentRef = useRef(content)
@@ -33,8 +44,7 @@ function useThrottledMarkdown(content: string, isStreaming: boolean) {
   }, [])
 
   useEffect(() => {
-    if (!isStreaming) {
-      // Streaming ended — final commit of the complete content.
+    if (!revealing) {
       if (commitTimerRef.current !== null) {
         clearTimeout(commitTimerRef.current)
         commitTimerRef.current = null
@@ -42,26 +52,22 @@ function useThrottledMarkdown(content: string, isStreaming: boolean) {
       setCommittedMarkdown(content)
       return
     }
-
-    // Schedule the next commit if one isn't already pending.
     if (commitTimerRef.current === null) {
       commitTimerRef.current = setTimeout(commit, COMMIT_INTERVAL_MS)
     }
-
     return () => {
       if (commitTimerRef.current !== null) {
         clearTimeout(commitTimerRef.current)
         commitTimerRef.current = null
       }
     }
-  }, [content, isStreaming, commit])
+  }, [content, revealing, commit])
 
-  // The tail is the text received since the last commit.
-  const tailText = isStreaming && content.length > committedMarkdown.length
+  const tailText = revealing && content.length > committedMarkdown.length
     ? content.slice(committedMarkdown.length)
     : ''
 
-  return { committedMarkdown, tailText }
+  return { committedMarkdown: revealing ? committedMarkdown : content, tailText }
 }
 
 function shouldInterceptLinkClick(event: ReactMouseEvent<HTMLElement>): boolean {
@@ -78,66 +84,83 @@ export function StreamingReplyCard({
   agentFirstName,
   agentAvatarUrl,
   isStreaming,
+  done = false,
+  streamId = null,
+  agentId = null,
+  handoffReady = false,
   onLinkClick,
 }: StreamingReplyCardProps) {
-  // Typewriter for non-streaming reveal of completed messages.
-  const { displayedContent, isWaiting } = useTypewriter(content, isStreaming, {
+  const dispatch = useAppDispatch()
+
+  // One reveal path for every arrival pattern: providers may stream the body
+  // incrementally or burst it whole at the end (tool-call arguments often arrive as one
+  // chunk) — the typewriter decouples what the user sees from how the network delivered
+  // it, and accelerates to finish once the stream is done.
+  const { displayedContent, isWaiting } = useTypewriter(content, isStreaming && !done, {
     charsPerFrame: 3,
     frameIntervalMs: 12,
     waitingThresholdMs: 200,
+    finishBoost: 4,
   })
 
-  // Throttled markdown for active streaming — avoids full re-parse each frame.
-  const { committedMarkdown, tailText } = useThrottledMarkdown(content, isStreaming)
-
-  // During streaming, use raw content for presence checks; otherwise use typewriter output.
-  const effectiveContent = isStreaming ? content : displayedContent
-  const hasContent = effectiveContent.trim().length > 0
+  const hasContent = displayedContent.trim().length > 0 || content.trim().length > 0
 
   const hasHtmlPrefix = useMemo(() => {
-    const trimmed = effectiveContent.trimStart()
+    const trimmed = content.trimStart()
     if (!trimmed.startsWith('<')) {
       return false
     }
-    const nextChar = trimmed.charAt(1)
-    return /[a-zA-Z!?\/]/.test(nextChar)
-  }, [effectiveContent])
+    return /[a-zA-Z!?\/]/.test(trimmed.charAt(1))
+  }, [content])
+  const shouldRenderHtml = hasContent && (looksLikeHtml(content) || hasHtmlPrefix)
 
-  const shouldRenderHtml = hasContent && (looksLikeHtml(effectiveContent) || (isStreaming && hasHtmlPrefix))
+  const revealComplete = shouldRenderHtml || displayedContent.length >= content.length
 
-  // Strip redundant quotes from blockquotes (e.g., > "text" → > text)
-  const normalizedContent = useMemo(
-    () => stripBlockquoteQuotes(isStreaming ? committedMarkdown : displayedContent),
-    [isStreaming, committedMarkdown, displayedContent],
+  // The swap: reveal caught up + persisted message rendered (suppressed) → clear the
+  // stream. The suppression lifts and this card unmounts in the same reducer commit, so
+  // the reply never flashes or double-renders.
+  useEffect(() => {
+    if (done && handoffReady && revealComplete && streamId && agentId) {
+      dispatch(chatActions.streamHandedOff({ agentId, streamId }))
+    }
+  }, [agentId, dispatch, done, handoffReady, revealComplete, streamId])
+
+  const revealing = !revealComplete
+  const { committedMarkdown, tailText } = useThrottledMarkdown(displayedContent, revealing)
+
+  const normalizedCommitted = useMemo(
+    () => stripBlockquoteQuotes(committedMarkdown),
+    [committedMarkdown],
   )
+
+  // Completed blocks are stable strings — MarkdownViewer is memoized on content, so only
+  // the growing tail block ever re-parses (and only at commit cadence, not frame rate).
+  const blocks = useMemo(() => splitMarkdownBlocks(normalizedCommitted), [normalizedCommitted])
+  const lastBlockIndex = blocks.length - 1
 
   const htmlContent = useMemo(() => {
     if (!shouldRenderHtml) {
       return null
     }
-    return sanitizeHtml(isStreaming ? content : normalizedContent)
-  }, [isStreaming, content, normalizedContent, shouldRenderHtml])
+    return sanitizeHtml(content)
+  }, [content, shouldRenderHtml])
 
   const handleContentClick = useCallback((event: ReactMouseEvent<HTMLElement>) => {
     if (!onLinkClick || !shouldInterceptLinkClick(event)) {
       return
     }
-
     const target = event.target
     if (!(target instanceof Element)) {
       return
     }
-
     const anchor = target.closest('a[href]')
     if (!(anchor instanceof HTMLAnchorElement)) {
       return
     }
-
     const href = anchor.getAttribute('href')
     if (!href) {
       return
     }
-
     if (onLinkClick(href)) {
       event.preventDefault()
     }
@@ -150,7 +173,8 @@ export function StreamingReplyCard({
   return (
     <article
       className="timeline-event chat-event is-agent streaming-reply-event"
-      data-streaming={isStreaming ? 'true' : 'false'}
+      data-streaming={isStreaming && !done ? 'true' : 'false'}
+      data-revealing={revealing ? 'true' : 'false'}
       data-waiting={isWaiting ? 'true' : 'false'}
     >
       <div className="chat-bubble chat-bubble--agent streaming-reply-bubble">
@@ -169,7 +193,13 @@ export function StreamingReplyCard({
             <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
           ) : (
             <>
-              <MarkdownViewer content={normalizedContent} enableHighlight={!isStreaming} />
+              {blocks.map((block, index) => (
+                <MarkdownViewer
+                  key={`block-${index}`}
+                  content={index === lastBlockIndex && revealing ? repairUnclosedFence(block) : block}
+                  enableHighlight={index !== lastBlockIndex || !revealing}
+                />
+              ))}
               {tailText && <span>{tailText}</span>}
             </>
           )}

--- a/frontend/src/components/agentChat/StreamingReplyCard.tsx
+++ b/frontend/src/components/agentChat/StreamingReplyCard.tsx
@@ -1,14 +1,12 @@
 import type { MouseEvent as ReactMouseEvent } from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { MarkdownViewer } from '../common/MarkdownViewer'
 import { AgentAvatarBadge } from '../common/AgentAvatarBadge'
 import { looksLikeHtml, sanitizeHtml, stripBlockquoteQuotes } from '../../util/sanitize'
 import { useTypewriter } from '../../hooks/useTypewriter'
 import { chatActions } from '../../store/chatSlice'
 import { useAppDispatch } from '../../store/hooks'
-import { repairUnclosedFence, splitMarkdownBlocks } from './streamingMarkdownBlocks'
-
-const COMMIT_INTERVAL_MS = 150
+import { repairIncompleteMarkdown, splitMarkdownBlocks } from './streamingMarkdownBlocks'
 
 type StreamingReplyCardProps = {
   content: string
@@ -24,50 +22,6 @@ type StreamingReplyCardProps = {
    *  once the reveal catches up the card dispatches the one-commit swap (bug #510). */
   handoffReady?: boolean
   onLinkClick?: (href: string) => boolean | void
-}
-
-/**
- * While text is revealing, split it into markdown "committed" text (re-committed at ~7 Hz)
- * and a plain-text tail span updated every animation frame — the parser never runs at
- * frame rate, and committed text is further split into blocks so completed blocks are
- * never re-parsed at all.
- */
-function useThrottledMarkdown(content: string, revealing: boolean) {
-  const [committedMarkdown, setCommittedMarkdown] = useState(content)
-  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const contentRef = useRef(content)
-  contentRef.current = content
-
-  const commit = useCallback(() => {
-    setCommittedMarkdown(contentRef.current)
-    commitTimerRef.current = null
-  }, [])
-
-  useEffect(() => {
-    if (!revealing) {
-      if (commitTimerRef.current !== null) {
-        clearTimeout(commitTimerRef.current)
-        commitTimerRef.current = null
-      }
-      setCommittedMarkdown(content)
-      return
-    }
-    if (commitTimerRef.current === null) {
-      commitTimerRef.current = setTimeout(commit, COMMIT_INTERVAL_MS)
-    }
-    return () => {
-      if (commitTimerRef.current !== null) {
-        clearTimeout(commitTimerRef.current)
-        commitTimerRef.current = null
-      }
-    }
-  }, [content, revealing, commit])
-
-  const tailText = revealing && content.length > committedMarkdown.length
-    ? content.slice(committedMarkdown.length)
-    : ''
-
-  return { committedMarkdown: revealing ? committedMarkdown : content, tailText }
 }
 
 function shouldInterceptLinkClick(event: ReactMouseEvent<HTMLElement>): boolean {
@@ -96,9 +50,12 @@ export function StreamingReplyCard({
   // incrementally or burst it whole at the end (tool-call arguments often arrive as one
   // chunk) — the typewriter decouples what the user sees from how the network delivered
   // it, and accelerates to finish once the stream is done.
+  // ~40fps reveal: every frame feeds the markdown renderer directly (no plain-text
+  // tail — the in-flight text must LOOK like markdown), and block memoization bounds the
+  // per-frame parse to just the growing tail block.
   const { displayedContent, isWaiting } = useTypewriter(content, isStreaming && !done, {
-    charsPerFrame: 3,
-    frameIntervalMs: 12,
+    charsPerFrame: 6,
+    frameIntervalMs: 24,
     waitingThresholdMs: 200,
     finishBoost: 4,
   })
@@ -126,16 +83,17 @@ export function StreamingReplyCard({
   }, [agentId, dispatch, done, handoffReady, revealComplete, streamId])
 
   const revealing = !revealComplete
-  const { committedMarkdown, tailText } = useThrottledMarkdown(displayedContent, revealing)
 
-  const normalizedCommitted = useMemo(
-    () => stripBlockquoteQuotes(committedMarkdown),
-    [committedMarkdown],
+  const normalizedDisplayed = useMemo(
+    () => stripBlockquoteQuotes(displayedContent),
+    [displayedContent],
   )
 
   // Completed blocks are stable strings — MarkdownViewer is memoized on content, so only
-  // the growing tail block ever re-parses (and only at commit cadence, not frame rate).
-  const blocks = useMemo(() => splitMarkdownBlocks(normalizedCommitted), [normalizedCommitted])
+  // the growing tail block re-parses each reveal frame. The tail block is repaired
+  // (fences/bold/italic/code closed, trailing half-links hidden) so the in-flight text
+  // renders as styled markdown the whole time, never as raw syntax.
+  const blocks = useMemo(() => splitMarkdownBlocks(normalizedDisplayed), [normalizedDisplayed])
   const lastBlockIndex = blocks.length - 1
 
   const htmlContent = useMemo(() => {
@@ -196,11 +154,10 @@ export function StreamingReplyCard({
               {blocks.map((block, index) => (
                 <MarkdownViewer
                   key={`block-${index}`}
-                  content={index === lastBlockIndex && revealing ? repairUnclosedFence(block) : block}
+                  content={index === lastBlockIndex && revealing ? repairIncompleteMarkdown(block) : block}
                   enableHighlight={index !== lastBlockIndex || !revealing}
                 />
               ))}
-              {tailText && <span>{tailText}</span>}
             </>
           )}
         </div>

--- a/frontend/src/components/agentChat/TimelineEventItem.tsx
+++ b/frontend/src/components/agentChat/TimelineEventItem.tsx
@@ -24,6 +24,9 @@ type TimelineEventItemProps = {
   suppressedThinkingCursor?: string | null
   statusExpansionTargets?: StatusExpansionTargets
   animateIncoming?: boolean
+  /** Message id whose content was already revealed by the stream card — its card must
+   *  render instantly, without the fast-reveal entrance (bug #510 polish). */
+  streamedMessageId?: string | null
   onIncomingAnimationConsumed?: (cursor: string) => void
   onMessageLinkClick?: (href: string) => boolean | void
   onReportMessage?: (message: AgentMessage) => void
@@ -40,6 +43,7 @@ export const TimelineEventItem = memo(function TimelineEventItem({
   suppressedThinkingCursor,
   statusExpansionTargets,
   animateIncoming = false,
+  streamedMessageId = null,
   onIncomingAnimationConsumed,
   onMessageLinkClick,
   onReportMessage,
@@ -85,6 +89,7 @@ export const TimelineEventItem = memo(function TimelineEventItem({
         eventCursor={event.cursor}
         agentId={activeAgentId}
         message={event.message}
+        disableFastReveal={event.message.id === streamedMessageId}
         agentFirstName={agentFirstName}
         agentAvatarUrl={agentAvatarUrl}
         viewerUserId={viewerUserId ?? null}

--- a/frontend/src/components/agentChat/streamingMarkdownBlocks.test.ts
+++ b/frontend/src/components/agentChat/streamingMarkdownBlocks.test.ts
@@ -68,9 +68,31 @@ describe('repairIncompleteMarkdown', () => {
     expect(repairIncompleteMarkdown('was ~~wro')).toBe('was ~~wro~~')
   })
 
-  it('hides a trailing incomplete link rather than fabricating a URL', () => {
-    expect(repairIncompleteMarkdown('see [the docs](https://exa')).toBe('see ')
-    expect(repairIncompleteMarkdown('see [the do')).toBe('see ')
+  it('renders an incomplete link as its text, never a fabricated URL', () => {
+    expect(repairIncompleteMarkdown('see [the docs](https://exa')).toBe('see the docs')
+    expect(repairIncompleteMarkdown('see [the do')).toBe('see the do')
+  })
+
+  it('drops an incomplete image entirely', () => {
+    expect(repairIncompleteMarkdown('shot: ![diagram](https://exa')).toBe('shot: ')
+    expect(repairIncompleteMarkdown('shot: ![diagr')).toBe('shot: ')
+  })
+
+  it('hides a trailing half-typed html tag', () => {
+    expect(repairIncompleteMarkdown('line break <br')).toBe('line break ')
+  })
+
+  it('neutralizes a nascent setext underline so the paragraph does not flash as a heading', () => {
+    expect(repairIncompleteMarkdown('Some paragraph\n-')).toBe('Some paragraph\n-\u200B')
+    expect(repairIncompleteMarkdown('Some paragraph\n=')).toBe('Some paragraph\n=\u200B')
+  })
+
+  it('leaves a bare trailing opener literal until content follows', () => {
+    expect(repairIncompleteMarkdown('ends with **')).toBe('ends with **')
+  })
+
+  it('completes a half-complete bold closer with one star, not a pair', () => {
+    expect(repairIncompleteMarkdown('a **bold thing*')).toBe('a **bold thing**')
   })
 
   it('leaves complete links alone', () => {

--- a/frontend/src/components/agentChat/streamingMarkdownBlocks.test.ts
+++ b/frontend/src/components/agentChat/streamingMarkdownBlocks.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { repairUnclosedFence, splitMarkdownBlocks } from './streamingMarkdownBlocks'
+
+describe('splitMarkdownBlocks', () => {
+  it('splits on blank lines', () => {
+    expect(splitMarkdownBlocks('para one\n\npara two\n\npara three')).toEqual([
+      'para one',
+      'para two',
+      'para three',
+    ])
+  })
+
+  it('keeps blank lines inside code fences in one block', () => {
+    const text = 'intro\n\n```python\ndef f():\n\n    return 1\n```\n\noutro'
+    expect(splitMarkdownBlocks(text)).toEqual([
+      'intro',
+      '```python\ndef f():\n\n    return 1\n```',
+      'outro',
+    ])
+  })
+
+  it('is append-stable: earlier blocks do not change as text grows', () => {
+    const first = splitMarkdownBlocks('alpha\n\nbeta gro')
+    const second = splitMarkdownBlocks('alpha\n\nbeta grown longer\n\ngamma')
+    expect(second[0]).toBe(first[0])
+    expect(second).toHaveLength(3)
+  })
+
+  it('handles empty and whitespace-only input', () => {
+    expect(splitMarkdownBlocks('')).toEqual([])
+    expect(splitMarkdownBlocks('\n\n')).toEqual([])
+  })
+})
+
+describe('repairUnclosedFence', () => {
+  it('closes an unclosed fence so the tail never renders as runaway code', () => {
+    expect(repairUnclosedFence('```js\nconst a = 1')).toBe('```js\nconst a = 1\n```')
+  })
+
+  it('leaves balanced fences alone', () => {
+    const block = '```js\nconst a = 1\n```'
+    expect(repairUnclosedFence(block)).toBe(block)
+  })
+
+  it('matches the fence token style', () => {
+    expect(repairUnclosedFence('~~~\ntext')).toBe('~~~\ntext\n~~~')
+  })
+
+  it('leaves plain text untouched', () => {
+    expect(repairUnclosedFence('just words **bold')).toBe('just words **bold')
+  })
+})

--- a/frontend/src/components/agentChat/streamingMarkdownBlocks.test.ts
+++ b/frontend/src/components/agentChat/streamingMarkdownBlocks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { repairUnclosedFence, splitMarkdownBlocks } from './streamingMarkdownBlocks'
+import { repairIncompleteMarkdown, repairUnclosedFence, splitMarkdownBlocks } from './streamingMarkdownBlocks'
 
 describe('splitMarkdownBlocks', () => {
   it('splits on blank lines', () => {
@@ -49,5 +49,51 @@ describe('repairUnclosedFence', () => {
 
   it('leaves plain text untouched', () => {
     expect(repairUnclosedFence('just words **bold')).toBe('just words **bold')
+  })
+})
+
+// The in-flight tail block must render as styled markdown, never as raw half-typed
+// syntax (#510 follow-up).
+describe('repairIncompleteMarkdown', () => {
+  it('closes unfinished bold so styling applies mid-word', () => {
+    expect(repairIncompleteMarkdown('This is **very import')).toBe('This is **very import**')
+  })
+
+  it('closes unfinished italic and inline code', () => {
+    expect(repairIncompleteMarkdown('some *empha')).toBe('some *empha*')
+    expect(repairIncompleteMarkdown('run `npm insta')).toBe('run `npm insta`')
+  })
+
+  it('closes strikethrough', () => {
+    expect(repairIncompleteMarkdown('was ~~wro')).toBe('was ~~wro~~')
+  })
+
+  it('hides a trailing incomplete link rather than fabricating a URL', () => {
+    expect(repairIncompleteMarkdown('see [the docs](https://exa')).toBe('see ')
+    expect(repairIncompleteMarkdown('see [the do')).toBe('see ')
+  })
+
+  it('leaves complete links alone', () => {
+    const text = 'see [docs](https://example.com) for more'
+    expect(repairIncompleteMarkdown(text)).toBe(text)
+  })
+
+  it('closes an open code fence and repairs nothing inside it', () => {
+    expect(repairIncompleteMarkdown('```py\nx = "**bold** is code')).toBe('```py\nx = "**bold** is code\n```')
+  })
+
+  it('does not treat list bullets as emphasis', () => {
+    const text = '* first item\n* second ite'
+    expect(repairIncompleteMarkdown(text)).toBe(text)
+  })
+
+  it('does not treat snake_case as italic', () => {
+    const text = 'call send_chat_message now'
+    expect(repairIncompleteMarkdown(text)).toBe(text)
+  })
+
+  it('leaves balanced text untouched', () => {
+    const text = 'A **bold** and *italic* and `code` sentence.'
+    expect(repairIncompleteMarkdown(text)).toBe(text)
   })
 })

--- a/frontend/src/components/agentChat/streamingMarkdownBlocks.ts
+++ b/frontend/src/components/agentChat/streamingMarkdownBlocks.ts
@@ -67,3 +67,100 @@ export function repairUnclosedFence(block: string): string {
   }
   return inFence ? `${block}\n${fenceToken}` : block
 }
+
+/**
+ * Make an in-flight block render as styled markdown rather than showing raw half-typed
+ * syntax (bug #510 follow-up: the tail must be *markdown*, not plain text). Closes
+ * constructs whose meaning is already known (fences, bold, italic, inline code,
+ * strikethrough) and hides a trailing incomplete link/image (a fabricated URL would be
+ * wrong; the characters reappear when the construct completes). Never touches content
+ * inside code fences or inline code.
+ */
+export function repairIncompleteMarkdown(block: string): string {
+  let repaired = repairUnclosedFence(block)
+  const fenceClosed = repaired !== block
+  if (fenceClosed) {
+    // Inside a code block: fence closure is the only safe repair.
+    return repaired
+  }
+
+  // Hide a trailing incomplete link or image: "[text](url-in-progress" or "[text-in-pr"
+  repaired = repaired.replace(/!?\[[^\]]*(\]\([^)]*)?$/u, (match, _closer, offset, whole) => {
+    // Keep escaped or footnote-looking brackets intact if the bracket is escaped.
+    if (offset > 0 && whole[offset - 1] === '\\') {
+      return match
+    }
+    return ''
+  })
+
+  // Scan outside code spans and count unbalanced inline markers.
+  let inCode = false
+  let lastLineEndedInCode = false
+  let inFence = false
+  let bold = 0
+  let italicStar = 0
+  let italicUnderscore = 0
+  let strike = 0
+  const lines = repaired.split('\n')
+  for (const line of lines) {
+    if (FENCE_RE.test(line)) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) {
+      continue
+    }
+    for (let i = 0; i < line.length; i += 1) {
+      const ch = line[i]
+      if (ch === '\\') {
+        i += 1
+        continue
+      }
+      if (ch === '`') {
+        inCode = !inCode
+        continue
+      }
+      if (inCode) {
+        continue
+      }
+      if (ch === '*') {
+        if (line[i + 1] === '*') {
+          bold += 1
+          i += 1
+        } else if (!(line.slice(0, i).trim() === '' && line[i + 1] === ' ')) {
+          // A leading "* " is a list bullet, not emphasis.
+          italicStar += 1
+        }
+      } else if (ch === '~' && line[i + 1] === '~') {
+        strike += 1
+        i += 1
+      } else if (ch === '_') {
+        const prev = i > 0 ? line[i - 1] : ' '
+        const next = i + 1 < line.length ? line[i + 1] : ' '
+        // Intra-word underscores (snake_case) are not emphasis.
+        if (!/[A-Za-z0-9]/.test(prev) || !/[A-Za-z0-9]/.test(next)) {
+          italicUnderscore += 1
+        }
+      }
+    }
+    lastLineEndedInCode = inCode
+    inCode = false
+  }
+
+  if (lastLineEndedInCode) {
+    repaired += '`'
+  }
+  if (bold % 2 === 1) {
+    repaired += '**'
+  }
+  if (italicStar % 2 === 1) {
+    repaired += '*'
+  }
+  if (italicUnderscore % 2 === 1) {
+    repaired += '_'
+  }
+  if (strike % 2 === 1) {
+    repaired += '~~'
+  }
+  return repaired
+}

--- a/frontend/src/components/agentChat/streamingMarkdownBlocks.ts
+++ b/frontend/src/components/agentChat/streamingMarkdownBlocks.ts
@@ -70,39 +70,55 @@ export function repairUnclosedFence(block: string): string {
 
 /**
  * Make an in-flight block render as styled markdown rather than showing raw half-typed
- * syntax (bug #510 follow-up: the tail must be *markdown*, not plain text). Closes
- * constructs whose meaning is already known (fences, bold, italic, inline code,
- * strikethrough) and hides a trailing incomplete link/image (a fabricated URL would be
- * wrong; the characters reappear when the construct completes). Never touches content
- * inside code fences or inline code.
+ * syntax (bug #510 follow-up: the tail must be *markdown*, not plain text). Rule set
+ * follows Vercel's remend (the streamdown repair pipeline): close constructs whose
+ * meaning is already known (fences, bold, italic, inline code, strikethrough — with
+ * half-complete-closer and bare-marker guards), render incomplete links as their text
+ * (never a fabricated URL), drop incomplete images and trailing half-typed HTML tags,
+ * and neutralize a nascent setext underline so the previous paragraph doesn't flash as
+ * a giant heading. Repairs apply only to the in-flight tail block; the final message
+ * always renders the raw text.
  */
 export function repairIncompleteMarkdown(block: string): string {
-  let repaired = repairUnclosedFence(block)
-  const fenceClosed = repaired !== block
-  if (fenceClosed) {
+  const fenceRepaired = repairUnclosedFence(block)
+  if (fenceRepaired !== block) {
     // Inside a code block: fence closure is the only safe repair.
-    return repaired
+    return fenceRepaired
   }
 
-  // Hide a trailing incomplete link or image: "[text](url-in-progress" or "[text-in-pr"
-  repaired = repaired.replace(/!?\[[^\]]*(\]\([^)]*)?$/u, (match, _closer, offset, whole) => {
-    // Keep escaped or footnote-looking brackets intact if the bracket is escaped.
-    if (offset > 0 && whole[offset - 1] === '\\') {
-      return match
-    }
-    return ''
-  })
+  let repaired = block
 
-  // Scan outside code spans and count unbalanced inline markers.
+  // Trailing half-typed HTML tag ("text <sp") — hide it until the '>' arrives.
+  repaired = repaired.replace(/<[a-zA-Z/][^>]*$/, '')
+
+  // Incomplete image: remove entirely (a partial URL would fire a broken request).
+  repaired = repaired.replace(/!\[[^\]]*(?:\]\([^)]*)?$/, '')
+  // Incomplete link URL: keep the text flowing, drop the link markup ("text-only" mode).
+  repaired = repaired.replace(/\[([^\]]*)\]\([^)]*$/, '$1')
+  // Incomplete link text: strip just the opening bracket.
+  repaired = repaired.replace(/(^|[^\\])\[([^\]]*)$/, '$1$2')
+
+  // A lone "-"/"=" line under a paragraph is a setext underline mid-flight: the whole
+  // previous paragraph would flash as an <h1>/<h2>. A zero-width space keeps it inert.
+  const lines = repaired.split('\n')
+  if (lines.length >= 2) {
+    const last = lines[lines.length - 1]
+    const prev = lines[lines.length - 2]
+    if (/^\s{0,3}(-{1,2}|={1,2})\s*$/.test(last) && prev.trim() !== '') {
+      repaired += '\u200B'
+    }
+  }
+
+  // Scan outside fenced code and inline code spans, counting unbalanced markers.
   let inCode = false
   let lastLineEndedInCode = false
   let inFence = false
   let bold = 0
   let italicStar = 0
   let italicUnderscore = 0
+  let underscoreDouble = 0
   let strike = 0
-  const lines = repaired.split('\n')
-  for (const line of lines) {
+  for (const line of repaired.split('\n')) {
     if (FENCE_RE.test(line)) {
       inFence = !inFence
       continue
@@ -135,10 +151,15 @@ export function repairIncompleteMarkdown(block: string): string {
         strike += 1
         i += 1
       } else if (ch === '_') {
-        const prev = i > 0 ? line[i - 1] : ' '
-        const next = i + 1 < line.length ? line[i + 1] : ' '
+        if (line[i + 1] === '_') {
+          underscoreDouble += 1
+          i += 1
+          continue
+        }
+        const prevCh = i > 0 ? line[i - 1] : ' '
+        const nextCh = i + 1 < line.length ? line[i + 1] : ' '
         // Intra-word underscores (snake_case) are not emphasis.
-        if (!/[A-Za-z0-9]/.test(prev) || !/[A-Za-z0-9]/.test(next)) {
+        if (!/[A-Za-z0-9]/.test(prevCh) || !/[A-Za-z0-9]/.test(nextCh)) {
           italicUnderscore += 1
         }
       }
@@ -150,17 +171,45 @@ export function repairIncompleteMarkdown(block: string): string {
   if (lastLineEndedInCode) {
     repaired += '`'
   }
-  if (bold % 2 === 1) {
-    repaired += '**'
+
+  // A closer is only appended when there is real content after the dangling opener —
+  // a bare trailing "**" stays literal until text follows (remend guard). Half-complete
+  // closers ("**text*", "~~text~", "__text_") get the one missing character, not a
+  // fresh pair.
+  const hasContentAfter = (marker: string): boolean => {
+    const index = repaired.lastIndexOf(marker)
+    if (index < 0) {
+      return false
+    }
+    return !/^[\s_~*`]*$/.test(repaired.slice(index + marker.length))
   }
-  if (italicStar % 2 === 1) {
+
+  if (bold % 2 === 1) {
+    if (/\*\*(?:[^*]|\*(?!\*))+\*$/.test(repaired)) {
+      repaired += '*'
+    } else if (hasContentAfter('**')) {
+      repaired += '**'
+    }
+  }
+  if (italicStar % 2 === 1 && hasContentAfter('*')) {
     repaired += '*'
   }
-  if (italicUnderscore % 2 === 1) {
+  if (underscoreDouble % 2 === 1) {
+    if (/__(?:[^_]|_(?!_))+_$/.test(repaired)) {
+      repaired += '_'
+    } else if (hasContentAfter('__')) {
+      repaired += '__'
+    }
+  }
+  if (italicUnderscore % 2 === 1 && hasContentAfter('_')) {
     repaired += '_'
   }
   if (strike % 2 === 1) {
-    repaired += '~~'
+    if (/~~(?:[^~]|~(?!~))+~$/.test(repaired)) {
+      repaired += '~'
+    } else if (hasContentAfter('~~')) {
+      repaired += '~~'
+    }
   }
   return repaired
 }

--- a/frontend/src/components/agentChat/streamingMarkdownBlocks.ts
+++ b/frontend/src/components/agentChat/streamingMarkdownBlocks.ts
@@ -1,0 +1,69 @@
+/**
+ * Block splitting for streamed markdown (bug #510).
+ *
+ * Rendering the whole accumulated markdown on every commit re-parses everything the user
+ * has already read. Split on blank lines (outside fenced code) instead: completed blocks
+ * are stable strings, so a memoized renderer skips them entirely and only the growing
+ * tail block ever re-parses. (The pattern and its measured ~2.3x win come from the AI SDK
+ * memoization cookbook and LibreChat's streaming renderer.)
+ */
+
+const FENCE_RE = /^(\s*)(```|~~~)/
+
+export function splitMarkdownBlocks(text: string): string[] {
+  if (!text) {
+    return []
+  }
+  const lines = text.split('\n')
+  const blocks: string[] = []
+  let current: string[] = []
+  let inFence = false
+  let fenceToken = ''
+  for (const line of lines) {
+    const fenceMatch = line.match(FENCE_RE)
+    if (fenceMatch) {
+      if (!inFence) {
+        inFence = true
+        fenceToken = fenceMatch[2]
+      } else if (fenceMatch[2] === fenceToken) {
+        inFence = false
+      }
+      current.push(line)
+      continue
+    }
+    if (!inFence && line.trim() === '' && current.length > 0) {
+      blocks.push(current.join('\n'))
+      current = []
+      continue
+    }
+    if (current.length === 0 && line.trim() === '') {
+      continue
+    }
+    current.push(line)
+  }
+  if (current.length > 0) {
+    blocks.push(current.join('\n'))
+  }
+  return blocks
+}
+
+/** Close an unclosed code fence so the parser never renders the rest of a message as
+ *  code while the closing ``` is still in flight. Only ever applied to the tail block. */
+export function repairUnclosedFence(block: string): string {
+  const lines = block.split('\n')
+  let inFence = false
+  let fenceToken = ''
+  for (const line of lines) {
+    const fenceMatch = line.match(FENCE_RE)
+    if (!fenceMatch) {
+      continue
+    }
+    if (!inFence) {
+      inFence = true
+      fenceToken = fenceMatch[2]
+    } else if (fenceMatch[2] === fenceToken) {
+      inFence = false
+    }
+  }
+  return inFence ? `${block}\n${fenceToken}` : block
+}

--- a/frontend/src/hooks/useTypewriter.ts
+++ b/frontend/src/hooks/useTypewriter.ts
@@ -9,6 +9,9 @@ type TypewriterOptions = {
   waitingThresholdMs?: number
   /** Disable typewriter effect (shows content immediately) */
   disabled?: boolean
+  /** Speed multiplier applied once the stream has finished, so the tail of a
+   *  still-revealing message catches up quickly instead of typing on for seconds. */
+  finishBoost?: number
 }
 
 type TypewriterResult = {
@@ -46,6 +49,7 @@ export function useTypewriter(
     frameIntervalMs = 16,
     waitingThresholdMs = 150,
     disabled = false,
+    finishBoost = 3,
   } = options
 
   const [displayedContent, setDisplayedContent] = useState('')
@@ -120,6 +124,7 @@ export function useTypewriter(
   }, [cancelAnimation])
 
   const adaptiveCharsPerFrame = getAdaptiveCharsPerFrame(charsPerFrame, targetContent.length)
+    * (isStreaming ? 1 : Math.max(1, finishBoost))
   const motionDisabled = disabled || prefersReducedMotion || !isPageVisible
 
   useEffect(() => {

--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -62,6 +62,11 @@ export type AgentChatProcessingState = {
 
 export type AgentChatStreamState = {
   streaming: StreamState | null
+  /** The persisted message a completed stream handed off to. Its content was already
+   *  revealed on screen by the stream card, so the message card must render it
+   *  instantly — replaying the fast-reveal entrance re-types the whole reply and
+   *  reads as an end-of-stream flash (bug #510 polish). */
+  lastHandoffMessageId: string | null
   streamingLastUpdatedAt: number | null
   streamingClearOnDone: boolean
   streamingThinkingCollapsed: boolean
@@ -197,6 +202,7 @@ export function createInitialSession(): AgentChatSession {
     },
     stream: {
       streaming: null,
+      lastHandoffMessageId: null,
       streamingLastUpdatedAt: null,
       streamingClearOnDone: false,
       streamingThinkingCollapsed: false,
@@ -1141,6 +1147,7 @@ const chatSlice = createSlice({
     streamHandedOff(state, action: PayloadAction<{ agentId: string; streamId: string }>) {
       const session = getSession(state, action.payload.agentId)
       if (session?.stream.streaming?.streamId === action.payload.streamId) {
+        session.stream.lastHandoffMessageId = session.stream.streaming.handoffMessageId ?? null
         session.stream.streaming = null
         session.stream.streamingClearOnDone = false
         session.stream.streamingLastUpdatedAt = Date.now()

--- a/frontend/src/store/chatSlice.ts
+++ b/frontend/src/store/chatSlice.ts
@@ -1072,7 +1072,22 @@ const chatSlice = createSlice({
         session.stream.streamingClearOnDone = false
       }
       if (isOutboundMessage) {
-        session.stream.streaming = null
+        // Don't tear the stream card down here: this reducer commit removes the card but
+        // the message paints in a later commit (cache injection is a separate dispatch),
+        // leaving a blank flash (bug #510). Record the handoff instead — the page clears
+        // the stream once the message is rendered and the reveal has caught up. Streams
+        // without content have nothing to hand off; clear those immediately as before.
+        if (session.stream.streaming?.source === 'stream' && session.stream.streaming.content.trim()) {
+          if (!session.stream.streaming.handoffMessageId) {
+            session.stream.streaming = {
+              ...session.stream.streaming,
+              done: true,
+              handoffMessageId: normalized.message.id,
+            }
+          }
+        } else {
+          session.stream.streaming = null
+        }
         session.stream.streamingClearOnDone = false
       }
       if (normalized.kind === 'thinking' || normalized.kind === 'steps' || isOutboundMessage) {
@@ -1121,6 +1136,14 @@ const chatSlice = createSlice({
       const until = Date.now() + Math.max(0, action.payload.durationMs)
       if (!session.timelineUi.autoScrollPinSuppressedUntil || session.timelineUi.autoScrollPinSuppressedUntil < until) {
         session.timelineUi.autoScrollPinSuppressedUntil = until
+      }
+    },
+    streamHandedOff(state, action: PayloadAction<{ agentId: string; streamId: string }>) {
+      const session = getSession(state, action.payload.agentId)
+      if (session?.stream.streaming?.streamId === action.payload.streamId) {
+        session.stream.streaming = null
+        session.stream.streamingClearOnDone = false
+        session.stream.streamingLastUpdatedAt = Date.now()
       }
     },
     streamingThinkingCollapsedSet(state, action: PayloadAction<boolean>) {

--- a/frontend/src/store/chatSliceStreamHandoff.test.ts
+++ b/frontend/src/store/chatSliceStreamHandoff.test.ts
@@ -85,4 +85,14 @@ describe('stream handoff (#510)', () => {
     expect(stream?.done).toBe(true)
     expect(stream?.content).toBe('Here is the reply.')
   })
+
+  it('records the handed-off message id so its card skips the fast-reveal replay', () => {
+    const store = setupStreamingStore()
+    store.dispatch(chatActions.realtimeEventReceived({ agentId: AGENT, event: outboundMessageEvent('m1') }))
+    store.dispatch(chatActions.streamHandedOff({ agentId: AGENT, streamId: 's1' }))
+
+    const stream = selectActiveChatSession(store.getState()).stream
+    expect(stream.streaming).toBeNull()
+    expect(stream.lastHandoffMessageId).toBe('m1')
+  })
 })

--- a/frontend/src/store/chatSliceStreamHandoff.test.ts
+++ b/frontend/src/store/chatSliceStreamHandoff.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #510: the stream card must hand off to the persisted message without a blank frame.
+ * Clearing the stream the moment the outbound message event arrived unmounted the card
+ * one commit before the timeline painted the message — the reply visibly disappeared
+ * and re-rendered from scratch.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { TimelineEvent } from '../types/agentChat'
+import { createAppStore } from './appStore'
+import { chatActions, receiveStreamEvent, selectActiveChatSession } from './chatSlice'
+
+const AGENT = 'agent-510'
+
+function outboundMessageEvent(id: string): TimelineEvent {
+  return {
+    kind: 'message',
+    cursor: `cursor-${id}`,
+    timestamp: '2026-07-29T17:00:00Z',
+    message: {
+      id,
+      cursor: `cursor-${id}`,
+      bodyText: 'Here is the reply.',
+      bodyHtml: '',
+      isOutbound: true,
+      channel: 'web',
+      attachments: [],
+      timestamp: '2026-07-29T17:00:00Z',
+    },
+  } as unknown as TimelineEvent
+}
+
+function setupStreamingStore(content = 'Here is the reply.') {
+  const store = createAppStore()
+  store.dispatch(chatActions.agentSelected({ agentId: AGENT }))
+  store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'start' }))
+  store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'delta', content_delta: content }))
+  return store
+}
+
+describe('stream handoff (#510)', () => {
+  it('records the handoff id instead of clearing the stream on outbound message arrival', () => {
+    const store = setupStreamingStore()
+    store.dispatch(chatActions.realtimeEventReceived({ agentId: AGENT, event: outboundMessageEvent('m1') }))
+
+    const stream = selectActiveChatSession(store.getState()).stream.streaming
+    expect(stream).not.toBeNull()
+    expect(stream?.handoffMessageId).toBe('m1')
+    expect(stream?.done).toBe(true)
+    expect(stream?.content).toBe('Here is the reply.')
+  })
+
+  it('keeps the first handoff id when further outbound messages arrive', () => {
+    const store = setupStreamingStore()
+    store.dispatch(chatActions.realtimeEventReceived({ agentId: AGENT, event: outboundMessageEvent('m1') }))
+    store.dispatch(chatActions.realtimeEventReceived({ agentId: AGENT, event: outboundMessageEvent('m2') }))
+
+    expect(selectActiveChatSession(store.getState()).stream.streaming?.handoffMessageId).toBe('m1')
+  })
+
+  it('still clears immediately when the stream has no content to hand off', () => {
+    const store = createAppStore()
+    store.dispatch(chatActions.agentSelected({ agentId: AGENT }))
+    store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'start' }))
+    store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'delta', reasoning_delta: 'thinking…' }))
+    store.dispatch(chatActions.realtimeEventReceived({ agentId: AGENT, event: outboundMessageEvent('m1') }))
+
+    expect(selectActiveChatSession(store.getState()).stream.streaming).toBeNull()
+  })
+
+  it('streamHandedOff clears exactly the named stream', () => {
+    const store = setupStreamingStore()
+    store.dispatch(chatActions.streamHandedOff({ agentId: AGENT, streamId: 'other' }))
+    expect(selectActiveChatSession(store.getState()).stream.streaming).not.toBeNull()
+
+    store.dispatch(chatActions.streamHandedOff({ agentId: AGENT, streamId: 's1' }))
+    expect(selectActiveChatSession(store.getState()).stream.streaming).toBeNull()
+  })
+
+  it('keeps streamed content through done so the reveal can finish', () => {
+    const store = setupStreamingStore()
+    store.dispatch(receiveStreamEvent(AGENT, { stream_id: 's1', status: 'done' }))
+
+    const stream = selectActiveChatSession(store.getState()).stream.streaming
+    expect(stream?.done).toBe(true)
+    expect(stream?.content).toBe('Here is the reply.')
+  })
+})

--- a/frontend/src/types/agentChat.ts
+++ b/frontend/src/types/agentChat.ts
@@ -405,4 +405,10 @@ export type StreamState = {
   done: boolean
   cursor?: string | null
   source?: 'stream' | 'timeline'
+  /** The persisted outbound message this stream became. The stream card owns the
+   *  content (and the timeline suppresses this message) until the reveal animation
+   *  catches up, then the two swap in a single commit — clearing the stream the
+   *  instant the message event arrived left a blank frame before the timeline
+   *  painted it (bug #510). */
+  handoffMessageId?: string | null
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "2ef585ccea6a313719f0dc1551491713523ceba8",
+  "baseline_sha": "9fedac20803cc86e8327ae9a681d97ed34bd716b",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9270,
+        "fitted_tokens": 9250,
         "system_bytes": 32433,
         "tools_bytes": 23494,
         "total_bytes": 67636,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8671,
+        "fitted_tokens": 8651,
         "system_bytes": 29314,
         "tools_bytes": 23494,
         "total_bytes": 64550,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8830,
+        "fitted_tokens": 8837,
         "system_bytes": 29951,
         "tools_bytes": 23494,
         "total_bytes": 65190,
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 936,
+    "file_count": 937,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 264180
+    "limit": 264471
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "22dd9a623f0f6f0c06ff9e8022d70ee3b7b89b86",
+  "baseline_sha": "2ef585ccea6a313719f0dc1551491713523ceba8",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9275,
+        "fitted_tokens": 9270,
         "system_bytes": 32433,
         "tools_bytes": 23494,
         "total_bytes": 67636,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8636,
+        "fitted_tokens": 8671,
         "system_bytes": 29314,
         "tools_bytes": 23494,
         "total_bytes": 64550,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8858,
+        "fitted_tokens": 8830,
         "system_bytes": 29951,
         "tools_bytes": 23494,
         "total_bytes": 65190,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 264080
+    "limit": 264180
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "9fedac20803cc86e8327ae9a681d97ed34bd716b",
+  "baseline_sha": "79c2c82ef185c3b83e13968715005c32f16705c9",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9250,
+        "fitted_tokens": 9265,
         "system_bytes": 32433,
         "tools_bytes": 23494,
         "total_bytes": 67636,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8651,
+        "fitted_tokens": 8676,
         "system_bytes": 29314,
         "tools_bytes": 23494,
         "total_bytes": 64550,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8837,
+        "fitted_tokens": 8851,
         "system_bytes": 29951,
         "tools_bytes": 23494,
         "total_bytes": 65190,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 264471
+    "limit": 264490
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "9785d06fd401de86f2bcb2a4e2b3508dbed29427",
+  "baseline_sha": "22dd9a623f0f6f0c06ff9e8022d70ee3b7b89b86",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9268,
-        "system_bytes": 32484,
-        "tools_bytes": 23607,
-        "total_bytes": 67800,
+        "fitted_tokens": 9275,
+        "system_bytes": 32433,
+        "tools_bytes": 23494,
+        "total_bytes": 67636,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8651,
-        "system_bytes": 29375,
-        "tools_bytes": 23607,
-        "total_bytes": 64724,
+        "fitted_tokens": 8636,
+        "system_bytes": 29314,
+        "tools_bytes": 23494,
+        "total_bytes": 64550,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8827,
-        "system_bytes": 30012,
-        "tools_bytes": 23607,
-        "total_bytes": 65364,
+        "fitted_tokens": 8858,
+        "system_bytes": 29951,
+        "tools_bytes": 23494,
+        "total_bytes": 65190,
         "user_bytes": 11745
       }
     },
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 930,
+    "file_count": 936,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 280000
+    "limit": 264080
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,18 +1,18 @@
 {
-  "baseline_sha": "79c2c82ef185c3b83e13968715005c32f16705c9",
+  "baseline_sha": "858b674613af6ee27c3683083f63f499f9b0f76c",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9265,
+        "fitted_tokens": 9270,
         "system_bytes": 32433,
         "tools_bytes": 23494,
         "total_bytes": 67636,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8676,
+        "fitted_tokens": 8656,
         "system_bytes": 29314,
         "tools_bytes": 23494,
         "total_bytes": 64550,
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 937,
+    "file_count": 941,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 264490
+    "limit": 266192
   }
 }

--- a/tests/unit/test_web_streaming.py
+++ b/tests/unit/test_web_streaming.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase, tag
 
-from api.agent.core.web_streaming import resolve_web_stream_target
+from api.agent.core.web_streaming import WebStreamBroadcaster, WebStreamTarget, resolve_web_stream_target
 from api.models import (
     BrowserUseAgent,
     CommsChannel,
@@ -127,3 +127,46 @@ class ResolveWebStreamTargetTests(TestCase):
         )
         self._inbound(mismatched)
         self.assertIsNone(resolve_web_stream_target(self.agent))
+
+@tag("batch_event_processing")
+class WebStreamBroadcasterFlushTests(TestCase):
+    """#510: the first content delta must flush immediately — it is the reader's first
+    visible sign of the reply, and batching it just delays perceived streaming start."""
+
+    def _broadcaster(self):
+        from unittest.mock import patch
+
+        broadcaster = WebStreamBroadcaster(
+            target=WebStreamTarget(agent_id="a", user_id=1, address="web://user/1/agent/a"),
+            min_flush_interval=10.0,
+            max_buffer_chars=10_000,
+        )
+        sent: list[dict] = []
+        patcher = patch.object(broadcaster, "_send", side_effect=lambda payload: sent.append(payload))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return broadcaster, sent
+
+    def test_first_content_delta_flushes_immediately(self):
+        broadcaster, sent = self._broadcaster()
+        broadcaster.push_delta("thinking about it", None)
+        self.assertEqual([p["status"] for p in sent], ["start"])  # reasoning batches
+
+        broadcaster.push_delta(None, "Hey")
+        deltas = [p for p in sent if p["status"] == "delta"]
+        self.assertEqual(len(deltas), 1)
+        self.assertEqual(deltas[0]["content_delta"], "Hey")
+        self.assertEqual(deltas[0]["reasoning_delta"], "thinking about it")
+
+    def test_subsequent_content_deltas_batch_normally(self):
+        broadcaster, sent = self._broadcaster()
+        broadcaster.push_delta(None, "Hey")
+        broadcaster.push_delta(None, " there")
+        broadcaster.push_delta(None, " friend")
+        deltas = [p for p in sent if p["status"] == "delta"]
+        self.assertEqual(len(deltas), 1)
+
+        broadcaster.finish()
+        deltas = [p for p in sent if p["status"] == "delta"]
+        self.assertEqual(len(deltas), 2)
+        self.assertEqual(deltas[1]["content_delta"], " there friend")


### PR DESCRIPTION
Fixes #510: web chat replies did not visibly stream, then flashed blank and re-rendered at completion.

## Root causes (measured, then fixed)

Instrumented probes on prod-equivalent code (WS frame capture + 100–150ms DOM sampling) showed **deltas arriving that the UI never painted**: reasoning streamed at ~80ms cadence, but the message body arrived end-loaded — providers burst tool-call arguments, one run delivered the entire body as a single `content_delta` 160ms before `done`. Three stacked defects:

1. **Gate:** `showStreamingSlot = hasStreamingContent && isStreaming` hid the card the instant `done` arrived — ≤160ms of visibility in the burst case.
2. **Teardown race:** the outbound message event nulled the stream in one commit; the message painted via a separate later dispatch — a guaranteed blank frame whenever content had been showing.
3. **No interpolation:** the card rendered raw target text (the recently-added `useTypewriter` only activated when `isStreaming` was false — the exact moment the gate unmounted the card, so it never ran).

## The fix

- **Interpolated reveal for every arrival pattern** (research: llm-ui throttling, Vercel smoothStream/AI-SDK): the typewriter runs during streaming and through bursts, decoupling visual cadence from network cadence; 4× catch-up once the stream finishes; respects `prefers-reduced-motion` and hidden tabs.
- **Flash-free handoff:** the slot survives `done`; the persisted message renders *suppressed* in the timeline while the card owns the content; when the reveal catches up the card dispatches `streamHandedOff` and the suppression lifts in the same reducer commit — atomic swap, no double render, no hole. 10s safety valve if the send never persisted.
- **Markdown at frame rate without re-parsing the world** (AI-SDK memoization cookbook / LibreChat pattern): committed text splits into blocks at blank lines (fence-aware); completed blocks are stable strings the memoized `MarkdownViewer` never re-parses; only the tail block re-commits at ~7Hz with unclosed code fences auto-repaired; sub-commit characters render as a plain span.
- **Backend:** the first content delta flushes immediately instead of waiting out the 80ms/200-char batching window.

## Evidence (pr-1471 preview, video + telemetry on file)

| Metric (100ms sampling) | Before (main) | After |
|---|---|---|
| Stream card ever rendered | **never** (2 runs, 7 & 11 delta frames arrived) | 26–32 samples over 2.5–3.2s |
| Distinct rendered lengths (smoothness) | 0 | **32 of 32 samples** — continuous reveal |
| Blank gap at completion | n/a (nothing ever showed) | **0 samples** |
| Double-render (card + message) | n/a | **0 samples** |
| Card→message swap | blank flash (report + code trace) | ≤1 sample (≤100ms), same-commit |

Screen recordings: `videos-after3/` (fix) in the session scratchpad; raw telemetry JSON alongside.

## Live markdown while streaming (follow-up in this PR)

The tail is no longer a plain-text span: the reveal feeds the markdown renderer every frame (block memoization bounds per-frame parse to the tail block — measured ~0.2ms per parse), and the tail block is repaired with the remend rule set (Vercel streamdown's repair pipeline, implemented from its source): fences/bold/italic/inline-code/strikethrough closed with half-closer and bare-marker guards, incomplete links rendered as their text (never a fabricated URL), incomplete images and half-typed HTML tags hidden, nascent setext underlines neutralized so paragraphs never flash as headings. Repairs apply only in flight; the final message renders raw text.

**Mid-reveal telemetry (pr-1471, 100ms sampling): 39/39 revealing samples contained styled markdown elements (up to 17 at once — headings, bold, list items, code); raw `**` markers visible in 0 samples.** Video frame on file shows a half-typed heading already styled mid-word.

## Final polish: the end-of-stream "settling flash" (root-caused + fixed)

The persisted message card had a pre-existing fast-reveal that re-typed any recent agent message from length zero on mount — so the swap was atomic, and then the finalized message re-revealed the whole reply (full text → blink → rapid re-fill). The handed-off message id is now recorded at the swap and its card renders instantly complete (per the finalization literature: a finalized message must never be "new" to the UI). **Final-build telemetry: first post-swap sample already full length (3,145 chars) — no replay; 45/45 mid-reveal samples styled; 0 blank-gap; 0 double-render; swap ≤103ms.** One 100ms sample showed a literal `**` — the designed bare-opener guard (an opener with no content yet stays literal), not a repair failure.

## Tests (31 new)
- `chatSliceStreamHandoff.test.ts` — handoff recorded instead of clearing; first handoff wins; contentless streams still clear; `streamHandedOff` scoped by stream id; content survives `done`
- `StreamingReplyCard.test.tsx` — card holds until message rendered; dispatches the swap when done+rendered+revealed; never swaps mid-stream
- `streamingMarkdownBlocks.test.ts` — fence-aware splitting, append-stability, fence repair
- `test_web_streaming.py` — first content delta flushes immediately (red→green); later deltas batch

Full suites green: 334 frontend (60 files), backend event-processing/tool-arg/web-streaming OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
