### PR TITLE
Replace older-history loading line with an edge-less glow (#500)

### DIFF
--- a/frontend/src/components/agentChat/AgentTimelinePane.tsx
+++ b/frontend/src/components/agentChat/AgentTimelinePane.tsx
@@ -218,9 +218,7 @@ export const AgentTimelinePane = memo(function AgentTimelinePane({
           what they are reading by its own height each time it toggles.
         */}
         {loadingOlder ? (
-          <div className="timeline-load-control" data-side="older" role="status" aria-label="Loading earlier messages">
-            <span className="timeline-load-bar" aria-hidden="true" />
-          </div>
+          <div className="timeline-load-control" data-side="older" role="status" aria-label="Loading earlier messages" />
         ) : null}
         <div ref={timelineRef} id="timeline-shell" data-scroll-pinned={autoScrollPinned ? 'true' : 'false'}>
           <div id="timeline-spacer" aria-hidden="true" />

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -2900,43 +2900,49 @@
     margin: 0;
     min-height: 0;
 }
-/* An indeterminate line rather than a pill. A pill floating over the conversation reads as a
-   dialog interrupting it; a line at the edge of the scrollport is the conventional "more is on
-   its way" signal, costs no layout, and cannot obscure a message. */
+/* An edge-less glow rather than a full-width line. The region narrows when the plan panel
+   reserves width while the visible card does not, so anything with endpoints spanning the
+   region terminates mid-card (#500). The gradients fade to transparent before any edge, and
+   the message column is centered in the region in every panel mode, so a region-centered
+   glow always sits centered over the conversation. */
 .timeline-load-control[data-side="older"] {
-    height: 2px;
+    height: 6rem;
     min-height: 0;
     padding: 0;
     display: block;
     overflow: hidden;
-    background: rgba(99, 102, 241, 0.1);
-    border-radius: 9999px;
+    animation: timeline-glow-in 200ms ease;
 }
-.timeline-load-bar {
-    display: block;
-    height: 100%;
-    width: 34%;
-    border-radius: 9999px;
-    background: linear-gradient(
-        90deg,
-        rgba(99, 102, 241, 0) 0%,
-        rgba(99, 102, 241, 0.9) 50%,
-        rgba(99, 102, 241, 0) 100%
-    );
-    transform: translate3d(-40%, 0, 0);
-    will-change: transform;
-    animation: timeline-load-sweep 1.15s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+.timeline-load-control[data-side="older"]::before,
+.timeline-load-control[data-side="older"]::after {
+    content: '';
+    position: absolute;
+    inset: 0;
 }
-@keyframes timeline-load-sweep {
-    0% { transform: translate3d(-40%, 0, 0); }
-    100% { transform: translate3d(340%, 0, 0); }
+.timeline-load-control[data-side="older"]::before {
+    background: radial-gradient(50% 90% at 50% 0%, rgba(124, 58, 237, 0.22), rgba(124, 58, 237, 0) 70%);
+    animation: timeline-glow-breathe 1.5s ease-in-out infinite alternate;
+}
+.timeline-load-control[data-side="older"]::after {
+    background: radial-gradient(18% 70% at 50% 0%, rgba(147, 51, 234, 0.38), rgba(147, 51, 234, 0) 78%);
+    animation: timeline-glow-drift 2.6s ease-in-out infinite alternate;
+}
+@keyframes timeline-glow-in {
+    from { opacity: 0; }
+}
+@keyframes timeline-glow-breathe {
+    from { opacity: 0.55; }
+    to { opacity: 1; }
+}
+@keyframes timeline-glow-drift {
+    from { transform: translateX(-22%); }
+    to { transform: translateX(22%); }
 }
 @media (prefers-reduced-motion: reduce) {
-    .timeline-load-bar {
+    .timeline-load-control[data-side="older"],
+    .timeline-load-control[data-side="older"]::before,
+    .timeline-load-control[data-side="older"]::after {
         animation: none;
-        width: 100%;
-        opacity: 0.65;
-        transform: none;
     }
 }
 /* Collapsed runs are otherwise a column of identical chips with nothing placing them in time. */


### PR DESCRIPTION
## What

Fixes bug **#500**: the loading-older-messages indicator misaligned when the task/plan panel was visible.

**Layer: platform code (CSS/markup)** — `frontend/src/styles/agentChatLegacy.css` + one line of markup in `AgentTimelinePane.tsx`.

## Root cause (proven)

The indicator was a full-width 2px sweep line, `position:absolute; left:0; right:0` inside `.agent-chat-timeline-region`. When the plan panel docks the region narrows but the visible chat card does not, so the line terminated ~310px short of the card's right edge at an invisible boundary. Playwright geometry at 1440×900: control right edge **1118** vs card edge **1428** with panel docked; spans correctly (288→1428) with panel hidden.

## Fix

Replaced the line with a soft violet radial glow (breathing bloom + slowly drifting core) at the top of the conversation. Design chosen by Andrew from an instrumented side-by-side lab of the repro and three candidates. It cannot regress the same way: the gradients fade to transparent before any edge, and the message column is centered in the region in every panel mode, so a region-centered glow is always centered over the conversation. Reduced-motion disables all animation. The newer-side indicator (`timeline-load-button`) is untouched; the now-unused `.timeline-load-bar` styles and sweep keyframes are removed.

## Verification

- Rebuilt bundle, both panel modes: indicator center == message-column center exactly (858/858 hidden, 703/703 docked); old bar absent; both gradient layers present.
- vitest 349/349, `tsc -b --force` clean, lint count unchanged vs main (186).
- **Not unit-covered**: this is CSS-layer visual behavior; verification is the scripted geometry probe + human review of the animated result. Preview validation of the live pagination interaction still needed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)