### PR TITLE
Keep peer identities out of email recipients

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -2782,10 +2782,29 @@ def _build_contacts_block(
     )
 
     if peer_links:
-        peer_lines: list[str] = [
-            "These are linked agents you can contact via the send_agent_message tool. "
-            "Agents listed as sharing a channel already receive the same messages there that you do."
+        counterpart_ids = [
+            link.agent_b_id if link.agent_a_id == agent.id else link.agent_a_id
+            for link in peer_links
         ]
+        peer_email_by_agent_id = dict(
+            PersistentAgentCommsEndpoint.objects.filter(
+                owner_agent_id__in=counterpart_ids,
+                channel=CommsChannel.EMAIL,
+            )
+            .order_by("owner_agent_id", "is_primary", "id")
+            .values_list("owner_agent_id", "address")
+        )
+
+        email_rule = (
+            " For explicit email To/CC/BCC, use the listed email address; never put an agent ID in an email recipient field."
+            if peer_email_by_agent_id
+            else ""
+        )
+        peer_intro = (
+            "These are linked agents you can contact via the send_agent_message tool. Agents listed as sharing "
+            f"a channel already receive the same messages there that you do.{email_rule}"
+        )
+        peer_lines: list[str] = [peer_intro]
         shared_channels = _get_shared_channel_names(agent)
         for link in peer_links:
             counterpart = link.get_other_agent(agent)
@@ -2805,13 +2824,12 @@ def _build_contacts_block(
                 if state and state.window_reset_at
                 else "pending"
             )
-            desc_part = ""
-            if counterpart.short_description:
-                desc_part = f" - {counterpart.short_description}"
+            desc_part = f" - {counterpart.short_description}" if counterpart.short_description else ""
             names = shared_channels.get(counterpart.id)
             shared_part = " | shares {} with you".format(", ".join(names)) if names else ""
+            email_part = f" | email: {email}" if (email := peer_email_by_agent_id.get(counterpart.id)) else ""
             peer_lines.append(
-                "- {} (id: {}){}| quota {} msgs / {} h | remaining: {} | next reset: {}{}".format(
+                "- {} (id: {}){}| quota {} msgs / {} h | remaining: {} | next reset: {}{}{}".format(
                     counterpart.name,
                     counterpart.id,
                     f"{desc_part} " if desc_part else "",
@@ -2819,6 +2837,7 @@ def _build_contacts_block(
                     link.window_hours,
                     remaining,
                     reset_at,
+                    email_part,
                     shared_part,
                 )
             )

--- a/api/agent/tools/email_sender.py
+++ b/api/agent/tools/email_sender.py
@@ -5,7 +5,10 @@ import re
 from typing import Dict, Any
 
 from django.conf import settings
-from django.db import transaction
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from django.db import close_old_connections, transaction
+from django.db.utils import OperationalError
 
 from ...models import (
     CommsAllowlistEntry,
@@ -65,6 +68,21 @@ class _EmailDeliveryFailed(Exception):
 
 class _EmailMessageCreateOperationalError(Exception):
     pass
+
+
+def _get_or_create_email_endpoint(address: str) -> PersistentAgentCommsEndpoint:
+    lookup = {
+        "channel": CommsChannel.EMAIL,
+        "address": address,
+        "defaults": {"owner_agent": None},
+    }
+    close_old_connections()
+    try:
+        endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(**lookup)
+    except OperationalError:
+        close_old_connections()
+        endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(**lookup)
+    return endpoint
 
 
 def _maybe_provision_simulated_from_endpoint(agent: PersistentAgent) -> PersistentAgentCommsEndpoint | None:
@@ -174,7 +192,7 @@ def get_send_email_tool() -> Dict[str, Any]:
         "function": {
             "name": "send_email",
             "description": (
-                "Body-only HTML; omit document tags, Markdown, and em/en/double dashes. No <style> blocks/classes; inline CSS only. "
+                "Body-only HTML; no document tags, Markdown, or long dashes. No <style> blocks/classes; inline CSS only. "
                 "Approval or preparation is not sent: send first, then record returned delivery_status; never infer delivered. "
                 "pending_approval is not received: tell user it awaits approval; never retry. "
                 "Reports need distinct styled sections/tables and highlighted values, plus a tasteful icon marker and obvious inline-styled badge for status/value. Never leave metrics in plain lists or use Markdown pipe tables."
@@ -182,14 +200,14 @@ def get_send_email_tool() -> Dict[str, Any]:
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "to_address": {"type": "string", "description": "Recipient email."},
+                    "to_address": {"type": "string", "format": "email", "description": "Email address; never an agent/user ID."},
                     "cc_addresses": {
                         "type": "array",
                         "items": {
                             "type": "string",
                             "format": "email",
                         },
-                        "description": "Optional CC email addresses."
+                        "description": "Optional email addresses; never agent/user IDs.",
                     },
                     "bcc_addresses": {
                         "type": "array",
@@ -197,10 +215,7 @@ def get_send_email_tool() -> Dict[str, Any]:
                             "type": "string",
                             "format": "email",
                         },
-                        "description": (
-                            "Optional hidden email recipients. Gobii keeps them in the owner's delivery audit, "
-                            "but they are not exposed to To or CC recipients."
-                        ),
+                        "description": "Hidden recipients, never agent/user IDs; kept in owner audit, hidden from To/CC.",
                     },
                     "subject": {"type": "string", "description": "Email subject."},
                     "reply_to_message_id": {
@@ -238,7 +253,6 @@ def get_send_email_tool() -> Dict[str, Any]:
 
 @handle_link_reference_errors
 def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Execute the send_email tool for a persistent agent."""
     if not can_bypass_email_verification_for_signup_preview_first_email(agent):
         try:
             require_verified_email(agent.user, action_description="send emails")
@@ -247,10 +261,8 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
 
     to_address = normalize_email_address(params.get("to_address"))
     subject = params.get("subject")
-    # Decode escape sequences and strip control chars from HTML body
     mobile_first_html = decode_unicode_escapes(params.get("mobile_first_html"))
     mobile_first_html = strip_control_chars(mobile_first_html)
-    # Substitute $[var] placeholders with actual values (e.g., $[/charts/...]).
     mobile_first_html = substitute_variables_with_filespace(mobile_first_html, agent)
     cc_addresses = [normalize_email_address(addr) for addr in params.get("cc_addresses", [])]
     bcc_addresses = [normalize_email_address(addr) for addr in params.get("bcc_addresses", [])]
@@ -261,6 +273,18 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
     if not all([to_address, subject, mobile_first_html]):
         return {"status": "error", "message": "Missing required parameters: to_address, subject, or mobile_first_html"}
 
+    for address in [to_address, *cc_addresses, *bcc_addresses]:
+        try:
+            validate_email(address)
+        except ValidationError:
+            return {
+                "status": "error",
+                "message": (
+                    f"Recipient '{address}' is not a valid email address. "
+                    "Use an actual email address, never an agent or user ID."
+                ),
+            }
+
     if body_error := _email_body_error(mobile_first_html, bool(attachment_paths)):
         return {"status": "error", "message": body_error}
 
@@ -269,7 +293,6 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
     except AttachmentResolutionError as exc:
         return {"status": "error", "message": str(exc)}
 
-    # Log email attempt
     body_preview = mobile_first_html[:100] + "..." if len(mobile_first_html) > 100 else mobile_first_html
     cc_info = f", CC: {cc_addresses}" if cc_addresses else ""
     bcc_info = f", BCC count: {len(bcc_addresses)}" if bcc_addresses else ""
@@ -280,9 +303,6 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
     )
 
     try:
-        # Ensure a healthy DB connection for subsequent ORM ops
-        from django.db import close_old_connections
-        from django.db.utils import OperationalError
         all_recipients = [to_address] + cc_addresses + bcc_addresses
         outbox_enabled = email_review_outbox_enabled()
         policy_decision = classify_email_recipients(agent, all_recipients) if outbox_enabled else None
@@ -335,47 +355,9 @@ def execute_send_email(agent: PersistentAgent, params: Dict[str, Any]) -> Dict[s
                     ),
                 }
 
-        close_old_connections()
-        try:
-            to_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
-                channel=CommsChannel.EMAIL, address=to_address, defaults={"owner_agent": None}
-            )
-        except OperationalError:
-            close_old_connections()
-            to_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
-                channel=CommsChannel.EMAIL, address=to_address, defaults={"owner_agent": None}
-            )
-        
-        # Create CC endpoints
-        cc_endpoint_objects = []
-        for cc_addr in cc_addresses:
-            close_old_connections()
-            try:
-                cc_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
-                    channel=CommsChannel.EMAIL, address=cc_addr, defaults={"owner_agent": None}
-                )
-                cc_endpoint_objects.append(cc_endpoint)
-            except OperationalError:
-                close_old_connections()
-                cc_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
-                    channel=CommsChannel.EMAIL, address=cc_addr, defaults={"owner_agent": None}
-                )
-                cc_endpoint_objects.append(cc_endpoint)
-
-        bcc_endpoint_objects = []
-        for bcc_addr in bcc_addresses:
-            close_old_connections()
-            try:
-                bcc_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
-                    channel=CommsChannel.EMAIL, address=bcc_addr, defaults={"owner_agent": None}
-                )
-                bcc_endpoint_objects.append(bcc_endpoint)
-            except OperationalError:
-                close_old_connections()
-                bcc_endpoint, _ = PersistentAgentCommsEndpoint.objects.get_or_create(
-                    channel=CommsChannel.EMAIL, address=bcc_addr, defaults={"owner_agent": None}
-                )
-                bcc_endpoint_objects.append(bcc_endpoint)
+        to_endpoint = _get_or_create_email_endpoint(to_address)
+        cc_endpoint_objects = [_get_or_create_email_endpoint(address) for address in cc_addresses]
+        bcc_endpoint_objects = [_get_or_create_email_endpoint(address) for address in bcc_addresses]
 
         conversation = _get_or_create_conversation(
             CommsChannel.EMAIL,

--- a/api/evals/scenarios/behavior_micro.py
+++ b/api/evals/scenarios/behavior_micro.py
@@ -1238,7 +1238,9 @@ class GuidedFirstAssignmentAsksUsefulQuestionsScenario(BehaviorMicroScenario):
                 "useful, frame its evidence before the cards. They must not claim the deliverable has started, ask the "
                 "decisions in prose, duplicate the cards, repeat each other, or promise results. "
                 + (
-                    "The backup email must clearly carry the same decisions and choices, not a kickoff or different questions."
+                    "The backup email must carry the same decisions and choices, not a kickoff or different questions. "
+                    "It must also group each question with clearly separated choices using restrained email-safe "
+                    "hierarchy; fail a plain wall of text or run-together question and option boundaries."
                     if self.requires_fallback_copy
                     else "No backup message is needed when no separate fallback channel is configured."
                 )

--- a/api/evals/scenarios/structured_peer_handoffs.py
+++ b/api/evals/scenarios/structured_peer_handoffs.py
@@ -10,9 +10,11 @@ from api.agent.tools.tool_manager import mark_tool_enabled_without_discovery
 from api.evals.base import EvalScenario, ScenarioTask
 from api.evals.execution import ScenarioExecutionTools
 from api.evals.registry import ScenarioRegistry
+from api.evals.tool_params import resolved_tool_param
 from api.models import (
     AgentPeerLink,
     BrowserUseAgent,
+    CommsAllowlistEntry,
     CommsChannel,
     EvalRunTask,
     PersistentAgent,
@@ -33,6 +35,7 @@ STRUCTURED_PEER_SCOPED_HANDOFF = "structured_peer_scoped_handoff"
 STRUCTURED_PEER_NEGATIVE_DECISION = "structured_peer_negative_decision"
 STRUCTURED_PEER_MIXED_DECISIONS = "structured_peer_mixed_decisions"
 STRUCTURED_PEER_CORRECTION_RECONCILES_STALE_STATE = "structured_peer_correction_reconciles_stale_state"
+PEER_EMAIL_CC_RESOLVES_ADDRESS = "peer_email_cc_resolves_address"
 STRUCTURED_PEER_HANDOFF_SUITE_SLUG = "structured_peer_handoffs"
 STRUCTURED_PEER_HANDOFF_SCENARIO_SLUGS = (
     STRUCTURED_PEER_SINGLE_RECORD,
@@ -43,6 +46,7 @@ STRUCTURED_PEER_HANDOFF_SCENARIO_SLUGS = (
     STRUCTURED_PEER_NEGATIVE_DECISION,
     STRUCTURED_PEER_MIXED_DECISIONS,
     STRUCTURED_PEER_CORRECTION_RECONCILES_STALE_STATE,
+    PEER_EMAIL_CC_RESOLVES_ADDRESS,
 )
 
 HANDOFF_CHARTER = (
@@ -435,6 +439,141 @@ class StructuredPeerHandoffScenario(EvalScenario, ScenarioExecutionTools):
 
 for case in STRUCTURED_PEER_HANDOFF_CASES:
     ScenarioRegistry.register(StructuredPeerHandoffScenario(case))
+
+
+class PeerEmailCcResolutionScenario(EvalScenario, ScenarioExecutionTools):
+    slug = PEER_EMAIL_CC_RESOLVES_ADDRESS
+    description = (
+        "An explicit request to CC a named linked agent uses that peer's actual email address, never its agent UUID."
+    )
+    tier = "core"
+    category = "structured_peer_handoffs"
+    expected_runtime = "short"
+    cost_class = "low"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = ("agent_behavior", "agent_teams", "email", "recipient_integrity", "real_harness")
+    tasks = [
+        ScenarioTask(name="inject_request", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_email_participants", assertion_type="tool_call"),
+    ]
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        PersistentAgent.objects.filter(id=agent_id).update(
+            name=f"Launch Coordinator {str(agent_id)[:8]}",
+            charter=(
+                "Send concise launch updates when the owner asks. Ledger Agent owns the finalized migration record."
+            ),
+            planning_state=PersistentAgent.PlanningState.SKIPPED,
+        )
+        StructuredPeerHandoffScenario._seed_prior_run(agent_id)
+        agent = PersistentAgent.objects.select_related("user", "organization").get(id=agent_id)
+        peer = StructuredPeerHandoffScenario._create_linked_peer(
+            agent,
+            run_id,
+            role="Ledger Agent",
+            charter="Maintain finalized migration records and receive launch updates.",
+        )
+        peer_email = f"ledger-{run_id}@eval.local"
+        PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=peer,
+            channel=CommsChannel.EMAIL,
+            address=peer_email,
+            is_primary=True,
+        )
+        CommsAllowlistEntry.objects.update_or_create(
+            agent=agent,
+            channel=CommsChannel.EMAIL,
+            address="ops@example.test",
+            defaults={
+                "is_active": True,
+                "allow_inbound": True,
+                "allow_outbound": True,
+                "verified": True,
+            },
+        )
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="inject_request",
+        )
+        with self.wait_for_agent_idle(agent_id, timeout=120):
+            inbound = self.inject_message(
+                agent_id,
+                (
+                    "Email ops@example.test saying the migration is complete, and CC Ledger Agent "
+                    "so they have the same update."
+                ),
+                trigger_processing=False,
+                eval_run_id=run_id,
+            )
+            self.trigger_processing(
+                agent_id,
+                eval_run_id=run_id,
+                mock_config={
+                    "send_email": {
+                        "status": "ok",
+                        "message": "Mocked email delivery for peer recipient regression eval.",
+                        "message_id": "eval-peer-email-cc",
+                    },
+                },
+                eval_stop_policy={
+                    "stop_on_tool_names_after_finish": ["send_email"],
+                    "ignored_tool_names": ["send_chat_message", "sqlite_batch"],
+                    "max_relevant_tool_calls": 4,
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_request",
+            observed_summary="A natural email request named a linked agent as a CC recipient.",
+            artifacts={"message": inbound},
+        )
+
+        calls = list(
+            PersistentAgentToolCall.objects.filter(
+                step__eval_run_id=run_id,
+                step__created_at__gte=inbound.timestamp,
+                tool_name="send_email",
+            )
+            .select_related("step")
+            .order_by("step__created_at", "step__id")
+        )
+        to_address = str(resolved_tool_param(calls[0], "to_address") or "") if calls else ""
+        cc_addresses = resolved_tool_param(calls[0], "cc_addresses") if calls else []
+        cc_addresses = cc_addresses if isinstance(cc_addresses, list) else []
+        all_recipient_values = [
+            to_address,
+            *[str(address) for address in cc_addresses],
+        ]
+        passed = (
+            len(calls) == 1
+            and to_address == "ops@example.test"
+            and cc_addresses == [peer_email]
+            and str(peer.id) not in all_recipient_values
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if passed else EvalRunTask.Status.FAILED,
+            task_name="verify_email_participants",
+            observed_summary=(
+                "The named peer was CC'd at its actual email address."
+                if passed
+                else (
+                    f"Expected CC {peer_email}; observed to={to_address!r}, "
+                    f"cc={cc_addresses!r}, peer_id={peer.id}."
+                )
+            ),
+            artifacts={"step": calls[0].step} if calls else {},
+        )
+
+
+ScenarioRegistry.register(PeerEmailCcResolutionScenario())
 
 
 @dataclass(frozen=True)

--- a/api/evals/tests/test_structured_peer_handoffs.py
+++ b/api/evals/tests/test_structured_peer_handoffs.py
@@ -5,6 +5,7 @@ from api.agent.core.prompt_context import _get_peer_communication_instruction
 from api.agent.tools.peer_dm import get_send_agent_message_tool
 from api.evals.registry import ScenarioRegistry
 from api.evals.scenarios.structured_peer_handoffs import (
+    PEER_EMAIL_CC_RESOLVES_ADDRESS,
     STRUCTURED_PEER_HANDOFF_CASES,
     STRUCTURED_PEER_CORRECTION_RECONCILES_STALE_STATE,
     STRUCTURED_DECISION_ROUTING_CASES,
@@ -51,6 +52,12 @@ class StructuredPeerHandoffEvalTests(SimpleTestCase):
             self.assertEqual(metadata.expected_runtime, "short")
             self.assertEqual(metadata.cost_class, "low")
             self.assertIn("real_harness", metadata.tags)
+
+        email_scenario = ScenarioRegistry.get(PEER_EMAIL_CC_RESOLVES_ADDRESS)
+        self.assertEqual(
+            [task.name for task in email_scenario.tasks],
+            ["inject_request", "verify_email_participants"],
+        )
 
     def test_eval_prompts_do_not_name_the_expected_transport(self):
         prompts = " ".join(case.prompt for case in STRUCTURED_PEER_HANDOFF_CASES).lower()

--- a/tests/unit/test_email_sender_db_connections.py
+++ b/tests/unit/test_email_sender_db_connections.py
@@ -212,6 +212,33 @@ class EmailSenderDbConnectionTests(TransactionTestCase):
         self.assertIn(self.from_ep.address, participant_addresses)
         self.assertIn(params["to_address"], participant_addresses)
 
+    def test_execute_send_email_rejects_non_email_recipient_before_delivery(self):
+        invalid_cc = "16857729-f540-4a9e-ad4d-8d84de86d58d"
+        CommsAllowlistEntry.objects.create(
+            agent=self.agent,
+            channel=CommsChannel.EMAIL,
+            address=invalid_cc,
+            is_active=True,
+        )
+
+        with patch("api.agent.tools.email_sender.deliver_agent_email") as deliver:
+            result = execute_send_email(
+                self.agent,
+                {
+                    "to_address": self.user.email,
+                    "cc_addresses": [invalid_cc],
+                    "subject": "Launch update",
+                    "mobile_first_html": "<p>The migration is complete.</p>",
+                },
+            )
+
+        self.assertEqual(result.get("status"), "error")
+        self.assertIn("valid email address", result.get("message", ""))
+        deliver.assert_not_called()
+        self.assertFalse(
+            PersistentAgentMessage.objects.filter(owner_agent=self.agent).exists()
+        )
+
     def test_execute_send_email_persists_bcc_recipients(self):
         bcc_address = "audit@example.com"
         CommsAllowlistEntry.objects.create(

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -772,6 +772,39 @@ class PromptContextBuilderTests(TestCase):
         self.assertIn("<current_plan>", content)
         self.assertIn("Current plan: none", content)
 
+    def test_peer_roster_includes_email_for_explicit_email_participation(self):
+        peer = PersistentAgent.objects.create(
+            user=self.user,
+            name="Ledger Agent",
+            charter="Maintain the finalized ledger.",
+            browser_use_agent=BrowserUseAgent.objects.create(
+                user=self.user,
+                name="Ledger Browser Agent",
+            ),
+        )
+        backup_email = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=peer,
+            channel=CommsChannel.EMAIL,
+            address="ledger.backup@example.com",
+        )
+        peer_email = PersistentAgentCommsEndpoint.objects.create(
+            owner_agent=peer,
+            channel=CommsChannel.EMAIL,
+            address="ledger.agent@example.com",
+            is_primary=True,
+        )
+        AgentPeerLink.objects.create(
+            agent_a=self.agent,
+            agent_b=peer,
+            created_by=self.user,
+        )
+
+        content = self._build_user_prompt_content()
+
+        self.assertIn(f"email: {peer_email.address}", content)
+        self.assertNotIn(f"email: {backup_email.address}", content)
+        self.assertIn("never put an agent ID in an email recipient field", content)
+
     def test_prompt_includes_current_plan_independent_of_skill_limit(self):
         config, _ = PromptConfig.objects.get_or_create(singleton_id=1)
         config.standard_skill_prompt_limit = 0


### PR DESCRIPTION
## Why
A production agent was asked to CC a linked peer and put the peer UUID in the email CC field. The prompt exposed the peer ID but not the peer email, and send_email accepted the invalid recipient.

## What changed
- show the primary email address for linked peers when one exists, with channel-specific recipient guidance
- validate every To, CC, and BCC address before persistence or delivery
- add a real-harness linked-peer CC regression and preserve readable hierarchy in the existing email fallback judge
- deduplicate email endpoint retry code; production source and shared prompt remain within existing budgets

## Evidence
- DeepSeek V4 Flash linked-peer CC: main 0/16, candidate 16/16; Fisher exact p=3.33e-9
- DeepSeek V4 Flash guided email intake: 3/3 tasks passed
- affected structured peer suite: 17/19 on first stochastic pass; both misses passed isolated reruns, and the new case passed
- focused Django tests: 200/200 passed
- complexity budgets: source 266416/266417; shared tool prompt 3 bytes below baseline

## Backlog truth
Reconciled 15 related tickets with Troy: #518 is the only claimed/current-PR item; 3 were already terminal, 3 are explicitly separate security/frontend work, and 8 remain open rather than being falsely closed.

Internal bug: #518