### PR TITLE
Keep agents current under loaded context

### DIFF
--- a/api/agent/core/compaction.py
+++ b/api/agent/core/compaction.py
@@ -273,9 +273,9 @@ def llm_summarise_comms(
             "content": (
                 "Maintain a compact current-state memory from an existing conversation summary and new messages. "
                 "Preserve exact identifiers, owners, deadlines, evidence links, durable decisions, commitments, and "
-                "unresolved work. Replace superseded state with the newest explicit correction; retain older state "
-                "only for unresolved conflict. Delete resolved/completed items, repeated chatter/status, and message "
-                "mechanics unless they constrain current work; collapse unavoidable groups so output does not grow with history. Preserve who said, requested, observed, or changed each retained item and its source "
+                "unresolved work. Replace superseded state with the newest explicit correction; never retain replaced "
+                "values as history. Keep competing claims only while unresolved. Drop resolved singletons; collapse closed batches to counts. Delete repeated chatter/status and message "
+                "mechanics unless they constrain current work. Default to under 2,000 characters; exceed that only when omitting unresolved facts would change a decision. Preserve who said, requested, observed, or changed each retained item and its source "
                 "channel. Never transfer a statement to another person; keep uncertain attribution explicit."
             ),
         },

--- a/api/agent/core/compaction.py
+++ b/api/agent/core/compaction.py
@@ -271,12 +271,12 @@ def llm_summarise_comms(
         {
             "role": "system",
             "content": (
-                "You are a summarisation assistant. Given an *existing* summary\n"
-                "of a conversation and a list of *new* messages, return an\n"
-                "updated concise summary capturing the important details. Preserve\n"
-                "who said, requested, observed, or changed each important item and\n"
-                "the source channel. Never transfer a statement to another person;\n"
-                "if attribution is uncertain, keep that uncertainty explicit."
+                "Maintain a compact current-state memory from an existing conversation summary and new messages. "
+                "Preserve exact identifiers, owners, deadlines, evidence links, durable decisions, commitments, and "
+                "unresolved work. Replace superseded state with the newest explicit correction; retain older state "
+                "only for unresolved conflict. Delete resolved/completed items, repeated chatter/status, and message "
+                "mechanics unless they constrain current work; collapse unavoidable groups so output does not grow with history. Preserve who said, requested, observed, or changed each retained item and its source "
+                "channel. Never transfer a statement to another person; keep uncertain attribution explicit."
             ),
         },
         {
@@ -284,7 +284,7 @@ def llm_summarise_comms(
             "content": (
                 f"Previous summary:\n{previous or '(none)'}\n\n"
                 f"New messages:\n{new_msgs_block}\n\n"
-                "Return ONLY the updated summary text (no markdown, no code fences)."
+                "Rewrite the state rather than appending a narrative. Return ONLY the updated concise summary text (no markdown, no code fences)."
             ),
         },
     ]

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1622,6 +1622,13 @@ def _render_prompt_context_once(
             non_shrinkable=True,
         )
 
+    important_group.section_text(
+        "current_plan",
+        format_current_plan_for_prompt(agent),
+        weight=3,
+        non_shrinkable=True,
+    )
+
     if agent.charter:
         important_group.section_text(
             "charter",
@@ -1644,13 +1651,6 @@ def _render_prompt_context_once(
             weight=5,
             non_shrinkable=True
         )
-
-    important_group.section_text(
-        "current_plan",
-        format_current_plan_for_prompt(agent),
-        weight=3,
-        non_shrinkable=True,
-    )
 
     # Schedule block
     schedule_str = _format_agent_schedule_context(agent)

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1622,6 +1622,29 @@ def _render_prompt_context_once(
             non_shrinkable=True,
         )
 
+    if agent.charter:
+        important_group.section_text(
+            "charter",
+            agent.charter,
+            weight=5,
+            non_shrinkable=True
+        )
+        important_group.section_text(
+            "charter_note",
+            "Charter is authoritative durable role/scope. Patch authorized lasting critique/refinement first; preserve "
+            "unrelated guidance and omit finite, completed, or guessed facts. “You have/should have” access is a "
+            "lasting correction to a contrary blocker.",
+            weight=2,
+            non_shrinkable=True
+        )
+    else:
+        important_group.section_text(
+            "charter_missing",
+            "⚠️ NO CHARTER SET. Your FIRST action should be to set your charter via sqlite_batch. Without a charter, you have no persistent identity. Capture your purpose immediately based on what the user wants.",
+            weight=5,
+            non_shrinkable=True
+        )
+
     important_group.section_text(
         "current_plan",
         format_current_plan_for_prompt(agent),
@@ -1749,29 +1772,6 @@ def _render_prompt_context_once(
         weight=3,
         non_shrinkable=True,
     )
-
-    if agent.charter:
-        important_group.section_text(
-            "charter",
-            agent.charter,
-            weight=5,
-            non_shrinkable=True
-        )
-        important_group.section_text(
-            "charter_note",
-            "Charter is authoritative durable role/scope. Patch authorized lasting critique/refinement first; preserve "
-            "unrelated guidance and omit finite, completed, or guessed facts. “You have/should have” access is a "
-            "lasting correction to a contrary blocker.",
-            weight=2,
-            non_shrinkable=True
-        )
-    else:
-        important_group.section_text(
-            "charter_missing",
-            "⚠️ NO CHARTER SET. Your FIRST action should be to set your charter via sqlite_batch. Without a charter, you have no persistent identity. Capture your purpose immediately based on what the user wants.",
-            weight=5,
-            non_shrinkable=True
-        )
 
     recent_skills_block = format_recent_skills_for_prompt(agent, limit=skill_prompt_limit(agent))
     if recent_skills_block:
@@ -4981,7 +4981,7 @@ def _get_unified_history_prompt(
         )
         history_group.section_text(
             "step_summary_note",
-            "The previous section is a condensed summary of all past agent tool calls and internal steps that occurred before the fully detailed history below. Use it as historical context only; you do not need to repeat any of this information back to the user.",
+            "Condensed execution state before the detailed tail. Use retained outcomes, artifacts, blockers, and unresolved work; newer detailed events override it. Do not repeat it without purpose.",
             weight=1
         )
     if comm_snap and comm_snap.summary:
@@ -4992,7 +4992,7 @@ def _get_unified_history_prompt(
         )
         history_group.section_text(
             "comms_summary_note",
-            "The previous section is a concise summary of the user-agent conversation before the fully detailed history below. Treat it purely as historical context—avoid reiterating these messages unless it helps progress the task.",
+            "Condensed conversation state before the detailed tail. Use retained decisions, commitments, owners, and open work; newer detailed messages override it. Avoid reiterating it unless useful.",
             weight=1
         )
 

--- a/api/agent/core/step_compaction.py
+++ b/api/agent/core/step_compaction.py
@@ -441,7 +441,7 @@ def llm_summarise_steps(
             "content": (
                 "Maintain a compact current-state summary of an agent's execution. Preserve durable outcomes, exact "
                 "identifiers, created artifacts, source provenance, unresolved work, and active blockers. Replace superseded "
-                "state; omit repeated attempts, resolved mechanics, and transient reasoning. Given the existing summary and new raw steps, rewrite the concise execution state rather than appending a log."
+                "state; omit repeated attempts, resolved mechanics, and transient reasoning. Default to under 2,000 characters; exceed that only when omitting unresolved facts would change a decision. Given the existing summary and new raw steps, rewrite the concise execution state rather than appending a log."
             ),
         },
         {

--- a/api/agent/core/step_compaction.py
+++ b/api/agent/core/step_compaction.py
@@ -439,9 +439,9 @@ def llm_summarise_steps(
         {
             "role": "system",
             "content": (
-                "You are an assistant that maintains a running high-level summary of "
-                "an AI agent's execution steps. Given the *existing* summary and a "
-                "list of new raw steps, produce an updated concise summary."
+                "Maintain a compact current-state summary of an agent's execution. Preserve durable outcomes, exact "
+                "identifiers, created artifacts, source provenance, unresolved work, and active blockers. Replace superseded "
+                "state; omit repeated attempts, resolved mechanics, and transient reasoning. Given the existing summary and new raw steps, rewrite the concise execution state rather than appending a log."
             ),
         },
         {

--- a/api/evals/scenarios/pressure_resilience.py
+++ b/api/evals/scenarios/pressure_resilience.py
@@ -18,6 +18,7 @@ from api.models import (
     CommsChannel,
     EvalRunTask,
     PersistentAgent,
+    PersistentAgentCommsSnapshot,
     PersistentAgentCommsEndpoint,
     PersistentAgentCompletion,
     PersistentAgentConversationParticipant,
@@ -36,6 +37,7 @@ PRESSURE_RESILIENCE_SCENARIO_SLUGS = (
     "pressure_resilience_competing_channels",
     "pressure_resilience_advisory_after_delivery",
     "pressure_resilience_compacted_source_attribution",
+    "pressure_resilience_loaded_current_state",
 )
 
 
@@ -716,4 +718,293 @@ class AdvisoryAfterDeliveryPressureScenario(EvalScenario, ScenarioExecutionTools
                     f"outbound_messages={len(outbound)}."
                 )
             ),
+        )
+
+
+@register_scenario
+class LoadedCurrentStatePressureScenario(EvalScenario, ScenarioExecutionTools):
+    slug = PRESSURE_RESILIENCE_SCENARIO_SLUGS[3]
+    version = "1.0"
+    description = "A heavily loaded agent should retain corrected current state without reviving stale thread facts."
+    tier = "core"
+    category = "agent_behavior"
+    expected_runtime = "medium"
+    cost_class = "medium"
+    owner = "agent-platform"
+    area = "agent_behavior"
+    tags = (
+        "agent_behavior",
+        "pressure",
+        "context_limit",
+        "compaction",
+        "messy_data",
+        "durable_recall",
+        "llm_judge",
+        "real_harness",
+    )
+    tasks = [
+        ScenarioTask(name="inject_loaded_history", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_context_pressure", assertion_type="token_usage"),
+        ScenarioTask(name="verify_compacted_current_state", assertion_type="persisted_state"),
+        ScenarioTask(name="verify_one_shot_convergence", assertion_type="tool_call"),
+        ScenarioTask(name="verify_current_state_reply", assertion_type="llm_judge"),
+    ]
+
+    current_facts = (
+        (
+            "CASE-17",
+            "SSO certificate rotation",
+            "Rowan",
+            "https://evidence.example.test/cases/case-17",
+        ),
+        (
+            "CASE-31",
+            "budget approval",
+            "Zora",
+            "https://evidence.example.test/cases/case-31",
+        ),
+    )
+    stale_terms = ("data import", "Mira", "blocked by legal review")
+
+    @staticmethod
+    def _loaded_charter() -> str:
+        operating_notes = "\n".join(
+            (
+                f"Reference policy {index:03d}: retain exact case identity, source, owner, deadline, and current "
+                "status for operational work; unrelated completed work is context, not a new assignment."
+            )
+            for index in range(640)
+        )
+        return (
+            "Own decision-ready operational status for the owner. Current explicit corrections supersede stale "
+            "tentative state. Report only currently open items with exact IDs, owners, and known evidence links.\n"
+            f"{operating_notes}"
+        )
+
+    @staticmethod
+    def _seed_prior_snapshot(agent: PersistentAgent) -> None:
+        old_cases = "\n".join(
+            f"Historical case OLD-{index:03d}: routine migration check owned by Team {index % 9}; closed."
+            for index in range(80)
+        )
+        PersistentAgentCommsSnapshot.objects.create(
+            agent=agent,
+            snapshot_until=timezone.now() - timedelta(hours=3),
+            summary=(
+                "Current launch state from the earlier thread:\n"
+                "- CASE-17 is blocked by data import and owned by Mira.\n"
+                "- CASE-22 is blocked by legal review and owned by Dana.\n"
+                f"{old_cases}"
+            ),
+        )
+
+    @staticmethod
+    def _seed_corrections(agent: PersistentAgent) -> None:
+        endpoint = PersistentAgentCommsEndpoint.objects.create(
+            channel=CommsChannel.DISCORD,
+            address=f"discord://eval/loaded-state/{agent.id}",
+        )
+        conversation = _get_or_create_conversation(
+            CommsChannel.DISCORD,
+            endpoint.address,
+            owner_agent=agent,
+        )
+        _ensure_participant(
+            conversation,
+            endpoint,
+            PersistentAgentConversationParticipant.ParticipantRole.EXTERNAL,
+        )
+        messages = [
+            (
+                f"Ops teammate {index}",
+                f"Routine note {index}: OLD-{index:03d} remains closed with its existing owner.",
+            )
+            for index in range(1, 12)
+        ]
+        messages.extend(
+            [
+                (
+                    "Nadia in #launch",
+                    "Correction: CASE-17's data import issue is resolved. Its current blocker is SSO certificate "
+                    "rotation, now owned by Rowan. Evidence: https://evidence.example.test/cases/case-17",
+                ),
+                (
+                    "Leo in #launch",
+                    "Final update: CASE-22 cleared legal review and is closed. Do not include it in the open list.",
+                ),
+                (
+                    "Nadia in #launch",
+                    "New current blocker: CASE-31 is waiting on budget approval, owned by Zora. Evidence: "
+                    "https://evidence.example.test/cases/case-31",
+                ),
+            ]
+        )
+        messages.extend(
+            (
+                f"Ops teammate {index}",
+                f"Routine note {index}: handoff OLD-{index:03d} is complete; no action is requested.",
+            )
+            for index in range(12, 21)
+        )
+        for source_label, body in messages:
+            PersistentAgentMessage.objects.create(
+                owner_agent=agent,
+                is_outbound=False,
+                from_endpoint=endpoint,
+                conversation=conversation,
+                body=body,
+                raw_payload={
+                    "source_kind": "discord",
+                    "source_label": source_label,
+                },
+            )
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        agent = PersistentAgent.objects.get(id=agent_id)
+        agent.name = f"Loaded Operations Lead {str(agent.id)[:8]}"
+        agent.charter = self._loaded_charter()
+        agent.planning_state = PersistentAgent.PlanningState.SKIPPED
+        agent.save(update_fields=["name", "charter", "planning_state", "updated_at"])
+        mark_tool_enabled_without_discovery(agent, "send_chat_message")
+        self._seed_prior_snapshot(agent)
+        self._seed_corrections(agent)
+
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.RUNNING,
+            task_name="inject_loaded_history",
+        )
+        with self.wait_for_agent_idle(agent_id, timeout=180):
+            inbound = self.inject_message(
+                agent_id,
+                (
+                    "I am walking into the launch review. From the messy thread, give me only the current open "
+                    "blockers with case ID, present owner, and evidence link. Do not revive resolved or superseded "
+                    "items."
+                ),
+                trigger_processing=True,
+                eval_run_id=run_id,
+                eval_stop_policy={
+                    "stop_on_tool_names_after_execution": ["send_chat_message"],
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": ["send_chat_message", "sqlite_batch"],
+                    "ignored_tool_names": ["sqlite_batch"],
+                    "max_relevant_tool_calls": 6,
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_loaded_history",
+            observed_summary="A large charter and rolling summary were combined with compacted corrections and noise.",
+            artifacts={"message": inbound},
+        )
+
+        usage = PersistentAgentCompletion.objects.filter(
+            eval_run_id=run_id,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+        ).aggregate(max_prompt_tokens=Max("prompt_tokens"))
+        max_prompt_tokens = int(usage["max_prompt_tokens"] or 0)
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if max_prompt_tokens >= 32_000 else EvalRunTask.Status.FAILED,
+            task_name="verify_context_pressure",
+            expected_summary="The regression should exercise a genuinely loaded prompt.",
+            observed_summary=f"max_prompt_tokens={max_prompt_tokens}.",
+        )
+
+        latest_snapshot = (
+            PersistentAgentCommsSnapshot.objects.filter(agent=agent)
+            .order_by("-snapshot_until")
+            .first()
+        )
+        summary = latest_snapshot.summary if latest_snapshot else ""
+        folded_summary = summary.casefold()
+        summary_has_current = all(
+            all(value.casefold() in folded_summary for value in fact)
+            for fact in self.current_facts
+        )
+        summary_dropped_stale = all(term.casefold() not in folded_summary for term in self.stale_terms)
+        summary_is_compact = len(summary) <= 2_500
+        self.record_task_result(
+            run_id,
+            None,
+            (
+                EvalRunTask.Status.PASSED
+                if summary_has_current and summary_dropped_stale and summary_is_compact
+                else EvalRunTask.Status.FAILED
+            ),
+            task_name="verify_compacted_current_state",
+            expected_summary="The rolling summary should retain current facts and remove superseded blockers.",
+            observed_summary=(
+                "The compacted state retained both current cases without stale blockers."
+                if summary_has_current and summary_dropped_stale and summary_is_compact
+                else (
+                    f"current_facts_complete={summary_has_current}, "
+                    "stale_terms_present="
+                    f"{[term for term in self.stale_terms if term.casefold() in folded_summary]}, "
+                    f"summary_chars={len(summary)}."
+                )
+            ),
+        )
+
+        calls = get_tool_calls_for_run(run_id, after=inbound.timestamp)
+        sqlite_calls = [call for call in calls if call.tool_name == "sqlite_batch"]
+        chat_calls = [call for call in calls if call.tool_name == "send_chat_message"]
+        rejected_calls = [
+            call for call in calls
+            if call.status == PersistentAgentToolCall.Status.ERROR
+        ]
+        one_shot = (
+            len(sqlite_calls) <= 1
+            and len(chat_calls) == 1
+            and not rejected_calls
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if one_shot else EvalRunTask.Status.FAILED,
+            task_name="verify_one_shot_convergence",
+            expected_summary="Current compacted state should yield one clean reply with at most one bounded lookup.",
+            observed_summary=(
+                "The loaded request converged without progress chatter or recovery."
+                if one_shot
+                else (
+                    f"sqlite_calls={len(sqlite_calls)}, chat_calls={len(chat_calls)}, "
+                    f"rejected_calls={len(rejected_calls)}."
+                )
+            ),
+            artifacts={"tool_calls": calls},
+        )
+
+        outbound = (
+            PersistentAgentMessage.objects.filter(
+                owner_agent=agent,
+                is_outbound=True,
+                timestamp__gt=inbound.timestamp,
+            )
+            .order_by("timestamp", "seq")
+            .first()
+        )
+        body = outbound.body if outbound else ""
+        choice, reasoning = self.llm_judge(
+            question=(
+                "Does the reply include exactly the two current open blockers—CASE-17, SSO certificate rotation, "
+                "Rowan, and its evidence link; plus CASE-31, budget approval, Zora, and its evidence link—while "
+                "excluding the superseded data-import/Mira state and closed CASE-22?"
+            ),
+            context=f"Owner request:\n{inbound.body}\n\nAgent reply:\n{body}",
+            options=["Pass", "Fail"],
+        )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED if outbound and choice == "Pass" else EvalRunTask.Status.FAILED,
+            task_name="verify_current_state_reply",
+            expected_summary="The first reply should be complete, current, sourced, and free of stale state.",
+            observed_summary=f"{choice}: {reasoning}",
+            artifacts={"message": outbound} if outbound else {},
         )

--- a/api/evals/scenarios/pressure_resilience.py
+++ b/api/evals/scenarios/pressure_resilience.py
@@ -764,7 +764,7 @@ class LoadedCurrentStatePressureScenario(EvalScenario, ScenarioExecutionTools):
             "https://evidence.example.test/cases/case-31",
         ),
     )
-    stale_terms = ("data import", "Mira", "blocked by legal review")
+    stale_terms = ("blocked by data import", "owned by Mira", "blocked by legal review")
 
     @staticmethod
     def _loaded_charter() -> str:

--- a/tests/unit/test_compaction.py
+++ b/tests/unit/test_compaction.py
@@ -252,5 +252,8 @@ class CompactionTests(TestCase):
         self.assertIn("Inbound discord from Will in #growth:", user_prompt)
         self.assertIn("Outbound email to owner@example.test:", user_prompt)
         self.assertIn("Replace superseded state", system_prompt)
+        self.assertIn("never retain replaced", system_prompt)
+        self.assertIn("collapse closed batches to counts", system_prompt)
         self.assertIn("exact identifiers", system_prompt)
         self.assertIn("unresolved work", system_prompt)
+        self.assertIn("under 2,000 characters", system_prompt)

--- a/tests/unit/test_compaction.py
+++ b/tests/unit/test_compaction.py
@@ -195,7 +195,7 @@ class CompactionTests(TestCase):
         prompt = run_completion_mock.call_args.kwargs["messages"][1]["content"]
         body_preview, payload_block = (
             prompt.split("New messages:\nInbound message from unknown sender: ", 1)[1]
-            .split("\n\nReturn ONLY", 1)[0]
+            .split("\n\nRewrite the state", 1)[0]
             .split("\nStructured payload:\n", 1)
         )
         payload_preview = json.loads(payload_block)
@@ -246,6 +246,11 @@ class CompactionTests(TestCase):
             summary = llm_summarise_comms("", messages)
 
         self.assertEqual(summary, "summary")
-        prompt = run_completion_mock.call_args.kwargs["messages"][1]["content"]
-        self.assertIn("Inbound discord from Will in #growth:", prompt)
-        self.assertIn("Outbound email to owner@example.test:", prompt)
+        messages = run_completion_mock.call_args.kwargs["messages"]
+        system_prompt = messages[0]["content"]
+        user_prompt = messages[1]["content"]
+        self.assertIn("Inbound discord from Will in #growth:", user_prompt)
+        self.assertIn("Outbound email to owner@example.test:", user_prompt)
+        self.assertIn("Replace superseded state", system_prompt)
+        self.assertIn("exact identifiers", system_prompt)
+        self.assertIn("unresolved work", system_prompt)

--- a/tests/unit/test_pressure_resilience_evals.py
+++ b/tests/unit/test_pressure_resilience_evals.py
@@ -52,3 +52,16 @@ class PressureResilienceEvalRegistrationTests(SimpleTestCase):
                 "verify_source_attribution",
             ],
         )
+        loaded = ScenarioRegistry.get(PRESSURE_RESILIENCE_SCENARIO_SLUGS[3])
+        self.assertIn("messy_data", loaded.tags)
+        self.assertIn("durable_recall", loaded.tags)
+        self.assertEqual(
+            [task.name for task in loaded.tasks],
+            [
+                "inject_loaded_history",
+                "verify_context_pressure",
+                "verify_compacted_current_state",
+                "verify_one_shot_convergence",
+                "verify_current_state_reply",
+            ],
+        )

--- a/tests/unit/test_prompt_context_message_placement.py
+++ b/tests/unit/test_prompt_context_message_placement.py
@@ -71,6 +71,26 @@ class PromptContextSqlitePlacementTests(TestCase):
         self.assertIn("batch gaps, follow up misses, and reconcile coverage", system_message["content"])
         self.assertIn("never repeat a successful URL/query", system_message["content"])
 
+    def test_durable_charter_precedes_volatile_runtime_state(self):
+        self.agent.charter = "DURABLE CHARTER CACHE ANCHOR"
+        self.agent.schedule = "0 9 * * 1"
+        self.agent.save(update_fields=["charter", "schedule", "updated_at"])
+
+        with patch("api.agent.core.prompt_context.ensure_steps_compacted"), patch(
+            "api.agent.core.prompt_context.ensure_comms_compacted"
+        ):
+            context, _, _ = build_prompt_context(self.agent)
+
+        user_content = next(message["content"] for message in context if message["role"] == "user")
+        self.assertLess(
+            user_content.index("DURABLE CHARTER CACHE ANCHOR"),
+            user_content.index("<current_plan>"),
+        )
+        self.assertLess(
+            user_content.index("DURABLE CHARTER CACHE ANCHOR"),
+            user_content.index("<schedule>"),
+        )
+
     def test_source_model_warning_uses_only_latest_process_cycle(self):
         old_cycle = PersistentAgentStep.objects.create(agent=self.agent, description="Process events")
         PersistentAgentSystemStep.objects.create(

--- a/tests/unit/test_prompt_context_message_placement.py
+++ b/tests/unit/test_prompt_context_message_placement.py
@@ -71,7 +71,7 @@ class PromptContextSqlitePlacementTests(TestCase):
         self.assertIn("batch gaps, follow up misses, and reconcile coverage", system_message["content"])
         self.assertIn("never repeat a successful URL/query", system_message["content"])
 
-    def test_durable_charter_precedes_volatile_runtime_state(self):
+    def test_active_plan_precedes_charter_and_charter_precedes_schedule(self):
         self.agent.charter = "DURABLE CHARTER CACHE ANCHOR"
         self.agent.schedule = "0 9 * * 1"
         self.agent.save(update_fields=["charter", "schedule", "updated_at"])
@@ -83,8 +83,8 @@ class PromptContextSqlitePlacementTests(TestCase):
 
         user_content = next(message["content"] for message in context if message["role"] == "user")
         self.assertLess(
-            user_content.index("DURABLE CHARTER CACHE ANCHOR"),
             user_content.index("<current_plan>"),
+            user_content.index("DURABLE CHARTER CACHE ANCHOR"),
         )
         self.assertLess(
             user_content.index("DURABLE CHARTER CACHE ANCHOR"),


### PR DESCRIPTION
## What changed

- rewrites conversation and execution compaction as bounded current-state memory: exact IDs, owners, evidence, decisions, blockers, and open work survive while superseded/resolved history is removed
- keeps the active plan ahead of large charters, then anchors the durable charter ahead of more volatile schedule/capability state for better loaded-context attention and cache reuse
- adds a real-harness regression with a 32k+ prompt, noisy cross-channel corrections, stale blockers, closed-item pressure, and exact current-state/evidence requirements

## Evidence

- Production RCA: very large charters and growing narrative snapshots produced 38k-69k-token turns, stale blockers, and inconsistent cache prefixes
- DeepSeek V4 Flash latest-main baseline: 61/80 tasks (76.25%) across 16 matched loaded-state runs
- Final loaded-state sample: 30/30 tasks across 6 runs; all answered from corrected current truth in one shot, without SQLite recovery or stale blockers
- Existing competing-channel pressure regression: 15/15 across 3 runs after preserving active-plan salience
- Focused Django tests: 18/18
- Complexity/token budgets: unchanged exactly (source 274405/274405; prompt totals 67614/64850/65403)
- Diff check clean

## Ticket cleanup

- Verified internal #125 was already resolved by merged code; Troy closed it with evidence
- Added/claimed internal #541 for loaded-context stale-blocker retrieval and turn exhaustion; this PR is its targeted fix
- No unsupported backlog closures; security/infra issue #127 remains untouched

## Risk

Focused agent-memory/prompt-order behavior change. No schema, frontend, migration, integration, or runtime token-limit changes.