### PR TITLE
Converge oversized tool results in one pass

### DIFF
--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -127,7 +127,7 @@ from ..tools.sqlite_query_quality import (
 from ..tools.sqlite_skills import format_recent_skills_for_prompt
 from ..tools.tool_manager import ensure_default_tools_enabled, ensure_skill_tools_enabled, get_enabled_tool_definitions
 from ..system_skills.discovery import format_system_skill_discovery_prompt
-from .tool_results import PREVIEW_TIER_COUNT, SPAWN_WEB_TASK_RESULT_TOOL_NAME, ToolCallResultRecord, ToolResultPromptInfo, build_short_result_id_map, entity_name_stem, prepare_tool_results_for_prompt, source_array_entity_groups
+from .tool_results import PREVIEW_TIER_COUNT, SPAWN_WEB_TASK_RESULT_TOOL_NAME, ToolCallResultRecord, ToolResultPromptInfo, build_short_result_id_map, entity_name_stem, prepare_tool_results_for_prompt, source_array_entity_groups, sqlite_result_has_query_result
 from .link_references import (
     LinkReferenceResolutionError,
     extract_http_urls,
@@ -4932,6 +4932,7 @@ def _is_terminal_sqlite_handoff(
         newest_record.tool_name != "sqlite_batch"
         or newest_record.will_continue_work is not False
         or not _tool_result_status_is_ok(newest_record.result_text)
+        or not sqlite_result_has_query_result(newest_record.result_text)
     ):
         return False
     newest_message_at = max(

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1803,7 +1803,12 @@ def _render_prompt_context_once(
 
     # Unified history follows the important context (order within user prompt: important -> unified_history -> critical)
     unified_history_group = prompt.group("unified_history", weight=3)
-    fresh_tool_call_step_ids, has_link_references, source_reconciliation_directives = _get_unified_history_prompt(
+    (
+        fresh_tool_call_step_ids,
+        has_link_references,
+        source_reconciliation_directives,
+        terminal_sqlite_handoff,
+    ) = _get_unified_history_prompt(
         agent,
         unified_history_group,
         config_authority,
@@ -1816,19 +1821,20 @@ def _render_prompt_context_once(
 
     variable_group = prompt.group("variable", weight=4)
 
-    variable_group.section_text(
-        "sqlite_schema",
-        sqlite_schema_block,
-        weight=1,
-        shrinker="hmt"
-    )
-    sqlite_digest_block = get_sqlite_digest_prompt()
-    variable_group.section_text(
-        "sqlite_digest",
-        sqlite_digest_block,
-        weight=1,
-        shrinker="hmt"
-    )
+    if not terminal_sqlite_handoff:
+        variable_group.section_text(
+            "sqlite_schema",
+            sqlite_schema_block,
+            weight=1,
+            shrinker="hmt"
+        )
+        sqlite_digest_block = get_sqlite_digest_prompt()
+        variable_group.section_text(
+            "sqlite_digest",
+            sqlite_digest_block,
+            weight=1,
+            shrinker="hmt"
+        )
 
     # Agent filesystem listing - recent metadata-only list from the same snapshot used for __files
     files_listing_block = format_agent_filesystem_prompt(
@@ -4915,6 +4921,26 @@ def _build_sqlite_files_snapshot(agent: PersistentAgent) -> _FileSnapshotBundle:
     return _FileSnapshotBundle(has_filespace=True, records=records)
 
 
+def _is_terminal_sqlite_handoff(
+    tool_call_records: Sequence[ToolCallResultRecord],
+    messages: Sequence[PersistentAgentMessage],
+) -> bool:
+    if not tool_call_records:
+        return False
+    newest_record = max(tool_call_records, key=lambda record: record.created_at)
+    if (
+        newest_record.tool_name != "sqlite_batch"
+        or newest_record.will_continue_work is not False
+        or not _tool_result_status_is_ok(newest_record.result_text)
+    ):
+        return False
+    newest_message_at = max(
+        (message.timestamp for message in messages),
+        default=None,
+    )
+    return newest_message_at is None or newest_record.created_at >= newest_message_at
+
+
 @tracer.start_as_current_span("Prompt Unified History")
 def _get_unified_history_prompt(
     agent: PersistentAgent,
@@ -4926,7 +4952,7 @@ def _get_unified_history_prompt(
     named_model_tables: Set[str] | None = None,
     named_model_columns: Mapping[str, Set[str]] | None = None,
     has_peer_links: bool = False,
-) -> Tuple[Set[str], bool, Tuple[str, ...]]:
+) -> Tuple[Set[str], bool, Tuple[str, ...], bool]:
     """Add summaries + interleaved recent steps & messages to the provided promptree group."""
     epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
     unified_limit, unified_hysteresis = _get_unified_history_limits(agent)
@@ -5706,7 +5732,12 @@ def _get_unified_history_prompt(
         for info in tool_result_prompt_info.values()
         if info.source_reconciliation_directive
     )
-    return fresh_tool_call_step_ids, has_link_references, source_reconciliation_directives
+    return (
+        fresh_tool_call_step_ids,
+        has_link_references,
+        source_reconciliation_directives,
+        _is_terminal_sqlite_handoff(tool_call_records, messages),
+    )
 
 
 def get_agent_tools(agent: PersistentAgent = None) -> List[dict]:

--- a/api/agent/core/result_analysis.py
+++ b/api/agent/core/result_analysis.py
@@ -1576,6 +1576,10 @@ def _detect_csv(text: str) -> Tuple[bool, CsvInfo]:
         for row in rows[data_start_idx:data_start_idx + 3]
         if any(cell.strip() for cell in row)
     ]
+    if looks_like_header and sum(row == header_row for row in data_rows) >= 2:
+        # Repeated prose boilerplate containing commas can fool the dialect
+        # sniffer. A real header should not also be most of its first data rows.
+        return False, CsvInfo()
     info.sample_rows = [dialect.delimiter.join(row)[:300] for row in data_rows]
 
     # Infer column types from sample data

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -737,7 +737,7 @@ def prepare_tool_results_for_prompt(
         terminal_directive = _terminal_result_directive(result_text)
         if terminal_directive:
             meta_text += f"\n{terminal_directive}"
-        if record.tool_name == "sqlite_batch":
+        if record.tool_name == "sqlite_batch" and sqlite_result_has_query_result(result_text):
             if record.will_continue_work is False and _tool_result_succeeded(result_text):
                 meta_text += (
                     "\nSQLITE RESULT: terminal answer rows. Deliver now; no more tools. Preserve returned values and "
@@ -1344,6 +1344,18 @@ def _tool_result_succeeded(result_text: str) -> bool:
     except (json.JSONDecodeError, TypeError):
         return False
     return isinstance(payload, dict) and payload.get("status") == "ok"
+
+
+def sqlite_result_has_query_result(result_text: str) -> bool:
+    try:
+        payload = json.loads(result_text)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    results = payload.get("results") if isinstance(payload, dict) else None
+    return isinstance(results, list) and any(
+        isinstance(item, dict) and "result" in item
+        for item in results
+    )
 
 
 def _terminal_result_directive(result_text: str) -> str:

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -76,10 +76,67 @@ MAX_OPTIONAL_SOURCE_HINT_CHARS = 900
 PROSE_INSPECTION_TOTAL_CHARS = 8_000
 PROSE_INSPECTION_MIN_CHARS = 400
 PROSE_INSPECTION_MAX_CHARS = 2_000
+EXPLICIT_SECTION_DELIMITERS = {
+    "\n---\n": "char(10)||'---'||char(10)",
+    "\n===\n": "char(10)||'==='||char(10)",
+}
+_LABELED_SECTION_DELIMITER_RE = re.compile(
+    r"\n((?:-{3,}|={3,})[ A-Za-z0-9_.:/]{1,64}(?:-{3,}|={3,}))\n"
+)
+
+
+@dataclass(frozen=True)
+class ExplicitSectionShape:
+    count: int
+    delimiter_sql: str
+    fields: tuple[str, ...]
+    stable_key: str
 
 
 def _is_scrape_as_markdown_tool(tool_name: str) -> bool:
     return tool_name.endswith("scrape_as_markdown")
+
+
+def _explicit_section_shape(text: str | None) -> ExplicitSectionShape | None:
+    if not text:
+        return None
+    delimiters = dict(EXPLICIT_SECTION_DELIMITERS)
+    for label in _LABELED_SECTION_DELIMITER_RE.findall(text):
+        delimiter = f"\n{label}\n"
+        delimiters[delimiter] = f"char(10)||'{label.replace(chr(39), chr(39) * 2)}'||char(10)"
+    matches = []
+    for delimiter, sql_expression in delimiters.items():
+        delimiter_count = text.count(delimiter)
+        if delimiter_count >= 2:
+            matches.append((delimiter_count + 1, delimiter, sql_expression))
+    if not matches:
+        return None
+    count, delimiter, delimiter_sql = max(matches)
+    sections = text.split(delimiter)[:32]
+    field_counts: dict[str, int] = {}
+    field_order: list[str] = []
+    for section in sections:
+        for field in dict.fromkeys(re.findall(r"(?m)^([A-Za-z_][\w-]{0,63}):[ \t]*", section)):
+            if field not in field_counts:
+                field_order.append(field)
+            field_counts[field] = field_counts.get(field, 0) + 1
+    minimum_count = max(2, len(sections) // 4)
+    fields = tuple(field for field in field_order if field_counts[field] >= minimum_count)
+    stable_key = next(
+        (
+            field for field in fields
+            if field.casefold() == "id" or field.casefold().endswith("_id")
+        ),
+        fields[0] if fields else "",
+    )
+    if not stable_key:
+        return None
+    return ExplicitSectionShape(
+        count=count,
+        delimiter_sql=delimiter_sql,
+        fields=fields,
+        stable_key=stable_key,
+    )
 
 
 def _mark_missing_item_links(text: str) -> str:
@@ -625,8 +682,9 @@ def prepare_tool_results_for_prompt(
             emitted_link_guidance.add(link_guidance_key)
             preview_text = (
                 "[VERIFIED LINK PRESENTATION: when presenting these sourced items, anchor each token on its exact "
-                "entity name using the active "
-                "surface syntax ([entity](token) or <a href='token'>entity</a>), never a host, URL, generic "
+                "entity name using the active surface syntax ([entity]($[link:ID]) or "
+                "<a href='$[link:ID]'>entity</a>). Copy the complete `$[link:ID]` destination verbatim, including "
+                "`$[link:` and `]`; never use the bare ID, a host, URL, generic "
                 "'link/page', or related entity. No separate URL/link column unless requested. "
                 "For an owner report with 4+ items, say "
                 "Covered N/N and use one channel-appropriate table for every item/requested field. Say Not returned "
@@ -637,12 +695,26 @@ def prepare_tool_results_for_prompt(
                 f"{preview_text}"
             )
         is_scrape_markdown = _is_scrape_as_markdown_tool(record.tool_name)
+        explicit_section_shape = (
+            _explicit_section_shape(stored_text)
+            if is_fresh_tool_call and stored_text
+            else None
+        )
         is_prose_work_set = (
             stored_in_db
             and is_current_source_batch
             and _record_is_source_bearing(record)
             and not _entity_arrays(analysis)
-            and (is_scrape_markdown or len(work_set) > 1)
+            and (not has_focus or explicit_section_shape is not None)
+            and (
+                is_scrape_markdown
+                or len(work_set) > 1
+                or (
+                    is_fresh_tool_call
+                    and not is_inline
+                    and meta["bytes"] > FRESH_RESULT_INLINE_THRESHOLD
+                )
+            )
         )
         if is_scrape_markdown:
             # The page preview is the useful context; a repeated title digest competes
@@ -710,6 +782,11 @@ def prepare_tool_results_for_prompt(
                     len(candidate.result_text.encode("utf-8")) <= SMALL_RESULT_ALWAYS_INLINE
                     for candidate in work_set_records
                 )
+                section_shape = (
+                    explicit_section_shape
+                    if len(work_set) == 1 and not previews_are_complete
+                    else None
+                )
                 evidence_chars = max(
                     PROSE_INSPECTION_MIN_CHARS,
                     min(
@@ -733,7 +810,36 @@ def prepare_tool_results_for_prompt(
                     "do not look either up again. The next SQLite call is the final import/decision call; set "
                     "will_continue_work=false unless a specific non-SQLite action remains. "
                 )
-                if len(work_set) > 1:
+                direct_import_guidance = ""
+                if section_shape:
+                    field_list = ",".join(section_shape.fields[:12])
+                    stable_key_pattern = f"'(?m)^{section_shape.stable_key}:[ ]*(.*)$'"
+                    extraction_sql = ", ".join(
+                        (
+                            "regexp_extract(s.value,"
+                            f"'(?m)^{re.escape(field)}:[ ]*(.*)$',1) AS \"{field}\""
+                        )
+                        for field in section_shape.fields[:12]
+                    )
+                    inspection_guidance = (
+                        f"The stored source has about {section_shape.count} explicit repeated sections with recurring "
+                        f"labels `{field_list}` and stable key `{section_shape.stable_key}`. PROSE CONTRACT: "
+                        "`result_json` is NULL; never use `json_each/json_extract` on it. Do not inspect or return the "
+                        "raw blob first. Make one terminal sqlite_batch with "
+                        "`rows=[],bindings={}`: create/evolve the keyed domain model; INSERT ... SELECT requested "
+                        "records from `__tool_results t,json_each(split_sections(t.result_text,"
+                        f"{section_shape.delimiter_sql})) s WHERE t.is_current_batch=1 AND "
+                        f"t.tool_name='{escaped_tool_name}'`; keep records where "
+                        f"`regexp_extract(s.value,{stable_key_pattern},1) IS NOT NULL`, apply that expression shape "
+                        f"using these ready source-derived columns: `{extraction_sql}`. Missing fields stay NULL; never "
+                        "construct one from another identifier. Upsert provenance, end with the decision SELECT in "
+                        "that same call, and set `will_continue_work=false` because its returned rows are the answer. "
+                    )
+                    direct_import_guidance = (
+                        "The split-section SELECT is the final import path; do not transcribe records into `rows`, "
+                        "copy source facts into SQL literals, pre-read, refetch, or later reread. "
+                    )
+                elif len(work_set) > 1:
                     inspection_guidance = (
                         "Before any multi-source prose model write, make exactly one compact set-wide evidence "
                         "inspection; do not import from memory or previews alone. Use it even when previews look "
@@ -751,14 +857,20 @@ def prepare_tool_results_for_prompt(
                         "Otherwise make exactly one compact inspection with one output row and at most "
                         f"{evidence_chars} evidence characters: {inspection_query} {inspection_contract}"
                     )
+                manual_import_guidance = (
+                    "Final import: top-level `rows=[{\"result_id\":\"exact ID\",\"fields\":{...}},...]`, one non-empty "
+                    "record per source; INSERT SELECT from `json_each(:rows) r JOIN __tool_results t ON "
+                    "t.result_id=json_extract(r.value,'$.result_id')`, reading facts at $.fields.<name> and provenance "
+                    "from t. "
+                    if not direct_import_guidance
+                    else direct_import_guidance
+                )
                 meta_text += (
                     f"\n{work_set_label} ({len(work_set)} {result_label}; exact source result IDs: "
                     f"`{source_ids}`): unstructured prose; this is the complete set. "
                     f"{inspection_guidance}"
-                    "Final import: top-level `rows=[{\"result_id\":\"exact ID\",\"fields\":{...}},...]`, one non-empty "
-                    "record per source; INSERT SELECT from `json_each(:rows) r JOIN __tool_results t ON "
-                    "t.result_id=json_extract(r.value,'$.result_id')`, reading facts at $.fields.<name> and provenance "
-                    "from t. End with decision-ready SELECTs. Upsert stable keys; no sourced SQL literals, ID-only "
+                    f"{manual_import_guidance}"
+                    "End with decision-ready SELECTs. Upsert stable keys; no sourced SQL literals, ID-only "
                     "rows, destructive rebuild, dump, or later reread. `fields` is evidence transcription, not "
                     "enrichment: preserve each source's specificity and omit unsupported fields. Never turn a "
                     "qualitative claim into a number, feature variant, certification level, integration, or "
@@ -835,7 +947,14 @@ def _should_add_barbell_hint(
     if meta.get("is_binary"):
         return False
     text_analysis = analysis.text_analysis
-    if not text_analysis or text_analysis.format not in BARBELL_TEXT_FORMATS:
+    if not text_analysis:
+        return False
+    is_headerless_csv = bool(
+        text_analysis.format == "csv"
+        and text_analysis.csv_info
+        and not text_analysis.csv_info.has_header
+    )
+    if text_analysis.format not in BARBELL_TEXT_FORMATS and not is_headerless_csv:
         return False
     if text_analysis.text_digest and text_analysis.text_digest.action == "skip":
         return False
@@ -1098,11 +1217,23 @@ def _maybe_auto_load_csv(
         return None
 
 
+def _unwrap_http_text_body(result_text: str, tool_name: str) -> str:
+    if tool_name != "http_request":
+        return result_text
+    try:
+        payload = json.loads(result_text)
+    except json.JSONDecodeError:
+        return result_text
+    content = payload.get("content") if isinstance(payload, dict) else None
+    return content if isinstance(content, str) else result_text
+
+
 def _summarize_result(
     result_text: str,
     result_id: str,
     tool_name: str = "",
 ) -> Tuple[Dict[str, object], Optional[str], Optional[str], Optional[ResultAnalysis]]:
+    result_text = _unwrap_http_text_body(result_text, tool_name)
     analysis: Optional[ResultAnalysis] = None
     try:
         analysis = analyze_result(result_text, result_id)
@@ -1164,13 +1295,12 @@ def _summarize_result(
 
             if isinstance(content, str):
                 result_text_store = content
-                if _is_scrape_as_markdown_tool(tool_name):
-                    # The wrapper is transport metadata, not a structured domain
-                    # payload. Keeping both shapes invites guessed JSON paths.
-                    result_json = None
-                    is_json = False
-                    json_type = ""
-                    top_keys = []
+                # Scrape previews have their own barbell path and deliberately
+                # keep the wrapper analysis used by that established contract.
+                result_json = None
+                is_json = False
+                json_type = ""
+                top_keys = []
             elif content is not None:
                 if (
                     tool_name == "http_request"

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -740,8 +740,8 @@ def prepare_tool_results_for_prompt(
         if record.tool_name == "sqlite_batch":
             if record.will_continue_work is False and _tool_result_succeeded(result_text):
                 meta_text += (
-                    "\nSQLITE RESULT: you marked this query terminal. Its returned rows are the answer source. "
-                    "NEXT ACTION MUST deliver the user-facing answer; do not call SQLite or another research tool."
+                    "\nSQLITE RESULT: terminal answer rows. Deliver now; no more tools. Preserve returned values and "
+                    "associations exactly: NULL/unavailable stays unavailable, never inferred from neighboring fields."
                 )
             else:
                 meta_text += (

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -498,6 +498,11 @@ def prepare_tool_results_for_prompt(
         meta, stored_json, stored_text, analysis = _summarize_result(result_text, result_id, record.tool_name)
         stored_in_db = record.tool_name not in EXCLUDED_TOOL_NAMES
         is_analysis_eligible = record.tool_name.startswith(SCHEMA_ELIGIBLE_TOOL_PREFIXES)
+        is_unwrapped_http_body = (
+            record.tool_name == "http_request"
+            and stored_text is not None
+            and stored_text != result_text
+        )
 
         recency_position = recency_positions.get(record.step_id)
         is_fresh_tool_call = record.step_id in fresh_step_ids
@@ -524,7 +529,11 @@ def prepare_tool_results_for_prompt(
                     )
                 except Exception:
                     pass  # Optimistic - no hint is fine
-        elif is_analysis_eligible and is_fresh_tool_call and _should_add_barbell_hint(analysis, meta):
+        elif (
+            is_analysis_eligible
+            and (is_fresh_tool_call or is_unwrapped_http_body)
+            and _should_add_barbell_hint(analysis, meta)
+        ):
             analysis_text = analysis.prepared_text if analysis and analysis.prepared_text is not None else result_text
             context_hint = hint_from_unstructured_text(analysis_text)
 

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -2410,20 +2410,18 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
         "function": {
             "name": "sqlite_batch",
             "description": (
-                "Domain model/logic for material row reconciliation. First shot: keyed DDL, one set-wise "
-                "upsert, then one filtered/ranked decision SELECT with both answer and supporting rows/URLs; aggregate-only "
-                "is incomplete; deliver without reread. "
-                "Structured: every `is_current_batch=1 AND tool_name='<exact>'` row. HTTP payload path: "
-                "`$.content`; parent fields from result_json, children from json_each(actual array), provenance from "
-                "t.result_id/source_url; rows=[]. Never filter result_id/URL or copy source facts into SQL. "
-                "Prose: inspect the whole set once; join rows to __tool_results, one row/result_id. Never inspect "
-                "messages/contacts for a missing outbound recipient. Structured inbound: first write SELECTs the latest "
-                "non-outbound non-null payload from __messages and json-extracts every field plus message_id; never "
-                "pre-read, bind, or quote payload state. Use normalized keyed entities/relations with provenance. "
-                "Bind messy/authored text. No draft/superseded SQL. "
-                "INSERT SELECT needs WHERE 1=1 before ON CONFLICT. Rank/top via separate SELECT/scalar subquery; "
-                "no ORDER BY/LIMIT in a UNION arm. No `->`, ATTACH, per-item writes, historical "
-                "mixing, or SELECT-all readback."
+                "Domain model/logic. Reconcile once: keyed DDL, set-wise upsert, then a filtered/ranked "
+                "decision SELECT with answer rows/URLs; aggregates alone are incomplete; deliver "
+                "without reread. Structured source: every `is_current_batch=1 AND tool_name='<exact>'` row; HTTP JSON "
+                "at `$.content`; parents from result_json, children from json_each(actual array), provenance from "
+                "t.result_id/source_url; rows=[]. Never filter result_id/URL or put source facts in SQL. Prose has NULL "
+                "result_json: split repeated sections set-wise from result_text, else inspect the full set once; join "
+                "one row/result_id. Inbound writes derive all fields plus message_id from the latest non-outbound "
+                "nonnull __messages payload in the same first write—no pre-read or copied state. Never inspect messages/contacts "
+                "for a missing outbound recipient. Normalize keyed entities/relations with provenance. Bind "
+                "messy/authored text. No draft SQL, per-item writes, historical mixing, `->`, ATTACH, or SELECT-all "
+                "readback. INSERT SELECT needs WHERE 1=1 before ON CONFLICT. Rank/top with a separate SELECT/scalar "
+                "subquery, not UNION-arm ORDER BY/LIMIT."
             ),
             "parameters": {
                 "type": "object",
@@ -2453,8 +2451,8 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
                             "additionalProperties": True,
                         },
                         "description": (
-                            "Use [] for structured/inspection/model-only work. Prose writes are REQUIRED and non-empty: "
-                            "include each exact result_id with fields; never invent IDs. SQL receives :rows."
+                            "Use [] for structured, inspection, model-only, and SQL-derived prose work. Transcribed "
+                            "prose writes need nonempty exact result_id/fields; never invent IDs. SQL receives :rows."
                         ),
                     },
                     "sql": {
@@ -2477,8 +2475,8 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
                     "will_continue_work": {
                         "type": "boolean",
                         "description": (
-                            "REQUIRED. True for action-producing reads (all queue reads); false for answer SELECTs. "
-                            "Never true merely to reread SQLite."
+                            "REQUIRED. True for action-producing queue reads; false for answer SELECTs before replying "
+                            "because returned rows continue the turn. Never reread SQLite."
                         ),
                     },
                 },

--- a/api/agent/tools/sqlite_batch.py
+++ b/api/agent/tools/sqlite_batch.py
@@ -2475,8 +2475,8 @@ def get_sqlite_batch_tool() -> Dict[str, Any]:
                     "will_continue_work": {
                         "type": "boolean",
                         "description": (
-                            "REQUIRED. True for action-producing queue reads; false for answer SELECTs before replying "
-                            "because returned rows continue the turn. Never reread SQLite."
+                            "REQUIRED. True for action-producing queue reads (all queue reads); false for answer SELECTs "
+                            "before replying. Never reread SQLite."
                         ),
                     },
                 },

--- a/api/evals/scenarios/hallucinated_links.py
+++ b/api/evals/scenarios/hallucinated_links.py
@@ -935,13 +935,26 @@ def tool_delivery_execution_failures(action_calls, orchestrator_completion_ids: 
     action_calls = tuple(action_calls)
     action_names = [call.tool_name for call in action_calls]
     failures = []
+    sends = [call for call in action_calls if call.tool_name == "send_chat_message"]
+    progress_sends = [
+        call for call in sends
+        if (call.tool_params or {}).get("will_continue_work") is True
+    ]
+    terminal_sends = [
+        call for call in sends
+        if (call.tool_params or {}).get("will_continue_work") is False
+    ]
 
     if action_names.count("http_request") != 1:
         failures.append(f"Tool-backed delivery required one source fetch; actions were {action_names}.")
     if action_names.count("sqlite_batch") > 1:
         failures.append(f"Tool-backed delivery reread or reshaped SQLite more than once: {action_names}.")
-    if action_names.count("send_chat_message") != 1 or action_names[-1:] != ["send_chat_message"]:
+    if len(progress_sends) > 1:
+        failures.append(f"Tool-backed delivery sent repeated progress updates: {action_names}.")
+    if len(terminal_sends) != 1 or action_calls[-1:] != tuple(terminal_sends):
         failures.append(f"Tool-backed delivery required one terminal web-chat send; actions were {action_names}.")
+    if len(sends) != len(progress_sends) + len(terminal_sends):
+        failures.append("Tool-backed delivery used a chat send without an explicit continuation state.")
 
     unexpected = [
         name for name in action_names
@@ -958,9 +971,13 @@ def tool_delivery_execution_failures(action_calls, orchestrator_completion_ids: 
     if bad_statuses:
         failures.append(f"Tool-backed delivery actions were not all successful: {bad_statuses}.")
 
+    # A model may pair one concise progress acknowledgement with the useful tool
+    # action in the same completion. Count the work path, not that communication,
+    # when proving every completion advanced the request.
+    work_calls = [call for call in action_calls if call not in progress_sends]
     action_completion_ids = [
         str(call.step.completion_id) if getattr(call.step, "completion_id", None) else None
-        for call in action_calls
+        for call in work_calls
     ]
     completion_ids = [str(completion_id) for completion_id in orchestrator_completion_ids]
     if len(set(action_completion_ids)) != len(action_completion_ids) or action_completion_ids != completion_ids:
@@ -969,9 +986,6 @@ def tool_delivery_execution_failures(action_calls, orchestrator_completion_ids: 
             f"actions={action_completion_ids}, completions={completion_ids}."
         )
 
-    sends = [call for call in action_calls if call.tool_name == "send_chat_message"]
-    if len(sends) != 1 or (sends[0].tool_params or {}).get("will_continue_work") is not False:
-        failures.append("Tool-backed delivery required exactly one successful terminal web-chat send.")
     return failures
 
 
@@ -1026,8 +1040,8 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
                         "sqlite_batch",
                     ]),
                     "ignored_tool_names": ["sleep_until_next_trigger"],
-                    # Let a bad pre-work send finish so the strict action-shape check can diagnose it.
-                    "max_relevant_tool_calls": 4,
+                    # One concise progress send may accompany the fetch/import path.
+                    "max_relevant_tool_calls": 5,
                 },
             )
 

--- a/api/evals/scenarios/hallucinated_links.py
+++ b/api/evals/scenarios/hallucinated_links.py
@@ -931,6 +931,50 @@ def owner_report_execution_failures(action_calls, orchestrator_completion_ids: I
     return failures
 
 
+def tool_delivery_execution_failures(action_calls, orchestrator_completion_ids: Iterable[object]) -> list[str]:
+    action_calls = tuple(action_calls)
+    action_names = [call.tool_name for call in action_calls]
+    failures = []
+
+    if action_names.count("http_request") != 1:
+        failures.append(f"Tool-backed delivery required one source fetch; actions were {action_names}.")
+    if action_names.count("sqlite_batch") > 1:
+        failures.append(f"Tool-backed delivery reread or reshaped SQLite more than once: {action_names}.")
+    if action_names.count("send_chat_message") != 1 or action_names[-1:] != ["send_chat_message"]:
+        failures.append(f"Tool-backed delivery required one terminal web-chat send; actions were {action_names}.")
+
+    unexpected = [
+        name for name in action_names
+        if name not in {"http_request", "sqlite_batch", "send_chat_message"}
+    ]
+    if unexpected:
+        failures.append(f"Tool-backed delivery used unrelated recovery actions: {unexpected}.")
+
+    bad_statuses = [
+        (call.tool_name, str(call.status or "").casefold(), _tool_result_status(call))
+        for call in action_calls
+        if str(call.status or "").casefold() != "complete" or _tool_result_status(call) != "ok"
+    ]
+    if bad_statuses:
+        failures.append(f"Tool-backed delivery actions were not all successful: {bad_statuses}.")
+
+    action_completion_ids = [
+        str(call.step.completion_id) if getattr(call.step, "completion_id", None) else None
+        for call in action_calls
+    ]
+    completion_ids = [str(completion_id) for completion_id in orchestrator_completion_ids]
+    if len(set(action_completion_ids)) != len(action_completion_ids) or action_completion_ids != completion_ids:
+        failures.append(
+            "Tool-backed delivery did not take exactly one useful action in every completion: "
+            f"actions={action_completion_ids}, completions={completion_ids}."
+        )
+
+    sends = [call for call in action_calls if call.tool_name == "send_chat_message"]
+    if len(sends) != 1 or (sends[0].tool_params or {}).get("will_continue_work") is not False:
+        failures.append("Tool-backed delivery required exactly one successful terminal web-chat send.")
+    return failures
+
+
 class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
     tier = "extended"
     category = "link_grounding"
@@ -941,6 +985,7 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
     tags = ("hallucinated_links", "url_provenance", "real_harness", "llm_judge")
     tasks = [
         ScenarioTask(name="inject_context_and_prompt", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_first_shot_delivery", assertion_type="exact_match"),
         ScenarioTask(name="verify_single_final_answer", assertion_type="manual"),
         ScenarioTask(name="verify_url_provenance", assertion_type="exact_match"),
         ScenarioTask(name="judge_link_grounding", assertion_type="llm_judge"),
@@ -977,17 +1022,12 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
                         "send_chat_message",
                     ] if owner_report else [
                         "http_request",
-                        "mcp_brightdata_scrape_as_markdown",
-                        "mcp_brightdata_search_engine",
-                        "read_file",
-                        "search_tools",
                         "send_chat_message",
                         "sqlite_batch",
-                        "update_plan",
                     ]),
                     "ignored_tool_names": ["sleep_until_next_trigger"],
                     # Let a bad pre-work send finish so the strict action-shape check can diagnose it.
-                    "max_relevant_tool_calls": 4 if owner_report else 32 if case.is_long else 16,
+                    "max_relevant_tool_calls": 4,
                 },
             )
 
@@ -1007,6 +1047,7 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
             artifacts={"message": inbound},
         )
 
+        self._record_first_shot_delivery(run_id, case, agent_id=agent_id, after=inbound.timestamp)
         message = self._record_single_answer(run_id, agent_id=agent_id, after=inbound.timestamp)
         if message is None:
             self._record_missing_answer_tasks(run_id)
@@ -1119,6 +1160,7 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
             artifacts={"message": inbound, "pending_tool_calls": pending_calls},
         )
         for task_name in (
+            "verify_first_shot_delivery",
             "verify_single_final_answer",
             "verify_url_provenance",
             "judge_link_grounding",
@@ -1130,6 +1172,68 @@ class HallucinatedLinkScenario(EvalScenario, ScenarioExecutionTools):
                 task_name=task_name,
                 observed_summary="Skipped because agent processing timed out.",
             )
+
+    def _record_first_shot_delivery(
+        self,
+        run_id: str,
+        case: LinkGroundingCase,
+        *,
+        agent_id: str,
+        after,
+    ) -> None:
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="verify_first_shot_delivery",
+        )
+        if case.pattern.context_source != "tool":
+            self.record_task_result(
+                run_id,
+                None,
+                EvalRunTask.Status.PASSED,
+                task_name="verify_first_shot_delivery",
+                observed_summary="History-backed case required no external source execution contract.",
+            )
+            return
+
+        action_calls = list(PersistentAgentToolCall.objects.filter(
+            step__eval_run_id=run_id,
+            step__agent_id=agent_id,
+            step__created_at__gt=after,
+        ).exclude(
+            tool_name="sleep_until_next_trigger",
+        ).order_by("step__created_at", "step_id"))
+        orchestrator_completion_ids = PersistentAgentCompletion.objects.filter(
+            eval_run_id=run_id,
+            agent_id=agent_id,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+            created_at__gt=after,
+        ).order_by("created_at", "id").values_list("id", flat=True)
+        failures = tool_delivery_execution_failures(action_calls, orchestrator_completion_ids)
+        status = EvalRunTask.Status.FAILED if failures else EvalRunTask.Status.PASSED
+        self.record_task_result(
+            run_id,
+            None,
+            status,
+            task_name="verify_first_shot_delivery",
+            observed_summary=(
+                "; ".join(failures)
+                if failures
+                else "Agent fetched once, used at most one SQLite shaping pass, and delivered terminally."
+            ),
+            artifacts={
+                "actions": [
+                    {
+                        "tool_name": call.tool_name,
+                        "status": call.status,
+                        "result_status": _tool_result_status(call),
+                        "completion_id": str(call.step.completion_id),
+                    }
+                    for call in action_calls
+                ],
+            },
+        )
 
     def _record_single_answer(self, run_id: str, *, agent_id: str, after) -> PersistentAgentMessage | None:
         self.record_task_result(

--- a/api/evals/tests/test_hallucinated_links.py
+++ b/api/evals/tests/test_hallucinated_links.py
@@ -260,6 +260,12 @@ class HallucinatedLinkScenarioTests(SimpleTestCase):
             self._owner_report_call("sqlite_batch", "completion-2"),
             self._owner_report_call("send_chat_message", "completion-3", terminal=False),
         )
+        with_progress = (
+            self._owner_report_call("send_chat_message", "completion-1", terminal=True),
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("sqlite_batch", "completion-2"),
+            self._owner_report_call("send_chat_message", "completion-3", terminal=False),
+        )
 
         self.assertEqual(
             tool_delivery_execution_failures(direct, ("completion-1", "completion-2")),
@@ -268,6 +274,13 @@ class HallucinatedLinkScenarioTests(SimpleTestCase):
         self.assertEqual(
             tool_delivery_execution_failures(
                 shaped,
+                ("completion-1", "completion-2", "completion-3"),
+            ),
+            [],
+        )
+        self.assertEqual(
+            tool_delivery_execution_failures(
+                with_progress,
                 ("completion-1", "completion-2", "completion-3"),
             ),
             [],
@@ -299,12 +312,19 @@ class HallucinatedLinkScenarioTests(SimpleTestCase):
             self._owner_report_call("http_request", "completion-1"),
             self._owner_report_call("send_chat_message", "completion-2", terminal=True),
         )
+        repeated_progress = (
+            self._owner_report_call("send_chat_message", "completion-1", terminal=True),
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("send_chat_message", "completion-2", terminal=True),
+            self._owner_report_call("send_chat_message", "completion-3", terminal=False),
+        )
         cases = (
             (repeated_fetch, ("completion-1", "completion-2", "completion-3"), "one source fetch"),
             (repeated_shape, ("completion-1", "completion-2", "completion-3", "completion-4"), "more than once"),
             (file_detour, ("completion-1", "completion-2", "completion-3"), "recovery actions"),
             (parallel, ("completion-1", "completion-2"), "one useful action"),
             (continuing, ("completion-1", "completion-2"), "terminal web-chat"),
+            (repeated_progress, ("completion-1", "completion-2", "completion-3"), "repeated progress"),
         )
         for attempts, completion_ids, expected in cases:
             with self.subTest(expected=expected):

--- a/api/evals/tests/test_hallucinated_links.py
+++ b/api/evals/tests/test_hallucinated_links.py
@@ -21,6 +21,7 @@ from api.evals.scenarios.hallucinated_links import (
     owner_report_has_resolved_summary,
     owner_report_table_failures,
     provenance_failures,
+    tool_delivery_execution_failures,
 )
 from api.evals.execution import WaitForIdleContext
 from api.evals.runner import _update_suite_state
@@ -247,6 +248,67 @@ class HallucinatedLinkScenarioTests(SimpleTestCase):
         for attempts, completion_ids, expected in cases:
             with self.subTest(expected=expected):
                 failures = owner_report_execution_failures(attempts, completion_ids)
+                self.assertTrue(any(expected in failure for failure in failures), failures)
+
+    def test_tool_delivery_execution_contract_accepts_direct_and_single_shape_paths(self):
+        direct = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("send_chat_message", "completion-2", terminal=False),
+        )
+        shaped = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("sqlite_batch", "completion-2"),
+            self._owner_report_call("send_chat_message", "completion-3", terminal=False),
+        )
+
+        self.assertEqual(
+            tool_delivery_execution_failures(direct, ("completion-1", "completion-2")),
+            [],
+        )
+        self.assertEqual(
+            tool_delivery_execution_failures(
+                shaped,
+                ("completion-1", "completion-2", "completion-3"),
+            ),
+            [],
+        )
+
+    def test_tool_delivery_execution_contract_rejects_eventual_recovery(self):
+        repeated_fetch = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("http_request", "completion-2"),
+            self._owner_report_call("send_chat_message", "completion-3", terminal=False),
+        )
+        repeated_shape = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("sqlite_batch", "completion-2"),
+            self._owner_report_call("sqlite_batch", "completion-3"),
+            self._owner_report_call("send_chat_message", "completion-4", terminal=False),
+        )
+        file_detour = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("read_file", "completion-2", result_status="error"),
+            self._owner_report_call("send_chat_message", "completion-3", terminal=False),
+        )
+        parallel = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("sqlite_batch", "completion-1"),
+            self._owner_report_call("send_chat_message", "completion-2", terminal=False),
+        )
+        continuing = (
+            self._owner_report_call("http_request", "completion-1"),
+            self._owner_report_call("send_chat_message", "completion-2", terminal=True),
+        )
+        cases = (
+            (repeated_fetch, ("completion-1", "completion-2", "completion-3"), "one source fetch"),
+            (repeated_shape, ("completion-1", "completion-2", "completion-3", "completion-4"), "more than once"),
+            (file_detour, ("completion-1", "completion-2", "completion-3"), "recovery actions"),
+            (parallel, ("completion-1", "completion-2"), "one useful action"),
+            (continuing, ("completion-1", "completion-2"), "terminal web-chat"),
+        )
+        for attempts, completion_ids, expected in cases:
+            with self.subTest(expected=expected):
+                failures = tool_delivery_execution_failures(attempts, completion_ids)
                 self.assertTrue(any(expected in failure for failure in failures), failures)
 
     def test_url_extraction_handles_plain_markdown_and_html_urls(self):

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "89f09fd6aa3443baabe408bbed75b0b7b958f3a6",
+  "baseline_sha": "914fe6ab8429509a480bb0dad0ae0abde3050ce9",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
@@ -7,22 +7,22 @@
       "first_run": {
         "fitted_tokens": 9203,
         "system_bytes": 32079,
-        "tools_bytes": 23805,
-        "total_bytes": 67636,
+        "tools_bytes": 23783,
+        "total_bytes": 67614,
         "user_bytes": 11752
       },
       "normal_explicit_send": {
         "fitted_tokens": 8656,
         "system_bytes": 29282,
-        "tools_bytes": 23805,
-        "total_bytes": 64872,
+        "tools_bytes": 23783,
+        "total_bytes": 64850,
         "user_bytes": 11785
       },
       "web_chat_implied_send": {
         "fitted_tokens": 8804,
         "system_bytes": 29832,
-        "tools_bytes": 23805,
-        "total_bytes": 65425,
+        "tools_bytes": 23783,
+        "total_bytes": 65403,
         "user_bytes": 11788
       }
     },
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 274392
+    "limit": 274405
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,5 +1,5 @@
 {
-  "baseline_sha": "41304b0ee63f69743fc58ae2cc81e16aff011390",
+  "baseline_sha": "89f09fd6aa3443baabe408bbed75b0b7b958f3a6",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 274381
+    "limit": 274392
   }
 }

--- a/scripts/budgets/complexity_budgets.json
+++ b/scripts/budgets/complexity_budgets.json
@@ -1,28 +1,28 @@
 {
-  "baseline_sha": "5834725cead63254f958e5c3aa9236920f398b23",
+  "baseline_sha": "41304b0ee63f69743fc58ae2cc81e16aff011390",
   "generated_by": "uv run python scripts/check_complexity_budgets.py --update-baselines",
   "prompt_size": {
     "description": "Rendered prompt messages plus JSON tool definitions for representative send and first-run paths.",
     "limits": {
       "first_run": {
-        "fitted_tokens": 9223,
+        "fitted_tokens": 9203,
         "system_bytes": 32079,
-        "tools_bytes": 23825,
-        "total_bytes": 67656,
+        "tools_bytes": 23805,
+        "total_bytes": 67636,
         "user_bytes": 11752
       },
       "normal_explicit_send": {
-        "fitted_tokens": 8666,
+        "fitted_tokens": 8656,
         "system_bytes": 29282,
-        "tools_bytes": 23825,
-        "total_bytes": 64892,
+        "tools_bytes": 23805,
+        "total_bytes": 64872,
         "user_bytes": 11785
       },
       "web_chat_implied_send": {
         "fitted_tokens": 8804,
         "system_bytes": 29832,
-        "tools_bytes": 23825,
-        "total_bytes": 65445,
+        "tools_bytes": 23805,
+        "total_bytes": 65425,
         "user_bytes": 11788
       }
     },
@@ -149,6 +149,6 @@
       ".yml",
       ".zsh"
     ],
-    "limit": 274230
+    "limit": 274381
   }
 }

--- a/scripts/check_complexity_budgets.py
+++ b/scripts/check_complexity_budgets.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
+from uuid import NAMESPACE_URL, uuid5
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -291,11 +292,14 @@ def _create_agent(*, scenario: str):
         verified=True,
         primary=True,
     )
+    fixture_namespace = uuid5(NAMESPACE_URL, f"gobii-prompt-budget:{scenario}")
     browser_agent = BrowserUseAgent.objects.create(
+        id=uuid5(fixture_namespace, "browser-agent"),
         user=user,
         name=f"{scenario} Browser Agent",
     )
     agent = PersistentAgent.objects.create(
+        id=uuid5(fixture_namespace, "agent"),
         user=user,
         name=f"{scenario} Agent",
         charter="Track exact-source updates and report concise findings.",
@@ -303,12 +307,14 @@ def _create_agent(*, scenario: str):
         planning_state=PersistentAgent.PlanningState.SKIPPED,
     )
     endpoint = PersistentAgentCommsEndpoint.objects.create(
+        id=uuid5(fixture_namespace, "owned-endpoint"),
         owner_agent=agent,
         channel=CommsChannel.EMAIL,
         address=f"{scenario}-agent@example.com",
         is_primary=True,
     )
     external_endpoint = PersistentAgentCommsEndpoint.objects.create(
+        id=uuid5(fixture_namespace, "external-endpoint"),
         channel=CommsChannel.EMAIL,
         address=f"{scenario}-recipient@example.com",
     )

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -28,13 +28,27 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
             step_id="sqlite-terminal",
             tool_name="sqlite_batch",
             created_at=started_at + timedelta(seconds=1),
-            result_text='{"status": "ok", "results": [{"rows": [{"id": 1}]}]}',
+            result_text='{"status": "ok", "results": [{"result": [{"id": 1}]}]}',
             will_continue_work=False,
         )
 
         self.assertTrue(
             prompt_context._is_terminal_sqlite_handoff([result], [inbound])
         )
+
+    def test_config_only_terminal_sqlite_write_keeps_model_guidance(self):
+        result = prompt_context.ToolCallResultRecord(
+            step_id="sqlite-config",
+            tool_name="sqlite_batch",
+            created_at=datetime(2026, 8, 3, 1, 0, tzinfo=timezone.utc),
+            result_text=(
+                '{"status": "ok", "results": [{"message": "Query 0 affected 1 rows."}], '
+                '"agent_config_update": {"updated_fields": ["charter"]}}'
+            ),
+            will_continue_work=False,
+        )
+
+        self.assertFalse(prompt_context._is_terminal_sqlite_handoff([result], []))
 
     def test_terminal_sqlite_handoff_requires_the_newest_successful_event(self):
         started_at = datetime(2026, 8, 3, 1, 0, tzinfo=timezone.utc)

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -21,6 +21,72 @@ from api.models import (
 
 @tag("batch_promptree")
 class PromptContextSqliteGuidanceTests(SimpleTestCase):
+    def test_successful_terminal_sqlite_result_suppresses_immediate_model_guidance(self):
+        started_at = datetime(2026, 8, 3, 1, 0, tzinfo=timezone.utc)
+        inbound = SimpleNamespace(timestamp=started_at)
+        result = prompt_context.ToolCallResultRecord(
+            step_id="sqlite-terminal",
+            tool_name="sqlite_batch",
+            created_at=started_at + timedelta(seconds=1),
+            result_text='{"status": "ok", "results": [{"rows": [{"id": 1}]}]}',
+            will_continue_work=False,
+        )
+
+        self.assertTrue(
+            prompt_context._is_terminal_sqlite_handoff([result], [inbound])
+        )
+
+    def test_terminal_sqlite_handoff_requires_the_newest_successful_event(self):
+        started_at = datetime(2026, 8, 3, 1, 0, tzinfo=timezone.utc)
+        terminal = prompt_context.ToolCallResultRecord(
+            step_id="sqlite-terminal",
+            tool_name="sqlite_batch",
+            created_at=started_at + timedelta(seconds=1),
+            result_text='{"status": "ok"}',
+            will_continue_work=False,
+        )
+        continuing = prompt_context.ToolCallResultRecord(
+            step_id="sqlite-continuing",
+            tool_name="sqlite_batch",
+            created_at=started_at + timedelta(seconds=2),
+            result_text='{"status": "ok"}',
+            will_continue_work=True,
+        )
+        failed = prompt_context.ToolCallResultRecord(
+            step_id="sqlite-failed",
+            tool_name="sqlite_batch",
+            created_at=started_at + timedelta(seconds=2),
+            result_text='{"status": "error"}',
+            will_continue_work=False,
+        )
+        source = prompt_context.ToolCallResultRecord(
+            step_id="source",
+            tool_name="http_request",
+            created_at=started_at + timedelta(seconds=2),
+            result_text='{"status": "ok"}',
+            will_continue_work=False,
+        )
+        newer_message = SimpleNamespace(timestamp=started_at + timedelta(seconds=2))
+
+        self.assertFalse(
+            prompt_context._is_terminal_sqlite_handoff(
+                [terminal, continuing],
+                [],
+            )
+        )
+        self.assertFalse(
+            prompt_context._is_terminal_sqlite_handoff([terminal, failed], [])
+        )
+        self.assertFalse(
+            prompt_context._is_terminal_sqlite_handoff([terminal, source], [])
+        )
+        self.assertFalse(
+            prompt_context._is_terminal_sqlite_handoff(
+                [terminal],
+                [newer_message],
+            )
+        )
+
     def test_active_source_batch_spans_completions_for_one_request(self):
         process_started = datetime(2026, 7, 27, 9, 0, tzinfo=timezone.utc)
         process_step = SimpleNamespace(

--- a/tests/unit/test_result_analysis.py
+++ b/tests/unit/test_result_analysis.py
@@ -237,6 +237,18 @@ class TextAnalysisTests(SimpleTestCase):
         self.assertEqual(analysis.csv_info.column_types[2], "float")  # price
         self.assertEqual(analysis.csv_info.column_types[3], "text")  # active (bool as text)
 
+    def test_repeated_comma_boilerplate_is_not_misclassified_as_csv(self):
+        text = (
+            ("Archive note, routine approvals, no source.\n" * 20)
+            + "name: Alice\nrole: Controller\nprofile_url: https://example.test/alice\n"
+            + ("Archive note, routine approvals, no source.\n" * 20)
+        )
+
+        analysis = analyze_text(text)
+
+        self.assertNotEqual(analysis.format, "csv")
+        self.assertIsNone(analysis.csv_info)
+
     def test_detects_markdown_format(self):
         text = """# Main Heading
 

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -224,18 +224,18 @@ class SqliteBatchCoreTests(SqliteBatchTestCase):
     def test_tool_contract_explains_batch_and_upsert_shapes(self):
         tool = get_sqlite_batch_tool()["function"]
 
-        self.assertIn("one set-wise upsert", tool["description"])
+        self.assertIn("set-wise upsert", tool["description"])
         self.assertIn("WHERE 1=1 before ON CONFLICT", tool["description"])
-        self.assertIn("parent fields from result_json", tool["description"])
+        self.assertIn("parents from result_json", tool["description"])
         self.assertIn("children from json_each(actual array)", tool["description"])
         self.assertIn("Never filter result_id/URL", tool["description"])
-        self.assertIn("json-extracts every field plus message_id", tool["description"])
+        self.assertIn("derive all fields plus message_id", tool["description"])
         self.assertIn("deliver without reread", tool["description"])
-        self.assertIn("material row reconciliation", tool["description"])
-        self.assertIn("both answer and supporting rows/URLs", tool["description"])
-        self.assertIn("aggregate-only is incomplete", tool["description"])
-        self.assertIn("inspect the whole set once", tool["description"])
-        self.assertIn("copy source facts into SQL", tool["description"])
+        self.assertIn("Domain model/logic", tool["description"])
+        self.assertIn("decision SELECT with answer rows/URLs", tool["description"])
+        self.assertIn("aggregates alone are incomplete", tool["description"])
+        self.assertIn("inspect the full set once", tool["description"])
+        self.assertIn("put source facts in SQL", tool["description"])
         self.assertEqual(tool["parameters"]["properties"]["rows"]["type"], "array")
         self.assertEqual(tool["parameters"]["properties"]["bindings"]["type"], "object")
 
@@ -872,37 +872,41 @@ class SqliteBatchCoreTests(SqliteBatchTestCase):
 
         for expected in (
             "keyed DDL",
-            "one set-wise upsert",
+            "set-wise upsert",
             "filtered/ranked decision SELECT",
             "rows=[]",
             "is_current_batch=1",
             "tool_name='<exact>'",
             "t.result_id/source_url",
-            "inspect the whole set once",
-            "join rows to __tool_results",
-            "latest non-outbound non-null payload",
-            "json-extracts every field plus message_id",
-            "never pre-read, bind",
+            "inspect the full set once",
+            "split repeated sections set-wise",
+            "Prose has NULL result_json",
+            "one row/result_id",
+            "latest non-outbound nonnull __messages payload",
+            "no pre-read or copied state",
             "INSERT SELECT needs WHERE 1=1 before ON CONFLICT",
             "per-item",
             "historical mixing",
-            "normalized keyed entities/relations",
+            "Normalize keyed entities/relations",
             "SELECT-all readback",
-            "No draft/superseded SQL",
+            "No draft SQL",
             "Never inspect messages/contacts for a missing outbound recipient",
         ):
             self.assertIn(expected, description)
         continuation_description = (
             definition["function"]["parameters"]["properties"]["will_continue_work"]["description"]
         )
-        self.assertIn("True for action-producing reads", continuation_description)
-        self.assertIn("all queue reads", continuation_description)
+        self.assertIn("True for action-producing queue reads", continuation_description)
         self.assertIn("false for answer SELECTs", continuation_description)
-        self.assertIn("Never true merely to reread SQLite", continuation_description)
+        self.assertIn(
+            "before replying",
+            continuation_description,
+        )
+        self.assertIn("Never reread SQLite", continuation_description)
         rows_schema = definition["function"]["parameters"]["properties"]["rows"]
         self.assertEqual(rows_schema["type"], "array")
-        self.assertIn("REQUIRED and non-empty", rows_schema["description"])
-        self.assertIn("Use [] for structured/inspection/model-only work", rows_schema["description"])
+        self.assertIn("need nonempty exact result_id/fields", rows_schema["description"])
+        self.assertIn("SQL-derived prose work", rows_schema["description"])
         self.assertIn("SQL receives :rows", rows_schema["description"])
         self.assertEqual(rows_schema["items"]["required"], ["result_id", "fields"])
         self.assertEqual(
@@ -919,8 +923,8 @@ class SqliteBatchCoreTests(SqliteBatchTestCase):
         self.assertIn("json_each(:rows)", sql_description)
         self.assertIn("$.fields.*", sql_description)
         self.assertIn("Message writes derive payload/message_id from __messages", sql_description)
-        self.assertIn("latest non-outbound non-null payload", description)
-        self.assertIn("json-extracts every field", description)
+        self.assertIn("latest non-outbound nonnull __messages payload", description)
+        self.assertIn("derive all fields plus message_id", description)
         self.assertIn("requested decision/evidence SELECT", sql_description)
         bindings_description = definition["function"]["parameters"]["properties"]["bindings"]["description"]
         self.assertIn("one complete payload unavailable in __messages", bindings_description)

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -496,8 +496,9 @@ class ToolResultSchemaTests(SimpleTestCase):
             fresh_tool_call_step_id="sqlite-step",
         )
 
-        self.assertIn("NEXT ACTION MUST deliver", info["sqlite-step"].meta)
-        self.assertIn("do not call SQLite", info["sqlite-step"].meta)
+        self.assertIn("terminal answer rows", info["sqlite-step"].meta)
+        self.assertIn("NULL/unavailable stays unavailable", info["sqlite-step"].meta)
+        self.assertIn("no more tools", info["sqlite-step"].meta)
 
     def test_scrape_as_markdown_preview_uses_plain_markdown_and_meta_guidance(self):
         markdown = "# Gemma 4\n\nBenchmark table"

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -500,6 +500,28 @@ class ToolResultSchemaTests(SimpleTestCase):
         self.assertIn("NULL/unavailable stays unavailable", info["sqlite-step"].meta)
         self.assertIn("no more tools", info["sqlite-step"].meta)
 
+    def test_config_only_sqlite_write_is_not_labeled_as_answer_rows(self):
+        record = tool_results.ToolCallResultRecord(
+            step_id="sqlite-config",
+            tool_name="sqlite_batch",
+            created_at=datetime.now(timezone.utc),
+            result_text=json.dumps({
+                "status": "ok",
+                "results": [{"message": "Query 0 affected 1 rows."}],
+                "agent_config_update": {"updated_fields": ["charter"]},
+            }),
+            will_continue_work=False,
+        )
+
+        info = tool_results.prepare_tool_results_for_prompt(
+            [record],
+            recency_positions={},
+            fresh_tool_call_step_id="sqlite-config",
+        )
+
+        self.assertNotIn("terminal answer rows", info["sqlite-config"].meta)
+        self.assertNotIn("use returned rows directly", info["sqlite-config"].meta)
+
     def test_scrape_as_markdown_preview_uses_plain_markdown_and_meta_guidance(self):
         markdown = "# Gemma 4\n\nBenchmark table"
         record = tool_results.ToolCallResultRecord(

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -439,6 +439,45 @@ class ToolResultSchemaTests(SimpleTestCase):
         self.assertIsNotNone(stored_json)
         self.assertEqual(stored_text, markdown)
 
+    def test_http_string_content_is_analyzed_as_payload_not_transport_wrapper(self):
+        content = (
+            "account_id: account_001\nname: Northstar\n---\n"
+            "account_id: account_002\nname: Beacon"
+        )
+        payload = {
+            "status": "ok",
+            "url": "https://example.test/accounts",
+            "content": content,
+        }
+
+        meta, stored_json, stored_text, analysis = tool_results._summarize_result(
+            json.dumps(payload), "test-id", "http_request"
+        )
+
+        self.assertFalse(meta["is_json"])
+        self.assertIsNone(meta["result_json_path"])
+        self.assertIsNone(stored_json)
+        self.assertEqual(stored_text, content)
+        self.assertFalse(analysis.is_json)
+
+    def test_http_json_string_content_keeps_inner_json_without_wrapper_path(self):
+        content = json.dumps({"accounts": [{"account_id": "account_001", "name": "Northstar"}]})
+        payload = {
+            "status": "ok",
+            "url": "https://example.test/accounts",
+            "content": content,
+        }
+
+        meta, stored_json, stored_text, analysis = tool_results._summarize_result(
+            json.dumps(payload), "test-id", "http_request"
+        )
+
+        self.assertTrue(meta["is_json"])
+        self.assertIsNone(meta["result_json_path"])
+        self.assertEqual(json.loads(stored_json), json.loads(content))
+        self.assertEqual(json.loads(stored_text), json.loads(content))
+        self.assertEqual(analysis.json_analysis.primary_array.path, "$.accounts")
+
     def test_terminal_sqlite_result_requires_delivery_next(self):
         record = tool_results.ToolCallResultRecord(
             step_id="sqlite-step",
@@ -609,6 +648,111 @@ class ToolResultSchemaTests(SimpleTestCase):
         self.assertIn('["profile-0","profile-1","profile-2"]', combined_meta)
         self.assertIn("top-level `rows=[", combined_meta)
         self.assertIn("no sourced SQL literals", combined_meta)
+
+    def test_large_record_delimited_http_prose_gets_one_shot_modeling_path(self):
+        records = [
+            "\n".join((
+                f"account_id: account_{index:03d}",
+                f"name: Account {index}",
+                f"owner: Owner {index}",
+                f"source_url: https://accounts.example.test/{index}",
+            ))
+            for index in range(24)
+        ]
+        appendices = [
+            f"archive_note: historical routing observation {index}\nstatus: superseded"
+            for index in range(700)
+        ]
+        record = tool_results.ToolCallResultRecord(
+            step_id="large-directory",
+            tool_name="http_request",
+            created_at=datetime.now(timezone.utc),
+            result_text=json.dumps({
+                "status": "ok",
+                "url": "https://api.example.test/accounts",
+                "content": "\n---\n".join((*records, *appendices)),
+            }),
+        )
+
+        info = tool_results.prepare_tool_results_for_prompt(
+            [record],
+            recency_positions={},
+            fresh_tool_call_step_id="large-directory",
+        )["large-directory"]
+
+        self.assertIn("PROSE SOURCE WORK SET", info.meta)
+        self.assertIn("explicit repeated sections", info.meta)
+        self.assertIn("stable key `account_id`", info.meta)
+        self.assertIn("`result_json` is NULL", info.meta)
+        self.assertIn("json_each(split_sections(t.result_text", info.meta)
+        self.assertIn("regexp_extract(s.value,'(?m)^account_id:[ ]*(.*)$',1)", info.meta)
+        self.assertIn('AS "source_url"', info.meta)
+        self.assertIn("Missing fields stay NULL", info.meta)
+        self.assertIn("set `will_continue_work=false`", info.meta)
+        self.assertIn("one terminal sqlite_batch", info.meta)
+        self.assertIn("create/evolve the keyed domain model", info.meta)
+        self.assertIn("decision SELECT in that same call", info.meta)
+        self.assertIn("Do not inspect or return the raw blob first", info.meta)
+        self.assertNotIn("instr(result_text,'keyword')", info.meta)
+
+    def test_labeled_record_delimiter_is_detected_after_large_prefix(self):
+        records = [
+            "\n".join((
+                f"candidate_id: candidate_{index:03d}",
+                f"name: Candidate {index}",
+                f"market: Market {index % 3}",
+            ))
+            for index in range(18)
+        ]
+        text = (
+            ("Archive note without source fields.\n" * 2_000)
+            + "\n--- candidate record ---\n".join(records)
+        )
+
+        shape = tool_results._explicit_section_shape(text)
+
+        self.assertIsNotNone(shape)
+        self.assertEqual(shape.count, 18)
+        self.assertEqual(shape.stable_key, "candidate_id")
+        self.assertIn("candidate record", shape.delimiter_sql)
+        self.assertEqual(shape.fields[:3], ("candidate_id", "name", "market"))
+
+    def test_large_focused_http_prose_does_not_require_redundant_sqlite_read(self):
+        filler = "".join(
+            f"Archive note {index:04d}: the operating review covered staffing assumptions, escalation ownership, "
+            "quarterly checkpoints, routine approvals, regional dependencies, and follow-up timing. "
+            "The note contains no additional source reference.\n"
+            for index in range(1, 2_401)
+        )
+        source = (
+            "Current cohort company API response:\n"
+            "company=Atlas Forge | founders=Mina Shah, Leon Wu | "
+            "company_url=https://atlas.example.test/team\n"
+            "company=Beacon Labs | founder=Elena Ruiz | "
+            "company_url=https://beacon.example.test/about\n"
+        )
+        midpoint = len(filler) // 2
+        content = filler[:midpoint] + source + filler[midpoint:]
+        record = tool_results.ToolCallResultRecord(
+            step_id="focused-owner-report",
+            tool_name="http_request",
+            created_at=datetime.now(timezone.utc),
+            result_text=json.dumps({
+                "status": "ok",
+                "url": "https://api.example.test/cohort",
+                "content": content,
+            }),
+        )
+
+        info = tool_results.prepare_tool_results_for_prompt(
+            [record],
+            recency_positions={},
+            fresh_tool_call_step_id="focused-owner-report",
+        )["focused-owner-report"]
+
+        self.assertIn("FOCUS:", info.meta)
+        self.assertIn("Atlas Forge", info.meta)
+        self.assertNotIn("PROSE SOURCE WORK SET", info.meta)
 
     def test_http_mutation_outcomes_do_not_expand_the_source_work_set(self):
         records = [
@@ -1052,7 +1196,8 @@ class PreviewByteLimitTests(SimpleTestCase):
         )["step-http"]
         for expected in (
             "VERIFIED LINK PRESENTATION", "anchor each token on its exact entity name",
-            "<a href='token'>entity</a>", "No separate URL/link column unless requested", "owner report with 4+ items",
+            "<a href='$[link:ID]'>entity</a>", "complete `$[link:ID]` destination verbatim",
+            "never use the bare ID", "No separate URL/link column unless requested", "owner report with 4+ items",
             "Say Not returned where a requested URL is absent", "Follow any preceding source-write directive",
             "does not change the requested audience or action",
         ):


### PR DESCRIPTION
## What changed

- Treat an HTTP response whose `content` is text as the actual source body instead of asking the model to reason over the transport wrapper.
- Detect explicit repeated prose records and give the model one executable, set-wise `split_sections` / `regexp_extract` import shape.
- Keep a successful terminal SQLite answer query next to its returned rows and omit the competing live schema/digest on that handoff.
- Preserve config-only SQLite writes as config writes; they are never mislabeled as answer rows.
- Reject repeated comma-heavy prose boilerplate as false CSV so focused evidence and verified links remain available on later turns.
- Make the link-grounding eval reject fetch/SQLite/recovery loops while still allowing one useful progress update.
- Make prompt complexity fixtures deterministic so UUID noise cannot silently absorb prompt growth.

## Root cause

Large HTTP text bodies were advertised as JSON transport objects. For repeated prose, the prompt then offered inspection primitives but no executable set-wise import path. After the eventual answer query, fresh schema/digest guidance competed with the terminal result and tempted another read. This changes those model inputs directly; it does not rewrite model output or add a recovery layer.

## Verification

Model: `openrouter/deepseek/deepseek-v4-flash`

- Main/control reproduced the defect: one max-context run used two SQLite passes before delivery; another made six SQLite attempts (including a malformed-link error) without delivering before the run was interrupted.
- Latest max-context repeat: 10/10 execution paths and 10/10 deterministic URL-provenance checks passed at about 106k prompt tokens. Raw suite result was 48/50 because two LLM-judge choices said `Misassociated` while both explanations explicitly concluded every link was grounded.
- Full affected suite: 66/70 raw. Its only two red scenarios were rerun unchanged after the final config-vs-answer classification fix:
  - `association_candidate_tool_short`: 15/15
  - `association_vendor_history_short`: 15/15
- Earlier full affected-suite candidate run: 70/70.
- Adjacent pressure-resilience suite: 13/13.
- Focused Django regressions: 385/385. The first CI pass exposed two branch-related compatibility regressions; both now reproduce green locally.
- Prompt and source complexity checks pass.

Suite IDs:

- Max-context final: `f365f25f-a0a4-49bb-acad-a85244d1a434`
- Full affected suite: `c9860c1d-f65c-46bf-a284-950d2326098f`
- Candidate short rerun: `ea7de135-366f-4267-a9a1-6a8697842034`
- History short rerun: `82f79d5a-bd7b-40fe-8f6b-b26771327abd`
- Earlier full green: `a6323bf9-365b-49f0-8adc-8eaeff67725f`
- Pressure resilience: `f9d1ee06-22e1-43c1-9d9c-d37f9b847f87`

## Complexity

Representative static prompt fixtures are no larger than main:

- tools: 23,825 → 23,783 bytes
- first-run total: 67,656 → 67,614 bytes
- normal send: 64,892 → 64,850 bytes
- web-chat send: 65,445 → 65,403 bytes

Audited source LoC rises by 175 lines, primarily the general repeated-prose input path and adversarial regression coverage. The LoC budget was raised by exactly that amount; prompt budgets were lowered to the deterministic measurements.

## Risk

Moderate agent-context risk, limited to tool-result rendering and the immediate terminal-SQLite handoff. No migrations or frontend changes. The preview should be smoke-tested for authenticated agent chat plus API behavior before merge.
