### PR TITLE
Recover agents from corrupt persisted SQLite state

### DIFF
--- a/api/agent/tools/sqlite_state.py
+++ b/api/agent/tools/sqlite_state.py
@@ -1095,6 +1095,13 @@ def _recover_sqlite_db_in_subprocess(db_path: str, tmp_dir: str) -> bool:
             return False
 
         validate_sqlite_file(recovered_db_path)
+        with contextlib.closing(sqlite3.connect(recovered_db_path, timeout=5)) as conn:
+            recovered_table = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' LIMIT 1;"
+            ).fetchone()
+        if recovered_table is None:
+            return False
         replace_sqlite_file(recovered_db_path, db_path)
         return True
     except (OSError, subprocess.TimeoutExpired, SQLiteStateValidationError):

--- a/api/agent/tools/sqlite_state.py
+++ b/api/agent/tools/sqlite_state.py
@@ -27,7 +27,12 @@ from django.core.files import File
 from django.core.files.storage import default_storage
 from opentelemetry import trace
 
-from api.utils.sqlite_files import create_validated_sqlite_snapshot, validate_sqlite_file
+from api.utils.sqlite_files import (
+    create_validated_sqlite_snapshot,
+    remove_sqlite_sidecars,
+    replace_sqlite_file,
+    validate_sqlite_file,
+)
 
 from .sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
 from .sqlite_recovery import (
@@ -105,6 +110,7 @@ JSON_DETECTION_THRESHOLD = 0.6
 JSON_HINT_THRESHOLD = 0.2
 CSV_DETECTION_THRESHOLD = 0.4
 SQLITE_RESTORE_SUBPROCESS_TIMEOUT_SECONDS = 120
+SQLITE_RECOVERY_SUBPROCESS_TIMEOUT_SECONDS = 120
 
 _JSON_START_RE = re.compile(r"^\s*[\[{]")
 _CSV_DELIMS = [",", "\t", "|", ";"]
@@ -1009,6 +1015,11 @@ def sqlite_storage_key(agent_uuid: str) -> str:
     return f"agent_state/{clean_uuid[:2]}/{clean_uuid[2:4]}/{agent_uuid}.db.zst"
 
 
+def sqlite_quarantine_storage_key(agent_uuid: str) -> str:
+    """Return the forensic backup key used before replacing corrupt state."""
+    return f"{sqlite_storage_key(agent_uuid)}.corrupt"
+
+
 def _decompress_sqlite_archive_in_subprocess(archive_path: str, db_path: str) -> None:
     """Decompress an archive in a child process to isolate native crashes.
 
@@ -1055,18 +1066,115 @@ def _decompress_sqlite_archive_in_subprocess(archive_path: str, db_path: str) ->
     )
 
 
+def _recover_sqlite_db_in_subprocess(db_path: str, tmp_dir: str) -> bool:
+    """Use SQLite's recovery shell to salvage a validated database."""
+    recovered_sql_path = os.path.join(tmp_dir, "state.recover.sql")
+    recovered_db_path = os.path.join(tmp_dir, "state.recovered.db")
+    try:
+        with open(recovered_sql_path, "wb") as recovered_sql:
+            export = subprocess.run(
+                ["sqlite3", "--safe", "-batch", db_path, ".recover"],
+                check=False,
+                stdout=recovered_sql,
+                stderr=subprocess.PIPE,
+                timeout=SQLITE_RECOVERY_SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        if export.returncode != 0:
+            return False
+
+        with open(recovered_sql_path, "rb") as recovered_sql:
+            restore = subprocess.run(
+                ["sqlite3", "--safe", "-batch", "-bail", recovered_db_path],
+                check=False,
+                stdin=recovered_sql,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                timeout=SQLITE_RECOVERY_SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        if restore.returncode != 0:
+            return False
+
+        validate_sqlite_file(recovered_db_path)
+        replace_sqlite_file(recovered_db_path, db_path)
+        return True
+    except (OSError, subprocess.TimeoutExpired, SQLiteStateValidationError):
+        logger.warning("SQLite shell recovery failed.", exc_info=True)
+        return False
+    finally:
+        for path in (recovered_sql_path, recovered_db_path):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+
+
+def _quarantine_sqlite_archive(
+    archive_path: str,
+    *,
+    agent_uuid: str,
+) -> None:
+    quarantine_key = sqlite_quarantine_storage_key(agent_uuid)
+    _upload_sqlite_archive(quarantine_key, archive_path)
+    logger.error(
+        "Quarantined corrupt SQLite archive for agent %s at %s.",
+        agent_uuid,
+        quarantine_key,
+    )
+
+
 def _restore_sqlite_db_from_storage(storage_key: str, db_path: str, agent_uuid: str) -> bool:
     """Restore persisted SQLite DB, returning True when restore succeeds."""
     archive_path = db_path + ".restore.zst"
     try:
         with default_storage.open(storage_key, "rb") as src, open(archive_path, "wb") as dst:
             shutil.copyfileobj(src, dst)
-        _decompress_sqlite_archive_in_subprocess(archive_path, db_path)
-        validate_sqlite_file(db_path)
-        return True
-    except (OSError, RuntimeError, SQLiteStateValidationError, zstd.ZstdError):
+
+        try:
+            _decompress_sqlite_archive_in_subprocess(archive_path, db_path)
+            validate_sqlite_file(db_path)
+            return True
+        except (RuntimeError, SQLiteStateValidationError, zstd.ZstdError) as exc:
+            _quarantine_sqlite_archive(archive_path, agent_uuid=agent_uuid)
+            if os.path.exists(db_path) and _recover_sqlite_db_in_subprocess(
+                db_path,
+                os.path.dirname(db_path),
+            ):
+                logger.error(
+                    "Recovered corrupt persisted SQLite state for agent %s.",
+                    agent_uuid,
+                )
+                _log_sqlite_persistence_error(
+                    agent_uuid,
+                    exc,
+                    recovered=True,
+                    error_code="sqlite_restore_salvaged",
+                    source="api.agent.tools.sqlite_state._restore_sqlite_db_from_storage",
+                    message=f"SQLite restore salvaged corrupt state for agent {agent_uuid}",
+                )
+                return True
+
+            remove_sqlite_sidecars(db_path)
+            try:
+                os.remove(db_path)
+            except FileNotFoundError:
+                pass
+            _log_sqlite_persistence_error(
+                agent_uuid,
+                exc,
+                recovered=False,
+                error_code="sqlite_restore_reset_after_corruption",
+                source="api.agent.tools.sqlite_state._restore_sqlite_db_from_storage",
+                message=f"SQLite restore reset corrupt state for agent {agent_uuid}",
+            )
+            logger.error(
+                "Persisted SQLite state for agent %s could not be salvaged; "
+                "starting from a validated empty database after quarantine.",
+                agent_uuid,
+            )
+            return False
+    except OSError:
         logger.error(
-            "Failed to restore a valid SQLite DB for agent %s; refusing to start fresh.",
+            "Failed to read persisted SQLite state for agent %s; preserving canonical state.",
             agent_uuid,
             exc_info=True,
         )
@@ -1265,6 +1373,9 @@ def _log_sqlite_persistence_error(
     exc: BaseException,
     *,
     recovered: bool,
+    error_code: str | None = None,
+    source: str = "api.agent.tools.sqlite_state._persist_validated_sqlite_state",
+    message: str | None = None,
 ) -> None:
     from django.core.exceptions import ValidationError
     from django.db import DatabaseError
@@ -1287,13 +1398,14 @@ def _log_sqlite_persistence_error(
     log_agent_error(
         agent,
         category=PersistentAgentError.Category.TOOL_PERSISTENCE,
-        source="api.agent.tools.sqlite_state._persist_validated_sqlite_state",
-        message=f"SQLite persistence failed for agent {agent_uuid}",
+        source=source,
+        message=message or f"SQLite persistence failed for agent {agent_uuid}",
         exc=exc,
         logger=logger,
         context={
             "agent_id": str(agent_uuid),
-            "error_code": (
+            "error_code": error_code
+            or (
                 SQLITE_STATE_UNRECOVERABLE_ERROR
                 if isinstance(exc, SQLiteStateUnrecoverableError)
                 else (

--- a/api/agent/tools/sqlite_state.py
+++ b/api/agent/tools/sqlite_state.py
@@ -1098,7 +1098,7 @@ def _recover_sqlite_db_in_subprocess(db_path: str, tmp_dir: str) -> bool:
         with contextlib.closing(sqlite3.connect(recovered_db_path, timeout=5)) as conn:
             recovered_table = conn.execute(
                 "SELECT 1 FROM sqlite_master "
-                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' LIMIT 1;"
+                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name != 'lost_and_found' LIMIT 1;"
             ).fetchone()
         if recovered_table is None:
             return False

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -387,11 +387,11 @@ def _derives_structured_message_fields(
     )
 
 
-def _derives_bound_structured_message_fields(
+def _bound_json_payload_placeholder(
     call,
     statement: str,
     expected_payload: dict[str, str],
-) -> bool:
+) -> str | None:
     bindings = (getattr(call, "tool_params", None) or {}).get("bindings") or {}
     lowered = sqlparse.format(statement, strip_comments=True).casefold()
     for key, raw_payload in bindings.items():
@@ -418,9 +418,21 @@ def _derives_bound_structured_message_fields(
             for field in expected_payload
         ):
             continue
-        if _structured_outcome_assignments_use_extracted_fields(lowered):
-            return True
-    return False
+        return placeholder
+    return None
+
+
+def _derives_bound_structured_message_fields(
+    call,
+    statement: str,
+    expected_payload: dict[str, str],
+) -> bool:
+    return bool(
+        _bound_json_payload_placeholder(call, statement, expected_payload)
+        and _structured_outcome_assignments_use_extracted_fields(
+            sqlparse.format(statement, strip_comments=True).casefold()
+        )
+    )
 
 
 def _structured_outcome_assignments_use_extracted_fields(lowered_statement: str) -> bool:
@@ -3978,23 +3990,34 @@ class SqliteStructuredPeerEventPersistenceScenario(SqliteDomainModelScenario):
             and _reads_table(statement, "operational_events")
             for call_index, statement_index, _call, statement in statement_entries
         )
-        expected_bound_values = {
-            "evt-2048",
-            "accepted_setup",
-            "thread-2048",
-            "2026-07-28T15:42:00Z",
-            str(peer_event.id),
+        expected_payload = {
+            "event_id": "evt-2048",
+            "event_type": "accepted_setup",
+            "thread_key": "thread-2048",
+            "occurred_at": "2026-07-28T15:42:00Z",
         }
         statement_without_comments = sqlparse.format(write_statement, strip_comments=True)
         direct_message_import = (
             write_entry is not None
             and _reads_table(write_statement, "__messages")
             and "structured_payload_json" in write_statement.casefold()
-            and not any(value in statement_without_comments for value in expected_bound_values)
+            and not any(
+                value in statement_without_comments
+                for value in (*expected_payload.values(), str(peer_event.id))
+            )
         )
         bound_message_import = (
             write_call is not None
-            and _uses_bound_source_values(write_call, write_statement, expected_bound_values)
+            and _uses_bound_source_values(
+                write_call,
+                write_statement,
+                {str(peer_event.id)},
+            )
+            and _bound_json_payload_placeholder(
+                write_call,
+                write_statement,
+                expected_payload,
+            )
         )
         message_grounded_import = direct_message_import or bound_message_import
 

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -393,7 +393,19 @@ def _bound_json_payload_placeholder(
     expected_payload: dict[str, str],
 ) -> str | None:
     bindings = (getattr(call, "tool_params", None) or {}).get("bindings") or {}
-    lowered = sqlparse.format(statement, strip_comments=True).casefold()
+    statement_without_comments = sqlparse.format(statement, strip_comments=True)
+    lowered = statement_without_comments.casefold()
+    expected_values = set(expected_payload.values())
+    sql_literals = {
+        match.group(1).replace("''", "'")
+        for match in re.finditer(r"'((?:''|[^'])*)'", statement_without_comments)
+    }
+    sql_literals.update(
+        match.group(1).replace('""', '"')
+        for match in re.finditer(r'"((?:""|[^"])*)"', statement_without_comments)
+    )
+    if expected_values.intersection(sql_literals):
+        return None
     for key, raw_payload in bindings.items():
         placeholder = f":{str(key).casefold()}"
         if placeholder not in lowered:
@@ -409,6 +421,13 @@ def _bound_json_payload_placeholder(
             continue
         if any(str(payload.get(field)) != value for field, value in expected_payload.items()):
             continue
+        if any(
+            other_key != key
+            and isinstance(other_value, (str, int, float))
+            and str(other_value) in expected_values
+            for other_key, other_value in bindings.items()
+        ):
+            continue
         if not all(
             re.search(
                 rf"json_extract\s*\(\s*{re.escape(placeholder)}\s*,\s*['\"]\$\."
@@ -420,6 +439,94 @@ def _bound_json_payload_placeholder(
             continue
         return placeholder
     return None
+
+
+def _insert_values_derive_bound_payload_fields(
+    statement: str,
+    *,
+    table_name: str,
+    placeholder: str,
+    expected_fields: set[str],
+) -> bool:
+    parsed = sqlparse.parse(statement)
+    if len(parsed) != 1:
+        return False
+    tokens = [token for token in parsed[0].tokens if not token.is_whitespace]
+    into_index = next(
+        (
+            index
+            for index, token in enumerate(tokens)
+            if str(getattr(token, "normalized", "")).casefold() == "into"
+        ),
+        -1,
+    )
+    target = tokens[into_index + 1] if 0 <= into_index < len(tokens) - 1 else None
+    target_name = str(getattr(target, "get_name", lambda: "")() or "").casefold()
+    if target_name != table_name.casefold():
+        return False
+    values = next(
+        (
+            token
+            for token in tokens
+            if isinstance(token, sqlparse.sql.Values)
+        ),
+        None,
+    )
+    if values is None:
+        return False
+
+    if isinstance(target, sqlparse.sql.Function):
+        target_parenthesis = next(
+            (
+                token
+                for token in target.tokens
+                if isinstance(token, sqlparse.sql.Parenthesis)
+            ),
+            None,
+        )
+    else:
+        target_parenthesis = (
+            tokens[into_index + 2]
+            if into_index < len(tokens) - 2
+            and isinstance(tokens[into_index + 2], sqlparse.sql.Parenthesis)
+            else None
+        )
+    values_parenthesis = next(
+        (token for token in values.tokens if isinstance(token, sqlparse.sql.Parenthesis)),
+        None,
+    )
+    if target_parenthesis is None or values_parenthesis is None:
+        return False
+
+    def _items(parenthesis):
+        identifier_list = next(
+            (
+                token
+                for token in parenthesis.tokens
+                if isinstance(token, sqlparse.sql.IdentifierList)
+            ),
+            None,
+        )
+        return (
+            [str(item).strip() for item in identifier_list.get_identifiers()]
+            if identifier_list is not None
+            else []
+        )
+
+    columns = [item.strip('"`[] ').casefold() for item in _items(target_parenthesis)]
+    expressions = _items(values_parenthesis)
+    if len(columns) != len(expressions):
+        return False
+    assignments = dict(zip(columns, expressions))
+    return all(
+        field.casefold() in assignments
+        and re.fullmatch(
+            rf"json_extract\s*\(\s*{re.escape(placeholder)}\s*,\s*['\"]\$\."
+            rf"{re.escape(field.casefold())}['\"]\s*\)",
+            assignments[field.casefold()].casefold(),
+        )
+        for field in expected_fields
+    )
 
 
 def _derives_bound_structured_message_fields(
@@ -1527,30 +1634,43 @@ def _seed_outreach_reconciliation_model(agent_id: str) -> None:
 def _schema_grounded_read_failures(calls) -> list[str]:
     calls = list(calls)
     failures = _sqlite_attempt_failures(calls)
-    schema_call_indexes = []
+    schema_positions = []
     data_reads = []
     for call_index, call in enumerate(calls):
         sql = str((call.tool_params or {}).get("sql") or "")
         schema_evidence = json.dumps(_result_payload(call) or {})
-        if (
+        has_schema_evidence = (
             HANDOFF_LEDGER_TABLE.casefold() in sql.casefold()
             and all(field in schema_evidence.casefold() for field in (
                 "handoff_key",
                 "worker_ref",
                 "resolution_code",
             ))
-        ):
-            schema_call_indexes.append(call_index)
-        for statement in sqlparse.split(sql):
+        )
+        for statement_index, statement in enumerate(sqlparse.split(sql)):
             structural = _structural_sql(statement)
+            if has_schema_evidence and (
+                re.search(
+                    r"\bpragma\s+(?:(?:main|temp)\.)?table_(?:info|xinfo)\s*\(",
+                    structural,
+                    re.I,
+                )
+                or re.search(r"\bpragma_table_(?:info|xinfo)\s*\(", structural, re.I)
+                or re.search(
+                    r"\bfrom\s+(?:(?:main|temp)\.)?sqlite_(?:master|schema)\b",
+                    structural,
+                    re.I,
+                )
+            ):
+                schema_positions.append((call_index, statement_index))
             if _reads_table(structural, HANDOFF_LEDGER_TABLE):
-                data_reads.append((call_index, structural))
+                data_reads.append((call_index, statement_index))
 
-    if not schema_call_indexes:
+    if not schema_positions:
         failures.append("existing ledger schema was not inspected")
     if not data_reads:
         failures.append("existing ledger was not queried")
-    if schema_call_indexes and data_reads and min(schema_call_indexes) >= min(item[0] for item in data_reads):
+    if schema_positions and data_reads and min(schema_positions) >= min(data_reads):
         failures.append("ledger columns were referenced before schema inspection completed")
     return failures
 
@@ -4013,10 +4133,18 @@ class SqliteStructuredPeerEventPersistenceScenario(SqliteDomainModelScenario):
                 write_statement,
                 {str(peer_event.id)},
             )
-            and _bound_json_payload_placeholder(
-                write_call,
+            and (
+                bound_payload_placeholder := _bound_json_payload_placeholder(
+                    write_call,
+                    write_statement,
+                    expected_payload,
+                )
+            )
+            and _insert_values_derive_bound_payload_fields(
                 write_statement,
-                expected_payload,
+                table_name="operational_events",
+                placeholder=bound_payload_placeholder,
+                expected_fields=set(expected_payload),
             )
         )
         message_grounded_import = direct_message_import or bound_message_import

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "7a3c39592db14ffce5497712b877baf05e1b556a",
+  "baseline_sha": "7ec0272f6e9492eefb29f415f451c2856b0627a4",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 266500
+    "limit": 266603
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "7ec0272f6e9492eefb29f415f451c2856b0627a4",
+  "baseline_sha": "8662010f45de21b59c96be23382211e8407c2895",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 266603
+    "limit": 266610
   }
 }

--- a/tests/unit/test_sqlite_source_array_eval.py
+++ b/tests/unit/test_sqlite_source_array_eval.py
@@ -28,6 +28,7 @@ from api.evals.scenarios.sqlite_tool_results import (
     SqliteSourceArrayFirstWriteScenario,
     SqliteStructuredPeerEventPersistenceScenario,
     SqliteUnstructuredBindingsFirstWriteScenario,
+    _bound_json_payload_placeholder,
     _derives_bound_structured_message_fields,
     _derives_structured_message_fields,
     _mutation_target_table,
@@ -312,6 +313,42 @@ class SqliteSourceArrayEvalTests(SimpleTestCase):
                     "state=outcome.delivery_status",
                     "state=CASE WHEN outcome.delivery_status='bounced' THEN 'bounced' "
                     "ELSE outcome.delivery_status END",
+                ),
+                payload,
+            )
+        )
+
+    def test_bound_operational_event_payload_is_grounded_without_scalar_copying(self):
+        payload = {
+            "event_id": "evt-2048",
+            "event_type": "accepted_setup",
+            "thread_key": "thread-2048",
+            "occurred_at": "2026-07-28T15:42:00Z",
+        }
+        sql = (
+            "INSERT INTO operational_events "
+            "(event_id, event_type, thread_key, occurred_at, source_message_id) "
+            "VALUES (json_extract(:source_payload,'$.event_id'), "
+            "json_extract(:source_payload,'$.event_type'), "
+            "json_extract(:source_payload,'$.thread_key'), "
+            "json_extract(:source_payload,'$.occurred_at'), :source_message_id)"
+        )
+        call = _sqlite_call(sql)
+        call.tool_params["bindings"] = {
+            "source_payload": payload,
+            "source_message_id": "message-2048",
+        }
+
+        self.assertEqual(
+            _bound_json_payload_placeholder(call, sql, payload),
+            ":source_payload",
+        )
+        self.assertIsNone(
+            _bound_json_payload_placeholder(
+                call,
+                sql.replace(
+                    "json_extract(:source_payload,'$.occurred_at')",
+                    "'2026-07-28T15:42:00Z'",
                 ),
                 payload,
             )

--- a/tests/unit/test_sqlite_source_array_eval.py
+++ b/tests/unit/test_sqlite_source_array_eval.py
@@ -31,8 +31,10 @@ from api.evals.scenarios.sqlite_tool_results import (
     _bound_json_payload_placeholder,
     _derives_bound_structured_message_fields,
     _derives_structured_message_fields,
+    _insert_values_derive_bound_payload_fields,
     _mutation_target_table,
     _repeated_source_import_tables,
+    _schema_grounded_read_failures,
     _sqlite_attempt_failures,
     _source_array_first_write_failures,
     _uses_bound_source_values,
@@ -87,6 +89,71 @@ class SqliteSourceArrayEvalTests(SimpleTestCase):
         FROM release_events
         ORDER BY starts_at;
     """
+
+    schema_result = json.dumps(
+        {
+            "status": "ok",
+            "results": [
+                {
+                    "result": [
+                        {"name": "handoff_key"},
+                        {"name": "worker_ref"},
+                        {"name": "resolution_code"},
+                    ]
+                },
+                {
+                    "result": [
+                        {
+                            "handoff_key": "handoff-01",
+                            "worker_ref": "agent-red",
+                            "resolution_code": "open",
+                        }
+                    ]
+                },
+            ],
+        }
+    )
+
+    def test_schema_grounding_accepts_inspection_before_read_in_same_batch(self):
+        call = _sqlite_call(
+            "PRAGMA table_info(z_handoff_ledger); "
+            "SELECT * FROM z_handoff_ledger;",
+            result=self.schema_result,
+        )
+
+        self.assertEqual(_schema_grounded_read_failures([call]), [])
+
+    def test_schema_grounding_rejects_read_before_inspection_in_same_batch(self):
+        call = _sqlite_call(
+            "SELECT * FROM z_handoff_ledger; "
+            "PRAGMA table_info(z_handoff_ledger);",
+            result=self.schema_result,
+        )
+
+        self.assertIn(
+            "ledger columns were referenced before schema inspection completed",
+            _schema_grounded_read_failures([call]),
+        )
+
+    def test_schema_grounding_rejects_unverified_schema_probe(self):
+        call = _sqlite_call(
+            "PRAGMA table_info(z_handoff_ledger); "
+            "SELECT * FROM z_handoff_ledger;",
+            result=json.dumps(
+                {
+                    "status": "ok",
+                    "results": [
+                        {"result": []},
+                        {"result": []},
+                    ],
+                }
+            ),
+        )
+
+        self.assertIn(
+            "existing ledger schema was not inspected",
+            _schema_grounded_read_failures([call]),
+        )
 
     def test_peer_outcome_fixture_uses_role_aligned_seller(self):
         scenario = SqlitePeerOutcomeReconcilesCanonicalModelScenario()
@@ -351,6 +418,62 @@ class SqliteSourceArrayEvalTests(SimpleTestCase):
                     "'2026-07-28T15:42:00Z'",
                 ),
                 payload,
+            )
+        )
+        scalar_copy_sql = sql.replace(
+            "json_extract(:source_payload,'$.event_type')",
+            ":event_type",
+        )
+        call.tool_params["bindings"]["event_type"] = "accepted_setup"
+        self.assertIsNone(
+            _bound_json_payload_placeholder(call, scalar_copy_sql, payload)
+        )
+        unused_extracts = (
+            "WITH inspected AS (SELECT "
+            "json_extract(:source_payload,'$.event_id'), "
+            "json_extract(:source_payload,'$.event_type'), "
+            "json_extract(:source_payload,'$.thread_key'), "
+            "json_extract(:source_payload,'$.occurred_at')) "
+            "INSERT INTO operational_events "
+            "(event_id, event_type, thread_key, occurred_at, source_message_id) "
+            "VALUES (:event_id, :event_type, :thread_key, :occurred_at, :source_message_id)"
+        )
+        call.tool_params["bindings"].update(payload)
+        self.assertIsNone(
+            _bound_json_payload_placeholder(call, unused_extracts, payload)
+        )
+        literal_copy = unused_extracts.replace(":event_id", "'evt-2048'")
+        self.assertIsNone(
+            _bound_json_payload_placeholder(call, literal_copy, payload)
+        )
+        self.assertTrue(
+            _insert_values_derive_bound_payload_fields(
+                sql,
+                table_name="operational_events",
+                placeholder=":source_payload",
+                expected_fields=set(payload),
+            )
+        )
+        self.assertTrue(
+            _insert_values_derive_bound_payload_fields(
+                sql.replace(
+                    "INSERT INTO operational_events",
+                    'INSERT OR IGNORE INTO "operational_events"',
+                ),
+                table_name="operational_events",
+                placeholder=":source_payload",
+                expected_fields=set(payload),
+            )
+        )
+        self.assertFalse(
+            _insert_values_derive_bound_payload_fields(
+                sql.replace(
+                    "json_extract(:source_payload,'$.event_type')",
+                    "lower(json_extract(:source_payload,'$.event_type'))",
+                ),
+                table_name="operational_events",
+                placeholder=":source_payload",
+                expected_fields=set(payload),
             )
         )
 

--- a/tests/unit/test_sqlite_state_recovery.py
+++ b/tests/unit/test_sqlite_state_recovery.py
@@ -11,6 +11,7 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import FileSystemStorage
 from django.test import SimpleTestCase, TestCase, tag
 
+from api.agent.core import event_processing as ep
 from api.agent.tools.sqlite_batch import execute_sqlite_batch
 from api.agent.tools.sqlite_recovery import (
     SQLITE_STATE_RECOVERED_ERROR,
@@ -25,6 +26,7 @@ from api.agent.tools.sqlite_recovery import (
 )
 from api.agent.tools.sqlite_state import (
     _agent_sqlite_db_uncoordinated,
+    _recover_sqlite_db_in_subprocess,
     reset_sqlite_db_path,
     set_sqlite_db_path,
     sqlite_storage_key,
@@ -217,6 +219,44 @@ class SQLiteRecoveryFileTests(SimpleTestCase):
             conn.close()
         self.assertEqual(value, "safe")
 
+    def test_sqlite_shell_recovery_returns_a_valid_database(self):
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("PRAGMA page_size=4096;")
+            conn.execute("CREATE TABLE durable_state (value TEXT NOT NULL);")
+            conn.executemany(
+                "INSERT INTO durable_state (value) VALUES (?);",
+                [("x" * 1000,) for _ in range(100)],
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with open(self.db_path, "r+b") as db_file:
+            db_file.seek((9 * 4096) + 64)
+            db_file.write(b"\xff" * 32)
+
+        with self.assertRaises(SQLiteStateValidationError):
+            validate_sqlite_file(self.db_path)
+
+        self.assertTrue(_recover_sqlite_db_in_subprocess(self.db_path, self.tmp_dir))
+        validate_sqlite_file(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            table_names = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table';"
+                )
+            }
+            recovered_rows = conn.execute(
+                "SELECT count(*) FROM durable_state;"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        self.assertIn("durable_state", table_names)
+        self.assertGreater(recovered_rows, 0)
+
 
 @tag("batch_sqlite")
 class SQLitePersistenceSafetyTests(SimpleTestCase):
@@ -250,7 +290,81 @@ class SQLitePersistenceSafetyTests(SimpleTestCase):
         self.assertEqual(value, "persisted")
         delete.assert_not_called()
 
-    def test_corrupt_stored_database_is_not_replaced_with_fresh_state(self):
+    def test_corrupt_stored_database_is_quarantined_before_fresh_fallback(self):
+        corrupt_path = os.path.join(self.storage_dir, "corrupt.db")
+        _create_test_database(corrupt_path)
+        _overwrite_header_with_tls_record(corrupt_path)
+        with open(corrupt_path, "rb") as corrupt_file:
+            corrupt_archive = zstd.ZstdCompressor(level=3).compress(corrupt_file.read())
+        self.storage.save(self.storage_key, ContentFile(corrupt_archive))
+        original_bytes = self._stored_bytes()
+        quarantine_key = f"{self.storage_key}.corrupt"
+
+        with patch(
+            "api.agent.tools.sqlite_state.default_storage", self.storage
+        ), patch(
+            "api.agent.tools.sqlite_state._log_sqlite_persistence_error"
+        ) as log_error:
+            with _agent_sqlite_db_uncoordinated(self.agent_uuid) as db_path:
+                validate_sqlite_file(db_path)
+                _create_test_database(db_path, ("rebuilt",))
+
+        self.assertEqual(
+            log_error.call_args.kwargs["error_code"],
+            "sqlite_restore_reset_after_corruption",
+        )
+        with self.storage.open(quarantine_key, "rb") as quarantined:
+            self.assertEqual(quarantined.read(), original_bytes)
+        with patch("api.agent.tools.sqlite_state.default_storage", self.storage):
+            with _agent_sqlite_db_uncoordinated(self.agent_uuid) as db_path:
+                conn = sqlite3.connect(db_path)
+                try:
+                    value = conn.execute("SELECT value FROM durable_state;").fetchone()[0]
+                finally:
+                    conn.close()
+        self.assertEqual(value, "rebuilt")
+
+    def test_empty_stored_database_is_quarantined_before_fresh_fallback(self):
+        empty_archive = zstd.ZstdCompressor(level=3).compress(b"")
+        self.storage.save(self.storage_key, ContentFile(empty_archive))
+        original_bytes = self._stored_bytes()
+        quarantine_key = f"{self.storage_key}.corrupt"
+
+        with patch(
+            "api.agent.tools.sqlite_state.default_storage", self.storage
+        ), patch(
+            "api.agent.tools.sqlite_state._log_sqlite_persistence_error"
+        ) as log_error:
+            with _agent_sqlite_db_uncoordinated(self.agent_uuid) as db_path:
+                validate_sqlite_file(db_path)
+
+        self.assertEqual(
+            log_error.call_args.kwargs["error_code"],
+            "sqlite_restore_salvaged",
+        )
+        with self.storage.open(quarantine_key, "rb") as quarantined:
+            self.assertEqual(quarantined.read(), original_bytes)
+
+    def test_storage_read_failure_does_not_replace_or_quarantine_state(self):
+        with patch("api.agent.tools.sqlite_state.default_storage", self.storage):
+            with _agent_sqlite_db_uncoordinated(self.agent_uuid) as db_path:
+                _create_test_database(db_path, ("known-good",))
+        original_bytes = self._stored_bytes()
+
+        with patch(
+            "api.agent.tools.sqlite_state.default_storage", self.storage
+        ), patch.object(
+            self.storage,
+            "open",
+            side_effect=OSError("storage unavailable"),
+        ), self.assertRaisesMessage(OSError, "storage unavailable"):
+            with _agent_sqlite_db_uncoordinated(self.agent_uuid):
+                self.fail("A storage read failure must not expose or replace state.")
+
+        self.assertEqual(self._stored_bytes(), original_bytes)
+        self.assertFalse(self.storage.exists(f"{self.storage_key}.corrupt"))
+
+    def test_quarantine_failure_leaves_canonical_archive_unchanged(self):
         corrupt_path = os.path.join(self.storage_dir, "corrupt.db")
         _create_test_database(corrupt_path)
         _overwrite_header_with_tls_record(corrupt_path)
@@ -259,22 +373,17 @@ class SQLitePersistenceSafetyTests(SimpleTestCase):
         self.storage.save(self.storage_key, ContentFile(corrupt_archive))
         original_bytes = self._stored_bytes()
 
-        with patch("api.agent.tools.sqlite_state.default_storage", self.storage):
-            with self.assertRaises(SQLiteStateValidationError):
-                with _agent_sqlite_db_uncoordinated(self.agent_uuid):
-                    self.fail("Corrupt restored state must not be exposed.")
-
-        self.assertEqual(self._stored_bytes(), original_bytes)
-
-    def test_empty_stored_database_is_not_replaced_with_fresh_state(self):
-        empty_archive = zstd.ZstdCompressor(level=3).compress(b"")
-        self.storage.save(self.storage_key, ContentFile(empty_archive))
-        original_bytes = self._stored_bytes()
-
-        with patch("api.agent.tools.sqlite_state.default_storage", self.storage):
-            with self.assertRaisesMessage(SQLiteStateValidationError, "file is empty"):
-                with _agent_sqlite_db_uncoordinated(self.agent_uuid):
-                    self.fail("Empty restored state must not be exposed.")
+        with patch(
+            "api.agent.tools.sqlite_state.default_storage", self.storage
+        ), patch(
+            "api.agent.tools.sqlite_state._upload_sqlite_archive",
+            side_effect=SQLiteStatePersistenceError("quarantine unavailable"),
+        ), self.assertRaisesMessage(
+            SQLiteStatePersistenceError,
+            "quarantine unavailable",
+        ):
+            with _agent_sqlite_db_uncoordinated(self.agent_uuid):
+                self.fail("Canonical state must remain untouched until quarantine succeeds.")
 
         self.assertEqual(self._stored_bytes(), original_bytes)
 
@@ -439,3 +548,29 @@ class SQLiteBatchRecoveryResultTests(TestCase):
         )
         self.assertEqual(error.context["error_code"], SQLITE_STATE_RECOVERED_ERROR)
         self.assertTrue(error.context["recovered"])
+
+    @patch("api.agent.core.event_processing._process_agent_events_locked")
+    def test_corrupt_persisted_state_does_not_block_agent_processing(self, process_locked):
+        storage = FileSystemStorage(location=os.path.join(self.tmp_dir, "storage"))
+        corrupt_path = os.path.join(self.tmp_dir, "corrupt.db")
+        _create_test_database(corrupt_path)
+        _overwrite_header_with_tls_record(corrupt_path)
+        with open(corrupt_path, "rb") as corrupt_file:
+            archive = zstd.ZstdCompressor(level=3).compress(corrupt_file.read())
+        storage.save(sqlite_storage_key(str(self.agent.id)), ContentFile(archive))
+        process_locked.return_value = self.agent
+
+        with patch(
+            "api.agent.tools.sqlite_state.default_storage", storage
+        ), patch(
+            "api.agent.tools.sqlite_state._recover_sqlite_db_in_subprocess",
+            return_value=False,
+        ):
+            ep.process_agent_events(self.agent.id)
+
+        process_locked.assert_called_once()
+        error = PersistentAgentError.objects.get(
+            agent=self.agent,
+            context__error_code="sqlite_restore_reset_after_corruption",
+        )
+        self.assertFalse(error.context["recovered"])

--- a/tests/unit/test_sqlite_state_recovery.py
+++ b/tests/unit/test_sqlite_state_recovery.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import shutil
 import sqlite3
+import subprocess
 import tempfile
 from unittest.mock import patch
 
@@ -55,6 +56,23 @@ def _overwrite_header_with_tls_record(db_path: str) -> None:
     with open(db_path, "r+b") as db_file:
         db_file.seek(5)
         db_file.write(tls_record)
+
+
+def _sqlite_shell_supports_safe_recovery() -> bool:
+    sqlite_shell = shutil.which("sqlite3")
+    if sqlite_shell is None:
+        return False
+    try:
+        probe = subprocess.run(
+            [sqlite_shell, "--safe", "-batch", ":memory:", ".recover"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return probe.returncode == 0
 
 
 @tag("batch_sqlite")
@@ -220,6 +238,9 @@ class SQLiteRecoveryFileTests(SimpleTestCase):
         self.assertEqual(value, "safe")
 
     def test_sqlite_shell_recovery_returns_a_valid_database(self):
+        if not _sqlite_shell_supports_safe_recovery():
+            self.skipTest("sqlite3 shell with safe recovery is not installed")
+
         conn = sqlite3.connect(self.db_path)
         try:
             conn.execute("PRAGMA page_size=4096;")
@@ -340,7 +361,7 @@ class SQLitePersistenceSafetyTests(SimpleTestCase):
 
         self.assertEqual(
             log_error.call_args.kwargs["error_code"],
-            "sqlite_restore_salvaged",
+            "sqlite_restore_reset_after_corruption",
         )
         with self.storage.open(quarantine_key, "rb") as quarantined:
             self.assertEqual(quarantined.read(), original_bytes)

--- a/tests/unit/test_sqlite_state_recovery.py
+++ b/tests/unit/test_sqlite_state_recovery.py
@@ -278,6 +278,22 @@ class SQLiteRecoveryFileTests(SimpleTestCase):
         self.assertIn("durable_state", table_names)
         self.assertGreater(recovered_rows, 0)
 
+    def test_sqlite_shell_recovery_rejects_only_lost_and_found_artifact(self):
+        if not _sqlite_shell_supports_safe_recovery():
+            self.skipTest("sqlite3 shell with safe recovery is not installed")
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute("CREATE TABLE lost_and_found (value TEXT NOT NULL);")
+            conn.execute("INSERT INTO lost_and_found (value) VALUES ('orphan');")
+            conn.commit()
+        finally:
+            conn.close()
+
+        self.assertFalse(
+            _recover_sqlite_db_in_subprocess(self.db_path, self.tmp_dir)
+        )
+
 
 @tag("batch_sqlite")
 class SQLitePersistenceSafetyTests(SimpleTestCase):


### PR DESCRIPTION
## Outcome

- A corrupt persisted agent SQLite archive no longer strands every wake before event processing. Restore quarantines the original, attempts bounded SQLite-shell salvage, validates that a real user table survived, and resets to a fresh validated database only when salvage is impossible.
- Recovery emits typed `sqlite_restore_salvaged` / `sqlite_restore_reset_after_corruption` diagnostics. Storage-read or quarantine failures still fail closed without replacing canonical state.
- Two SQLite eval blind spots are closed: ordered schema inspection is judged at statement rather than whole-call granularity, and a bound structured payload passes only when each extracted field actually feeds its corresponding inserted column. Literal, scalar-copy, dead-extract, transformed-value, and unsafe-provenance paths remain failures.

This addresses internal bug #524.

## Production RCA

The affected production agent had 821 cron triggers in three days but no `Process events` after its last successful runs logged `Failed to read skills table from SQLite`. Persisted-state restore runs before the locked event loop and previously re-raised the same corrupt archive on every cron/MCP wake, so the agent could never reach its work. Other scheduled agents continued normally, isolating the failure to this agent's restored SQLite state.

## Verification

- Red first: corrupt and empty archive restores failed before reaching agent processing; same-batch schema inspection was falsely rejected; unsafe payload extraction could satisfy the structured-event scorer.
- `batch_sqlite`: **143/143** green.
- Combined recovery/eval focused tests: **47/47** green; structured-source scorer file: **26/26** green.
- Actual `.recover` regression corrupts a data page and proves a valid table plus durable rows survive. A separate regression rejects SQLite's recovery-only `lost_and_found` artifact.
- Django system check and `git diff --check` clean.
- Required CI on exact head `90b98f2090024cfb5755c75ef8294bca77171e82`: all 10 backend shards, frontend, sandbox, tag, combined-result, and complexity checks green.
- Runtime review surface is 128 added / 9 removed lines in one core file; the remainder is focused recovery and eval regression coverage. Rendered prompt size is unchanged and remains below every budget.

## DeepSeek V4 Flash evals

Real harness, `openrouter-deepseek-v4-flash`:

- Capability routing: **9/9** tasks (3/3 runs).
- Unicode charter patching: **6/6** tasks (3/3 runs).
- Incremental domain model: **9/9** tasks (3/3 runs).
- Canonical peer-outcome reconciliation: **9/9** tasks (3/3 runs).
- Complete 20-scenario `sqlite_tool_results` suite `7fd2ccf6-0000-4a70-96c1-d19b649b2faa`: recorded **63/67 tasks (94%)**, with 16/20 scenarios perfect.
- Fresh exact-head 20-scenario repeat `733757e7-6c05-47ef-a613-b382b2a617d6`: **61/67 tasks (91%)**, completed without harness errors.
- Post-audit schema-grounding repeat `0cc55b6e-daf4-4507-b772-cefcf8187670`: **8/9**. Two ordered inspections passed; one run genuinely skipped inspection and was rejected.
- Post-review structured-event repeat `3a49e225-b9be-488b-88be-138e414f6826`: **8/9**. Two exact bound-payload writes passed; one scalar-copy write persisted the right values but was correctly rejected as ungrounded.

The original complete suite's stored four misses remain visible. Trace review proved one was an evaluator false negative—the agent ran `PRAGMA table_info` before `SELECT` in the same batch—and this PR fixes that judgment red-first. The fresh repeat's six misses were individually audited and are genuine one-shot behavior debt: repeated sibling imports, a failed SQL attempt, dependence on auto-correction, skipped schema inspection, an omitted requested source URL, and unsafe scalar copying. No healthy-path prompt changed, and no score was relaxed to hide those misses.

## Exact-head preview QA

`https://pr-1490.ship.gobii.ai` is healthy on exact head `90b98f2090024cfb5755c75ef8294bca77171e82`.

- Preview deployment workflow completed successfully; every platform deployment is ready on the exact `sha-90b98f...` image.
- Authenticated ping and MCP initialize returned HTTP 200 / protocol `2025-11-25`.
- A contained five-credit probe agent completed the requested MCP-to-web marker round trip, produced no external side effects or errors, reported `processing_active: false`, and was archived.
- Authenticated headed-browser QA reached the probe's agent-chat page through a one-time login, showed the exact inbound/outbound marker and normal UI, and showed no login form.
- In-container runtime probes confirmed pinned SQLite `3.53.3`; deliberately corrupting a populated data page invoked the recovery path, returned a valid database with substantive rows, and passed `PRAGMA integrity_check`, while a database containing only `lost_and_found` was correctly rejected.

Independent reliability review on the exact head: **PASS**, no concrete P1/P2 blocker. GitHub Codex also reviewed exact head `90b98f2090` and found no major issues. Its prior P2 was addressed with adversarial unit coverage and a stricter column-to-extraction check.

## Safety and follow-up

- Original compressed bytes are quarantined before canonical replacement.
- Recovery runs with safe/batch/bail modes and 120-second subprocess bounds.
- Recovered state must pass SQLite validation and contain a substantive table before atomic replacement.
- #522 is supported as a transient provider 500 with bounded fallback and #319 as fixed by existing charter-patch work. #445 remains a reproducible staging-host issue. #22, #249, #345, #449, and #520 remain open/unclaimed pending their separate owners or exact evidence.
