### PR TITLE
Guide first-shot SQLite source imports

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -4018,7 +4018,8 @@ def _get_continuation_mode_prompt_block() -> str:
     return (
         "## Continuation Mode\n\n"
         "Continue from history and state without restarting solved work. Identify the latest result or blocker, then "
-        "take the smallest concrete next action and follow tool retry/setup guidance. Reconcile fresh completion/outcome "
+        "take the smallest concrete next action and follow tool retry/setup guidance. When structured result_meta gives "
+        "an import shape, execute it next without pre-reading or copying its source. Reconcile fresh completion/outcome "
         "events into canonical state before counts/queues. Under load, use the plan and "
         "SQLite as the control board: preserve owners and deadlines, finish or park one bounded step, then take the "
         "highest-impact authorized commitment. Park blocked streams, continue unblocked work, and negotiate capacity/scope "

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -4287,7 +4287,7 @@ def _get_system_instruction(
         "localhost/private/rendered/login page -> spawn_web_task (or retry with it after scrape/http cannot access)\n"
         "webpage screenshot/visual capture/PDF/rendered artifact -> spawn_web_task\n"
         "provided filespace path -> pass directly; read_file only for requested contents, never URL/auth preflight\n"
-        "non-secret data/api/feed/file URL -> http_request; reconcile reusable sets/existing tables only; PDF may need read_file; browser only after access/render/login blockage\n"
+        "non-secret data/api/feed/file URL -> http_request; PDF may need read_file; browser only after access/render/login blockage\n"
         "HTML page to read -> scrape_as_markdown or structured extractor; known platforms/social -> structured extractor first\n"
         "local reviews/maps lead screen -> structured Maps/reviews tool directly; omitted city -> representative market/broad query, not human input\n"
         "weather geocoding -> forecast/current API before replying\n"

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -587,9 +587,9 @@ def prepare_tool_results_for_prompt(
                 # instead of the set-wise import needed for the durable model.
                 context_hint = None
                 preview_text = (
-                    "[SOURCE SET STORED IN __tool_results. Create/evolve the durable model and use the exact "
-                    "result_meta INSERT ... SELECT shape now; __tool_results is read-only source. Do not inspect "
-                    "or copy the source first.]"
+                    "[NEXT: one sqlite_batch rows=[],bindings={}. CREATE/evolve the model, use result_meta's "
+                    "INSERT ... SELECT, then decision SELECT in that batch. Never SELECT/inspect/copy "
+                    "__tool_results first.]"
                 )
                 is_inline = False
         if requires_source_import:

--- a/api/evals/scenarios/sqlite_tool_results.py
+++ b/api/evals/scenarios/sqlite_tool_results.py
@@ -1881,6 +1881,13 @@ def _domain_refresh_state_failures(agent_id: str) -> list[str]:
     return _inspect_domain_refresh_state(agent_id)[0]
 
 
+def _release_source_url_column(column_names: set[str]) -> str | None:
+    for column_name in ("source_url", "event_source_url", "feed_source_url"):
+        if column_name in column_names:
+            return column_name
+    return None
+
+
 def _inspect_release_model(agent_id: str) -> tuple[list[str], str | None]:
     expected = {
         (*row, RELEASE_CALENDAR_URL, RELEASE_CALENDAR_OBSERVED_AT)
@@ -1901,12 +1908,14 @@ def _inspect_release_model(agent_id: str) -> tuple[list[str], str | None]:
                 names = {column[1] for column in columns}
                 required = {
                     "release_id", "service", "starts_at", "owner", "status",
-                    "source_url", "observed_at",
+                    "observed_at",
                 }
-                if not required.issubset(names):
+                source_url_column = _release_source_url_column(names)
+                if not required.issubset(names) or source_url_column is None:
                     continue
                 rows = conn.execute(
-                    f"SELECT release_id, service, starts_at, owner, status, source_url, observed_at "
+                    f"SELECT release_id, service, starts_at, owner, status, "
+                    f'"{source_url_column}", observed_at '
                     f"FROM {quoted};"
                 ).fetchall()
                 unique_indexes = [

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "70f8083877e659074c829a017d7282516812c929",
+  "baseline_sha": "7020e13de9cd7522fa334d02fb212c0e339dc60e",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9263,
-        "system_bytes": 32327,
-        "tools_bytes": 23829,
-        "total_bytes": 67908,
+        "fitted_tokens": 9242,
+        "system_bytes": 32261,
+        "tools_bytes": 23818,
+        "total_bytes": 67831,
         "user_bytes": 11752
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8685,
-        "system_bytes": 29293,
-        "tools_bytes": 23829,
-        "total_bytes": 64907,
+        "fitted_tokens": 8702,
+        "system_bytes": 29401,
+        "tools_bytes": 23818,
+        "total_bytes": 65004,
         "user_bytes": 11785
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8865,
-        "system_bytes": 29930,
-        "tools_bytes": 23829,
-        "total_bytes": 65547,
+        "fitted_tokens": 8878,
+        "system_bytes": 30038,
+        "tools_bytes": 23818,
+        "total_bytes": 65644,
         "user_bytes": 11788
       }
     },
@@ -109,7 +109,7 @@
       "frontend/src/test/",
       "tests/"
     ],
-    "file_count": 953,
+    "file_count": 955,
     "include_files": [
       "manage.py",
       "pyproject.toml",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 280000
+    "limit": 272478
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "7020e13de9cd7522fa334d02fb212c0e339dc60e",
+  "baseline_sha": "209cb0ad6dc553d88e1e18fa0e310b06d4b3cf14",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9242,
-        "system_bytes": 32261,
+        "fitted_tokens": 9254,
+        "system_bytes": 32215,
         "tools_bytes": 23818,
-        "total_bytes": 67831,
+        "total_bytes": 67785,
         "user_bytes": 11752
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8702,
-        "system_bytes": 29401,
+        "fitted_tokens": 8674,
+        "system_bytes": 29355,
         "tools_bytes": 23818,
-        "total_bytes": 65004,
+        "total_bytes": 64958,
         "user_bytes": 11785
       },
       "web_chat_implied_send": {
-        "fitted_tokens": 8878,
-        "system_bytes": 30038,
+        "fitted_tokens": 8870,
+        "system_bytes": 29992,
         "tools_bytes": 23818,
-        "total_bytes": 65644,
+        "total_bytes": 65598,
         "user_bytes": 11788
       }
     },

--- a/tests/unit/test_agent_planning_mode.py
+++ b/tests/unit/test_agent_planning_mode.py
@@ -168,6 +168,7 @@ class PersistentAgentPlanningModeTests(TestCase):
         self.assertIn("Prior-action question", prompt)
         self.assertIn("create/start nothing", prompt)
         self.assertIn("exact API endpoint + http_request", prompt)
+        self.assertIn("execute it next without pre-reading or copying its source", prompt)
         self.assertIn("Short action or current-batch continuation", prompt)
         self.assertIn("Meaningful shared win/repeated failure", prompt)
         self.assertIn("Campaign/bulk review", prompt)

--- a/tests/unit/test_sqlite_source_array_eval.py
+++ b/tests/unit/test_sqlite_source_array_eval.py
@@ -34,6 +34,7 @@ from api.evals.scenarios.sqlite_tool_results import (
     _insert_values_derive_bound_payload_fields,
     _mutation_target_table,
     _repeated_source_import_tables,
+    _release_source_url_column,
     _schema_grounded_read_failures,
     _sqlite_attempt_failures,
     _source_array_first_write_failures,
@@ -89,6 +90,17 @@ class SqliteSourceArrayEvalTests(SimpleTestCase):
         FROM release_events
         ORDER BY starts_at;
     """
+
+    def test_release_model_accepts_semantic_provenance_column_names(self):
+        self.assertEqual(
+            _release_source_url_column({"release_id", "event_source_url"}),
+            "event_source_url",
+        )
+        self.assertEqual(
+            _release_source_url_column({"release_id", "feed_source_url"}),
+            "feed_source_url",
+        )
+        self.assertIsNone(_release_source_url_column({"release_id", "service"}))
 
     def test_schema_grounding_accepts_direct_live_schema_read(self):
         call = _sqlite_call(

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -1185,6 +1185,7 @@ class PreviewByteLimitTests(SimpleTestCase):
             "step-first-model",
             payload,
             named_model_tables=set(),
+            will_continue_work=True,
         )
 
         for expected in (
@@ -1206,6 +1207,9 @@ class PreviewByteLimitTests(SimpleTestCase):
             self.assertIn(expected, info.meta)
         self.assertNotIn("[SOURCE ARRAYS", info.preview_text)
         self.assertNotIn(" VALUES ", info.preview_text)
+        self.assertIn("NEXT: one sqlite_batch rows=[],bindings={}", info.preview_text)
+        self.assertIn("INSERT ... SELECT, then decision SELECT in that batch", info.preview_text)
+        self.assertIn("Never SELECT/inspect/copy __tool_results first", info.preview_text)
         self.assertEqual(info.meta.count("[SOURCE SET"), 1)
         self.assertNotIn("result_id=", info.meta)
         self.assertNotIn("json_extract(j.value,'$.id')", info.meta)


### PR DESCRIPTION
## Summary

- make the first post-result action explicit when structured `result_meta` already provides a set-wise SQLite import shape
- replace a weaker source-set preview with one compact, executable next-action contract
- remove a contradictory generic qualifier that limited source reconciliation to existing tables even when `result_meta` correctly called for a new model
- make the release-model eval accept semantically equivalent event/feed provenance column names
- retain the established existing-table refresh route and tighten complexity limits to the exact measured head

## Evidence

- Main baseline: `sqlite_source_array_first_write` failed its first-shot contract in 8/16 DeepSeek V4 Flash runs, including about 7 direct pre-read/reimport failures
- Exact final head: 9/10 full-contract passes; the lone miss duplicated the HTTP fetch but still performed one correct set-wise import. Zero runs pre-read or copied `__tool_results` before the model write
- The previously tested prompt+preview pair reached 17/18 clean first-shot imports; an ablation showed the preview alone was insufficient (6/10), proving the small continuation cue is material
- Two complete 20-scenario `sqlite_tool_results` sweeps were 92.5% then 97.0%; every miss was inspected
- Exact-head full suite: 423/423 scenarios completed with zero errors and 1788/1820 tasks passing (98.2%). An exact rerun of all 25 affected scenarios recovered 25/30 missed assertions. Two more runs of the five residual families left only the pre-existing outreach-preflight QA misses and one Discord kickoff-order miss; the charter, reaction, and long-link cases recovered
- 71 focused unit tests pass
- complexity guard passes; normal/web system prompts increase by 62 bytes (~0.2%), first-run shrinks by 112 bytes, and the source-LOC ceiling drops from 280,000 to 272,478

## Preview QA

Exact preview deploy run `30712663078` resolved and deployed `19b6c36832159fd49ac241237a32e32412c2419d`.

- authenticated MCP probe fetched one harmless JSON array, then immediately used one `sqlite_batch` to create the model, `INSERT ... SELECT/json_each` all 10 rows directly from the current source result, and query count/top rows in the same batch
- zero SQLite errors, source pre-reads, or copied source literals; correct reply delivered and probe archived
- authenticated browser-session ticket redeemed on `pr-1496`, app shell painted normally, screenshot inspected, no login form or auth error

## Tests

- `uv run python manage.py test tests.unit.test_tool_results_schema.PreviewByteLimitTests tests.unit.test_agent_planning_mode.PersistentAgentPlanningModeTests tests.unit.test_sqlite_source_array_eval.SqliteSourceArrayEvalTests api.evals.tests.test_effort_calibration.FirstRunPromptCalibrationTests.test_system_prompt_has_delivery_and_config_guardrails --settings=config.test_settings --parallel 1`
- `uv run python scripts/check_complexity_budgets.py --prompt-only`
- `uv run python manage.py run_evals --scenario sqlite_source_array_first_write --n-runs 10 --routing-profile openrouter-deepseek-v4-flash --max-concurrency 10 --settings=config.eval_postgres_settings`
- `uv run python manage.py run_evals --suite sqlite_tool_results --n-runs 1 --routing-profile openrouter-deepseek-v4-flash --max-concurrency 8 --settings=config.eval_postgres_settings` (twice)
- `uv run python manage.py run_evals --suite all --n-runs 1 --routing-profile openrouter-deepseek-v4-flash --max-concurrency 24 --settings=config.eval_postgres_settings`

Tracker: Gobii platform bug #532.
