### PR TITLE
Fix agent control-surface reliability batch

### DIFF
--- a/api/agent/tools/meta_gobii.py
+++ b/api/agent/tools/meta_gobii.py
@@ -163,6 +163,22 @@ _LINK_OUTPUT = _output_object(
         "id": _UUID,
         "agent_a": _AGENT_REF_OUTPUT,
         "agent_b": _AGENT_REF_OUTPUT,
+        "health": _output_object(
+            {
+                "status": {"type": "string"},
+                "issues": {
+                    "type": "array",
+                    "items": _output_object(
+                        {
+                            "agent_id": _UUID,
+                            "reason": {"type": "string"},
+                        },
+                        required=("agent_id", "reason"),
+                    ),
+                },
+            },
+            required=("status", "issues"),
+        ),
         "is_enabled": {"type": "boolean"},
         "messages_per_window": {"type": "integer"},
         "window_hours": {"type": "integer"},
@@ -1907,6 +1923,7 @@ def _serialize_peer_link(link: AgentPeerLink) -> dict[str, Any]:
         "id": str(link.id),
         "agent_a": _serialize_agent_ref(link.agent_a),
         "agent_b": _serialize_agent_ref(link.agent_b),
+        "health": link.health_summary(),
         "is_enabled": link.is_enabled,
         "messages_per_window": link.messages_per_window,
         "window_hours": link.window_hours,

--- a/api/evals/execution.py
+++ b/api/evals/execution.py
@@ -307,6 +307,20 @@ class ScenarioExecutionTools:
     def get_run(self, run_id: str) -> EvalRun:
         return EvalRun.objects.get(id=run_id)
 
+    def enable_sandbox_tool_visibility(self, agent_id: str) -> None:
+        """Expose sandbox-backed tools when a scenario explicitly exercises them."""
+        from waffle.models import Flag
+
+        from api.services.system_settings import get_setting_definition, set_setting_value
+
+        agent = PersistentAgent.objects.select_related("user").get(id=agent_id)
+        definition = get_setting_definition("SANDBOX_COMPUTE_ENABLED")
+        if definition:
+            set_setting_value(definition, True)
+        flag, _ = Flag.objects.get_or_create(name="sandbox_compute")
+        if agent.user_id:
+            flag.users.add(agent.user)
+
     def inject_message(
         self,
         agent_id: str,

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -818,19 +818,6 @@ class BehaviorMicroScenario(EvalScenario, ScenarioExecutionTools):
                 tool_name=tool_name,
             )
 
-    def _enable_sandbox_tool_visibility(self, agent_id):
-        from waffle.models import Flag
-
-        from api.services.system_settings import get_setting_definition, set_setting_value
-
-        agent = PersistentAgent.objects.select_related("user").get(id=agent_id)
-        definition = get_setting_definition("SANDBOX_COMPUTE_ENABLED")
-        if definition:
-            set_setting_value(definition, True)
-        flag, _ = Flag.objects.get_or_create(name="sandbox_compute")
-        if agent.user_id:
-            flag.users.add(agent.user)
-
     def _planning_guardrail_mocks(self):
         return {
             "spawn_web_task": {"status": "error", "message": "Browser work disabled during planning eval."},
@@ -4880,7 +4867,7 @@ class CommonUseCaseToolChoiceScenario(BehaviorMicroScenario):
             [tool_name for tool_name in tool_names if tool_name not in synthetic_tool_names],
         )
         if "create_custom_tool" in self._accepted_expected_tool_names():
-            self._enable_sandbox_tool_visibility(agent_id)
+            self.enable_sandbox_tool_visibility(agent_id)
         self._enable_eval_synthetic_tools(agent_id, list(dict.fromkeys(synthetic_tool_names)))
 
         self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="inject_prompt")

--- a/api/evals/scenarios/custom_tool_result_contract.py
+++ b/api/evals/scenarios/custom_tool_result_contract.py
@@ -217,12 +217,7 @@ class CustomToolResultContractScenario(EvalScenario, ScenarioExecutionTools):
     ]
     case: CustomToolResultContractCase | None = None
 
-    def run(self, run_id: str, agent_id: str) -> None:
-        if self.case is None:
-            raise ValueError("Custom tool result contract eval is missing case metadata.")
-
-        case = self.case
-        custom_tool_name = self._custom_tool_name(case)
+    def _prepare_agent(self, agent_id: str) -> None:
         PersistentAgent.objects.filter(id=agent_id).update(
             charter=(
                 "You are an eval agent. Use the real agent tool stack to satisfy the user's request. "
@@ -230,6 +225,15 @@ class CustomToolResultContractScenario(EvalScenario, ScenarioExecutionTools):
             ),
             planning_state=PersistentAgent.PlanningState.SKIPPED,
         )
+        self.enable_sandbox_tool_visibility(agent_id)
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        if self.case is None:
+            raise ValueError("Custom tool result contract eval is missing case metadata.")
+
+        case = self.case
+        custom_tool_name = self._custom_tool_name(case)
+        self._prepare_agent(agent_id)
 
         self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="inject_prompt")
         with self.wait_for_agent_idle(agent_id, timeout=180):

--- a/api/evals/scenarios/effort_calibration.py
+++ b/api/evals/scenarios/effort_calibration.py
@@ -48,6 +48,7 @@ EFFORT_EXPLICIT_DEEP_RESEARCH_REMAINS_CAPABLE = "effort_explicit_deep_research_r
 EFFORT_UNSCHEDULED_REMAINING_WORK_SETS_RESUME = "effort_unscheduled_remaining_work_sets_resume"
 EFFORT_PARTIAL_SOURCE_BLOCK_REPORTS_AND_RESUMES = "effort_partial_source_block_reports_and_resumes"
 EFFORT_TOOL_WAIT_NEXT_SCHEDULE_REQUIRES_SCHEDULE = "effort_tool_wait_next_schedule_requires_schedule"
+EFFORT_AUTOMATIC_FUTURE_EVENTS_STAY_OFF_PLAN = "effort_automatic_future_events_stay_off_plan"
 DEEP_WORK_CORRECTION_STEP_PREFIX = "Deep-work communication correction:"
 
 EFFORT_CALIBRATION_SCENARIO_SLUGS = [
@@ -64,6 +65,7 @@ EFFORT_CALIBRATION_SCENARIO_SLUGS = [
     EFFORT_UNSCHEDULED_REMAINING_WORK_SETS_RESUME,
     EFFORT_PARTIAL_SOURCE_BLOCK_REPORTS_AND_RESUMES,
     EFFORT_TOOL_WAIT_NEXT_SCHEDULE_REQUIRES_SCHEDULE,
+    EFFORT_AUTOMATIC_FUTURE_EVENTS_STAY_OFF_PLAN,
 ]
 
 MESSAGE_TOOL_NAMES = {
@@ -2313,6 +2315,97 @@ class EffortToolWaitNextScheduleRequiresScheduleScenario(EffortCalibrationScenar
             forbidden_tool_names=EFFORT_OVERWORK_TOOL_NAMES | ARTIFACT_TOOL_NAMES | RESEARCH_TOOL_NAMES,
         )
         self._record_orchestrator_budget(run_id, task_name="verify_turn_budget", max_completions=5)
+
+
+@register_scenario
+class EffortAutomaticFutureEventsStayOffPlanScenario(EffortCalibrationScenario):
+    slug = EFFORT_AUTOMATIC_FUTURE_EVENTS_STAY_OFF_PLAN
+    description = (
+        "Schedules, replies, and future source batches wake agents automatically; an agent with no current action "
+        "should finish the run instead of turning those passive events into user-visible plan tasks."
+    )
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="manual"),
+        ScenarioTask(name="verify_current_batch_checked", assertion_type="manual"),
+        ScenarioTask(name="verify_no_passive_wait_task", assertion_type="manual"),
+        ScenarioTask(name="verify_turn_budget", assertion_type="manual"),
+    ]
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._ready_agent(
+            agent_id,
+            charter="Process each available partner batch and report its status before ending the current run.",
+            schedule="@every 4h",
+        )
+        self._enable_eval_synthetic_tools(agent_id, ["eval_prepare_next_batch"])
+        mock_config = {
+            "eval_prepare_next_batch": {
+                "status": "ok",
+                "prepared_count": 12,
+                "remaining_work": 0,
+                "next_cursor": None,
+                "next_action": (
+                    "Current work is complete. A scheduled run, inbound replies, or a fresh partner batch will "
+                    "wake the agent automatically."
+                ),
+            }
+        }
+
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="inject_prompt")
+        with self.wait_for_agent_idle(agent_id, timeout=180):
+            inbound = self.inject_message(
+                agent_id,
+                (
+                    "Wrap up the current partner batch and tell me where it landed. We have the normal recurring "
+                    "schedule, and replies or new partner data may arrive later."
+                ),
+                trigger_processing=True,
+                eval_run_id=run_id,
+                mock_config=mock_config,
+                eval_stop_policy={
+                    "stop_when_all_seen": [
+                        {"tool_name": "eval_prepare_next_batch", "after_execution": True},
+                    ],
+                    "stop_on_tool_names": list(EFFORT_OVERWORK_TOOL_NAMES | ARTIFACT_TOOL_NAMES),
+                    "stop_on_human_input_request": True,
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": ["eval_prepare_next_batch", "sqlite_batch"],
+                    "max_relevant_tool_calls": 3,
+                    "ignored_tool_names": list(MESSAGE_TOOL_NAMES | STOP_TOOL_NAMES),
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_prompt",
+            observed_summary="Prompt injected and processing completed.",
+            artifacts={"message": inbound},
+        )
+
+        calls = _tool_calls_for_run(
+            run_id,
+            after=inbound.timestamp,
+            tool_names={"eval_prepare_next_batch"},
+        )
+        self.record_task_result(
+            run_id,
+            calls[0].step if calls else None,
+            EvalRunTask.Status.PASSED if calls else EvalRunTask.Status.FAILED,
+            task_name="verify_current_batch_checked",
+            observed_summary=(
+                "The agent checked the current batch before finishing."
+                if calls
+                else "The agent did not check the current batch."
+            ),
+        )
+        self._record_no_overwork_tools(
+            run_id,
+            after=inbound.timestamp,
+            task_name="verify_no_passive_wait_task",
+            forbidden_tool_names={"update_plan"},
+        )
+        self._record_orchestrator_budget(run_id, task_name="verify_turn_budget", max_completions=3)
 
 
 @register_scenario

--- a/api/evals/tests/test_custom_tool_result_contract.py
+++ b/api/evals/tests/test_custom_tool_result_contract.py
@@ -1,9 +1,15 @@
 import json
 from types import SimpleNamespace
 
-from django.test import SimpleTestCase, tag
+from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase, TestCase, tag
+from waffle.models import Flag
 
 from api.evals.scenarios.custom_tool_result_contract import CustomToolResultContractScenario
+from api.models import BrowserUseAgent, PersistentAgent
+
+
+User = get_user_model()
 
 
 @tag("eval_sim")
@@ -30,3 +36,31 @@ class CustomToolResultContractEvaluatorTests(SimpleTestCase):
         ]
 
         self.assertEqual(CustomToolResultContractScenario._successful_create_calls(calls), calls)
+
+
+@tag("eval_sim")
+class CustomToolResultContractSetupTests(TestCase):
+    def test_prepare_agent_enables_sandbox_tool_visibility(self):
+        user = User.objects.create_user(
+            username="custom-tool-eval@example.test",
+            email="custom-tool-eval@example.test",
+        )
+        browser_agent = BrowserUseAgent.objects.create(
+            user=user,
+            name="Custom tool eval browser",
+        )
+        agent = PersistentAgent.objects.create(
+            user=user,
+            name="Custom tool eval",
+            charter="Initial eval charter.",
+            browser_use_agent=browser_agent,
+        )
+        scenario = CustomToolResultContractScenario()
+
+        scenario._prepare_agent(agent.id)
+
+        agent.refresh_from_db()
+        self.assertEqual(agent.planning_state, PersistentAgent.PlanningState.SKIPPED)
+        self.assertTrue(
+            Flag.objects.get(name="sandbox_compute").users.filter(id=user.id).exists()
+        )

--- a/api/models.py
+++ b/api/models.py
@@ -11360,6 +11360,23 @@ class AgentPeerLink(models.Model):
             return self.agent_a
         return None
 
+    def health_summary(self) -> dict:
+        issues = []
+        for agent in (self.agent_a, self.agent_b):
+            if agent.is_deleted:
+                reason = "deleted"
+            elif agent.life_state != PersistentAgent.LifeState.ACTIVE:
+                reason = agent.life_state
+            elif not agent.is_active:
+                reason = "inactive"
+            else:
+                continue
+            issues.append({"agent_id": str(agent.id), "reason": reason})
+        return {
+            "status": "unhealthy" if issues else "healthy",
+            "issues": issues,
+        }
+
     def remove_preserving_history(self) -> None:
         try:
             conversation = self.conversation

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -442,6 +442,7 @@ class PersistentAgentSerializer(serializers.ModelSerializer):
             'personal_mcp_server_ids',
         )
         ref_name = "PersistentAgentDetail"
+        extra_kwargs = {'name': {'required': False}}
 
     def validate_preferred_contact_endpoint(self, value):
         if value is None:
@@ -642,7 +643,11 @@ class PersistentAgentSerializer(serializers.ModelSerializer):
             from api.agent.tasks import enqueue_interactive_process_agent_events
 
             agent_id = str(agent.id)
-            transaction.on_commit(lambda: enqueue_interactive_process_agent_events(agent_id))
+            # The row is durable before callbacks run, so a queue outage must not report creation as failed.
+            transaction.on_commit(
+                lambda: enqueue_interactive_process_agent_events(agent_id),
+                robust=True,
+            )
 
         return agent
 

--- a/api/services/remote_mcp.py
+++ b/api/services/remote_mcp.py
@@ -192,6 +192,22 @@ _LINK_OUTPUT = _object_output(
         "id": _UUID_OUTPUT,
         "agent_a": _AGENT_REF_OUTPUT,
         "agent_b": _AGENT_REF_OUTPUT,
+        "health": _object_output(
+            {
+                "status": {"type": "string"},
+                "issues": {
+                    "type": "array",
+                    "items": _object_output(
+                        {
+                            "agent_id": _UUID_OUTPUT,
+                            "reason": {"type": "string"},
+                        },
+                        required=("agent_id", "reason"),
+                    ),
+                },
+            },
+            required=("status", "issues"),
+        ),
         "is_enabled": {"type": "boolean"},
         "messages_per_window": {"type": "integer"},
         "window_hours": {"type": "integer"},
@@ -2290,6 +2306,7 @@ def _serialize_peer_link(link):
         "id": str(link.id),
         "agent_a": _serialize_agent_ref(link.agent_a),
         "agent_b": _serialize_agent_ref(link.agent_b),
+        "health": link.health_summary(),
         "is_enabled": link.is_enabled,
         "messages_per_window": link.messages_per_window,
         "window_hours": link.window_hours,

--- a/api/views.py
+++ b/api/views.py
@@ -710,7 +710,12 @@ class PersistentAgentViewSet(viewsets.ModelViewSet):
     queryset = (
         PersistentAgent.objects.non_eval()
         .alive()
-        .select_related('browser_use_agent', 'organization', 'preferred_contact_endpoint')
+        .select_related(
+            'browser_use_agent',
+            'organization',
+            'preferred_contact_endpoint',
+            'preferred_llm_tier',
+        )
     )
     serializer_class = PersistentAgentSerializer
     permission_classes = [IsAuthenticated]
@@ -727,6 +732,7 @@ class PersistentAgentViewSet(viewsets.ModelViewSet):
         props = {
             'agent_id': str(agent.id),
             'agent_name': agent.name,
+            'preferred_llm_tier': agent.preferred_llm_tier.key if agent.preferred_llm_tier_id else 'standard',
         }
         org = self._request_organization()
         if org is not None:

--- a/console/agent_creation.py
+++ b/console/agent_creation.py
@@ -558,6 +558,11 @@ def create_persistent_agent_from_charter(
             "initial_message": initial_message,
             "charter": initial_message or "",
             "preferred_contact_method": preferred_contact_method,
+            "preferred_llm_tier": (
+                persistent_agent.preferred_llm_tier.key
+                if persistent_agent.preferred_llm_tier_id
+                else "standard"
+            ),
             "template_code": selected_template.code if selected_template else "",
             "template_source": template_source if selected_template else "",
             "template_schedule_applied": applied_schedule or "",

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,25 +1,25 @@
 {
-  "baseline_sha": "70842772f0592fc0eaae3e03a200e9aac6548bd7",
+  "baseline_sha": "a1bc6a90fc585d442a52d164237de5ff2db11480",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9270,
+        "fitted_tokens": 9275,
         "system_bytes": 32433,
         "tools_bytes": 23494,
         "total_bytes": 67636,
         "user_bytes": 11709
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8666,
+        "fitted_tokens": 8676,
         "system_bytes": 29314,
         "tools_bytes": 23494,
         "total_bytes": 64550,
         "user_bytes": 11742
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8851,
+        "fitted_tokens": 8844,
         "system_bytes": 29951,
         "tools_bytes": 23494,
         "total_bytes": 65190,
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 266241
+    "limit": 266307
   }
 }

--- a/tests/unit/test_api_persistent_agents.py
+++ b/tests/unit/test_api_persistent_agents.py
@@ -21,6 +21,7 @@ from api.models import (
     UserPhoneNumber,
     UserQuota,
 )
+from util.analytics import AnalyticsEvent
 
 PERSISTENT_AGENT_BASE_URL = '/api/v1/agents/'
 
@@ -545,7 +546,10 @@ class PersistentAgentAPITests(TestCase):
         self._standard_delay_patcher = patch('api.agent.tasks.process_agent_events_task.delay')
         self.standard_process_events_mock = self._standard_delay_patcher.start()
         self.addCleanup(self._standard_delay_patcher.stop)
-        self._on_commit_patcher = patch('api.serializers.transaction.on_commit', side_effect=lambda fn: fn())
+        self._on_commit_patcher = patch(
+            'api.serializers.transaction.on_commit',
+            side_effect=lambda fn, **_kwargs: fn(),
+        )
         self.on_commit_mock = self._on_commit_patcher.start()
         self.addCleanup(self._on_commit_patcher.stop)
         self._analytics_patcher = patch('api.views.Analytics.track_event')
@@ -595,6 +599,12 @@ class PersistentAgentAPITests(TestCase):
         self.assertTrue(email_meta.verified)
         self.assertEqual(email_meta.display_name, "API @ Persistent Agent")
         self.process_events_mock.assert_called_with(str(agent.id))
+        created_event = next(
+            call
+            for call in self.analytics_mock.call_args_list
+            if call.kwargs.get("event") == AnalyticsEvent.PERSISTENT_AGENT_CREATED
+        )
+        self.assertEqual(created_event.kwargs["properties"]["preferred_llm_tier"], "standard")
 
     def test_create_agent_persists_contact_approval_mode(self):
         payload = self._create_agent_via_api({

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -2908,6 +2908,7 @@ class ConsoleViewsTest(TestCase):
         _mock_delay,
     ):
         from agents.services import PretrainedWorkerTemplateService
+        from api.models import PersistentAgent
 
         template = PretrainedWorkerTemplateService.get_active_templates()[0]
         session = self.client.session
@@ -2930,6 +2931,11 @@ class ConsoleViewsTest(TestCase):
         properties = created_event_calls[0]["properties"]
         self.assertEqual(properties.get("template_code"), template.code)
         self.assertEqual(properties.get("template_source"), AGENT_TEMPLATE_SOURCE_PRETRAINED_WORKER)
+        created_agent = PersistentAgent.objects.latest("created_at")
+        self.assertEqual(
+            properties.get("preferred_llm_tier"),
+            created_agent.preferred_llm_tier.key if created_agent.preferred_llm_tier_id else "standard",
+        )
         self.assertNotIn(AGENT_TEMPLATE_SOURCE_SESSION_KEY, self.client.session)
 
     @override_settings(

--- a/tests/unit/test_custom_tool_result_contract_evals.py
+++ b/tests/unit/test_custom_tool_result_contract_evals.py
@@ -552,6 +552,7 @@ if __name__ == "__main__":
             self.fail("LLM judge should not run after prerequisite local checks fail.")
 
         scenario.wait_for_agent_idle = lambda *args, **kwargs: nullcontext()
+        scenario._prepare_agent = lambda *args, **kwargs: None
         scenario.inject_message = lambda *args, **kwargs: SimpleNamespace(timestamp=timezone.now())
         scenario._tool_calls_for_run = lambda *args, **kwargs: [create_call, custom_call]
         scenario.record_task_result = record_task_result
@@ -589,6 +590,7 @@ if __name__ == "__main__":
             self.fail("LLM judge should not run after repeated create_custom_tool calls.")
 
         scenario.wait_for_agent_idle = lambda *args, **kwargs: nullcontext()
+        scenario._prepare_agent = lambda *args, **kwargs: None
         scenario.inject_message = lambda *args, **kwargs: SimpleNamespace(timestamp=timezone.now())
         scenario._tool_calls_for_run = lambda *args, **kwargs: [first_create, second_create, custom_call]
         scenario.record_task_result = record_task_result

--- a/tests/unit/test_eval_behavior_micro_scenarios.py
+++ b/tests/unit/test_eval_behavior_micro_scenarios.py
@@ -1348,7 +1348,7 @@ class BehaviorMicroHelperTests(TestCase):
         scenario = ScenarioRegistry.get("common_use_case_122_custom_tool_bulk_api_sqlite")
 
         scenario._enable_builtin_tools(self.agent.id, ["create_custom_tool"])
-        scenario._enable_sandbox_tool_visibility(self.agent.id)
+        scenario.enable_sandbox_tool_visibility(self.agent.id)
 
         names = {
             definition["function"]["name"]

--- a/tests/unit/test_event_processing_parallel_tools.py
+++ b/tests/unit/test_event_processing_parallel_tools.py
@@ -971,7 +971,9 @@ class TestParallelToolCallsExecution(TestCase):
     def test_parallel_safe_batch_respects_configured_worker_limit(self, mock_execute_enabled, _mock_credit):
         active = 0
         max_active = 0
+        started = 0
         lock = threading.Lock()
+        first_worker_batch = threading.Barrier(4)
 
         def side_effect(
             _agent,
@@ -981,13 +983,16 @@ class TestParallelToolCallsExecution(TestCase):
             current_sqlite_db_path=None,
             resolved_entry=None,
         ):
-            nonlocal active, max_active
+            nonlocal active, max_active, started
             self.assertTrue(isolated_mcp)
             self.assertIsNone(current_sqlite_db_path)
             with lock:
+                started += 1
+                worker_number = started
                 active += 1
                 max_active = max(max_active, active)
-            time.sleep(0.05)
+            if worker_number <= first_worker_batch.parties:
+                first_worker_batch.wait(timeout=2)
             with lock:
                 active -= 1
             return {"status": "ok", "auto_sleep_ok": True}

--- a/tests/unit/test_meta_gobii_tools.py
+++ b/tests/unit/test_meta_gobii_tools.py
@@ -311,6 +311,33 @@ class MetaGobiiDirectToolTests(TestCase):
         self.assertEqual(child.contact_approval_mode, "auto_approve_email")
         self.assertEqual(created["agent"]["contact_approval_mode"], "auto_approve_email")
 
+    @patch("api.agent.tasks.process_agent_events_task.delay")
+    @patch("api.agent.tools.meta_gobii.AgentService.has_agents_available", return_value=True)
+    @patch("api.services.persistent_agents.AgentService.has_agents_available", return_value=True)
+    @patch("api.models.AgentService.get_agents_available", return_value=10)
+    def test_create_agent_generates_name_when_omitted(
+        self,
+        _model_capacity,
+        _provision_capacity,
+        _tool_capacity,
+        _mock_delay,
+    ):
+        schema = TOOL_DEFINITIONS["meta_gobii_create_agent"]["parameters"]
+        self.assertNotIn("name", schema.get("required", []))
+
+        created = execute_meta_gobii_tool(
+            self.manager,
+            "meta_gobii_create_agent",
+            {
+                "charter": "Own the generated-name workflow.",
+                "user_confirmed": True,
+            },
+        )
+
+        self.assertEqual(created["status"], "ok")
+        self.assertTrue(created["agent"]["name"].strip())
+        self.assertEqual(created["agent"]["charter"], "Own the generated-name workflow.")
+
     @patch("api.services.agent_settings_resume.process_agent_events_task.delay")
     def test_update_agent_requires_confirmation_and_respects_access(self, _mock_delay):
         update_schema = TOOL_DEFINITIONS["meta_gobii_update_agent"]["parameters"]
@@ -448,6 +475,26 @@ class MetaGobiiDirectToolTests(TestCase):
         link = AgentPeerLink.objects.get(id=result["link"]["id"])
         self.assertEqual(link.messages_per_window, 10)
         self.assertEqual(link.window_hours, 4)
+        self.assertEqual(result["link"]["health"], {"status": "healthy", "issues": []})
+
+        PersistentAgent.objects.filter(id=self.peer.id).update(
+            life_state=PersistentAgent.LifeState.EXPIRED,
+        )
+        listed = execute_meta_gobii_tool(
+            self.manager,
+            "meta_gobii_list_agent_links",
+            {"agent_id": str(self.manager.id)},
+        )
+        self.assertEqual(
+            listed["links"][0]["health"],
+            {
+                "status": "unhealthy",
+                "issues": [{"agent_id": str(self.peer.id), "reason": "expired"}],
+            },
+        )
+        PersistentAgent.objects.filter(id=self.peer.id).update(
+            life_state=PersistentAgent.LifeState.ACTIVE,
+        )
 
         blocked_unlink = execute_meta_gobii_tool(
             self.manager,

--- a/tests/unit/test_remote_mcp.py
+++ b/tests/unit/test_remote_mcp.py
@@ -546,7 +546,21 @@ class RemoteMCPViewTests(TestCase):
             {"agent_id": str(existing_agent.id)},
         )
         self.assertEqual(list_links_response.status_code, 200)
-        self.assertEqual(len(self._structured_content(list_links_response)["links"]), 1)
+        listed_link = self._structured_content(list_links_response)["links"][0]
+        self.assertEqual(listed_link["health"], {"status": "healthy", "issues": []})
+
+        created_agent.life_state = PersistentAgent.LifeState.EXPIRED
+        created_agent.save(update_fields=["life_state"])
+        unhealthy_response = self._call_tool(
+            "gobii_list_agent_links",
+            {"agent_id": str(existing_agent.id)},
+        )
+        unhealthy_link = self._structured_content(unhealthy_response)["links"][0]
+        self.assertEqual(unhealthy_link["health"]["status"], "unhealthy")
+        self.assertEqual(
+            unhealthy_link["health"]["issues"],
+            [{"agent_id": created_agent_id, "reason": "expired"}],
+        )
 
         unlink_response = self._call_tool(
             "gobii_unlink_agents",
@@ -647,6 +661,61 @@ class RemoteMCPViewTests(TestCase):
         self.assertEqual(
             self._structured_content(response)["agent"]["contact_approval_mode"],
             "auto_approve_email",
+        )
+
+    def test_create_agent_generates_name_when_omitted(self):
+        create_tool = next(
+            tool
+            for tool in self._post_mcp("tools/list").json()["result"]["tools"]
+            if tool["name"] == "gobii_create_agent"
+        )
+        self.assertNotIn("name", create_tool["inputSchema"].get("required", []))
+
+        with (
+            patch.object(BrowserUseAgent, "select_random_proxy", return_value=None),
+            patch("api.services.persistent_agents.maybe_schedule_short_description"),
+            patch("api.services.persistent_agents.maybe_schedule_mini_description"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_tags"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_avatar"),
+            patch("api.agent.tasks.enqueue_interactive_process_agent_events"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self._call_tool(
+                "gobii_create_agent",
+                {"charter": "Own the generated-name workflow."},
+            )
+
+        self.assertFalse(response.json()["result"]["isError"], response.content)
+        created = self._structured_content(response)["agent"]
+        self.assertTrue(created["name"].strip())
+        self.assertEqual(created["charter"], "Own the generated-name workflow.")
+
+    def test_create_agent_succeeds_when_post_commit_wake_fails(self):
+        agent_name = "Post-commit MCP Agent"
+        with (
+            patch.object(BrowserUseAgent, "select_random_proxy", return_value=None),
+            patch("api.services.persistent_agents.maybe_schedule_short_description"),
+            patch("api.services.persistent_agents.maybe_schedule_mini_description"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_tags"),
+            patch("api.services.persistent_agents.maybe_schedule_agent_avatar"),
+            patch(
+                "api.agent.tasks.enqueue_interactive_process_agent_events",
+                side_effect=RuntimeError("queue unavailable"),
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self._call_tool(
+                "gobii_create_agent",
+                {
+                    "name": agent_name,
+                    "charter": "Own the post-commit handoff.",
+                },
+            )
+
+        self.assertFalse(response.json()["result"]["isError"], response.content)
+        self.assertEqual(
+            PersistentAgent.objects.filter(user=self.user, name=agent_name).count(),
+            1,
         )
 
     def test_update_agent_tier_and_explicit_null_schedule_retain_omitted_credit_limit(self):


### PR DESCRIPTION
## Summary

Closes a compact batch of agent/API reliability gaps:

- expose linked-agent endpoint health in MetaGobii and remote MCP
- let MCP/MetaGobii create agents without supplying a name, matching their schemas
- keep an already-committed agent creation successful when its post-commit wake enqueue fails
- include preferred intelligence tier in API and console creation analytics
- make the custom-tool contract eval expose the sandbox capability it actually exercises
- replace a timing-sensitive parallelism assertion with deterministic synchronization
- add a real-harness regression that keeps automatic future events off the active plan

Tracker work in this cycle also verified and closed eight already-fixed/stale reports (#422, #243, #473, #474, #354, #393, #333, #340), for 15 legitimate outcomes total.

## Evidence

- 13 focused Django tests pass across all touched contracts
- complexity budget passes; production/source increase is 66 LoC
- DeepSeek V4 Flash:
  - `effort_automatic_future_events_stay_off_plan`: 4/4 (`13f9fab2-628f-48b1-9c5f-8c99afee47ed`)
  - targeted custom-tool contract: 4/4 (`f2153c2d-8ec9-4682-94ce-5e96c0474b1a`)
  - pressure-resilience verification used to close #393: 5/5 (`98b79bc3-4b7f-4f0f-933f-6dad2bca8854`)
  - secure credential delegation closure for #354: 12/12 (`6c0f5d87-675b-45e8-afe5-33df57545de6`)

A diagnostic six-case custom-tool sweep was 18/24: four cases were fully green; two exposed pre-existing DeepSeek first-pass design/correction-loop misses after the formerly hidden tool became available. This PR does not weaken those checks or claim those separate behavior scars are fixed.

Closes #508
Closes #265
Closes #147
Closes #316
Closes #428
Closes #375
Closes #245
