### PR TITLE
Add MCP-native agent attachments

### DIFF
--- a/api/mcp_views.py
+++ b/api/mcp_views.py
@@ -11,7 +11,18 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from api.auth import MCPAPIKeyAuthentication
-from api.services.remote_mcp import MCPToolError, MCP_PROTOCOL_VERSION, SERVER_INFO, call_tool, list_tools, make_tool_result
+from api.services.remote_mcp import (
+    MCPToolError,
+    MCP_PROTOCOL_VERSION,
+    SERVER_INFO,
+    call_tool,
+    list_resource_templates,
+    list_resources,
+    list_tools,
+    make_tool_result,
+    read_resource,
+)
+from api.services.remote_mcp_resources import MCPResourceError
 
 
 JSON_RPC_PARSE_ERROR = -32700
@@ -19,6 +30,7 @@ JSON_RPC_INVALID_REQUEST = -32600
 JSON_RPC_METHOD_NOT_FOUND = -32601
 JSON_RPC_INVALID_PARAMS = -32602
 JSON_RPC_HEADER_MISMATCH = -32001
+JSON_RPC_RESOURCE_NOT_FOUND = -32002
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -130,7 +142,10 @@ def _handle_json_rpc_request(request, payload):
             request_id,
             {
                 "protocolVersion": MCP_PROTOCOL_VERSION,
-                "capabilities": {"tools": {"listChanged": False}},
+                "capabilities": {
+                    "tools": {"listChanged": False},
+                    "resources": {"subscribe": False, "listChanged": False},
+                },
                 "serverInfo": SERVER_INFO,
                 "instructions": (
                     "Use Gobii tools to create, manage, link, message, and attach files to "
@@ -144,6 +159,33 @@ def _handle_json_rpc_request(request, payload):
 
     if method == "tools/list":
         return _json_rpc_success_payload(request_id, {"tools": list_tools()}), 200
+
+    if method == "resources/list":
+        return _json_rpc_success_payload(request_id, {"resources": list_resources()}), 200
+
+    if method == "resources/templates/list":
+        return _json_rpc_success_payload(
+            request_id,
+            {"resourceTemplates": list_resource_templates()},
+        ), 200
+
+    if method == "resources/read":
+        uri = params.get("uri")
+        if not isinstance(uri, str) or not uri:
+            return _json_rpc_error_payload(
+                JSON_RPC_INVALID_PARAMS,
+                "resources/read requires params.uri.",
+                request_id=request_id,
+            ), 200
+        try:
+            result = read_resource(request, uri)
+        except MCPResourceError:
+            return _json_rpc_error_payload(
+                JSON_RPC_RESOURCE_NOT_FOUND,
+                "Resource not found or inaccessible.",
+                request_id=request_id,
+            ), 200
+        return _json_rpc_success_payload(request_id, result), 200
 
     if method == "tools/call":
         tool_name = params.get("name")

--- a/api/services/remote_mcp.py
+++ b/api/services/remote_mcp.py
@@ -47,6 +47,13 @@ from api.services.agent_debug_trace import (
 from api.services.agent_lifecycle import build_agent_inactive_payload
 from api.services.daily_credit_limits import calculate_daily_credit_slider_bounds, get_tier_credit_multiplier
 from api.services.daily_credit_settings import get_daily_credit_settings_for_owner
+from api.services.remote_mcp_resources import (
+    MCPResourceError,
+    build_attachment_resource_uri,
+    build_file_resource_uri,
+    parse_agent_resource_uri,
+    read_agent_resource,
+)
 from console.agent_chat.timeline import (
     DEFAULT_PAGE_SIZE as TIMELINE_DEFAULT_PAGE_SIZE,
     MAX_PAGE_SIZE as TIMELINE_MAX_PAGE_SIZE,
@@ -78,12 +85,20 @@ WAIT_FILTER_FIELDS = {
     "status",
     "tool_name",
 }
+MCP_INLINE_ATTACHMENT_LIMIT = 10
+MCP_NATIVE_IMAGE_TYPES = {"image/gif", "image/jpeg", "image/png", "image/webp"}
 
 
 class MCPToolError(Exception):
     def __init__(self, message, data=None):
         super().__init__(message)
         self.data = data
+
+
+@dataclass(frozen=True)
+class MCPToolResponse:
+    structured_content: object
+    content: tuple[dict, ...] = ()
 
 
 def _agent_schema(description):
@@ -219,10 +234,26 @@ _FILE_NODE_OUTPUT = _object_output(
         "node_type": {"type": "string"},
         "size_bytes": _INTEGER_OR_NULL,
         "mime_type": _STRING_OR_NULL,
+        "checksum_sha256": _STRING_OR_NULL,
+        "resource_uri": {"type": ["string", "null"], "format": "uri"},
         "created_at": _STRING_OR_NULL,
         "updated_at": _STRING_OR_NULL,
     },
     required=("id", "name", "path", "node_type"),
+)
+
+_FILE_UPLOAD_OUTPUT = _object_output(
+    {
+        "status": {"type": "string"},
+        "path": {"type": "string"},
+        "node_id": _UUID_OUTPUT,
+        "filename": {"type": "string"},
+        "resource_uri": {"type": "string", "format": "uri"},
+        "mime_type": _STRING_OR_NULL,
+        "size_bytes": _INTEGER_OR_NULL,
+        "checksum_sha256": _STRING_OR_NULL,
+    },
+    required=("status", "path", "node_id", "filename", "resource_uri"),
 )
 
 _ACCESS_METADATA_OUTPUT = _object_output(
@@ -589,6 +620,37 @@ TOOL_DEFINITIONS = [
                     "items": {"type": "string"},
                     "description": "Optional filespace paths such as /uploads/report.pdf to attach to the message.",
                 },
+                "attachments": {
+                    "type": "array",
+                    "maxItems": MCP_INLINE_ATTACHMENT_LIMIT,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "description": "Destination filespace path, such as /uploads/report.pdf.",
+                            },
+                            "content_base64": {
+                                "type": "string",
+                                "description": "Base64-encoded file contents.",
+                            },
+                            "mime_type": {
+                                "type": "string",
+                                "default": "application/octet-stream",
+                            },
+                            "overwrite": {
+                                "type": "boolean",
+                                "default": False,
+                            },
+                        },
+                        "required": ["path", "content_base64"],
+                        "additionalProperties": False,
+                    },
+                    "description": (
+                        "Optional small files to upload and attach in this message call. "
+                        "Use this instead of a separate upload call when the content is already available."
+                    ),
+                },
                 "trigger_processing": {
                     "type": "boolean",
                     "default": True,
@@ -620,6 +682,7 @@ TOOL_DEFINITIONS = [
                 "timeline_event": _TIMELINE_EVENT_OUTPUT,
                 "conversation_id": _UUID_OUTPUT,
                 "attachment_count": {"type": "integer"},
+                "uploaded_attachments": _array_output(_FILE_UPLOAD_OUTPUT),
                 "access": _ACCESS_METADATA_OUTPUT,
             },
             required=("status", "message_id", "agent_id", "cursor", "latest_cursor"),
@@ -819,6 +882,42 @@ TOOL_DEFINITIONS = [
         "annotations": {"readOnlyHint": True},
     },
     {
+        "name": "gobii_read_agent_resource",
+        "title": "Read Agent File",
+        "description": (
+            "Read an authenticated file or image from a Gobii resource URI returned by agent timeline "
+            "or filespace tools. Content is returned as native MCP resource or image content."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "A gobii:// resource URI returned by another Gobii MCP tool.",
+                },
+            },
+            "required": ["uri"],
+            "additionalProperties": False,
+        },
+        "outputSchema": _object_output(
+            {
+                "resource": _object_output(
+                    {
+                        "uri": {"type": "string", "format": "uri"},
+                        "name": {"type": "string"},
+                        "mime_type": {"type": "string"},
+                        "size_bytes": {"type": "integer"},
+                        "checksum_sha256": {"type": "string"},
+                    },
+                    required=("uri", "name", "mime_type", "size_bytes", "checksum_sha256"),
+                ),
+            },
+            required=("resource",),
+        ),
+        "annotations": {"readOnlyHint": True},
+    },
+    {
         "name": "gobii_list_agent_files",
         "title": "List Agent Files",
         "description": "List files and folders in an agent's default filespace.",
@@ -860,10 +959,7 @@ TOOL_DEFINITIONS = [
         },
         "outputSchema": _object_output(
             {
-                "status": {"type": "string"},
-                "path": {"type": "string"},
-                "node_id": _UUID_OUTPUT,
-                "filename": {"type": "string"},
+                **_FILE_UPLOAD_OUTPUT["properties"],
                 "message": _STRING_OR_NULL,
                 "access": _ACCESS_METADATA_OUTPUT,
             },
@@ -881,13 +977,18 @@ def list_tools():
 
 
 def make_tool_result(data, *, is_error=False):
+    extra_content = ()
+    if isinstance(data, MCPToolResponse):
+        extra_content = data.content
+        data = data.structured_content
     safe_data = _json_safe(data)
     return {
         "content": [
             {
                 "type": "text",
                 "text": json.dumps(safe_data, cls=DjangoJSONEncoder, indent=2),
-            }
+            },
+            *[_json_safe(item) for item in extra_content],
         ],
         "structuredContent": safe_data,
         "isError": bool(is_error),
@@ -915,6 +1016,7 @@ def call_tool(request, name, arguments):
         "gobii_get_agent_timeline": _tool_get_agent_timeline,
         DEBUG_TRACE_TOOL_NAME: _tool_get_agent_debug_trace,
         "gobii_wait_for_agent_event": _tool_wait_for_agent_event,
+        "gobii_read_agent_resource": _tool_read_agent_resource,
         "gobii_list_agent_files": _tool_list_agent_files,
         "gobii_upload_agent_file": _tool_upload_agent_file,
     }[name]
@@ -1199,14 +1301,29 @@ def _tool_send_agent_message(request, arguments):
     attachment_paths = arguments.get("attachment_file_paths") or []
     if not isinstance(attachment_paths, list):
         raise MCPToolError("attachment_file_paths must be an array of filespace paths.")
+    inline_attachments = _decode_inline_attachments(arguments.get("attachments"))
 
     sender_user = _message_sender_user(request, access)
     sender_address = build_web_user_address(user_id=sender_user.id, agent_id=agent.id)
     if not agent.is_sender_whitelisted(CommsChannel.WEB, sender_address):
         raise MCPToolError("Authenticated user is not allowed to message this agent.")
 
+    uploaded_attachments = [
+        _write_agent_file(
+            agent,
+            path=item["path"],
+            content=item["content"],
+            mime_type=item["mime_type"],
+            overwrite=item["overwrite"],
+        )
+        for item in inline_attachments
+    ]
+    all_attachment_paths = [
+        *attachment_paths,
+        *[item["path"] for item in uploaded_attachments],
+    ]
     try:
-        resolved_attachments = resolve_filespace_attachments(agent, attachment_paths)
+        resolved_attachments = resolve_filespace_attachments(agent, all_attachment_paths)
     except AttachmentResolutionError as exc:
         raise MCPToolError(str(exc)) from exc
 
@@ -1224,8 +1341,9 @@ def _tool_send_agent_message(request, arguments):
         create_message_attachments(message, resolved_attachments)
 
     event = serialize_message_event(message)
+    _add_timeline_resource_uris([event], agent.id)
     cursor = event.get("cursor")
-    return _with_access_metadata(
+    payload = _with_access_metadata(
         {
             "status": "queued" if trigger_processing else "stored",
             "accepted_state": "queued" if trigger_processing else "stored",
@@ -1242,10 +1360,12 @@ def _tool_send_agent_message(request, arguments):
             "timeline_event": event,
             "conversation_id": str(conversation.id),
             "attachment_count": len(resolved_attachments),
+            "uploaded_attachments": uploaded_attachments,
         },
         access=access,
         agent=agent,
     )
+    return _with_resource_links(payload)
 
 
 def _tool_get_agent_timeline(request, arguments):
@@ -1267,7 +1387,8 @@ def _tool_get_agent_timeline(request, arguments):
     _validate_timeline_cursor(cursor, "cursor/after_cursor")
 
     window = fetch_timeline_window(agent, cursor=cursor, direction=direction, limit=limit)
-    return _with_access_metadata(
+    _add_timeline_resource_uris(window.events, agent.id)
+    payload = _with_access_metadata(
         {
             "events": window.events,
             "next_cursor": window.newest_cursor,
@@ -1283,6 +1404,7 @@ def _tool_get_agent_timeline(request, arguments):
         access=access,
         agent=agent,
     )
+    return _with_resource_links(payload)
 
 
 def _tool_get_agent_debug_trace(request, arguments):
@@ -1408,34 +1530,180 @@ def _tool_list_agent_files(request, arguments):
     nodes = (
         AgentFsNode.objects.alive()
         .filter(filespace=filespace)
-        .only("id", "parent_id", "name", "path", "node_type", "size_bytes", "mime_type", "created_at", "updated_at")
+        .only(
+            "id",
+            "parent_id",
+            "name",
+            "path",
+            "node_type",
+            "size_bytes",
+            "mime_type",
+            "checksum_sha256",
+            "created_at",
+            "updated_at",
+        )
         .order_by("parent_id", "node_type", "name")
     )
-    return _with_access_metadata(
+    payload = _with_access_metadata(
         {
             "filespace": {"id": str(filespace.id), "name": filespace.name},
-            "nodes": [_serialize_file_node(node) for node in nodes],
+            "nodes": [_serialize_file_node(node, agent.id) for node in nodes],
         },
         access=access,
         agent=agent,
     )
+    return _with_resource_links(payload)
+
+
+def _tool_read_agent_resource(request, arguments):
+    uri = _required_string(arguments, "uri", allow_blank=False)
+    try:
+        reference = parse_agent_resource_uri(uri)
+        access = _get_agent_access(request, reference.agent_id, {})
+        resource = read_agent_resource(access.agent, reference)
+    except (MCPResourceError, MCPToolError) as exc:
+        raise MCPToolError("Resource not found or inaccessible.") from exc
+
+    contents = resource.mcp_contents()
+    if "blob" in contents and resource.mime_type in MCP_NATIVE_IMAGE_TYPES:
+        native_content = {
+            "type": "image",
+            "data": contents["blob"],
+            "mimeType": resource.mime_type,
+        }
+    else:
+        native_content = {"type": "resource", "resource": contents}
+    payload = _with_access_metadata(
+        {
+            "resource": {
+                "uri": resource.uri,
+                "name": resource.name,
+                "mime_type": resource.mime_type,
+                "size_bytes": resource.size_bytes,
+                "checksum_sha256": resource.checksum_sha256,
+            },
+        },
+        access=access,
+        agent=access.agent,
+    )
+    return MCPToolResponse(payload, (native_content,))
 
 
 def _tool_upload_agent_file(request, arguments):
     access = _get_agent_access(request, arguments.get("agent_id"), arguments)
     agent = access.agent
-    path = _required_string(arguments, "path", allow_blank=False)
-    content_base64 = _required_string(arguments, "content_base64", allow_blank=False)
-    mime_type = arguments.get("mime_type") or "application/octet-stream"
-    if not isinstance(mime_type, str):
-        raise MCPToolError("mime_type must be a string.")
-    overwrite = _optional_bool(arguments.get("overwrite", False), "overwrite")
+    result = _write_agent_file(
+        agent,
+        path=_required_string(arguments, "path", allow_blank=False),
+        content=_decode_base64(
+            _required_string(arguments, "content_base64", allow_blank=False),
+            "content_base64",
+        ),
+        mime_type=_mime_type_argument(arguments.get("mime_type")),
+        overwrite=_optional_bool(arguments.get("overwrite", False), "overwrite"),
+    )
+    payload = _with_access_metadata(result, access=access, agent=agent)
+    return _with_resource_links(payload)
 
+
+def read_resource(request, uri):
     try:
-        content = base64.b64decode(content_base64, validate=True)
-    except (binascii.Error, ValueError) as exc:
-        raise MCPToolError("content_base64 must be valid base64.") from exc
+        reference = parse_agent_resource_uri(uri)
+        access = _get_agent_access(request, reference.agent_id, {})
+        resource = read_agent_resource(access.agent, reference)
+    except (MCPResourceError, MCPToolError) as exc:
+        raise MCPResourceError("Resource not found or inaccessible.") from exc
+    return {"contents": [resource.mcp_contents()]}
 
+
+def list_resources():
+    # Agent files can be numerous and authorization-dependent. Resource links are
+    # returned by the bounded timeline/files tools instead of enumerating them globally.
+    return []
+
+
+def list_resource_templates():
+    return [
+        {
+            "uriTemplate": "gobii://agents/{agent_id}/files/{node_id}",
+            "name": "gobii-agent-file",
+            "title": "Gobii agent file",
+            "description": "An authenticated file in a Gobii agent's filespace.",
+        },
+        {
+            "uriTemplate": "gobii://agents/{agent_id}/attachments/{attachment_id}",
+            "name": "gobii-message-attachment",
+            "title": "Gobii message attachment",
+            "description": "An authenticated attachment from a Gobii agent timeline message.",
+        },
+    ]
+
+
+def _decode_inline_attachments(value):
+    if value in (None, []):
+        return []
+    if not isinstance(value, list):
+        raise MCPToolError("attachments must be an array.")
+    if len(value) > MCP_INLINE_ATTACHMENT_LIMIT:
+        raise MCPToolError(
+            f"attachments supports at most {MCP_INLINE_ATTACHMENT_LIMIT} files.",
+            {"field": "attachments", "maximum": MCP_INLINE_ATTACHMENT_LIMIT},
+        )
+
+    decoded = []
+    supported_fields = {"path", "content_base64", "mime_type", "overwrite"}
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise MCPToolError(
+                "Each attachments item must be an object.",
+                {"field": f"attachments[{index}]"},
+            )
+        unknown = sorted(set(item) - supported_fields)
+        if unknown:
+            raise MCPToolError(
+                "Unsupported inline attachment field(s).",
+                {
+                    "field": f"attachments[{index}]",
+                    "unsupported_fields": unknown,
+                    "supported_fields": sorted(supported_fields),
+                },
+            )
+        decoded.append(
+            {
+                "path": _required_string(item, "path", allow_blank=False),
+                "content": _decode_base64(
+                    _required_string(item, "content_base64", allow_blank=False),
+                    f"attachments[{index}].content_base64",
+                ),
+                "mime_type": _mime_type_argument(
+                    item.get("mime_type"),
+                    field=f"attachments[{index}].mime_type",
+                ),
+                "overwrite": _optional_bool(
+                    item.get("overwrite", False),
+                    f"attachments[{index}].overwrite",
+                ),
+            }
+        )
+    return decoded
+
+
+def _decode_base64(value, field):
+    try:
+        return base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise MCPToolError(f"{field} must be valid base64.") from exc
+
+
+def _mime_type_argument(value, *, field="mime_type"):
+    if value in (None, ""):
+        return "application/octet-stream"
+    if not isinstance(value, str):
+        raise MCPToolError(f"{field} must be a string.")
+    return value.strip() or "application/octet-stream"
+
+
+def _write_agent_file(agent, *, path, content, mime_type, overwrite):
     result = write_bytes_to_dir(
         agent,
         content,
@@ -1445,7 +1713,88 @@ def _tool_upload_agent_file(request, arguments):
     )
     if result.get("status") != "ok":
         raise MCPToolError(result.get("message") or "File upload failed.", result)
-    return _with_access_metadata(result, access=access, agent=agent)
+    node = (
+        AgentFsNode.objects.alive()
+        .files()
+        .filter(id=result.get("node_id"), filespace__access__agent=agent)
+        .distinct()
+        .first()
+    )
+    if node is None:
+        raise MCPToolError("Uploaded file could not be resolved.")
+    serialized = _serialize_file_node(node, agent.id)
+    return {
+        "status": "ok",
+        "path": serialized["path"],
+        "node_id": serialized["id"],
+        "filename": serialized["name"],
+        "resource_uri": serialized["resource_uri"],
+        "mime_type": serialized["mime_type"],
+        "size_bytes": serialized["size_bytes"],
+        "checksum_sha256": serialized["checksum_sha256"],
+    }
+
+
+def _add_timeline_resource_uris(events, agent_id):
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        message = event.get("message")
+        if not isinstance(message, dict):
+            continue
+        for attachment in message.get("attachments") or []:
+            if not isinstance(attachment, dict):
+                continue
+            node_id = attachment.get("filespaceNodeId")
+            attachment_id = attachment.get("id")
+            if node_id:
+                attachment["resource_uri"] = build_file_resource_uri(agent_id, node_id)
+            elif attachment_id:
+                attachment["resource_uri"] = build_attachment_resource_uri(agent_id, attachment_id)
+            if "mime_type" not in attachment:
+                attachment["mime_type"] = attachment.get("contentType")
+            if "size_bytes" not in attachment:
+                attachment["size_bytes"] = attachment.get("fileSize")
+            if "checksum_sha256" not in attachment:
+                attachment["checksum_sha256"] = attachment.get("contentSha256")
+
+
+def _with_resource_links(payload):
+    links = []
+    seen = set()
+    for item in _walk_dicts(payload):
+        uri = item.get("resource_uri")
+        if not isinstance(uri, str) or not uri or uri in seen:
+            continue
+        seen.add(uri)
+        link = {
+            "type": "resource_link",
+            "uri": uri,
+            "name": (
+                item.get("filename")
+                or item.get("name")
+                or item.get("path")
+                or "Gobii agent file"
+            ),
+        }
+        mime_type = item.get("mime_type")
+        size_bytes = item.get("size_bytes")
+        if isinstance(mime_type, str) and mime_type:
+            link["mimeType"] = mime_type
+        if isinstance(size_bytes, int) and size_bytes >= 0:
+            link["size"] = size_bytes
+        links.append(link)
+    return MCPToolResponse(payload, tuple(links))
+
+
+def _walk_dicts(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_dicts(child)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            yield from _walk_dicts(child)
 
 
 def _reject_unknown_arguments(name, arguments):
@@ -1968,8 +2317,8 @@ def _serialize_message(message):
     }
 
 
-def _serialize_file_node(node):
-    return {
+def _serialize_file_node(node, agent_id=None):
+    payload = {
         "id": str(node.id),
         "parent_id": str(node.parent_id) if node.parent_id else None,
         "name": node.name,
@@ -1977,9 +2326,13 @@ def _serialize_file_node(node):
         "node_type": node.node_type,
         "size_bytes": node.size_bytes,
         "mime_type": node.mime_type or None,
+        "checksum_sha256": node.checksum_sha256 or None,
         "created_at": _iso(node.created_at),
         "updated_at": _iso(node.updated_at),
     }
+    if agent_id and node.node_type == AgentFsNode.NodeType.FILE:
+        payload["resource_uri"] = build_file_resource_uri(agent_id, node.id)
+    return payload
 
 
 def _validate_timeline_cursor(cursor, key):

--- a/api/services/remote_mcp_resources.py
+++ b/api/services/remote_mcp_resources.py
@@ -1,0 +1,213 @@
+import base64
+import hashlib
+import mimetypes
+import re
+import uuid
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from api.agent.files.filespace_service import FILESPACE_PERSISTENCE_ERRORS
+from api.models import AgentFsNode, PersistentAgentMessageAttachment
+from api.services.system_settings import get_max_file_size
+
+
+RESOURCE_SCHEME = "gobii"
+RESOURCE_AUTHORITY = "agents"
+_MIME_TYPE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*$")
+
+
+class MCPResourceError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class AgentResourceReference:
+    uri: str
+    agent_id: uuid.UUID
+    kind: str
+    resource_id: uuid.UUID
+
+
+@dataclass(frozen=True)
+class AgentResource:
+    uri: str
+    name: str
+    mime_type: str
+    size_bytes: int
+    checksum_sha256: str
+    content: bytes
+
+    def mcp_contents(self):
+        try:
+            if _is_text_mime_type(self.mime_type):
+                return {
+                    "uri": self.uri,
+                    "mimeType": self.mime_type,
+                    "text": self.content.decode("utf-8"),
+                }
+        except UnicodeDecodeError:
+            pass
+        return {
+            "uri": self.uri,
+            "mimeType": self.mime_type,
+            "blob": _base64_content(self.content),
+        }
+
+
+def build_file_resource_uri(agent_id, node_id):
+    return f"{RESOURCE_SCHEME}://{RESOURCE_AUTHORITY}/{agent_id}/files/{node_id}"
+
+
+def build_attachment_resource_uri(agent_id, attachment_id):
+    return f"{RESOURCE_SCHEME}://{RESOURCE_AUTHORITY}/{agent_id}/attachments/{attachment_id}"
+
+
+def parse_agent_resource_uri(uri):
+    if not isinstance(uri, str) or not uri:
+        raise MCPResourceError("Invalid resource URI.")
+    parsed = urlparse(uri)
+    parts = [part for part in parsed.path.split("/") if part]
+    if (
+        parsed.scheme != RESOURCE_SCHEME
+        or parsed.netloc != RESOURCE_AUTHORITY
+        or len(parts) != 3
+        or parts[1] not in {"files", "attachments"}
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise MCPResourceError("Invalid resource URI.")
+    try:
+        agent_id = uuid.UUID(parts[0])
+        resource_id = uuid.UUID(parts[2])
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise MCPResourceError("Invalid resource URI.") from exc
+    return AgentResourceReference(
+        uri=uri,
+        agent_id=agent_id,
+        kind=parts[1],
+        resource_id=resource_id,
+    )
+
+
+def read_agent_resource(agent, reference):
+    if reference.agent_id != agent.id:
+        raise MCPResourceError("Resource not found or inaccessible.")
+    if reference.kind == "files":
+        return _read_filespace_resource(agent, reference)
+    return _read_message_attachment_resource(agent, reference)
+
+
+def _read_filespace_resource(agent, reference):
+    node = (
+        AgentFsNode.objects.alive()
+        .files()
+        .filter(
+            id=reference.resource_id,
+            filespace__access__agent=agent,
+        )
+        .distinct()
+        .first()
+    )
+    if node is None:
+        raise MCPResourceError("Resource not found or inaccessible.")
+    return _read_file_field(
+        reference.uri,
+        node.name,
+        node.mime_type,
+        node.size_bytes,
+        node.checksum_sha256,
+        node.content,
+    )
+
+
+def _read_message_attachment_resource(agent, reference):
+    attachment = (
+        PersistentAgentMessageAttachment.objects.filter(
+            id=reference.resource_id,
+            message__owner_agent=agent,
+        )
+        .select_related("filespace_node")
+        .first()
+    )
+    if attachment is None:
+        raise MCPResourceError("Resource not found or inaccessible.")
+
+    node = attachment.filespace_node
+    if node and node.content and getattr(node.content, "name", None):
+        return _read_file_field(
+            reference.uri,
+            attachment.filename or node.name,
+            attachment.content_type or node.mime_type,
+            attachment.file_size or node.size_bytes,
+            attachment.content_sha256 or node.checksum_sha256,
+            node.content,
+        )
+    return _read_file_field(
+        reference.uri,
+        attachment.filename,
+        attachment.content_type,
+        attachment.file_size,
+        attachment.content_sha256,
+        attachment.file,
+    )
+
+
+def _read_file_field(uri, name, mime_type, declared_size, declared_checksum, file_field):
+    if not file_field or not getattr(file_field, "name", None):
+        raise MCPResourceError("Resource content is unavailable.")
+
+    max_size = get_max_file_size()
+    size_bytes = _integer_size(declared_size)
+    if max_size and size_bytes is not None and size_bytes > max_size:
+        raise MCPResourceError("Resource exceeds the MCP file size limit.")
+
+    try:
+        with file_field.open("rb") as handle:
+            content = handle.read((max_size + 1) if max_size else -1)
+    except FILESPACE_PERSISTENCE_ERRORS as exc:
+        raise MCPResourceError("Resource content is unavailable.") from exc
+    if max_size and len(content) > max_size:
+        raise MCPResourceError("Resource exceeds the MCP file size limit.")
+
+    checksum = hashlib.sha256(content).hexdigest()
+    if declared_checksum and declared_checksum != checksum:
+        raise MCPResourceError("Resource failed its integrity check.")
+    return AgentResource(
+        uri=uri,
+        name=name or "attachment",
+        mime_type=_normalize_mime_type(mime_type, name),
+        size_bytes=len(content),
+        checksum_sha256=checksum,
+        content=content,
+    )
+
+
+def _normalize_mime_type(value, name):
+    candidate = (value or "").strip().lower()
+    if _MIME_TYPE_RE.fullmatch(candidate):
+        return candidate
+    guessed, _ = mimetypes.guess_type(name or "")
+    if guessed and _MIME_TYPE_RE.fullmatch(guessed):
+        return guessed
+    return "application/octet-stream"
+
+
+def _integer_size(value):
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_text_mime_type(mime_type):
+    return (
+        mime_type.startswith("text/")
+        or mime_type in {"application/json", "application/ld+json", "application/xml"}
+        or mime_type.endswith("+json")
+        or mime_type.endswith("+xml")
+    )
+
+
+def _base64_content(content):
+    return base64.b64encode(content).decode("ascii")

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -497,6 +497,9 @@ def _serialize_attachment(att: PersistentAgentMessageAttachment, agent_id: uuid.
         "downloadUrl": download_url,
         "filespacePath": filespace_path,
         "filespaceNodeId": filespace_node_id,
+        "contentType": att.content_type or None,
+        "fileSize": att.file_size,
+        "contentSha256": att.content_sha256 or None,
         "fileSizeLabel": size_label,
     }
 

--- a/docs/content/developers/mcp-server.mdx
+++ b/docs/content/developers/mcp-server.mdx
@@ -21,6 +21,7 @@ References:
 
 - MCP Streamable HTTP transport: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
 - MCP tools protocol and structured tool results: https://modelcontextprotocol.io/specification/2025-11-25/server/tools
+- MCP resources and resource links: https://modelcontextprotocol.io/specification/2025-11-25/server/resources
 - MCP schema reference: https://modelcontextprotocol.io/specification/2025-11-25/schema
 - MCP HTTP authorization guidance: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
 
@@ -104,14 +105,15 @@ Gobii also validates `Mcp-Method` and `Mcp-Name` request headers when clients se
 | `gobii_list_agent_links` | List peer-agent links. |
 | `gobii_link_agents` | Create or enable a peer-agent link. |
 | `gobii_unlink_agents` | Remove a peer-agent link while preserving history. |
-| `gobii_send_agent_message` | Send an authenticated Gobii MCP message to an agent, optionally with existing filespace attachments. |
+| `gobii_send_agent_message` | Send an authenticated Gobii MCP message to an agent, optionally uploading and attaching small files in the same call. |
 | `gobii_get_agent_timeline` | Fetch timeline events and processing state using durable cursors. |
 | `gobii_get_agent_debug_trace` | Fetch bounded, sanitized debugging context for one accessible agent. |
 | `gobii_wait_for_agent_event` | Bounded long-poll for matching timeline events after a cursor. |
+| `gobii_read_agent_resource` | Read a file or image from a `gobii://` resource URI as native MCP content. |
 | `gobii_list_agent_files` | List an agent's default filespace. |
 | `gobii_upload_agent_file` | Upload a small base64 file into the agent filespace. |
 
-Gobii does not expose MCP resources or prompts in v1. The current product capabilities map more cleanly to MCP tools.
+Gobii exposes authenticated file resources alongside its tools. File and timeline results include `resource_link` content blocks; clients can use `resources/read` or `gobii_read_agent_resource` to retrieve the bytes. Gobii does not expose MCP prompts.
 
 ## Agent Config
 
@@ -188,13 +190,17 @@ Linked-agent messages appear as peer direct-message events in each participating
 
 ## Files And Attachments
 
-Preferred flow:
+When a file already exists in the agent filespace:
 
 1. Upload a small file with `gobii_upload_agent_file`, or create/upload the file in the Gobii agent filespace through the product.
 2. Send a message with `gobii_send_agent_message`.
 3. Pass filespace paths in `attachment_file_paths`, for example `["/uploads/brief.pdf"]`.
 
-This keeps message calls small and uses Gobii's existing filespace and attachment models. Arbitrary URL fetching is intentionally not exposed through the MCP server v1. Very large files should be added to the agent filespace outside MCP, then referenced by path.
+When a client already has the bytes, it can instead pass up to 10 items in the message call's `attachments` array. Each item contains `path`, `content_base64`, optional `mime_type`, and optional `overwrite`; Gobii uploads and attaches them in one call.
+
+`gobii_list_agent_files`, `gobii_get_agent_timeline`, upload results, and message results return authenticated `gobii://` resource URIs. Use MCP `resources/read` for standard resource content, or `gobii_read_agent_resource` when a tool-centric client needs an image surfaced directly as MCP image content. Reads re-check API-key access, enforce the platform file-size limit, and verify stored checksums when available. Resource URIs are not public download links.
+
+These flows use Gobii's existing filespace and attachment models. Arbitrary URL fetching is intentionally not exposed through the MCP server. Very large files should be added to the agent filespace outside MCP, then referenced by path.
 
 ## Hermes Example
 
@@ -223,6 +229,7 @@ mcp_servers:
         - gobii_get_agent_timeline
         - gobii_get_agent_debug_trace
         - gobii_wait_for_agent_event
+        - gobii_read_agent_resource
         - gobii_list_agent_files
         - gobii_upload_agent_file
 ```
@@ -243,9 +250,10 @@ Use this flow for local dev, preview, or production smoke testing. Archive tempo
 8. `gobii_get_agent_debug_trace`; verify returned sections are bounded and sanitized
 9. `gobii_wait_for_agent_event` with a cursor and a short timeout; verify both match and timeout behavior as appropriate
 10. `gobii_upload_agent_file`
-11. `gobii_list_agent_files`
-12. `gobii_unlink_agents`
-13. `gobii_archive_agent` for temporary agents
+11. `gobii_list_agent_files`, then read its `resource_link`
+12. `gobii_send_agent_message` with an inline `attachments` item
+13. `gobii_unlink_agents`
+14. `gobii_archive_agent` for temporary agents
 
 ## Limitations
 

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -7,12 +7,14 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, tag
 from django.utils import timezone
 
 from api.agent.core.llm_config import AgentLLMTier
 from api.agent.core.processing_flags import get_human_inbound_generation
 from api.models import (
+    AgentFsNode,
     AgentPeerLink,
     BrowserUseAgent,
     CommsChannel,
@@ -27,6 +29,7 @@ from api.models import (
     PersistentAgentCompletion,
     PersistentAgentError,
     PersistentAgentMessage,
+    PersistentAgentMessageAttachment,
     PersistentAgentPromptArchive,
     PersistentAgentStep,
     PersistentAgentToolCall,
@@ -112,6 +115,13 @@ class RemoteMCPViewTests(TestCase):
             "tools/call",
             {"name": name, "arguments": arguments or {}},
             auth=auth,
+            api_key=api_key,
+        )
+
+    def _read_resource(self, uri, *, api_key=None):
+        return self._post_mcp(
+            "resources/read",
+            {"uri": uri},
             api_key=api_key,
         )
 
@@ -219,6 +229,10 @@ class RemoteMCPViewTests(TestCase):
         payload = response.json()
         self.assertEqual(payload["result"]["protocolVersion"], "2025-11-25")
         self.assertIn("tools", payload["result"]["capabilities"])
+        self.assertEqual(
+            payload["result"]["capabilities"]["resources"],
+            {"subscribe": False, "listChanged": False},
+        )
 
         bearer_response = self._post_mcp("initialize", auth="bearer")
         self.assertEqual(bearer_response.status_code, 200)
@@ -235,6 +249,7 @@ class RemoteMCPViewTests(TestCase):
         self.assertIn("gobii_send_agent_message", tool_names)
         self.assertIn("gobii_wait_for_agent_event", tool_names)
         self.assertIn("gobii_get_agent_debug_trace", tool_names)
+        self.assertIn("gobii_read_agent_resource", tool_names)
         self.assertIn("gobii_upload_agent_file", tool_names)
 
         debug_tool = next(tool for tool in tools_response.json()["result"]["tools"] if tool["name"] == "gobii_get_agent_debug_trace")
@@ -250,6 +265,15 @@ class RemoteMCPViewTests(TestCase):
         self.assertEqual(content["total"], 1)
         self.assertEqual(content["agents"][0]["id"], str(agent.id))
         self.assertNotIn("access", content)
+
+        resources_response = self._post_mcp("resources/list")
+        self.assertEqual(resources_response.json()["result"]["resources"], [])
+        templates_response = self._post_mcp("resources/templates/list")
+        templates = templates_response.json()["result"]["resourceTemplates"]
+        self.assertEqual(
+            {template["name"] for template in templates},
+            {"gobii-agent-file", "gobii-message-attachment"},
+        )
 
     def test_non_admin_scope_params_return_structured_tool_error(self):
         other_agent = self._create_agent(self.other_user, "Scoped Other Agent")
@@ -868,6 +892,234 @@ class RemoteMCPViewTests(TestCase):
             inbound_generation=expected_generation,
             inbound_message_id=str(message.id),
         )
+
+    @patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)
+    @patch("api.auth.can_user_use_personal_agents_and_api", return_value=True)
+    def test_agent_file_is_a_native_mcp_resource(self, _mock_auth_access, _mock_scope_access):
+        agent = self._create_agent(self.user, "Resource MCP Agent")
+        content = b"\x89PNG\r\n\x1a\nsmall-image-fixture"
+        upload_response = self._call_tool(
+            "gobii_upload_agent_file",
+            {
+                "agent_id": str(agent.id),
+                "path": "/qa/screenshot.png",
+                "content_base64": base64.b64encode(content).decode("ascii"),
+                "mime_type": "image/png",
+            },
+        )
+        self.assertFalse(upload_response.json()["result"]["isError"])
+
+        files_response = self._call_tool(
+            "gobii_list_agent_files",
+            {"agent_id": str(agent.id)},
+        )
+        files_result = files_response.json()["result"]
+        screenshot = next(
+            node
+            for node in files_result["structuredContent"]["nodes"]
+            if node["path"] == "/qa/screenshot.png"
+        )
+        resource_uri = screenshot["resource_uri"]
+        self.assertTrue(resource_uri.startswith(f"gobii://agents/{agent.id}/files/"))
+        resource_links = [
+            item for item in files_result["content"] if item["type"] == "resource_link"
+        ]
+        self.assertEqual(resource_links[0]["uri"], resource_uri)
+        self.assertEqual(resource_links[0]["mimeType"], "image/png")
+        self.assertEqual(resource_links[0]["size"], len(content))
+
+        read_response = self._read_resource(resource_uri)
+        self.assertEqual(read_response.status_code, 200)
+        resource = read_response.json()["result"]["contents"][0]
+        self.assertEqual(resource["uri"], resource_uri)
+        self.assertEqual(resource["mimeType"], "image/png")
+        self.assertEqual(base64.b64decode(resource["blob"]), content)
+
+        tool_response = self._call_tool(
+            "gobii_read_agent_resource",
+            {"uri": resource_uri},
+        )
+        tool_result = tool_response.json()["result"]
+        self.assertFalse(tool_result["isError"])
+        image = next(item for item in tool_result["content"] if item["type"] == "image")
+        self.assertEqual(image["mimeType"], "image/png")
+        self.assertEqual(base64.b64decode(image["data"]), content)
+
+    @patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)
+    @patch("api.auth.can_user_use_personal_agents_and_api", return_value=True)
+    def test_timeline_exposes_native_resource_for_unimported_attachment(
+        self,
+        _mock_auth_access,
+        _mock_scope_access,
+    ):
+        agent = self._create_agent(self.user, "Timeline Attachment Agent")
+        message = self._create_web_message(agent, "Screenshot attached")
+        content = b"\x89PNG\r\n\x1a\nmessage-attachment"
+        attachment = PersistentAgentMessageAttachment.objects.create(
+            message=message,
+            file=SimpleUploadedFile("bug.png", content, content_type="image/png"),
+            content_type="image/png",
+            file_size=len(content),
+            filename="bug.png",
+        )
+
+        response = self._call_tool(
+            "gobii_get_agent_timeline",
+            {"agent_id": str(agent.id), "limit": 10},
+        )
+
+        result = response.json()["result"]
+        event = next(
+            event
+            for event in result["structuredContent"]["events"]
+            if event.get("kind") == "message" and event["message"]["id"] == str(message.id)
+        )
+        resource_uri = event["message"]["attachments"][0]["resource_uri"]
+        self.assertEqual(
+            resource_uri,
+            f"gobii://agents/{agent.id}/attachments/{attachment.id}",
+        )
+        self.assertIn(
+            resource_uri,
+            [item["uri"] for item in result["content"] if item["type"] == "resource_link"],
+        )
+        resource = self._read_resource(resource_uri).json()["result"]["contents"][0]
+        self.assertEqual(base64.b64decode(resource["blob"]), content)
+
+    @patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)
+    @patch("api.auth.can_user_use_personal_agents_and_api", return_value=True)
+    def test_resource_read_does_not_cross_agent_scope(self, _mock_auth_access, _mock_scope_access):
+        other_agent = self._create_agent(self.other_user, "Other Resource Agent")
+        encoded = base64.b64encode(b"private").decode("ascii")
+        raw_other_api_key, _ = ApiKey.create_for_user(self.other_user, name="other-mcp")
+        upload_response = self._call_tool(
+            "gobii_upload_agent_file",
+            {
+                "agent_id": str(other_agent.id),
+                "path": "/private.txt",
+                "content_base64": encoded,
+                "mime_type": "text/plain",
+            },
+            api_key=raw_other_api_key,
+        )
+        resource_uri = self._structured_content(upload_response)["resource_uri"]
+
+        read_response = self._read_resource(resource_uri)
+
+        self.assertEqual(read_response.status_code, 200)
+        self.assertEqual(read_response.json()["error"]["code"], -32002)
+        self.assertEqual(read_response.json()["error"]["message"], "Resource not found or inaccessible.")
+
+    @patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)
+    @patch("api.auth.can_user_use_personal_agents_and_api", return_value=True)
+    def test_send_message_accepts_inline_attachments_in_one_call(
+        self,
+        _mock_auth_access,
+        _mock_scope_access,
+    ):
+        agent = self._create_agent(self.user, "Inline Attachment Agent")
+        content = b"name,status\nAda,ready\n"
+
+        with (
+            patch("api.agent.tasks.enqueue_interactive_process_agent_events"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self._call_tool(
+                "gobii_send_agent_message",
+                {
+                    "agent_id": str(agent.id),
+                    "body": "Use the attached source data.",
+                    "attachments": [
+                        {
+                            "path": "/uploads/source.csv",
+                            "content_base64": base64.b64encode(content).decode("ascii"),
+                            "mime_type": "text/csv",
+                        }
+                    ],
+                },
+            )
+
+        result = self._structured_content(response)
+        self.assertFalse(response.json()["result"]["isError"], response.content)
+        self.assertEqual(result["attachment_count"], 1)
+        self.assertEqual(len(result["uploaded_attachments"]), 1)
+        uploaded = result["uploaded_attachments"][0]
+        self.assertEqual(uploaded["path"], "/uploads/source.csv")
+        self.assertTrue(uploaded["resource_uri"].startswith(f"gobii://agents/{agent.id}/files/"))
+        timeline_attachment = result["timeline_event"]["message"]["attachments"][0]
+        self.assertEqual(timeline_attachment["resource_uri"], uploaded["resource_uri"])
+        resource_links = [
+            item for item in response.json()["result"]["content"] if item["type"] == "resource_link"
+        ]
+        self.assertEqual([item["uri"] for item in resource_links], [uploaded["resource_uri"]])
+        attachment = PersistentAgentMessage.objects.get(id=result["message_id"]).attachments.get()
+        self.assertEqual(attachment.filespace_node.path, "/uploads/source.csv")
+        self.assertEqual(attachment.filespace_node.checksum_sha256, uploaded["checksum_sha256"])
+        resource = self._read_resource(uploaded["resource_uri"]).json()["result"]["contents"][0]
+        self.assertEqual(resource["text"], content.decode("utf-8"))
+
+    @patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)
+    @patch("api.auth.can_user_use_personal_agents_and_api", return_value=True)
+    def test_inline_attachments_are_fully_validated_before_upload(
+        self,
+        _mock_auth_access,
+        _mock_scope_access,
+    ):
+        agent = self._create_agent(self.user, "Invalid Inline Attachment Agent")
+
+        response = self._call_tool(
+            "gobii_send_agent_message",
+            {
+                "agent_id": str(agent.id),
+                "body": "Do not partially persist these files.",
+                "attachments": [
+                    {
+                        "path": "/uploads/valid.txt",
+                        "content_base64": base64.b64encode(b"valid").decode("ascii"),
+                    },
+                    {
+                        "path": "/uploads/invalid.txt",
+                        "content_base64": "not base64!",
+                    },
+                ],
+            },
+        )
+
+        self.assertTrue(response.json()["result"]["isError"])
+        self.assertFalse(
+            AgentFsNode.objects.alive().filter(filespace__access__agent=agent).exists()
+        )
+        self.assertFalse(
+            PersistentAgentMessage.objects.filter(
+                owner_agent=agent,
+                raw_payload__source="remote_mcp",
+            ).exists()
+        )
+
+    @patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)
+    @patch("api.auth.can_user_use_personal_agents_and_api", return_value=True)
+    def test_resource_read_rejects_checksum_mismatch(
+        self,
+        _mock_auth_access,
+        _mock_scope_access,
+    ):
+        agent = self._create_agent(self.user, "Checksum MCP Agent")
+        upload_response = self._call_tool(
+            "gobii_upload_agent_file",
+            {
+                "agent_id": str(agent.id),
+                "path": "/evidence.txt",
+                "content_base64": base64.b64encode(b"original evidence").decode("ascii"),
+                "mime_type": "text/plain",
+            },
+        )
+        uploaded = self._structured_content(upload_response)
+        AgentFsNode.objects.filter(id=uploaded["node_id"]).update(checksum_sha256="0" * 64)
+
+        response = self._read_resource(uploaded["resource_uri"])
+
+        self.assertEqual(response.json()["error"]["code"], -32002)
+        self.assertEqual(response.json()["error"]["message"], "Resource not found or inaccessible.")
 
     @patch("api.services.remote_mcp.can_user_use_personal_agents_and_api", return_value=True)
     @patch("api.auth.can_user_use_personal_agents_and_api", return_value=True)


### PR DESCRIPTION
## Outcome

Makes Gobii MCP attachments usable in both directions without adding a parallel storage system:

- file and timeline results expose scoped `resource_link` blocks and `gobii://` URIs
- standard `resources/read` returns text/blob resource contents
- `gobii_read_agent_resource` gives tool-centric clients native image/resource content
- `gobii_send_agent_message` can upload and attach up to 10 small files in one call
- every read rechecks agent access, enforces the platform size limit, and verifies stored checksums

The implementation follows the stable MCP 2025-11-25 resource primitives and keeps existing upload-then-send clients compatible.

## Red -> green evidence

The new protocol tests initially failed because Gobii advertised no resource capability, returned no resource URIs, rejected `resources/read`, and rejected inline message attachments. They now cover:

- filespace image resource links, direct reads, and native image content
- unimported timeline attachment reads
- cross-agent authorization isolation
- checksum mismatch rejection
- validation of all inline files before any write
- one-call upload + message attachment with text resource readback
- resource/tool discovery

## Local verification

- `RemoteMCPViewTests`: 37/37 green
- focused attachment/timeline tests: green
- Python compile check: green
- complexity LoC guard: green
- `git diff --check`: green

No behavioral prompt eval was added: this is deterministic MCP protocol, authorization, storage, and serialization behavior, fully covered at the real HTTP endpoint boundary.