### PR TITLE
Optimize agent timeline pagination and switch avatar thumbnails to WebP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,11 +274,69 @@ jobs:
 
       # No per-batch PR checks to reduce noise; artifacts are uploaded above.
 
+  timeline-postgres:
+    name: Timeline PostgreSQL Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [tag-guard, complexity-guardrails]
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: gobii_timeline
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d gobii_timeline"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DJANGO_SETTINGS_MODULE: config.postgres_test_settings
+      PYTHONUNBUFFERED: "1"
+      UV_PYTHON_DOWNLOADS: "never"
+      DJANGO_SECRET_KEY: test-secret
+      GOBII_ENCRYPTION_KEY: dummy-encryption-key-for-testing
+      POSTGRES_DB: gobii_timeline
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST: 127.0.0.1
+      POSTGRES_PORT: "5432"
+      REDIS_URL: redis://localhost:6379/0
+      OPENAI_API_KEY: dummy
+      BROWSER_USE_TASK_MAX_COUNT: "0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv (with cache)
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          ignore-nothing-to-cache: true
+
+      - name: Sync deps (locked)
+        run: uv sync --frozen --all-extras --dev
+
+      - name: Execute timeline candidate SQL on PostgreSQL
+        run: >-
+          uv run python manage.py test
+          tests.unit.test_agent_chat_api.AgentChatAPITests.test_postgres_timeline_candidates_execute_against_postgres
+          --settings=config.postgres_test_settings
+          --parallel 1
+
   report:
     name: Combined Test Results
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [tests, sandbox-server-tests]
+    needs: [tests, sandbox-server-tests, timeline-postgres]
     steps:
       - name: Download all test result artifacts
         uses: actions/download-artifact@v8

--- a/api/models.py
+++ b/api/models.py
@@ -6463,6 +6463,9 @@ class ToolFriendlyName(models.Model):
 
 
 class PersistentAgent(models.Model):
+    # Bump this whenever thumbnail encoding changes so immutable URLs and queued jobs rotate together.
+    AVATAR_THUMBNAIL_FORMAT_REVISION = "webp-q85-v1"
+
     class MiniDescriptionMode(models.TextChoices):
         AUTO = "auto", "Automatic"
         MANUAL = "manual", "Manual"
@@ -6849,7 +6852,7 @@ class PersistentAgent(models.Model):
         file_field = self.avatar
         if not self.has_avatar:
             return None
-        version_parts = [file_field.name]
+        version_parts = [file_field.name, self.AVATAR_THUMBNAIL_FORMAT_REVISION]
         if self.updated_at:
             version_parts.append(self.updated_at.isoformat())
         return self.get_avatar_version_for_name(":".join(version_parts))

--- a/api/services/agent_avatar_thumbnails.py
+++ b/api/services/agent_avatar_thumbnails.py
@@ -8,7 +8,9 @@ from PIL import Image, ImageOps, UnidentifiedImageError
 
 
 AGENT_AVATAR_THUMBNAIL_SIZE = 128
-AGENT_AVATAR_THUMBNAIL_CONTENT_TYPE = "image/png"
+AGENT_AVATAR_THUMBNAIL_CONTENT_TYPE = "image/webp"
+AGENT_AVATAR_THUMBNAIL_QUALITY = 85
+AGENT_AVATAR_THUMBNAIL_METHOD = 6
 
 
 class AvatarThumbnailUnavailable(Exception):
@@ -21,7 +23,7 @@ def _is_missing_s3_object(exc: ClientError) -> bool:
 
 
 def agent_avatar_thumbnail_name(agent_id, avatar_version: str) -> str:
-    return f"agent_avatar_thumbnails/{agent_id}/{avatar_version}.png"
+    return f"agent_avatar_thumbnails/{agent_id}/{avatar_version}.webp"
 
 
 def generate_agent_avatar_thumbnail(storage, original_name: str, thumbnail_name: str) -> None:
@@ -35,7 +37,12 @@ def generate_agent_avatar_thumbnail(storage, original_name: str, thumbnail_name:
                     method=Image.Resampling.LANCZOS,
                 )
                 output = io.BytesIO()
-                thumbnail.convert("RGBA").save(output, format="PNG", optimize=True)
+                thumbnail.convert("RGBA").save(
+                    output,
+                    format="WEBP",
+                    quality=AGENT_AVATAR_THUMBNAIL_QUALITY,
+                    method=AGENT_AVATAR_THUMBNAIL_METHOD,
+                )
     except (FileNotFoundError, OSError, NotFound, UnidentifiedImageError) as exc:
         raise AvatarThumbnailUnavailable("Avatar not found.") from exc
     except ClientError as exc:

--- a/config/postgres_test_settings.py
+++ b/config/postgres_test_settings.py
@@ -1,0 +1,17 @@
+"""Test settings for the focused PostgreSQL integration checks."""
+import os
+
+from .test_settings import *  # noqa: F403
+
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ["POSTGRES_DB"],
+        "USER": os.environ["POSTGRES_USER"],
+        "PASSWORD": os.environ["POSTGRES_PASSWORD"],
+        "HOST": os.environ["POSTGRES_HOST"],
+        "PORT": os.environ["POSTGRES_PORT"],
+        "CONN_MAX_AGE": 0,
+    }
+}

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -115,8 +115,10 @@ class CursorPayload:
             return None
         try:
             value_str, kind, identifier = raw.split(":", 2)
+            if kind == "kanban":
+                kind = "plan"
             return CursorPayload(value=int(value_str), kind=kind, identifier=identifier)
-        except Exception:
+        except (TypeError, ValueError):
             return None
 
 
@@ -972,163 +974,6 @@ def _build_cluster(entries: Sequence[StepEnvelope], labels: Mapping[str, str]) -
     }
 
 
-def _messages_queryset(agent: PersistentAgent, direction: TimelineDirection, cursor: CursorPayload | None) -> Sequence[PersistentAgentMessage]:
-    limit = MAX_PAGE_SIZE * 3
-    qs = (
-        visible_agent_message_queryset(agent)
-        .select_related(
-            "from_endpoint",
-            "to_endpoint",
-            "conversation__peer_link",
-            "peer_agent",
-            "owner_agent",
-            "outbound_email_review",
-        )
-        .prefetch_related("attachments__filespace_node", "cc_endpoints", "bcc_endpoints")
-        .order_by("-timestamp", "-seq")
-    )
-    if direction == "older" and cursor is not None:
-        qs = qs.filter(timestamp__lte=_dt_from_cursor(cursor))
-    elif direction == "newer" and cursor is not None:
-        # For "newer", we need messages AFTER the cursor
-        # This includes: timestamp > cursor_time OR (timestamp == cursor_time AND seq > cursor_seq)
-        dt = _dt_from_cursor(cursor)
-        if cursor.kind == "message":
-            qs = qs.filter(
-                Q(timestamp__gt=dt) | Q(timestamp=dt, seq__gt=cursor.identifier)
-            )
-        else:
-            qs = qs.filter(timestamp__gt=dt)
-    return list(qs[:limit])
-
-
-def _steps_queryset(agent: PersistentAgent, direction: TimelineDirection, cursor: CursorPayload | None) -> Sequence[PersistentAgentStep]:
-    limit = MAX_PAGE_SIZE * 3
-    qs = (
-        visible_tool_steps_queryset(agent)
-        .select_related("tool_call", "agent")
-        .prefetch_related("human_input_requests")
-        .order_by("-created_at", "-id")
-    )
-    if direction == "older" and cursor is not None:
-        qs = qs.filter(created_at__lte=_dt_from_cursor(cursor))
-    elif direction == "newer" and cursor is not None:
-        # For "newer", we need events AFTER the cursor
-        # This includes: created_at > cursor_time OR (created_at == cursor_time AND id > cursor_id)
-        dt = _dt_from_cursor(cursor)
-        if cursor.kind == "step":
-            try:
-                cursor_uuid = uuid.UUID(cursor.identifier)
-                qs = qs.filter(
-                    Q(created_at__gt=dt) | Q(created_at=dt, id__gt=cursor_uuid)
-                )
-            except Exception:
-                qs = qs.filter(created_at__gt=dt)
-        else:
-            qs = qs.filter(created_at__gt=dt)
-    return list(qs[:limit])
-
-
-def _thinking_queryset(
-    agent: PersistentAgent,
-    direction: TimelineDirection,
-    cursor: CursorPayload | None,
-) -> Sequence[PersistentAgentCompletion]:
-    limit = MAX_PAGE_SIZE * 3
-    qs = (
-        PersistentAgentCompletion.objects.filter(
-            agent=agent,
-            completion_type__in=THINKING_COMPLETION_TYPES,
-        )
-        .exclude(thinking_content__isnull=True)
-        .exclude(thinking_content__exact="")
-        .order_by("-created_at", "-id")
-    )
-    if direction == "older" and cursor is not None:
-        qs = qs.filter(created_at__lte=_dt_from_cursor(cursor))
-    elif direction == "newer" and cursor is not None:
-        dt = _dt_from_cursor(cursor)
-        if cursor.kind == "thinking":
-            try:
-                cursor_uuid = uuid.UUID(cursor.identifier)
-                qs = qs.filter(
-                    Q(created_at__gt=dt) | Q(created_at=dt, id__gt=cursor_uuid)
-                )
-            except Exception:
-                qs = qs.filter(created_at__gt=dt)
-        else:
-            qs = qs.filter(created_at__gt=dt)
-    return list(qs[:limit])
-
-
-def _plan_event_queryset(
-    agent: PersistentAgent,
-    direction: TimelineDirection,
-    cursor: CursorPayload | None,
-) -> Sequence[PersistentAgentKanbanEvent]:
-    limit = MAX_PAGE_SIZE * 3
-    qs = (
-        PersistentAgentKanbanEvent.objects.filter(agent=agent)
-        .prefetch_related("changes", "titles")
-        .order_by("-cursor_value", "-cursor_identifier")
-    )
-    if direction == "older" and cursor is not None:
-        qs = qs.filter(cursor_value__lte=cursor.value)
-    elif direction == "newer" and cursor is not None:
-        if cursor.kind in {"kanban", "plan"}:
-            try:
-                cursor_uuid = uuid.UUID(cursor.identifier)
-                qs = qs.filter(
-                    Q(cursor_value__gt=cursor.value)
-                    | Q(cursor_value=cursor.value, cursor_identifier__gt=cursor_uuid)
-                )
-            except Exception:
-                qs = qs.filter(cursor_value__gt=cursor.value)
-        else:
-            qs = qs.filter(cursor_value__gt=cursor.value)
-    return list(qs[:limit])
-
-
-def _user_action_event_queryset(
-    agent: PersistentAgent,
-    direction: TimelineDirection,
-    cursor: CursorPayload | None,
-) -> Sequence[PersistentAgentUserActionEvent]:
-    limit = MAX_PAGE_SIZE * 3
-    qs = (
-        PersistentAgentUserActionEvent.objects.filter(agent=agent)
-        .select_related("actor_user", "agent")
-        .order_by("-occurred_at", "-id")
-    )
-    if direction == "older" and cursor is not None:
-        dt = _dt_from_cursor(cursor)
-        if cursor.kind == "user_action":
-            try:
-                cursor_uuid = uuid.UUID(cursor.identifier)
-                qs = qs.filter(
-                    Q(occurred_at__lt=dt)
-                    | Q(occurred_at=dt, id__lt=cursor_uuid)
-                )
-            except (TypeError, ValueError):
-                qs = qs.filter(occurred_at__lte=dt)
-        else:
-            qs = qs.filter(occurred_at__lt=dt)
-    elif direction == "newer" and cursor is not None:
-        dt = _dt_from_cursor(cursor)
-        if cursor.kind == "user_action":
-            try:
-                cursor_uuid = uuid.UUID(cursor.identifier)
-                qs = qs.filter(
-                    Q(occurred_at__gt=dt)
-                    | Q(occurred_at=dt, id__gt=cursor_uuid)
-                )
-            except (TypeError, ValueError):
-                qs = qs.filter(occurred_at__gt=dt)
-        else:
-            qs = qs.filter(occurred_at__gte=dt)
-    return list(qs[:limit])
-
-
 def _dt_from_cursor(cursor: CursorPayload) -> datetime:
     micros = cursor.value
     return datetime.fromtimestamp(micros / 1_000_000, tz=dt_timezone.utc)
@@ -1573,39 +1418,6 @@ def _hydrate_timeline_candidates(
         for candidate in candidates
         if (candidate.kind, candidate.identifier) in envelope_by_key
     ]
-
-
-def _filter_by_direction(
-    envelopes: Sequence[MessageEnvelope | StepEnvelope | ThinkingEnvelope | PlanEnvelope | UserActionEnvelope],
-    direction: TimelineDirection,
-    cursor: CursorPayload | None,
-) -> list[MessageEnvelope | StepEnvelope | ThinkingEnvelope | PlanEnvelope | UserActionEnvelope]:
-    if not cursor or direction == "initial":
-        return list(envelopes)
-    pivot = (cursor.value, cursor.kind, cursor.identifier)
-    filtered: list[MessageEnvelope | StepEnvelope | ThinkingEnvelope | PlanEnvelope | UserActionEnvelope] = []
-    for env in envelopes:
-        key = env.sort_key
-        if direction == "older" and key < pivot:
-            filtered.append(env)
-        elif direction == "newer" and key > pivot:
-            filtered.append(env)
-    return filtered
-
-
-def _truncate_for_direction(
-    envelopes: list[MessageEnvelope | StepEnvelope | ThinkingEnvelope | PlanEnvelope | UserActionEnvelope],
-    direction: TimelineDirection,
-    limit: int,
-) -> list[MessageEnvelope | StepEnvelope | ThinkingEnvelope | PlanEnvelope | UserActionEnvelope]:
-    if not envelopes:
-        return []
-    if direction == "older":
-        return envelopes[-limit:]
-    if direction == "newer":
-        return envelopes[:limit]
-    # initial snapshot -> latest `limit` events
-    return envelopes[-limit:]
 
 
 def _has_more_before(agent: PersistentAgent, cursor: CursorPayload | None) -> bool:

--- a/console/agent_chat/timeline.py
+++ b/console/agent_chat/timeline.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth import get_user_model
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from django.db import connection
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.timesince import timesince
@@ -154,6 +155,17 @@ class UserActionEnvelope:
     sort_key: tuple[int, str, str]
     cursor: CursorPayload
     event: PersistentAgentUserActionEvent
+
+
+@dataclass(slots=True)
+class TimelineCandidate:
+    value: int
+    kind: Literal["message", "step", "thinking", "plan", "user_action"]
+    identifier: str
+
+    @property
+    def sort_key(self) -> tuple[int, str, str]:
+        return (self.value, self.kind, self.identifier)
 
 
 @dataclass(slots=True)
@@ -1122,6 +1134,271 @@ def _dt_from_cursor(cursor: CursorPayload) -> datetime:
     return datetime.fromtimestamp(micros / 1_000_000, tz=dt_timezone.utc)
 
 
+def _coerce_candidate_identifier(identifier: str, id_field: str):
+    if id_field == "seq":
+        return identifier
+    try:
+        return uuid.UUID(identifier)
+    except (TypeError, ValueError):
+        return None
+
+
+def _apply_candidate_cursor(
+    queryset,
+    cursor: CursorPayload | None,
+    *,
+    direction: TimelineDirection,
+    kind: str,
+    value_field: str,
+    id_field: str,
+    value_is_datetime: bool,
+):
+    if cursor is None or direction == "initial":
+        return queryset
+    pivot = _dt_from_cursor(cursor) if value_is_datetime else cursor.value
+    if direction == "older":
+        if kind < cursor.kind:
+            return queryset.filter(**{f"{value_field}__lte": pivot})
+        if kind > cursor.kind:
+            return queryset.filter(**{f"{value_field}__lt": pivot})
+        operator = "lt"
+    else:
+        if kind > cursor.kind:
+            return queryset.filter(**{f"{value_field}__gte": pivot})
+        if kind < cursor.kind:
+            return queryset.filter(**{f"{value_field}__gt": pivot})
+        operator = "gt"
+
+    identifier = _coerce_candidate_identifier(cursor.identifier, id_field)
+    if identifier is None:
+        return queryset.filter(**{f"{value_field}__{operator}": pivot})
+    return queryset.filter(
+        Q(**{f"{value_field}__{operator}": pivot})
+        | Q(**{value_field: pivot, f"{id_field}__{operator}": identifier})
+    )
+
+
+def _portable_timeline_candidates(
+    agent: PersistentAgent,
+    cursor: CursorPayload | None,
+    direction: TimelineDirection,
+    limit: int,
+) -> list[TimelineCandidate]:
+    query_direction = "newer" if direction == "newer" else "older"
+    definitions = (
+        (visible_agent_message_queryset(agent), "message", "timestamp", "seq", True),
+        (visible_tool_steps_queryset(agent), "step", "created_at", "id", True),
+        (
+            PersistentAgentCompletion.objects.filter(
+                agent=agent,
+                completion_type__in=THINKING_COMPLETION_TYPES,
+            )
+            .exclude(thinking_content__isnull=True)
+            .exclude(thinking_content__exact=""),
+            "thinking",
+            "created_at",
+            "id",
+            True,
+        ),
+        (PersistentAgentKanbanEvent.objects.filter(agent=agent), "plan", "cursor_value", "cursor_identifier", False),
+        (PersistentAgentUserActionEvent.objects.filter(agent=agent), "user_action", "occurred_at", "id", True),
+    )
+    candidates: list[TimelineCandidate] = []
+    prefix = "" if query_direction == "newer" else "-"
+    for queryset, kind, value_field, id_field, value_is_datetime in definitions:
+        queryset = _apply_candidate_cursor(
+            queryset,
+            cursor,
+            direction=query_direction,
+            kind=kind,
+            value_field=value_field,
+            id_field=id_field,
+            value_is_datetime=value_is_datetime,
+        )
+        rows = queryset.order_by(f"{prefix}{value_field}", f"{prefix}{id_field}").values_list(
+            value_field,
+            id_field,
+        )[: limit + 1]
+        for value, identifier in rows:
+            cursor_value = _microsecond_epoch(value) if value_is_datetime else int(value)
+            candidates.append(TimelineCandidate(cursor_value, kind, str(identifier)))
+    candidates.sort(key=lambda candidate: candidate.sort_key)
+    return candidates
+
+
+def _postgres_timeline_cursor_clause(
+    *,
+    cursor: CursorPayload | None,
+    direction: TimelineDirection,
+    kind: str,
+    value_sql: str,
+    identifier_sql: str,
+    identifier_cast: str,
+    value_is_datetime: bool,
+) -> tuple[str, list[object]]:
+    if cursor is None or direction == "initial":
+        return "", []
+    pivot = _dt_from_cursor(cursor) if value_is_datetime else cursor.value
+    if direction == "older":
+        if kind < cursor.kind:
+            return f" AND {value_sql} <= %s", [pivot]
+        if kind > cursor.kind:
+            return f" AND {value_sql} < %s", [pivot]
+        operator = "<"
+    else:
+        if kind > cursor.kind:
+            return f" AND {value_sql} >= %s", [pivot]
+        if kind < cursor.kind:
+            return f" AND {value_sql} > %s", [pivot]
+        operator = ">"
+
+    identifier = _coerce_candidate_identifier(cursor.identifier, "seq" if identifier_cast == "varchar" else "id")
+    if identifier is None:
+        return f" AND {value_sql} {operator} %s", [pivot]
+    return (
+        f" AND ({value_sql} {operator} %s OR "
+        f"({value_sql} = %s AND {identifier_sql} {operator} %s::{identifier_cast}))",
+        [pivot, pivot, identifier],
+    )
+
+
+def _postgres_timeline_candidates(
+    agent: PersistentAgent,
+    cursor: CursorPayload | None,
+    direction: TimelineDirection,
+    limit: int,
+) -> list[TimelineCandidate]:
+    quote = connection.ops.quote_name
+    message_table = quote(PersistentAgentMessage._meta.db_table)
+    step_table = quote(PersistentAgentStep._meta.db_table)
+    tool_table = quote(PersistentAgentToolCall._meta.db_table)
+    completion_table = quote(PersistentAgentCompletion._meta.db_table)
+    plan_table = quote(PersistentAgentKanbanEvent._meta.db_table)
+    user_action_table = quote(PersistentAgentUserActionEvent._meta.db_table)
+
+    def epoch_sql(field: str) -> str:
+        return f"(EXTRACT(EPOCH FROM {field}) * 1000000)::bigint"
+
+    thinking_placeholders = ", ".join(["%s"] * len(THINKING_COMPLETION_TYPES))
+    branch_specs = (
+        (
+            "message",
+            f"{message_table} e",
+            "e.timestamp",
+            epoch_sql("e.timestamp"),
+            "e.seq",
+            "varchar",
+            True,
+            "e.owner_agent_id = %s",
+            " AND (e.raw_payload -> 'hide_in_chat' IS NULL OR e.raw_payload -> 'hide_in_chat' = 'false'::jsonb)",
+            [],
+        ),
+        (
+            "step",
+            f"{step_table} e JOIN {tool_table} tc ON tc.step_id = e.id",
+            "e.created_at",
+            epoch_sql("e.created_at"),
+            "e.id",
+            "uuid",
+            True,
+            "e.agent_id = %s",
+            " AND (tc.status IS NULL OR tc.status <> 'queued')",
+            [],
+        ),
+        (
+            "thinking",
+            f"{completion_table} e",
+            "e.created_at",
+            epoch_sql("e.created_at"),
+            "e.id",
+            "uuid",
+            True,
+            "e.agent_id = %s",
+            f" AND e.completion_type IN ({thinking_placeholders}) AND e.thinking_content IS NOT NULL AND e.thinking_content <> ''",
+            list(THINKING_COMPLETION_TYPES),
+        ),
+        (
+            "plan",
+            f"{plan_table} e",
+            "e.cursor_value",
+            "e.cursor_value",
+            "e.cursor_identifier",
+            "uuid",
+            False,
+            "e.agent_id = %s",
+            "",
+            [],
+        ),
+        (
+            "user_action",
+            f"{user_action_table} e",
+            "e.occurred_at",
+            epoch_sql("e.occurred_at"),
+            "e.id",
+            "uuid",
+            True,
+            "e.agent_id = %s",
+            "",
+            [],
+        ),
+    )
+    query_direction = "newer" if direction == "newer" else "older"
+    order = "ASC" if query_direction == "newer" else "DESC"
+    branches: list[str] = []
+    params: list[object] = []
+    for (
+        kind,
+        table_sql,
+        value_sql,
+        projected_value_sql,
+        identifier_sql,
+        identifier_cast,
+        value_is_datetime,
+        owner_clause,
+        extra_clause,
+        extra_params,
+    ) in branch_specs:
+        cursor_clause, cursor_params = _postgres_timeline_cursor_clause(
+            cursor=cursor,
+            direction=query_direction,
+            kind=kind,
+            value_sql=value_sql,
+            identifier_sql=identifier_sql,
+            identifier_cast=identifier_cast,
+            value_is_datetime=value_is_datetime,
+        )
+        branches.append(
+            "(SELECT "
+            f"{projected_value_sql} AS cursor_value, %s AS kind, {identifier_sql}::text AS identifier "
+            f"FROM {table_sql} WHERE {owner_clause}{extra_clause}{cursor_clause} "
+            f"ORDER BY {value_sql} {order}, {identifier_sql} {order} LIMIT %s)"
+        )
+        params.extend([kind, agent.id, *extra_params, *cursor_params, limit + 1])
+    sql = (
+        "SELECT cursor_value, kind, identifier FROM ("
+        + " UNION ALL ".join(branches)
+        + f") candidates ORDER BY cursor_value {order}, kind {order}, identifier {order} LIMIT %s"
+    )
+    params.append(limit + 1)
+    with connection.cursor() as db_cursor:
+        db_cursor.execute(sql, params)
+        rows = db_cursor.fetchall()
+    candidates = [TimelineCandidate(int(value), kind, identifier) for value, kind, identifier in rows]
+    candidates.sort(key=lambda candidate: candidate.sort_key)
+    return candidates
+
+
+def _select_timeline_candidates(
+    agent: PersistentAgent,
+    cursor: CursorPayload | None,
+    direction: TimelineDirection,
+    limit: int,
+) -> list[TimelineCandidate]:
+    if connection.vendor == "postgresql":
+        return _postgres_timeline_candidates(agent, cursor, direction, limit)
+    return _portable_timeline_candidates(agent, cursor, direction, limit)
+
+
 def _envelop_messages(messages: Iterable[PersistentAgentMessage]) -> list[MessageEnvelope]:
     envelopes: list[MessageEnvelope] = []
     for message in messages:
@@ -1212,6 +1489,90 @@ def _envelop_user_action_events(events: Iterable[PersistentAgentUserActionEvent]
             )
         )
     return envelopes
+
+
+def _hydrate_timeline_candidates(
+    agent: PersistentAgent,
+    candidates: Sequence[TimelineCandidate],
+) -> list[MessageEnvelope | StepEnvelope | ThinkingEnvelope | PlanEnvelope | UserActionEnvelope]:
+    identifiers_by_kind: dict[str, list[str]] = {}
+    for candidate in candidates:
+        identifiers_by_kind.setdefault(candidate.kind, []).append(candidate.identifier)
+
+    envelope_by_key: dict[
+        tuple[str, str],
+        MessageEnvelope | StepEnvelope | ThinkingEnvelope | PlanEnvelope | UserActionEnvelope,
+    ] = {}
+
+    message_ids = identifiers_by_kind.get("message", [])
+    if message_ids:
+        messages = (
+            visible_agent_message_queryset(agent)
+            .filter(seq__in=message_ids)
+            .select_related(
+                "from_endpoint",
+                "to_endpoint",
+                "conversation__peer_link",
+                "peer_agent",
+                "owner_agent",
+                "outbound_email_review",
+            )
+            .prefetch_related("attachments__filespace_node", "cc_endpoints", "bcc_endpoints")
+        )
+        for envelope in _envelop_messages(messages):
+            envelope_by_key[(envelope.cursor.kind, envelope.cursor.identifier)] = envelope
+
+    step_ids = identifiers_by_kind.get("step", [])
+    if step_ids:
+        steps = (
+            visible_tool_steps_queryset(agent)
+            .filter(id__in=step_ids)
+            .select_related("tool_call", "agent")
+            .prefetch_related("human_input_requests")
+        )
+        for envelope in _envelop_steps(steps):
+            envelope_by_key[(envelope.cursor.kind, envelope.cursor.identifier)] = envelope
+
+    thinking_ids = identifiers_by_kind.get("thinking", [])
+    if thinking_ids:
+        completions = (
+            PersistentAgentCompletion.objects.filter(
+                agent=agent,
+                id__in=thinking_ids,
+                completion_type__in=THINKING_COMPLETION_TYPES,
+            )
+            .exclude(thinking_content__isnull=True)
+            .exclude(thinking_content__exact="")
+        )
+        for envelope in _envelop_thinking(completions):
+            envelope_by_key[(envelope.cursor.kind, envelope.cursor.identifier)] = envelope
+
+    plan_ids = identifiers_by_kind.get("plan", [])
+    if plan_ids:
+        plan_events = (
+            PersistentAgentKanbanEvent.objects.filter(
+                agent=agent,
+                cursor_identifier__in=plan_ids,
+            )
+            .prefetch_related("changes", "titles")
+        )
+        for envelope in _envelop_plan_events(plan_events):
+            envelope_by_key[(envelope.cursor.kind, envelope.cursor.identifier)] = envelope
+
+    user_action_ids = identifiers_by_kind.get("user_action", [])
+    if user_action_ids:
+        user_action_events = PersistentAgentUserActionEvent.objects.filter(
+            agent=agent,
+            id__in=user_action_ids,
+        ).select_related("actor_user", "agent")
+        for envelope in _envelop_user_action_events(user_action_events):
+            envelope_by_key[(envelope.cursor.kind, envelope.cursor.identifier)] = envelope
+
+    return [
+        envelope_by_key[(candidate.kind, candidate.identifier)]
+        for candidate in candidates
+        if (candidate.kind, candidate.identifier) in envelope_by_key
+    ]
 
 
 def _filter_by_direction(
@@ -1659,26 +2020,16 @@ def fetch_timeline_window(
     limit = max(1, min(limit, MAX_PAGE_SIZE))
     cursor_payload = CursorPayload.decode(cursor)
 
-    message_envelopes = _envelop_messages(_messages_queryset(agent, direction, cursor_payload))
-    step_envelopes = _envelop_steps(_steps_queryset(agent, direction, cursor_payload))
-    thinking_envelopes = _envelop_thinking(_thinking_queryset(agent, direction, cursor_payload))
-    plan_envelopes = _envelop_plan_events(_plan_event_queryset(agent, direction, cursor_payload))
-    user_action_envelopes = _envelop_user_action_events(_user_action_event_queryset(agent, direction, cursor_payload))
-    if direction == "initial" and not plan_envelopes:
-        baseline_event = ensure_plan_baseline_event(agent)
-        if baseline_event:
-            plan_envelopes = _envelop_plan_events([baseline_event])
+    if direction == "initial" and not PersistentAgentKanbanEvent.objects.filter(agent=agent).exists():
+        ensure_plan_baseline_event(agent)
 
-    merged: list[MessageEnvelope | StepEnvelope | ThinkingEnvelope | PlanEnvelope | UserActionEnvelope] = sorted(
-        [*message_envelopes, *step_envelopes, *thinking_envelopes, *plan_envelopes, *user_action_envelopes],
-        key=lambda env: env.sort_key,
-    )
-
-    filtered = _filter_by_direction(merged, direction, cursor_payload)
-    truncated = _truncate_for_direction(filtered, direction, limit)
-
-    # Ensure chronological order for presentation
-    truncated.sort(key=lambda env: env.sort_key)
+    candidates = _select_timeline_candidates(agent, cursor_payload, direction, limit)
+    has_more_in_direction = len(candidates) > limit
+    if direction == "newer":
+        selected_candidates = candidates[:limit]
+    else:
+        selected_candidates = candidates[-limit:]
+    truncated = _hydrate_timeline_candidates(agent, selected_candidates)
 
     tool_label_map = _load_tool_label_map(
         env.tool_call.tool_name for env in truncated if isinstance(env, StepEnvelope)
@@ -1689,7 +2040,9 @@ def fetch_timeline_window(
     agent_name = getattr(agent, "name", None) or "Agent"
     if " " in agent_name:
         agent_name = agent_name.split()[0]
-    user_lookup = _build_web_user_lookup(env.message for env in message_envelopes)
+    user_lookup = _build_web_user_lookup(
+        env.message for env in truncated if isinstance(env, MessageEnvelope)
+    )
     feedback_lookup = _build_viewer_message_feedback_lookup(
         (env.message for env in truncated if isinstance(env, MessageEnvelope)),
         viewer_user,
@@ -1715,10 +2068,12 @@ def fetch_timeline_window(
     oldest_cursor = truncated[0].cursor if truncated else None
     newest_cursor = truncated[-1].cursor if truncated else None
 
-    has_more_older = False
-    if oldest_cursor and (direction != "initial" or len(filtered) >= limit):
-        has_more_older = _has_more_before(agent, oldest_cursor)
-    has_more_newer = False if direction == "initial" else _has_more_after(agent, newest_cursor)
+    if direction == "newer":
+        has_more_older = bool(cursor_payload and oldest_cursor)
+        has_more_newer = has_more_in_direction
+    else:
+        has_more_older = has_more_in_direction
+        has_more_newer = bool(direction == "older" and cursor_payload and newest_cursor)
 
     processing_snapshot = build_processing_snapshot(agent)
 

--- a/frontend/src/screens/AgentChatPage.test.tsx
+++ b/frontend/src/screens/AgentChatPage.test.tsx
@@ -792,6 +792,7 @@ describe('AgentChatPage trial onboarding', () => {
   it('keeps the Insights panel preference scoped to the active agent', async () => {
     const firstAgentId = '11111111-1111-4111-8111-111111111111'
     const secondAgentId = '22222222-2222-4222-8222-222222222222'
+    const cancelQueries = vi.spyOn(queryClient, 'cancelQueries')
     rosterState.agents = [
       buildRosterAgent(firstAgentId, 'First Agent'),
       buildRosterAgent(secondAgentId, 'Second Agent'),
@@ -813,6 +814,10 @@ describe('AgentChatPage trial onboarding', () => {
     await waitFor(() => {
       expect(screen.getByTestId('active-agent-id')).toHaveTextContent(secondAgentId)
       expect(screen.getByTestId('insights-panel-expanded-preference')).toHaveTextContent('true')
+    })
+    expect(cancelQueries).toHaveBeenCalledWith({
+      queryKey: ['agent-timeline', firstAgentId],
+      exact: false,
     })
 
     fireEvent.click(screen.getByTestId('toggle-insights-panel'))

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -1146,14 +1146,21 @@ export function AgentChatPage({
   const autoScrollPinned = activeChatSession.timelineUi.autoScrollPinned
   const setAgentId = useCallback(
     (nextAgentId: string | null, options?: Parameters<typeof chatActions.agentSelected>[0]['options']) => {
+      const previousAgentId = activeAgentIdRef.current
+      if (previousAgentId && previousAgentId !== nextAgentId) {
+        void queryClient.cancelQueries({
+          queryKey: ['agent-timeline', previousAgentId],
+          exact: false,
+        })
+      }
+      activeAgentIdRef.current = nextAgentId
       dispatch(chatActions.agentSelected({ agentId: nextAgentId, options }))
     },
-    [dispatch],
+    [dispatch, queryClient],
   )
 
   useLayoutEffect(() => {
     const routeAgentId = agentId ?? null
-    activeAgentIdRef.current = routeAgentId
     setAgentId(routeAgentId)
   }, [agentId, setAgentId])
 

--- a/tests/unit/test_agent_avatar_generation.py
+++ b/tests/unit/test_agent_avatar_generation.py
@@ -222,13 +222,18 @@ class AgentAvatarGenerationTests(TestCase):
                 model="test-model",
                 error_detail=None,
             ),
-        ):
-            generate_agent_avatar_task.run(str(agent.id), charter_hash)
+        ), patch(
+            "api.tasks.avatar_thumbnails.enqueue_agent_avatar_thumbnail"
+        ) as mocked_enqueue_thumbnail:
+            with self.captureOnCommitCallbacks(execute=True):
+                generate_agent_avatar_task.run(str(agent.id), charter_hash)
 
         agent.refresh_from_db()
         self.assertTrue(agent.avatar)
         self.assertEqual(agent.avatar_charter_hash, charter_hash)
         self.assertEqual(agent.avatar_requested_hash, "")
+        mocked_enqueue_thumbnail.assert_called_once()
+        self.assertEqual(mocked_enqueue_thumbnail.call_args.args[0].id, agent.id)
 
     def test_generate_agent_avatar_task_skips_eval_agent_and_clears_request(self):
         agent = self._create_agent(execution_environment="eval")

--- a/tests/unit/test_agent_avatar_thumbnails.py
+++ b/tests/unit/test_agent_avatar_thumbnails.py
@@ -29,9 +29,13 @@ def _test_storages(media_root: str) -> dict:
     }
 
 
-def _image_bytes(size: tuple[int, int] = (512, 384), color: tuple[int, int, int] = (24, 96, 160)) -> bytes:
+def _image_bytes(
+    size: tuple[int, int] = (512, 384),
+    color: tuple[int, ...] = (24, 96, 160),
+    mode: str = "RGB",
+) -> bytes:
     output = io.BytesIO()
-    Image.new("RGB", size, color).save(output, format="PNG")
+    Image.new(mode, size, color).save(output, format="PNG")
     return output.getvalue()
 
 
@@ -68,8 +72,12 @@ class AgentAvatarThumbnailTests(TestCase):
         self.client = Client()
         self.client.force_login(self.user)
 
-    def _save_avatar(self, name: str = "avatar.png") -> None:
-        self.agent.avatar.save(name, ContentFile(_image_bytes()), save=True)
+    def _save_avatar(self, name: str = "avatar.png", image_bytes: bytes | None = None) -> None:
+        self.agent.avatar.save(
+            name,
+            ContentFile(image_bytes if image_bytes is not None else _image_bytes()),
+            save=True,
+        )
         self.agent.refresh_from_db()
 
     def test_thumbnail_endpoint_generates_cached_thumbnail(self):
@@ -77,14 +85,15 @@ class AgentAvatarThumbnailTests(TestCase):
 
         response = self.client.get(reverse("agent_avatar_thumbnail", kwargs={"pk": self.agent.id}))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "image/png")
+        self.assertEqual(response["Content-Type"], "image/webp")
 
         thumbnail_data = _response_bytes(response)
         with Image.open(io.BytesIO(thumbnail_data)) as image:
-            self.assertLessEqual(image.width, AGENT_AVATAR_THUMBNAIL_SIZE)
-            self.assertLessEqual(image.height, AGENT_AVATAR_THUMBNAIL_SIZE)
+            self.assertEqual(image.format, "WEBP")
+            self.assertEqual(image.size, (AGENT_AVATAR_THUMBNAIL_SIZE, AGENT_AVATAR_THUMBNAIL_SIZE))
 
         thumbnail_name = _agent_avatar_thumbnail_name(self.agent.id, self.agent.get_avatar_thumbnail_version())
+        self.assertTrue(thumbnail_name.endswith(".webp"))
         self.assertTrue(default_storage.exists(thumbnail_name))
 
         with (
@@ -94,9 +103,25 @@ class AgentAvatarThumbnailTests(TestCase):
             cached_response = self.client.get(reverse("agent_avatar_thumbnail", kwargs={"pk": self.agent.id}))
 
         self.assertEqual(cached_response.status_code, 200)
-        self.assertEqual(cached_response["Content-Type"], "image/png")
+        self.assertEqual(cached_response["Content-Type"], "image/webp")
         self.assertEqual(cached_response["Cache-Control"], "private, max-age=86400, immutable")
         self.assertTrue(_response_bytes(cached_response))
+
+    def test_thumbnail_preserves_transparency_in_webp_output(self):
+        self._save_avatar(
+            image_bytes=_image_bytes(
+                color=(24, 96, 160, 96),
+                mode="RGBA",
+            )
+        )
+
+        response = self.client.get(reverse("agent_avatar_thumbnail", kwargs={"pk": self.agent.id}))
+
+        self.assertEqual(response.status_code, 200)
+        with Image.open(io.BytesIO(_response_bytes(response))) as image:
+            self.assertEqual(image.format, "WEBP")
+            self.assertEqual(image.mode, "RGBA")
+            self.assertEqual(image.getpixel((64, 64))[3], 96)
 
     def test_thumbnail_task_is_idempotent_and_rejects_stale_version(self):
         self._save_avatar()
@@ -130,6 +155,17 @@ class AgentAvatarThumbnailTests(TestCase):
             original_thumbnail_name,
         )
 
+    def test_thumbnail_format_revision_rotates_private_url_and_public_token(self):
+        self._save_avatar()
+        original_version = self.agent.get_avatar_thumbnail_version()
+        original_url = self.agent.get_avatar_thumbnail_url()
+        original_public_url = build_public_agent_avatar_thumbnail_url(self.agent)
+
+        with patch.object(PersistentAgent, "AVATAR_THUMBNAIL_FORMAT_REVISION", "webp-test-next"):
+            self.assertNotEqual(self.agent.get_avatar_thumbnail_version(), original_version)
+            self.assertNotEqual(self.agent.get_avatar_thumbnail_url(), original_url)
+            self.assertNotEqual(build_public_agent_avatar_thumbnail_url(self.agent), original_public_url)
+
     def test_thumbnail_endpoint_returns_404_without_avatar(self):
         response = self.client.get(reverse("agent_avatar_thumbnail", kwargs={"pk": self.agent.id}))
 
@@ -148,7 +184,7 @@ class AgentAvatarThumbnailTests(TestCase):
         response = anonymous_client.get(public_url.removeprefix("https://app.example.test"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "image/png")
+        self.assertEqual(response["Content-Type"], "image/webp")
         self.assertEqual(response["Cache-Control"], "public, max-age=86400")
         self.assertTrue(_response_bytes(response))
 

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -94,8 +94,8 @@ from console.agent_chat.timeline import (
     CursorPayload,
     _has_more_after,
     _has_more_before,
+    _portable_timeline_candidates,
     _postgres_timeline_candidates,
-    _steps_queryset,
     fetch_timeline_window,
 )
 from console.agent_chat.timeline import serialize_plan_event
@@ -1022,15 +1022,33 @@ class AgentChatAPITests(TestCase):
             identifier=str(visible_step.id),
         )
 
-        self.assertEqual(
-            [step.id for step in _steps_queryset(agent, "initial", None)],
-            [visible_step.id],
+        initial = fetch_timeline_window(agent, limit=10, viewer_user=self.user)
+        older = fetch_timeline_window(
+            agent,
+            cursor=cursor.encode(),
+            direction="older",
+            limit=10,
+            viewer_user=self.user,
         )
-        self.assertEqual(
-            [step.id for step in _steps_queryset(agent, "older", cursor)],
-            [visible_step.id],
+        newer = fetch_timeline_window(
+            agent,
+            cursor=cursor.encode(),
+            direction="newer",
+            limit=10,
+            viewer_user=self.user,
         )
-        self.assertEqual(_steps_queryset(agent, "newer", cursor), [])
+
+        def tool_names(window):
+            return [
+                entry["toolName"]
+                for event in window.events
+                if event["kind"] == "steps"
+                for entry in event["entries"]
+            ]
+
+        self.assertEqual(tool_names(initial), ["visible_tool"])
+        self.assertNotIn("hidden_tool", tool_names(older))
+        self.assertNotIn("hidden_tool", tool_names(newer))
         self.assertFalse(_has_more_before(agent, cursor))
         self.assertFalse(_has_more_after(agent, cursor))
 
@@ -1162,23 +1180,6 @@ class AgentChatAPITests(TestCase):
         self.assertNotIn("$[link:", json.dumps(entry))
         self.assertIn("Link unavailable", entry["caption"])
         self.assertEqual(entry["parameters"]["url"], "Link unavailable")
-
-    @tag("batch_agent_chat")
-    def test_timeline_steps_load_agent_without_per_entry_queries(self):
-        for index in range(3):
-            step = PersistentAgentStep.objects.create(agent=self.agent, description=f"Step {index}")
-            PersistentAgentToolCall.objects.create(
-                step=step,
-                tool_name="http_request",
-                tool_params={"url": f"https://example.com/{index}"},
-                result=json.dumps({"status": "ok"}),
-            )
-
-        steps = _steps_queryset(self.agent, "initial", None)
-        with CaptureQueriesContext(connection) as queries:
-            self.assertTrue(all(step.agent is self.agent or step.agent_id == self.agent.id for step in steps))
-
-        self.assertEqual(len(queries), 0)
 
     @tag("batch_agent_chat")
     def test_timeline_preserves_empty_assignment_display_snapshot(self):
@@ -2127,6 +2128,46 @@ class AgentChatAPITests(TestCase):
         self.assertEqual(cursor_kinds, ["message", "plan", "step", "thinking", "user_action"])
 
     @tag("batch_agent_chat")
+    def test_legacy_kanban_cursor_uses_plan_identifier_tiebreaker(self):
+        cursor_value = int((timezone.now() + timedelta(days=1)).timestamp() * 1_000_000)
+        older_identifier = uuid.UUID(int=1)
+        newer_identifier = uuid.UUID(int=2)
+        for identifier in (older_identifier, newer_identifier):
+            PersistentAgentKanbanEvent.objects.create(
+                agent=self.agent,
+                cursor_value=cursor_value,
+                cursor_identifier=identifier,
+                display_text=f"Plan event {identifier}",
+                primary_action=PersistentAgentKanbanEvent.Action.UPDATED,
+            )
+
+        older_cursor = CursorPayload.decode(f"{cursor_value}:kanban:{older_identifier}")
+        newer_cursor = CursorPayload.decode(f"{cursor_value}:kanban:{newer_identifier}")
+
+        self.assertEqual(older_cursor.kind, "plan")
+        self.assertEqual(newer_cursor.kind, "plan")
+        newer_candidates = _portable_timeline_candidates(
+            self.agent,
+            older_cursor,
+            "newer",
+            10,
+        )
+        older_candidates = _portable_timeline_candidates(
+            self.agent,
+            newer_cursor,
+            "older",
+            10,
+        )
+        self.assertEqual(
+            [candidate.identifier for candidate in newer_candidates if candidate.kind == "plan"],
+            [str(newer_identifier)],
+        )
+        self.assertEqual(
+            [candidate.identifier for candidate in older_candidates if candidate.kind == "plan"],
+            [str(older_identifier)],
+        )
+
+    @tag("batch_agent_chat")
     def test_timeline_query_count_is_bounded_as_message_volume_grows(self):
         fetch_timeline_window(self.agent, limit=10, viewer_user=self.user)
 
@@ -2186,6 +2227,66 @@ class AgentChatAPITests(TestCase):
         self.assertIn("tc.status <> 'queued'", sql)
         self.assertIn("e.thinking_content <> ''", sql)
         self.assertEqual(params[-1], 41)
+
+    @tag("batch_agent_chat")
+    def test_postgres_timeline_candidates_execute_against_postgres(self):
+        if connection.vendor != "postgresql":
+            self.skipTest("The raw candidate query requires PostgreSQL")
+
+        shared_timestamp = timezone.now() + timedelta(minutes=1)
+        shared_cursor_value = int(shared_timestamp.timestamp() * 1_000_000)
+        message = PersistentAgentMessage.objects.create(
+            is_outbound=False,
+            from_endpoint=self.user_endpoint,
+            conversation=self.conversation,
+            owner_agent=self.agent,
+            body="PostgreSQL candidate message",
+        )
+        step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="PostgreSQL candidate step",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=step,
+            tool_name="postgres_candidate_tool",
+            status=PersistentAgentToolCall.Status.COMPLETE,
+        )
+        completion = PersistentAgentCompletion.objects.create(
+            agent=self.agent,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+            thinking_content="PostgreSQL candidate thinking",
+        )
+        PersistentAgentKanbanEvent.objects.create(
+            agent=self.agent,
+            cursor_value=shared_cursor_value,
+            cursor_identifier=uuid.uuid4(),
+            display_text="PostgreSQL candidate plan",
+            primary_action=PersistentAgentKanbanEvent.Action.UPDATED,
+        )
+        PersistentAgentUserActionEvent.objects.create(
+            agent=self.agent,
+            actor_user=self.user,
+            action_type=PersistentAgentUserActionEvent.ActionType.CONTACTS_APPROVED,
+            occurred_at=shared_timestamp,
+        )
+        PersistentAgentMessage.objects.filter(id=message.id).update(timestamp=shared_timestamp)
+        PersistentAgentStep.objects.filter(id=step.id).update(created_at=shared_timestamp)
+        PersistentAgentCompletion.objects.filter(id=completion.id).update(created_at=shared_timestamp)
+
+        initial = _portable_timeline_candidates(self.agent, None, "initial", 100)
+        self.assertEqual(
+            [candidate.sort_key for candidate in _postgres_timeline_candidates(self.agent, None, "initial", 100)],
+            [candidate.sort_key for candidate in initial],
+        )
+        pivot = initial[len(initial) // 2]
+        cursor = CursorPayload(pivot.value, pivot.kind, pivot.identifier)
+        for direction in ("older", "newer"):
+            expected = _portable_timeline_candidates(self.agent, cursor, direction, 100)
+            actual = _postgres_timeline_candidates(self.agent, cursor, direction, 100)
+            self.assertEqual(
+                [candidate.sort_key for candidate in actual],
+                [candidate.sort_key for candidate in expected],
+            )
 
     @tag("batch_agent_chat")
     @patch("console.agent_chat.timeline.get_processing_heartbeat")

--- a/tests/unit/test_agent_chat_api.py
+++ b/tests/unit/test_agent_chat_api.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from email.message import EmailMessage
 import json
 from smtplib import SMTPException
+import uuid
 from urllib.parse import parse_qs, urlparse
 from unittest.mock import MagicMock, patch
 
@@ -93,6 +94,7 @@ from console.agent_chat.timeline import (
     CursorPayload,
     _has_more_after,
     _has_more_before,
+    _postgres_timeline_candidates,
     _steps_queryset,
     fetch_timeline_window,
 )
@@ -2043,6 +2045,147 @@ class AgentChatAPITests(TestCase):
         payload = response.json()
 
         self.assertFalse(payload.get("has_more_older"))
+
+    @tag("batch_agent_chat")
+    def test_timeline_paginates_candidate_events_without_gaps(self):
+        start = timezone.now() + timedelta(minutes=1)
+        actions = [
+            PersistentAgentUserActionEvent.objects.create(
+                agent=self.agent,
+                actor_user=self.user,
+                action_type=PersistentAgentUserActionEvent.ActionType.CONTACTS_APPROVED,
+                occurred_at=start + timedelta(seconds=index),
+            )
+            for index in range(8)
+        ]
+
+        initial = fetch_timeline_window(self.agent, limit=3, viewer_user=self.user)
+        older = fetch_timeline_window(
+            self.agent,
+            cursor=initial.oldest_cursor,
+            direction="older",
+            limit=3,
+            viewer_user=self.user,
+        )
+        newer = fetch_timeline_window(
+            self.agent,
+            cursor=older.newest_cursor,
+            direction="newer",
+            limit=3,
+            viewer_user=self.user,
+        )
+
+        def action_ids(window):
+            return [event["action"]["id"] for event in window.events]
+
+        self.assertEqual(action_ids(initial), [str(action.id) for action in actions[-3:]])
+        self.assertEqual(action_ids(older), [str(action.id) for action in actions[-6:-3]])
+        self.assertEqual(action_ids(newer), action_ids(initial))
+        self.assertTrue(older.has_more_older)
+        self.assertTrue(older.has_more_newer)
+        self.assertTrue(newer.has_more_older)
+        self.assertFalse(newer.has_more_newer)
+
+    @tag("batch_agent_chat")
+    def test_timeline_candidate_order_matches_existing_kind_tiebreaker(self):
+        shared_timestamp = timezone.now() + timedelta(minutes=1)
+        shared_cursor_value = int(shared_timestamp.timestamp() * 1_000_000)
+        message = PersistentAgentMessage.objects.create(
+            is_outbound=False,
+            from_endpoint=self.user_endpoint,
+            conversation=self.conversation,
+            owner_agent=self.agent,
+            body="Shared candidate timestamp",
+        )
+        step = PersistentAgentStep.objects.create(agent=self.agent, description="Shared candidate step")
+        PersistentAgentToolCall.objects.create(step=step, tool_name="shared_candidate_tool")
+        completion = PersistentAgentCompletion.objects.create(
+            agent=self.agent,
+            completion_type=PersistentAgentCompletion.CompletionType.ORCHESTRATOR,
+            thinking_content="Shared candidate thinking",
+        )
+        PersistentAgentKanbanEvent.objects.create(
+            agent=self.agent,
+            cursor_value=shared_cursor_value,
+            cursor_identifier=uuid.uuid4(),
+            display_text="Shared candidate plan",
+            primary_action=PersistentAgentKanbanEvent.Action.UPDATED,
+        )
+        PersistentAgentUserActionEvent.objects.create(
+            agent=self.agent,
+            actor_user=self.user,
+            action_type=PersistentAgentUserActionEvent.ActionType.CONTACTS_APPROVED,
+            occurred_at=shared_timestamp,
+        )
+        PersistentAgentMessage.objects.filter(id=message.id).update(timestamp=shared_timestamp)
+        PersistentAgentStep.objects.filter(id=step.id).update(created_at=shared_timestamp)
+        PersistentAgentCompletion.objects.filter(id=completion.id).update(created_at=shared_timestamp)
+
+        window = fetch_timeline_window(self.agent, limit=5, viewer_user=self.user)
+
+        cursor_kinds = [CursorPayload.decode(event["cursor"]).kind for event in window.events]
+        self.assertEqual(cursor_kinds, ["message", "plan", "step", "thinking", "user_action"])
+
+    @tag("batch_agent_chat")
+    def test_timeline_query_count_is_bounded_as_message_volume_grows(self):
+        fetch_timeline_window(self.agent, limit=10, viewer_user=self.user)
+
+        def create_messages(count):
+            PersistentAgentMessage.objects.bulk_create(
+                [
+                    PersistentAgentMessage(
+                        is_outbound=False,
+                        from_endpoint=self.user_endpoint,
+                        conversation=self.conversation,
+                        owner_agent=self.agent,
+                        body=f"Bounded timeline message {index}",
+                    )
+                    for index in range(count)
+                ]
+            )
+
+        create_messages(20)
+        with CaptureQueriesContext(connection) as small_context:
+            small_window = fetch_timeline_window(self.agent, limit=10, viewer_user=self.user)
+
+        create_messages(100)
+        with CaptureQueriesContext(connection) as large_context:
+            large_window = fetch_timeline_window(self.agent, limit=10, viewer_user=self.user)
+
+        self.assertEqual(len(small_window.events), 10)
+        self.assertEqual(len(large_window.events), 10)
+        self.assertLessEqual(len(large_context), len(small_context))
+        self.assertLessEqual(len(large_context), 25)
+
+    @tag("batch_agent_chat")
+    def test_postgres_timeline_candidates_use_one_globally_limited_union(self):
+        db_cursor = MagicMock()
+        db_cursor.fetchall.return_value = []
+        mock_connection = MagicMock()
+        mock_connection.ops.quote_name.side_effect = lambda value: f'"{value}"'
+        mock_connection.cursor.return_value.__enter__.return_value = db_cursor
+        cursor = CursorPayload(
+            value=int(timezone.now().timestamp() * 1_000_000),
+            kind="message",
+            identifier="01K1TESTCANDIDATE0000000000",
+        )
+
+        with patch("console.agent_chat.timeline.connection", mock_connection):
+            candidates = _postgres_timeline_candidates(
+                self.agent,
+                cursor,
+                "older",
+                40,
+            )
+
+        self.assertEqual(candidates, [])
+        sql, params = db_cursor.execute.call_args.args
+        self.assertEqual(sql.count(" UNION ALL "), 4)
+        self.assertIn("ORDER BY cursor_value DESC, kind DESC, identifier DESC LIMIT %s", sql)
+        self.assertIn("e.raw_payload -> 'hide_in_chat'", sql)
+        self.assertIn("tc.status <> 'queued'", sql)
+        self.assertIn("e.thinking_content <> ''", sql)
+        self.assertEqual(params[-1], 41)
 
     @tag("batch_agent_chat")
     @patch("console.agent_chat.timeline.get_processing_heartbeat")

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -3428,22 +3428,28 @@ class ConsoleViewsTest(TestCase):
         )
 
         with override_settings(MEDIA_ROOT=tmp_media, MEDIA_URL="/media/"):
-            response = self.client.post(
-                reverse("console_agent_settings", kwargs={"agent_id": organization_agent.id}),
-                {
-                    "name": organization_agent.name,
-                    "charter": organization_agent.charter,
-                    "is_active": "on",
-                    "avatar": SimpleUploadedFile("avatar.png", png_bytes, content_type="image/png"),
-                },
-                HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-            )
+            with patch(
+                "api.tasks.avatar_thumbnails.enqueue_agent_avatar_thumbnail"
+            ) as mocked_enqueue_thumbnail:
+                with self.captureOnCommitCallbacks(execute=True):
+                    response = self.client.post(
+                        reverse("console_agent_settings", kwargs={"agent_id": organization_agent.id}),
+                        {
+                            "name": organization_agent.name,
+                            "charter": organization_agent.charter,
+                            "is_active": "on",
+                            "avatar": SimpleUploadedFile("avatar.png", png_bytes, content_type="image/png"),
+                        },
+                        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+                    )
 
             self.assertEqual(response.status_code, 200, response.content)
             self.assertTrue(response.json()["success"])
             organization_agent.refresh_from_db()
             self.assertTrue(organization_agent.avatar)
             self.assertTrue(default_storage.exists(organization_agent.avatar.name))
+            mocked_enqueue_thumbnail.assert_called_once()
+            self.assertEqual(mocked_enqueue_thumbnail.call_args.args[0].id, organization_agent.id)
 
     @tag("batch_console_agents_management")
     def test_org_agent_settings_reject_active_name_conflict_in_same_org(self):


### PR DESCRIPTION
## Summary

- Optimize timeline candidate selection and hydration, including PostgreSQL-specific pagination queries.
- Cancel stale timeline queries when switching agents.
- Generate 128px WebP avatar thumbnails with transparency support and revisioned cache URLs.
- Expand avatar, timeline, and frontend coverage for the new behavior.

## Testing

- Not run (not requested)