### PR TITLE
Fix SQLite source reconciliation loops

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -7,6 +7,7 @@ loop with LLM‑powered reasoning and tool execution using tiered failover.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import logging
@@ -1856,13 +1857,149 @@ def _source_reconciliation_parameters(directive: str) -> dict[str, Any]:
             },
             "sql": {
                 "type": "string",
-                "description": directive + " Start with source-derived model DDL/upserts; end with bounded task-relevant rows. No pre-read or copied values.",
+                "description": (
+                    directive
+                    + " Run one focused reconciliation batch: start with source-derived model DDL/upserts and "
+                    "end with bounded task-relevant rows. No pre-read or copied values. After validation, normal "
+                    "tool routing resumes."
+                ),
             },
             "will_continue_work": {"type": "boolean", "const": True},
         },
         "required": ["rows", "sql", "will_continue_work"],
         "additionalProperties": False,
     }
+
+
+SOURCE_RECONCILIATION_MAX_ATTEMPTS = 3
+SOURCE_RECONCILIATION_MAX_UNVERIFIED_SUCCESSES = 2
+SOURCE_RECONCILIATION_METADATA_KEY = "source_reconciliation"
+
+
+@dataclass(frozen=True)
+class _SourceReconciliationAttemptCounts:
+    total: int
+    successful_unverified: int
+
+    @property
+    def exhausted(self) -> bool:
+        return (
+            self.total >= SOURCE_RECONCILIATION_MAX_ATTEMPTS
+            or self.successful_unverified >= SOURCE_RECONCILIATION_MAX_UNVERIFIED_SUCCESSES
+        )
+
+
+def _source_reconciliation_directive_hash(
+    agent: PersistentAgent,
+    directive: str,
+    fresh_tool_call_step_ids: list[str],
+) -> str:
+    inbound = get_current_inbound_message(agent)
+    source_step_ids = []
+    if fresh_tool_call_step_ids:
+        rows = PersistentAgentToolCall.objects.filter(
+            step__agent=agent,
+            step_id__in=fresh_tool_call_step_ids,
+        ).values_list("step_id", "tool_name")
+        source_step_ids = sorted(
+            str(step_id)
+            for step_id, tool_name in rows
+            if is_source_bearing_tool(tool_name)
+        )
+    identity = json.dumps(
+        {
+            "directive": directive,
+            "inbound_message_id": str(inbound.id) if inbound is not None else None,
+            "source_step_ids": source_step_ids,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
+
+
+def _source_reconciliation_attempt_counts(
+    agent: PersistentAgent,
+    directive_hash: str,
+) -> _SourceReconciliationAttemptCounts:
+    total = 0
+    successful_unverified = 0
+    rows = PersistentAgentToolCall.objects.filter(
+        step__agent=agent,
+        tool_name="sqlite_batch",
+    ).values_list("status", "result", "display_metadata")
+    for status, result_text, display_metadata in rows:
+        metadata = display_metadata if isinstance(display_metadata, dict) else {}
+        reconciliation = metadata.get(SOURCE_RECONCILIATION_METADATA_KEY)
+        if not isinstance(reconciliation, dict) or reconciliation.get("directive_hash") != directive_hash:
+            continue
+        total += 1
+        if status != PersistentAgentToolCall.Status.COMPLETE:
+            continue
+        try:
+            result = json.loads(result_text)
+        except (TypeError, ValueError):
+            continue
+        if _tool_result_is_success(result):
+            successful_unverified += 1
+    return _SourceReconciliationAttemptCounts(
+        total=total,
+        successful_unverified=successful_unverified,
+    )
+
+
+def _source_reconciliation_release_history(
+    history: list[dict[str, Any]],
+    directive: str,
+) -> list[dict[str, Any]]:
+    released = [dict(message) for message in history]
+    for message in released:
+        content = str(message.get("content") or "")
+        if directive in content:
+            message["content"] = content.replace(directive, "")
+    instruction = (
+        "## SQLite Source Reconciliation Safety Release (CRITICAL)\n\n"
+        "Repeated focused SQLite attempts did not validate this source reconciliation. sqlite_batch is unavailable "
+        "for this completion. Continue with any remaining non-SQL action using the latest bounded result, or clearly "
+        "report that source reconciliation failed. Do not refetch or reconstruct source rows."
+    )
+    system_message = next((message for message in released if message.get("role") == "system"), None)
+    if system_message is None:
+        released.insert(0, {"role": "system", "content": instruction})
+    else:
+        system_message["content"] = str(system_message.get("content") or "") + "\n\n" + instruction
+    return released
+
+
+def _record_source_reconciliation_guard_warning(
+    agent: PersistentAgent,
+    directive_hash: str,
+    counts: _SourceReconciliationAttemptCounts,
+) -> None:
+    _create_agent_system_step_once(
+        agent=agent,
+        description=(
+            "SQLite source reconciliation stopped after repeated focused attempts "
+            f"({counts.total} total, {counts.successful_unverified} successful but unverified)."
+        ),
+        code=PersistentAgentSystemStep.Code.SYSTEM_DIRECTIVE,
+        notes=f"sqlite_source_reconciliation_guard:{directive_hash}",
+    )
+
+
+def _annotate_source_reconciliation_attempt(
+    prepared_calls: list[_PreparedToolExecution],
+    directive_hash: str,
+) -> None:
+    for prepared in prepared_calls:
+        if prepared.tool_name != "sqlite_batch":
+            continue
+        prepared.display_metadata = {
+            **prepared.display_metadata,
+            SOURCE_RECONCILIATION_METADATA_KEY: {
+                "directive_hash": directive_hash,
+            },
+        }
 
 
 CHARTER_PATCH_PARAMETERS = {
@@ -2267,6 +2404,7 @@ class _PreparedToolExecution:
     parallel_ineligible_reason: Optional[str]
     resolved_entry: Optional[ToolCatalogEntry] = None
     pipedream_google_sheets_blocked: bool = False
+    display_metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -3520,15 +3658,16 @@ def _capture_tool_display_metadata(
     prepared: _PreparedToolExecution,
     result: Any,
 ) -> Dict[str, Any]:
+    display_metadata = dict(getattr(prepared, "display_metadata", None) or {})
     if prepared.tool_name != "sqlite_batch" or not _tool_result_is_success(result):
-        return {}
+        return display_metadata
     fields = _sqlite_batch_agent_config_attempted_fields(prepared.exec_params)
     if not fields:
-        return {}
+        return display_metadata
 
     snapshot = read_sqlite_agent_config_snapshot()
     if snapshot is None:
-        return {}
+        return display_metadata
     agent_config: Dict[str, Any] = {
         "charter": snapshot.charter,
         "schedule": snapshot.schedule,
@@ -3539,7 +3678,8 @@ def _capture_tool_display_metadata(
     if "emotion" in fields:
         agent_config["emotion"] = snapshot.emotion
         agent_config["emotion_timeout_seconds"] = snapshot.emotion_timeout_seconds
-    return {"agent_config": agent_config}
+    display_metadata["agent_config"] = agent_config
+    return display_metadata
 
 
 def _mark_tool_outcome_failed(
@@ -7581,6 +7721,8 @@ def _run_agent_loop(
                 request_tools = iteration_tools
                 focused_feedback_reply_tool_name = None
                 source_reconciliation_directive = prompt_metadata.get("source_reconciliation_directive")
+                source_reconciliation_directive_hash = None
+                source_reconciliation_focused_this_iteration = False
                 terminal_plan_cleanup_this_iteration = terminal_plan_cleanup_pending
                 if terminal_plan_cleanup_this_iteration:
                     terminal_plan_cleanup_pending = False
@@ -7611,12 +7753,52 @@ def _run_agent_loop(
                         parameters=CHARTER_PATCH_PARAMETERS,
                     )
                 elif source_reconciliation_directive and "sqlite_batch" in tool_names:
-                    request_tools, request_failover_configs = _focused_tool_completion_request(
-                        iteration_tools, request_failover_configs, "sqlite_batch",
+                    source_reconciliation_directive_hash = _source_reconciliation_directive_hash(
+                        agent,
                         source_reconciliation_directive,
-                        parameters=_source_reconciliation_parameters(source_reconciliation_directive),
-                        fixed_continue=True,
+                        fresh_tool_call_step_ids,
                     )
+                    attempt_counts = _source_reconciliation_attempt_counts(
+                        agent,
+                        source_reconciliation_directive_hash,
+                    )
+                    if attempt_counts.exhausted:
+                        try:
+                            _record_source_reconciliation_guard_warning(
+                                agent,
+                                source_reconciliation_directive_hash,
+                                attempt_counts,
+                            )
+                        except DatabaseError:
+                            logger.exception(
+                                "Agent %s: failed to persist SQLite source reconciliation guard warning",
+                                agent.id,
+                            )
+                        request_history = _source_reconciliation_release_history(
+                            request_history,
+                            source_reconciliation_directive,
+                        )
+                        request_tools = [
+                            tool for tool in iteration_tools
+                            if tool.get("function", {}).get("name") != "sqlite_batch"
+                        ]
+                        logger.warning(
+                            "Agent %s: released SQLite source reconciliation focus hash=%s "
+                            "after %s attempts (%s successful but unverified)",
+                            agent.id,
+                            source_reconciliation_directive_hash[:12],
+                            attempt_counts.total,
+                            attempt_counts.successful_unverified,
+                        )
+                        source_reconciliation_directive = None
+                    else:
+                        source_reconciliation_focused_this_iteration = True
+                        request_tools, request_failover_configs = _focused_tool_completion_request(
+                            iteration_tools, request_failover_configs, "sqlite_batch",
+                            source_reconciliation_directive,
+                            parameters=_source_reconciliation_parameters(source_reconciliation_directive),
+                            fixed_continue=True,
+                        )
                 elif feedback_reply_pending:
                     reply_tool_name = _same_channel_reply_tool_name(feedback_inbound)
                     if reply_tool_name in tool_names:
@@ -8137,6 +8319,14 @@ def _run_agent_loop(
                     attach_prompt_archive=_attach_prompt_archive,
                     stale_prompt_checker=_is_orchestrator_prompt_stale,
                 )
+                if (
+                    source_reconciliation_focused_this_iteration
+                    and source_reconciliation_directive_hash
+                ):
+                    _annotate_source_reconciliation_attempt(
+                        prepared_batch.prepared_calls,
+                        source_reconciliation_directive_hash,
+                    )
                 followup_required = prepared_batch.followup_required
                 all_calls_sleep = prepared_batch.all_calls_sleep
 

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -1927,12 +1927,12 @@ def _source_reconciliation_attempt_counts(
     rows = PersistentAgentToolCall.objects.filter(
         step__agent=agent,
         tool_name="sqlite_batch",
-    ).values_list("status", "result", "display_metadata")
-    for status, result_text, display_metadata in rows:
-        metadata = display_metadata if isinstance(display_metadata, dict) else {}
-        reconciliation = metadata.get(SOURCE_RECONCILIATION_METADATA_KEY)
-        if not isinstance(reconciliation, dict) or reconciliation.get("directive_hash") != directive_hash:
-            continue
+        display_metadata__source_reconciliation__directive_hash=directive_hash,
+    ).order_by("step__created_at", "step_id").values_list(
+        "status",
+        "result",
+    )[:SOURCE_RECONCILIATION_MAX_ATTEMPTS]
+    for status, result_text in rows:
         total += 1
         if status != PersistentAgentToolCall.Status.COMPLETE:
             continue
@@ -1953,10 +1953,22 @@ def _source_reconciliation_release_history(
     directive: str,
 ) -> list[dict[str, Any]]:
     released = [dict(message) for message in history]
+    directives = tuple(item for item in directive.splitlines() if item)
     for message in released:
-        content = str(message.get("content") or "")
-        if directive in content:
-            message["content"] = content.replace(directive, "")
+        content = message.get("content")
+        if isinstance(content, str):
+            message["content"] = _strip_source_reconciliation_directives(content, directives)
+        elif isinstance(content, list):
+            parts = []
+            for part in content:
+                copied_part = dict(part) if isinstance(part, dict) else part
+                if isinstance(copied_part, dict) and isinstance(copied_part.get("text"), str):
+                    copied_part["text"] = _strip_source_reconciliation_directives(
+                        copied_part["text"],
+                        directives,
+                    )
+                parts.append(copied_part)
+            message["content"] = parts
     instruction = (
         "## SQLite Source Reconciliation Safety Release (CRITICAL)\n\n"
         "Repeated focused SQLite attempts did not validate this source reconciliation. sqlite_batch is unavailable "
@@ -1967,8 +1979,21 @@ def _source_reconciliation_release_history(
     if system_message is None:
         released.insert(0, {"role": "system", "content": instruction})
     else:
-        system_message["content"] = str(system_message.get("content") or "") + "\n\n" + instruction
+        system_content = system_message.get("content")
+        if isinstance(system_content, list):
+            system_message["content"] = [
+                *(dict(part) if isinstance(part, dict) else part for part in system_content),
+                {"type": "text", "text": instruction},
+            ]
+        else:
+            system_message["content"] = f"{system_content or ''}\n\n{instruction}".lstrip()
     return released
+
+
+def _strip_source_reconciliation_directives(content: str, directives: tuple[str, ...]) -> str:
+    for source_directive in directives:
+        content = content.replace(source_directive, "")
+    return content
 
 
 def _record_source_reconciliation_guard_warning(

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -114,12 +114,14 @@ from ..tools.sqlite_state import (
     FILES_TABLE,
     get_sqlite_digest_prompt,
     get_sqlite_model_table_columns,
+    get_sqlite_model_tables_with_identity,
     get_sqlite_schema_prompt,
 )
 from ..tools.sqlite_query_quality import (
     named_model_reference_tables,
     named_model_read_tables,
     source_derived_model_mutation_tables,
+    source_derived_model_reconciled_paths,
     source_derived_model_reconciled_tables,
     _sql_values_from_params,
     summarize_sqlite_tool_result_sql,
@@ -1795,6 +1797,7 @@ def _render_prompt_context_once(
     sqlite_table_priorities = _get_recent_sqlite_table_priorities(agent)
     sqlite_schema_block = get_sqlite_schema_prompt(sqlite_table_priorities)
     named_model_columns = get_sqlite_model_table_columns(sqlite_table_priorities)
+    keyed_model_tables = get_sqlite_model_tables_with_identity()
     named_model_tables = {
         match.group(1)
         for match in re.finditer(r"^Table ([^\s(]+)", sqlite_schema_block, re.MULTILINE)
@@ -1816,6 +1819,7 @@ def _render_prompt_context_once(
         run_cache=run_cache,
         named_model_tables=named_model_tables,
         named_model_columns=named_model_columns,
+        keyed_model_tables=keyed_model_tables,
         has_peer_links=has_peer_links,
     )
 
@@ -4952,6 +4956,7 @@ def _get_unified_history_prompt(
     run_cache: PromptRunCache | None = None,
     named_model_tables: Set[str] | None = None,
     named_model_columns: Mapping[str, Set[str]] | None = None,
+    keyed_model_tables: Set[str] | None = None,
     has_peer_links: bool = False,
 ) -> Tuple[Set[str], bool, Tuple[str, ...], bool]:
     """Add summaries + interleaved recent steps & messages to the provided promptree group."""
@@ -5075,7 +5080,7 @@ def _get_unified_history_prompt(
         )
         tool_call_parent_ids: Dict[str, str] = {}
         tool_call_parent_names: Dict[str, str] = {}
-        source_reconciliations = []
+        source_reconciliations: list[tuple[datetime, str, set[str]]] = []
         for row in tool_call_results:
             step_id = str(row["step_id"])
             step = step_lookup.get(step_id)
@@ -5107,8 +5112,22 @@ def _get_unified_history_prompt(
                     tool_call_parent_names[step_id] = str(parent_tool_name)
             if row.get("tool_name") == "sqlite_batch" and str(row.get("status") or "").casefold() == "complete" and _tool_result_status_is_ok(result_text):
                 sql_values = _sql_values_from_params(row.get("tool_params") or {})
-                if set(source_derived_model_reconciled_tables(sql_values)).intersection(named_model_tables or ()):
-                    source_reconciliations.append((step.created_at, "\n".join(sql_values)))
+                reconciled_tables = source_derived_model_reconciled_tables(sql_values)
+                sql_summary = summarize_sqlite_tool_result_sql(sql_values)
+                newly_created_keyed_tables = (
+                    set(sql_summary.working_table_names)
+                    - set(sql_summary.unkeyed_explicit_table_names)
+                )
+                eligible_tables = set(keyed_model_tables or ()) | newly_created_keyed_tables
+                if set(reconciled_tables).intersection(eligible_tables):
+                    reconciled_paths = source_derived_model_reconciled_paths(sql_values)
+                    reconciled_entities = {
+                        entity_name_stem(path.rsplit(".", 1)[-1].strip('"'))
+                        for path in reconciled_paths
+                    }
+                    source_reconciliations.append(
+                        (step.created_at, "\n".join(sql_values), reconciled_entities)
+                    )
             tool_name = row.get("tool_name") or ""
             tool_params = row.get("tool_params")
             source_bearing = _tool_result_is_source_bearing(tool_name, tool_params)
@@ -5225,7 +5244,7 @@ def _get_unified_history_prompt(
                         return True
                     required_entities = matching_entities | keyed_entities
                     reconciled_entities = set()
-                    for reconciled_at, sql in source_reconciliations:
+                    for reconciled_at, sql, source_entities in source_reconciliations:
                         if reconciled_at <= record.created_at:
                             continue
                         id_filter = sql_filters_column(sql, "result_id")
@@ -5235,10 +5254,7 @@ def _get_unified_history_prompt(
                         batch_match = not batch_filter or source_batch_id in sql
                         tool_match = not tool_filter or record.tool_name in sql
                         if id_match and batch_match and tool_match:
-                            reconciled_entities.update(
-                                entity_name_stem(table)
-                                for table in source_derived_model_reconciled_tables([sql])
-                            )
+                            reconciled_entities.update(source_entities)
                     return bool(required_entities) and required_entities.issubset(reconciled_entities)
 
                 fresh_tool_call_step_ids.update(

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -1797,7 +1797,6 @@ def _render_prompt_context_once(
     sqlite_table_priorities = _get_recent_sqlite_table_priorities(agent)
     sqlite_schema_block = get_sqlite_schema_prompt(sqlite_table_priorities)
     named_model_columns = get_sqlite_model_table_columns(sqlite_table_priorities)
-    keyed_model_tables = get_sqlite_model_tables_with_identity()
     named_model_tables = {
         match.group(1)
         for match in re.finditer(r"^Table ([^\s(]+)", sqlite_schema_block, re.MULTILINE)
@@ -1819,7 +1818,6 @@ def _render_prompt_context_once(
         run_cache=run_cache,
         named_model_tables=named_model_tables,
         named_model_columns=named_model_columns,
-        keyed_model_tables=keyed_model_tables,
         has_peer_links=has_peer_links,
     )
 
@@ -4956,7 +4954,6 @@ def _get_unified_history_prompt(
     run_cache: PromptRunCache | None = None,
     named_model_tables: Set[str] | None = None,
     named_model_columns: Mapping[str, Set[str]] | None = None,
-    keyed_model_tables: Set[str] | None = None,
     has_peer_links: bool = False,
 ) -> Tuple[Set[str], bool, Tuple[str, ...], bool]:
     """Add summaries + interleaved recent steps & messages to the provided promptree group."""
@@ -5081,6 +5078,7 @@ def _get_unified_history_prompt(
         tool_call_parent_ids: Dict[str, str] = {}
         tool_call_parent_names: Dict[str, str] = {}
         source_reconciliations: list[tuple[datetime, str, set[str]]] = []
+        keyed_model_tables: set[str] | None = None
         for row in tool_call_results:
             step_id = str(row["step_id"])
             step = step_lookup.get(step_id)
@@ -5113,12 +5111,16 @@ def _get_unified_history_prompt(
             if row.get("tool_name") == "sqlite_batch" and str(row.get("status") or "").casefold() == "complete" and _tool_result_status_is_ok(result_text):
                 sql_values = _sql_values_from_params(row.get("tool_params") or {})
                 reconciled_tables = source_derived_model_reconciled_tables(sql_values)
-                sql_summary = summarize_sqlite_tool_result_sql(sql_values)
-                newly_created_keyed_tables = (
-                    set(sql_summary.working_table_names)
-                    - set(sql_summary.unkeyed_explicit_table_names)
-                )
-                eligible_tables = set(keyed_model_tables or ()) | newly_created_keyed_tables
+                if reconciled_tables:
+                    if keyed_model_tables is None:
+                        keyed_model_tables = {
+                            table.casefold()
+                            for table in get_sqlite_model_tables_with_identity()
+                        }
+                    sql_summary = summarize_sqlite_tool_result_sql(sql_values)
+                    eligible_tables = keyed_model_tables | set(sql_summary.keyed_explicit_table_names)
+                else:
+                    eligible_tables = set()
                 if set(reconciled_tables).intersection(eligible_tables):
                     reconciled_paths = source_derived_model_reconciled_paths(sql_values)
                     reconciled_entities = {

--- a/api/agent/tools/sqlite_query_quality.py
+++ b/api/agent/tools/sqlite_query_quality.py
@@ -41,6 +41,11 @@ CTE_NAME_RE = re.compile(
 MANUAL_INSERT_VALUES_RE = re.compile(r'\binsert\s+(?:or\s+\w+\s+)?into\s+"?(?P<name>[a-z_]\w*)"?\s*(?:\(\s*"?[a-z_]\w*"?(?:\s*,\s*"?[a-z_]\w*"?)*\s*\)\s*)?values\b', re.I)
 JSON_FUNCTION_RE = re.compile(r"\bjson_(?:extract|each)\s*\(", re.I)
 JSON_EACH_RE = re.compile(r"\bjson_each\s*\(", re.I)
+SOURCE_JSON_EACH_PATH_RE = re.compile(
+    r"\bjson_each\s*\(\s*(?:(?:[a-z_]\w*)\s*\.\s*)?(?:result_json|analysis_json)\s*,\s*"
+    r"(?P<quote>['\"])(?P<path>\$[^'\"]+)(?P=quote)",
+    re.I,
+)
 TOOL_PAYLOAD_RE = re.compile(r"\b(?:result_json|result_text|analysis_json)\b", re.I)
 BOUND_ROWS_RE = re.compile(r"\bjson_each\s*\(\s*[:@$][a-z_]\w*\s*\)", re.I)
 BOUND_ROWS_PROVENANCE_RE = re.compile(
@@ -337,6 +342,36 @@ def source_derived_model_reconciled_tables(sql_values: Iterable[str]) -> tuple[s
                 pending.add(table)
                 reconciled = [reconciled_table for reconciled_table in reconciled if reconciled_table != table]
     return tuple(dict.fromkeys(reconciled))
+
+
+def source_derived_model_reconciled_paths(sql_values: Iterable[str]) -> tuple[str, ...]:
+    """Return structured source-array paths persisted and read through a durable model."""
+
+    pending: dict[str, set[str]] = {}
+    reconciled: dict[str, set[str]] = {}
+    for sql in sql_values:
+        for raw_statement in sqlparse.split(str(sql or "")):
+            for table in named_model_read_tables((raw_statement,)):
+                if table in pending:
+                    reconciled[table] = pending.pop(table)
+            mutation_tables = source_derived_model_mutation_tables((raw_statement,))
+            if not mutation_tables:
+                continue
+            paths = {
+                match.group("path")
+                for match in SOURCE_JSON_EACH_PATH_RE.finditer(raw_statement)
+            }
+            for table in mutation_tables:
+                pending[table] = (
+                    pending.get(table, set())
+                    | reconciled.pop(table, set())
+                    | paths
+                )
+    return tuple(dict.fromkeys(
+        path
+        for paths in reconciled.values()
+        for path in sorted(paths)
+    ))
 
 
 def _is_named_model_table(table_name: str) -> bool:

--- a/api/agent/tools/sqlite_query_quality.py
+++ b/api/agent/tools/sqlite_query_quality.py
@@ -41,9 +41,9 @@ CTE_NAME_RE = re.compile(
 MANUAL_INSERT_VALUES_RE = re.compile(r'\binsert\s+(?:or\s+\w+\s+)?into\s+"?(?P<name>[a-z_]\w*)"?\s*(?:\(\s*"?[a-z_]\w*"?(?:\s*,\s*"?[a-z_]\w*"?)*\s*\)\s*)?values\b', re.I)
 JSON_FUNCTION_RE = re.compile(r"\bjson_(?:extract|each)\s*\(", re.I)
 JSON_EACH_RE = re.compile(r"\bjson_each\s*\(", re.I)
-SOURCE_JSON_EACH_PATH_RE = re.compile(
-    r"\bjson_each\s*\(\s*(?:(?:[a-z_]\w*)\s*\.\s*)?(?:result_json|analysis_json)\s*,\s*"
-    r"(?P<quote>['\"])(?P<path>\$[^'\"]+)(?P=quote)",
+JSON_EXTRACT_RE = re.compile(r"\bjson_extract\s*\(", re.I)
+SOURCE_PAYLOAD_ALIAS_RE = re.compile(
+    r'\b(?:result_json|analysis_json)\b\s+as\s+"?(?P<name>[a-z_]\w*)"?',
     re.I,
 )
 TOOL_PAYLOAD_RE = re.compile(r"\b(?:result_json|result_text|analysis_json)\b", re.I)
@@ -164,7 +164,8 @@ def summarize_sqlite_tool_result_sql(sql_values: Iterable[str], *, sqlite_call_c
             if mentions:
                 working_sources.add(created_table)
         if index_match := CREATE_UNIQUE_INDEX_RE.search(statement):
-            explicit_table_identity[index_match.group("name").casefold()] = True
+            if not re.search(r"\bwhere\b", statement[index_match.end():], re.I):
+                explicit_table_identity[index_match.group("name").casefold()] = True
         if table := _manual_values_table_name(statement):
             manual_value_tables.append(table)
             manual_value_rows += _manual_values_row_count(statement)
@@ -187,6 +188,9 @@ def summarize_sqlite_tool_result_sql(sql_values: Iterable[str], *, sqlite_call_c
         manual_values_table_names=manual_values_unique,
         manual_values_rows=manual_value_rows,
         manual_values_working_tables=sum(1 for table in manual_values_unique if table in created_unique),
+        keyed_explicit_table_names=tuple(
+            table for table, keyed in explicit_table_identity.items() if keyed
+        ),
         unkeyed_explicit_table_names=tuple(table for table, keyed in explicit_table_identity.items() if not keyed),
         **{field: counts[field] for field in COUNT_FIELDS},
     )
@@ -282,7 +286,7 @@ def source_derived_model_mutation_tables(sql_values: Iterable[str]) -> tuple[str
             match = MODEL_MUTATION_RE.search(statement)
             if (
                 match
-                and _is_named_model_table(match.group("name"))
+                and is_named_model_table(match.group("name"))
                 and _mutation_derives_payload(statement, match)
             ):
                 tables.append(match.group("name").casefold())
@@ -300,7 +304,7 @@ def named_model_read_tables(sql_values: Iterable[str]) -> tuple[str, ...]:
             for match in READ_TABLE_RE.finditer(statement):
                 table = match.group("name").casefold()
                 trailing = statement[match.end():].lstrip()
-                if not trailing.startswith("(") and table not in cte_names and _is_named_model_table(table):
+                if not trailing.startswith("(") and table not in cte_names and is_named_model_table(table):
                     tables.append(table)
     return tuple(dict.fromkeys(tables))
 
@@ -315,14 +319,14 @@ def named_model_reference_tables(sql_values: Iterable[str]) -> tuple[str, ...]:
             tables.extend(named_model_read_tables((statement,)))
             if match := MODEL_MUTATION_RE.search(statement):
                 table = match.group("name").casefold()
-                if _is_named_model_table(table):
+                if is_named_model_table(table):
                     tables.append(table)
             if table := _created_table_name(statement):
-                if _is_named_model_table(table):
+                if is_named_model_table(table):
                     tables.append(table)
             if match := ALTER_TABLE_RE.search(statement):
                 table = match.group("name").casefold()
-                if _is_named_model_table(table):
+                if is_named_model_table(table):
                     tables.append(table)
     return tuple(dict.fromkeys(tables))
 
@@ -330,22 +334,22 @@ def named_model_reference_tables(sql_values: Iterable[str]) -> tuple[str, ...]:
 def source_derived_model_reconciled_tables(sql_values: Iterable[str]) -> tuple[str, ...]:
     """Return source-derived model targets read by a later statement."""
 
-    pending: set[str] = set()
-    reconciled: list[str] = []
-    for sql in sql_values:
-        for statement in sqlparse.split(str(sql or "")):
-            for table in named_model_read_tables((statement,)):
-                if table in pending:
-                    reconciled.append(table)
-                    pending.remove(table)
-            for table in source_derived_model_mutation_tables((statement,)):
-                pending.add(table)
-                reconciled = [reconciled_table for reconciled_table in reconciled if reconciled_table != table]
-    return tuple(dict.fromkeys(reconciled))
+    return tuple(_source_derived_model_reconciliations(sql_values))
 
 
 def source_derived_model_reconciled_paths(sql_values: Iterable[str]) -> tuple[str, ...]:
     """Return structured source-array paths persisted and read through a durable model."""
+
+    reconciled = _source_derived_model_reconciliations(sql_values)
+    return tuple(dict.fromkeys(
+        path
+        for paths in reconciled.values()
+        for path in sorted(paths)
+    ))
+
+
+def _source_derived_model_reconciliations(sql_values: Iterable[str]) -> dict[str, set[str]]:
+    """Map reconciled model tables to the source JSON paths persisted through them."""
 
     pending: dict[str, set[str]] = {}
     reconciled: dict[str, set[str]] = {}
@@ -357,24 +361,149 @@ def source_derived_model_reconciled_paths(sql_values: Iterable[str]) -> tuple[st
             mutation_tables = source_derived_model_mutation_tables((raw_statement,))
             if not mutation_tables:
                 continue
-            paths = {
-                match.group("path")
-                for match in SOURCE_JSON_EACH_PATH_RE.finditer(raw_statement)
-            }
+            paths = set(_source_json_each_paths(raw_statement))
             for table in mutation_tables:
                 pending[table] = (
                     pending.get(table, set())
                     | reconciled.pop(table, set())
                     | paths
                 )
-    return tuple(dict.fromkeys(
-        path
-        for paths in reconciled.values()
-        for path in sorted(paths)
-    ))
+    return reconciled
 
 
-def _is_named_model_table(table_name: str) -> bool:
+def _source_json_each_paths(statement: str) -> tuple[str, ...]:
+    """Return source paths iterated by json_each, including equivalent SQL forms."""
+
+    statement = sqlparse.format(statement or "", strip_comments=True)
+    paths: list[str] = []
+    for arguments in _function_arguments(statement, JSON_EACH_RE):
+        if not arguments:
+            continue
+        source_expression = arguments[0]
+        base_path = _json_extract_source_path(source_expression, statement)
+        if base_path is None and not _is_source_payload_expression(source_expression, statement):
+            continue
+        if len(arguments) > 1:
+            relative_path = _sql_string_literal_value(arguments[1])
+            if relative_path is None or not relative_path.startswith("$"):
+                continue
+            paths.append(_combine_json_paths(base_path or "$", relative_path))
+        else:
+            paths.append(base_path or "$")
+    return tuple(dict.fromkeys(paths))
+
+
+def _json_extract_source_path(expression: str, statement: str) -> str | None:
+    for arguments in _function_arguments(expression, JSON_EXTRACT_RE):
+        if len(arguments) < 2 or not _is_source_payload_expression(arguments[0], statement):
+            continue
+        path = _sql_string_literal_value(arguments[1])
+        if path is not None and path.startswith("$"):
+            return path
+    return None
+
+
+def _is_source_payload_expression(expression: str, statement: str) -> bool:
+    if TOOL_PAYLOAD_RE.search(expression):
+        return True
+    match = re.fullmatch(r'\s*(?:"?[a-z_]\w*"?\s*\.\s*)?"?(?P<name>[a-z_]\w*)"?\s*', expression, re.I)
+    if not match:
+        return False
+    aliases = {alias.group("name").casefold() for alias in SOURCE_PAYLOAD_ALIAS_RE.finditer(statement)}
+    return match.group("name").casefold() in aliases
+
+
+def _combine_json_paths(base_path: str, relative_path: str) -> str:
+    if base_path == "$":
+        return relative_path
+    if relative_path == "$":
+        return base_path
+    if relative_path.startswith(("$.", "$[")):
+        return base_path + relative_path[1:]
+    return relative_path
+
+
+def _function_arguments(statement: str, function_re: re.Pattern) -> tuple[tuple[str, ...], ...]:
+    calls: list[tuple[str, ...]] = []
+    for match in function_re.finditer(statement):
+        contents = _parenthesized_sql_contents(statement, match.end() - 1)
+        if contents is not None:
+            calls.append(_split_sql_arguments(contents))
+    return tuple(calls)
+
+
+def _parenthesized_sql_contents(statement: str, open_index: int) -> str | None:
+    depth = 1
+    quote = None
+    index = open_index + 1
+    while index < len(statement):
+        char = statement[index]
+        if quote is not None:
+            closing = "]" if quote == "[" else quote
+            if char == closing:
+                if quote != "[" and index + 1 < len(statement) and statement[index + 1] == closing:
+                    index += 2
+                    continue
+                quote = None
+        elif char in ("'", '"', "`", "["):
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return statement[open_index + 1:index]
+        index += 1
+    return None
+
+
+def _split_sql_arguments(arguments: str) -> tuple[str, ...]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote = None
+    index = 0
+    while index < len(arguments):
+        char = arguments[index]
+        if quote is not None:
+            closing = "]" if quote == "[" else quote
+            if char == closing:
+                if quote != "[" and index + 1 < len(arguments) and arguments[index + 1] == closing:
+                    index += 2
+                    continue
+                quote = None
+        elif char in ("'", '"', "`", "["):
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(0, depth - 1)
+        elif char == "," and depth == 0:
+            parts.append(arguments[start:index].strip())
+            start = index + 1
+        index += 1
+    parts.append(arguments[start:].strip())
+    return tuple(part for part in parts if part)
+
+
+def _sql_string_literal_value(expression: str) -> str | None:
+    expression = expression.strip()
+    if len(expression) < 2 or expression[0] not in ("'", '"') or expression[-1] != expression[0]:
+        return None
+    quote = expression[0]
+    value = expression[1:-1]
+    index = 0
+    while index < len(value):
+        if value[index] != quote:
+            index += 1
+            continue
+        if index + 1 >= len(value) or value[index + 1] != quote:
+            return None
+        index += 2
+    return value.replace(quote * 2, quote)
+
+
+def is_named_model_table(table_name: str) -> bool:
     normalized = str(table_name or "").casefold()
     return bool(normalized) and not normalized.startswith(NON_MODEL_TABLE_PREFIXES) and not normalized.endswith(
         NON_MODEL_TABLE_SUFFIXES
@@ -507,7 +636,7 @@ def _source_literal_copy_tables(
             raw_statement = str(statement)
             structural = _structural_sql(raw_statement)
             match = MODEL_MUTATION_RE.search(structural)
-            if not match or not _is_named_model_table(match.group("name")):
+            if not match or not is_named_model_table(match.group("name")):
                 continue
             matched_literals = set()
             copied_url = False
@@ -550,7 +679,7 @@ def _grounded_literal_insert_tables(
         for statement in sqlparse.parse(str(sql or "")):
             structural = _structural_sql(str(statement))
             match = MODEL_MUTATION_RE.search(structural)
-            if not match or not _is_named_model_table(match.group("name")):
+            if not match or not is_named_model_table(match.group("name")):
                 continue
             table = match.group("name").casefold()
             if table not in _source_literal_copy_tables((str(statement),), payloads):

--- a/api/agent/tools/sqlite_state.py
+++ b/api/agent/tools/sqlite_state.py
@@ -282,6 +282,43 @@ def get_sqlite_model_table_columns(
                 conn.close()
 
 
+def get_sqlite_model_tables_with_identity() -> set[str]:
+    """Return durable model tables backed by a primary or unique key."""
+    db_path = _sqlite_db_path_var.get(None)
+    if not db_path or not os.path.exists(db_path):
+        return set()
+
+    conn = None
+    try:
+        conn = open_guarded_sqlite_connection(db_path)
+        table_names = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name NOT LIKE 'sqlite_%' AND substr(name, 1, 2) != '__'"
+            ).fetchall()
+        }
+        keyed_tables = set()
+        for table_name in table_names:
+            quoted_name = table_name.replace('"', '""')
+            columns = conn.execute(f'PRAGMA table_info("{quoted_name}")').fetchall()
+            if any(int(column[5] or 0) > 0 for column in columns):
+                keyed_tables.add(table_name)
+                continue
+            indexes = conn.execute(f'PRAGMA index_list("{quoted_name}")').fetchall()
+            if any(bool(index[2]) for index in indexes):
+                keyed_tables.add(table_name)
+        return keyed_tables
+    except (OSError, sqlite3.Error):
+        logger.debug("Failed to inspect SQLite model identities", exc_info=True)
+        return set()
+    finally:
+        if conn is not None:
+            with contextlib.suppress(sqlite3.Error):
+                clear_guarded_connection(conn)
+                conn.close()
+
+
 def get_sqlite_digest_prompt() -> str:
     """Return a compact SQLite digest for the agent's database."""
     db_path = _sqlite_db_path_var.get(None)

--- a/api/agent/tools/sqlite_state.py
+++ b/api/agent/tools/sqlite_state.py
@@ -35,6 +35,7 @@ from api.utils.sqlite_files import (
 )
 
 from .sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
+from .sqlite_query_quality import is_named_model_table
 from .sqlite_recovery import (
     SQLITE_STATE_RECOVERED_ERROR,
     SQLITE_STATE_UNRECOVERABLE_ERROR,
@@ -292,11 +293,12 @@ def get_sqlite_model_tables_with_identity() -> set[str]:
     try:
         conn = open_guarded_sqlite_connection(db_path)
         table_names = {
-            str(row[0])
+            str(row[0]).casefold()
             for row in conn.execute(
                 "SELECT name FROM sqlite_master "
                 "WHERE type='table' AND name NOT LIKE 'sqlite_%' AND substr(name, 1, 2) != '__'"
             ).fetchall()
+            if is_named_model_table(row[0])
         }
         keyed_tables = set()
         for table_name in table_names:
@@ -306,7 +308,7 @@ def get_sqlite_model_tables_with_identity() -> set[str]:
                 keyed_tables.add(table_name)
                 continue
             indexes = conn.execute(f'PRAGMA index_list("{quoted_name}")').fetchall()
-            if any(bool(index[2]) for index in indexes):
+            if any(bool(index[2]) and not bool(index[4]) for index in indexes):
                 keyed_tables.add(table_name)
         return keyed_tables
     except (OSError, sqlite3.Error):

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2571,7 +2571,9 @@ class PromptContextBuilderTests(TestCase):
                 status=tool_status,
             )
 
-        self.assertIn("$.result.posts", build_metadata()["source_reconciliation_directive"])
+        with patch("api.agent.core.prompt_context.get_sqlite_model_tables_with_identity") as identity_probe:
+            self.assertIn("$.result.posts", build_metadata()["source_reconciliation_directive"])
+        identity_probe.assert_not_called()
 
         source_insert = (
             "INSERT INTO reddit_subreddit_posts_current(post_id,title) "
@@ -2598,6 +2600,25 @@ class PromptContextBuilderTests(TestCase):
                 "SELECT json_extract(j.value,'$.id'),json_extract(j.value,'$.title') "
                 "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j; "
                 "SELECT * FROM unkeyed_posts LIMIT 20"
+            ),
+            (
+                "CREATE TABLE ctas_posts AS SELECT result_json FROM __tool_results WHERE 0; "
+                "INSERT INTO ctas_posts(result_json) SELECT j.value "
+                "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j; "
+                "SELECT * FROM ctas_posts LIMIT 20"
+            ),
+            (
+                "CREATE TEMP TABLE ephemeral_posts(post_id TEXT PRIMARY KEY); "
+                "INSERT INTO ephemeral_posts(post_id) SELECT json_extract(j.value,'$.id') "
+                "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j; "
+                "SELECT * FROM ephemeral_posts LIMIT 20"
+            ),
+            (
+                "CREATE TABLE partial_posts(post_id TEXT); "
+                "CREATE UNIQUE INDEX partial_posts_key ON partial_posts(post_id) WHERE post_id IS NOT NULL; "
+                "INSERT INTO partial_posts(post_id) SELECT json_extract(j.value,'$.id') "
+                "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j; "
+                "SELECT * FROM partial_posts LIMIT 20"
             ),
         )
         for sql in invalid_attempts:

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2527,6 +2527,98 @@ class PromptContextBuilderTests(TestCase):
             reset_sqlite_db_path(token)
             sqlite_tmp.cleanup()
 
+    def test_source_path_reconciliation_accepts_new_durable_target_and_rejects_invalid_attempts(self):
+        sqlite_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(sqlite_tmp.cleanup)
+        token = set_sqlite_db_path(f"{sqlite_tmp.name}/state.db")
+        self.addCleanup(reset_sqlite_db_path, token)
+        with sqlite3.connect(f"{sqlite_tmp.name}/state.db") as conn:
+            conn.execute("CREATE TABLE posts(post_id TEXT PRIMARY KEY, title TEXT)")
+
+        source_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="fresh Reddit source",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=source_step,
+            tool_name="http_request",
+            tool_params={"url": "https://reddit.example.test/posts"},
+            result=json.dumps({
+                "status": "ok",
+                "result": {
+                    "posts": [{"id": "post-1", "title": "Fresh post"}],
+                },
+            }),
+            status="complete",
+        )
+
+        def build_metadata():
+            with patch("api.agent.core.prompt_context.ensure_steps_compacted"), patch(
+                "api.agent.core.prompt_context.ensure_comms_compacted"
+            ):
+                return build_prompt_context(self.agent, include_metadata=True)[3]
+
+        def record_sql(sql, *, result_status="ok", tool_status="complete"):
+            step = PersistentAgentStep.objects.create(
+                agent=self.agent,
+                description="SQLite source reconciliation attempt",
+            )
+            PersistentAgentToolCall.objects.create(
+                step=step,
+                tool_name="sqlite_batch",
+                tool_params={"sql": sql},
+                result=json.dumps({"status": result_status, "results": []}),
+                status=tool_status,
+            )
+
+        self.assertIn("$.result.posts", build_metadata()["source_reconciliation_directive"])
+
+        source_insert = (
+            "INSERT INTO reddit_subreddit_posts_current(post_id,title) "
+            "SELECT json_extract(j.value,'$.id'),json_extract(j.value,'$.title') "
+            "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j "
+            "WHERE t.is_current_batch=1 AND t.tool_name='http_request'"
+        )
+        invalid_attempts = (
+            source_insert + "; SELECT * FROM unrelated_posts LIMIT 20",
+            source_insert,
+            (
+                "INSERT INTO staging_posts(post_id) SELECT json_extract(j.value,'$.id') "
+                "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j; "
+                "SELECT * FROM staging_posts LIMIT 20"
+            ),
+            (
+                "INSERT INTO reddit_subreddit_posts_current(post_id,title) "
+                "VALUES ('post-1','Fresh post'); "
+                "SELECT * FROM reddit_subreddit_posts_current LIMIT 20"
+            ),
+            (
+                "CREATE TABLE unkeyed_posts(post_id TEXT,title TEXT); "
+                "INSERT INTO unkeyed_posts(post_id,title) "
+                "SELECT json_extract(j.value,'$.id'),json_extract(j.value,'$.title') "
+                "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j; "
+                "SELECT * FROM unkeyed_posts LIMIT 20"
+            ),
+        )
+        for sql in invalid_attempts:
+            record_sql(sql)
+            self.assertIsNotNone(build_metadata()["source_reconciliation_directive"])
+
+        record_sql(
+            source_insert + "; SELECT * FROM reddit_subreddit_posts_current LIMIT 20",
+            result_status="error",
+            tool_status="error",
+        )
+        self.assertIsNotNone(build_metadata()["source_reconciliation_directive"])
+
+        record_sql(
+            "CREATE TABLE reddit_subreddit_posts_current("
+            "post_id TEXT PRIMARY KEY,title TEXT); "
+            + source_insert
+            + "; SELECT * FROM reddit_subreddit_posts_current LIMIT 20"
+        )
+        self.assertIsNone(build_metadata()["source_reconciliation_directive"])
+
     def test_current_source_batch_hides_stale_same_tool_event_from_prompt(self):
         sqlite_tmp = tempfile.TemporaryDirectory()
         self.addCleanup(sqlite_tmp.cleanup)

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -16,6 +16,7 @@ from api.agent.comms.routing import (
     bind_inbound_routing_scope,
     capture_inbound_routing_scope,
     get_bound_inbound_routing_scope,
+    get_current_inbound_message,
     reset_inbound_routing_scope,
 )
 from api.agent.core.internal_reasoning import INTERNAL_REASONING_PREFIX
@@ -3455,19 +3456,38 @@ class ImpliedSendTests(TestCase):
         ]
         return response
 
-    def _run_feedback_flow(self, feedback, responses, tools, *, prompt_metadata=None, config_apply=None):
-        self._add_feedback_followup(
-            feedback,
-            initial_body="Draft outreach",
-            prior_body="Here is the draft.",
-        )
+    def _run_feedback_flow(
+        self,
+        feedback,
+        responses,
+        tools,
+        *,
+        prompt_metadata=None,
+        prompt_metadata_sequence=None,
+        config_apply=None,
+        tool_results=None,
+        add_feedback=True,
+    ):
+        if add_feedback:
+            self._add_feedback_followup(
+                feedback,
+                initial_body="Draft outreach",
+                prior_body="Here is the draft.",
+            )
         start_web_session(self.agent, self.user)
         failover_configs = [("provider-a", "model-a", {"supports_tool_choice": True})]
-        prompt_result = (
-            [{"role": "system", "content": "sys"}, {"role": "user", "content": feedback}],
-            1000,
-            None,
-            {"prompt_failover_configs": failover_configs, **(prompt_metadata or {})},
+        def prompt_result(metadata):
+            return (
+                [{"role": "system", "content": "sys"}, {"role": "user", "content": feedback}],
+                1000,
+                None,
+                {"prompt_failover_configs": failover_configs, **(metadata or {})},
+            )
+
+        prompt_results = (
+            [prompt_result(metadata) for metadata in prompt_metadata_sequence]
+            if prompt_metadata_sequence is not None
+            else None
         )
         usage = {
             "prompt_tokens": 10,
@@ -3480,19 +3500,25 @@ class ImpliedSendTests(TestCase):
 
         def execute_tool(_agent, *, tool_name, **_kwargs):
             executed_tools.append(tool_name)
+            if tool_results is not None:
+                return tool_results[len(executed_tools) - 1], None
             return {
                 "status": "ok",
                 "auto_sleep_ok": tool_name in ep.MESSAGE_TOOL_NAMES,
             }, None
 
         skill_apply = MagicMock(changed=False, errors=())
+        prompt_patch = (
+            patch.object(ep, "build_prompt_context", side_effect=prompt_results)
+            if prompt_results is not None
+            else patch.object(ep, "build_prompt_context", return_value=prompt_result(prompt_metadata))
+        )
         with patch.object(ep, "get_agent_tools", return_value=tools), \
              patch.object(ep, "get_agent_daily_credit_state", return_value=None), \
-             patch.object(ep, "build_prompt_context", return_value=prompt_result) as build_prompt, \
+             prompt_patch as build_prompt, \
              patch.object(ep, "get_llm_config_with_failover", side_effect=AssertionError("use prompt configs")), \
              patch.object(ep, "_completion_with_failover", side_effect=[(response, usage) for response in responses]) as completion, \
              patch.object(ep, "_execute_tool_call_runtime", side_effect=execute_tool), \
-             patch.object(ep, "_capture_tool_display_metadata", return_value={}), \
              patch.object(ep, "_ensure_credit_for_tool", return_value={"cost": None, "credit": None}), \
              patch.object(ep, "get_sqlite_db_path", return_value="/tmp/test-agent.sqlite3"), \
              patch.object(ep, "seed_sqlite_agent_config", return_value=MagicMock()), \
@@ -3742,6 +3768,200 @@ class ImpliedSendTests(TestCase):
         self.assertIs(kwargs["failover_configs"][0][2]["use_parallel_tool_calls"], False)
         self.assertIsNone(kwargs["stream_broadcaster"])
         self.assertIs(kwargs["allow_streamed_content"], False)
+        self.assertIn("one focused reconciliation batch", sqlite_parameters["properties"]["sql"]["description"])
+        self.assertIn("normal tool routing resumes", sqlite_parameters["properties"]["sql"]["description"])
+        tool_call = PersistentAgentToolCall.objects.filter(
+            step__agent=self.agent,
+            tool_name="sqlite_batch",
+        ).latest("step__created_at")
+        directive_hash = ep._source_reconciliation_directive_hash(
+            self.agent,
+            "[SOURCE ARRAYS result_id=abc123; stored paths: $.content.accounts(account_id,name).]",
+            [],
+        )
+        self.assertEqual(
+            tool_call.display_metadata[ep.SOURCE_RECONCILIATION_METADATA_KEY]["directive_hash"],
+            directive_hash,
+        )
+
+    def test_validated_source_reconciliation_restores_full_tool_routing(self):
+        tools = [
+            {"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "http_request", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "send_chat_message", "parameters": {"type": "object", "properties": {}}}},
+        ]
+        directive = "[SOURCE ARRAYS; paths: $.result.posts(id,title)[stable_key=id].]"
+        responses = [
+            self._tool_completion("sqlite_batch", {
+                "rows": [],
+                "sql": "INSERT INTO posts SELECT * FROM source; SELECT * FROM posts LIMIT 20",
+                "will_continue_work": True,
+            }),
+            self._tool_completion("http_request", {"url": "https://example.test/remaining-action"}),
+        ]
+
+        completion, _, executed_tools = self._run_feedback_flow(
+            "Import the source and continue.",
+            responses,
+            tools,
+            prompt_metadata_sequence=[
+                {"source_reconciliation_directive": directive},
+                {"source_reconciliation_directive": None},
+            ],
+        )
+
+        self.assertEqual(executed_tools, ["sqlite_batch", "http_request"])
+        self.assertEqual(
+            [tool["function"]["name"] for tool in completion.call_args_list[0].kwargs["tools"]],
+            ["sqlite_batch"],
+        )
+        self.assertEqual(
+            [tool["function"]["name"] for tool in completion.call_args_list[1].kwargs["tools"]],
+            ["sqlite_batch", "http_request", "send_chat_message"],
+        )
+
+    def test_successful_unverified_source_reconciliation_releases_after_two_attempts(self):
+        tools = [
+            {"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "http_request", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "send_chat_message", "parameters": {"type": "object", "properties": {}}}},
+        ]
+        directive = "[SOURCE ARRAYS; paths: $.result.posts(id,title)[stable_key=id].]"
+        sqlite_args = {
+            "rows": [],
+            "sql": "INSERT INTO posts SELECT * FROM source; SELECT * FROM posts LIMIT 20",
+            "will_continue_work": True,
+        }
+        responses = [
+            self._tool_completion("sqlite_batch", sqlite_args),
+            self._tool_completion("sqlite_batch", sqlite_args),
+            self._tool_completion("send_chat_message", {
+                "body": "I could not validate the source reconciliation.",
+                "will_continue_work": False,
+            }),
+        ]
+
+        completion, _, executed_tools = self._run_feedback_flow(
+            "Import the source.",
+            responses,
+            tools,
+            prompt_metadata={"source_reconciliation_directive": directive},
+        )
+
+        self.assertEqual(executed_tools, ["sqlite_batch", "sqlite_batch", "send_chat_message"])
+        released_kwargs = completion.call_args_list[2].kwargs
+        self.assertNotIn(
+            "sqlite_batch",
+            [tool["function"]["name"] for tool in released_kwargs["tools"]],
+        )
+        self.assertIn("SQLite Source Reconciliation Safety Release", released_kwargs["messages"][0]["content"])
+        self.assertNotIn(directive, "\n".join(message["content"] for message in released_kwargs["messages"]))
+        self.assertTrue(PersistentAgentSystemStep.objects.filter(
+            step__agent=self.agent,
+            notes__startswith="sqlite_source_reconciliation_guard:",
+        ).exists())
+
+    def test_failed_source_reconciliation_guard_persists_across_followup_run(self):
+        tools = [
+            {"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {}}}},
+            {"type": "function", "function": {"name": "send_chat_message", "parameters": {"type": "object", "properties": {}}}},
+        ]
+        directive = "[SOURCE ARRAYS; paths: $.result.posts(id,title)[stable_key=id].]"
+        source_step = PersistentAgentStep.objects.create(agent=self.agent, description="active source batch")
+        PersistentAgentToolCall.objects.create(
+            step=source_step,
+            tool_name="http_request",
+            tool_params={"url": "https://example.test/posts"},
+            result=json.dumps({"status": "ok", "result": {"posts": [{"id": "p1"}]}}),
+            status=PersistentAgentToolCall.Status.COMPLETE,
+        )
+        metadata = {
+            "source_reconciliation_directive": directive,
+            "fresh_tool_call_step_ids": [str(source_step.id)],
+        }
+        sqlite_response = lambda: self._tool_completion("sqlite_batch", {
+            "rows": [],
+            "sql": "INSERT INTO posts SELECT * FROM missing_source; SELECT * FROM posts LIMIT 20",
+            "will_continue_work": True,
+        })
+        retryable_error = {"status": "error", "error": "SQL failed", "retryable": True}
+
+        first_completion, _, first_executed = self._run_feedback_flow(
+            "Import the source.",
+            [sqlite_response(), sqlite_response()],
+            tools,
+            prompt_metadata=metadata,
+            tool_results=[retryable_error, retryable_error],
+        )
+        self.assertEqual(first_completion.call_count, 2)
+        self.assertEqual(first_executed, ["sqlite_batch", "sqlite_batch"])
+
+        second_completion, _, second_executed = self._run_feedback_flow(
+            "Continue the existing source task.",
+            [
+                sqlite_response(),
+                self._tool_completion("send_chat_message", {
+                    "body": "The source reconciliation failed after three attempts.",
+                    "will_continue_work": False,
+                }),
+            ],
+            tools,
+            prompt_metadata=metadata,
+            tool_results=[retryable_error, {"status": "ok", "auto_sleep_ok": True}],
+            add_feedback=False,
+        )
+
+        self.assertEqual(second_executed, ["sqlite_batch", "send_chat_message"])
+        self.assertNotIn(
+            "sqlite_batch",
+            [tool["function"]["name"] for tool in second_completion.call_args_list[1].kwargs["tools"]],
+        )
+        directive_hash = ep._source_reconciliation_directive_hash(
+            self.agent,
+            directive,
+            [str(source_step.id)],
+        )
+        counts = ep._source_reconciliation_attempt_counts(self.agent, directive_hash)
+        self.assertEqual(counts.total, 3)
+        self.assertEqual(counts.successful_unverified, 0)
+        self.assertTrue(counts.exhausted)
+
+        current_inbound = get_current_inbound_message(self.agent)
+        PersistentAgentMessage.objects.create(
+            owner_agent=self.agent,
+            is_outbound=False,
+            from_endpoint=current_inbound.from_endpoint,
+            conversation=current_inbound.conversation,
+            body="Start a new inbound source task.",
+        )
+        self.assertNotEqual(
+            directive_hash,
+            ep._source_reconciliation_directive_hash(
+                self.agent,
+                directive,
+                [str(source_step.id)],
+            ),
+        )
+
+        replacement_source_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="replacement source batch",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=replacement_source_step,
+            tool_name="http_request",
+            tool_params={"url": "https://example.test/posts?page=2"},
+            result=json.dumps({"status": "ok", "result": {"posts": [{"id": "p2"}]}}),
+            status=PersistentAgentToolCall.Status.COMPLETE,
+        )
+        self.assertNotEqual(
+            directive_hash,
+            ep._source_reconciliation_directive_hash(
+                self.agent,
+                directive,
+                [str(replacement_source_step.id)],
+            ),
+        )
 
     def test_direct_rewrite_continues_to_distinct_research_task(self):
         feedback = "That sounded robotic. Rewrite it, then find three prospects."

--- a/tests/unit/test_event_processing_implied_send.py
+++ b/tests/unit/test_event_processing_implied_send.py
@@ -3861,6 +3861,38 @@ class ImpliedSendTests(TestCase):
             notes__startswith="sqlite_source_reconciliation_guard:",
         ).exists())
 
+    def test_source_reconciliation_release_preserves_multimodal_content_and_strips_each_directive(self):
+        first_directive = "[SOURCE ARRAYS; paths: $.result.posts(id)[stable_key=id].]"
+        second_directive = "[SOURCE ARRAYS; paths: $.result.comments(id)[stable_key=id].]"
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        }
+        history = [{
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"Import these. {first_directive} More context. {second_directive}",
+                },
+                image_part,
+            ],
+        }]
+
+        released = ep._source_reconciliation_release_history(
+            history,
+            f"{first_directive}\n{second_directive}",
+        )
+
+        self.assertEqual(released[0]["role"], "system")
+        self.assertIn("SQLite Source Reconciliation Safety Release", released[0]["content"])
+        self.assertIsInstance(released[1]["content"], list)
+        self.assertNotIn(first_directive, released[1]["content"][0]["text"])
+        self.assertNotIn(second_directive, released[1]["content"][0]["text"])
+        self.assertEqual(released[1]["content"][1], image_part)
+        self.assertIn(first_directive, history[0]["content"][0]["text"])
+        self.assertIn(second_directive, history[0]["content"][0]["text"])
+
     def test_failed_source_reconciliation_guard_persists_across_followup_run(self):
         tools = [
             {"type": "function", "function": {"name": "sqlite_batch", "parameters": {"type": "object", "properties": {}}}},

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -45,6 +45,7 @@ from api.agent.tools.sqlite_query_quality import (
     named_model_read_tables,
     named_model_reference_tables,
     source_derived_model_mutation_tables,
+    source_derived_model_reconciled_paths,
     source_derived_model_reconciled_tables,
     summarize_sqlite_tool_result_calls,
     summarize_sqlite_tool_result_sql,
@@ -1916,6 +1917,48 @@ class SqliteBatchQualityTests(SqliteBatchTestCase):
         self.assertEqual(
             source_derived_model_reconciled_tables([
                 f"{derived_update[0]}; SELECT stage FROM accounts; {derived_update[0]}"
+            ]),
+            (),
+        )
+
+        posts_import = (
+            "INSERT INTO reddit_subreddit_posts_current(post_id,title) "
+            "SELECT json_extract(j.value,'$.id'),json_extract(j.value,'$.title') "
+            "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j "
+            "WHERE t.is_current_batch=1 AND t.tool_name='http_request'; "
+            "SELECT post_id,title FROM reddit_subreddit_posts_current LIMIT 50"
+        )
+        self.assertEqual(
+            source_derived_model_reconciled_paths([posts_import]),
+            ("$.result.posts",),
+        )
+        self.assertEqual(
+            set(source_derived_model_reconciled_paths([
+                posts_import.rsplit(";", 1)[0] + "; "
+                "INSERT INTO reddit_subreddit_posts_current(post_id,title) "
+                "SELECT json_extract(j.value,'$.id'),json_extract(j.value,'$.title') "
+                "FROM __tool_results t,json_each(t.result_json,'$.result.pinned_posts') j; "
+                "SELECT * FROM reddit_subreddit_posts_current LIMIT 50"
+            ])),
+            {"$.result.posts", "$.result.pinned_posts"},
+        )
+        self.assertEqual(
+            source_derived_model_reconciled_paths([
+                posts_import.rsplit(";", 1)[0],
+            ]),
+            (),
+        )
+        self.assertEqual(
+            source_derived_model_reconciled_paths([
+                posts_import.rsplit(";", 1)[0] + "; SELECT * FROM unrelated_posts",
+            ]),
+            (),
+        )
+        self.assertEqual(
+            source_derived_model_reconciled_paths([
+                "INSERT INTO temp_posts(post_id) SELECT json_extract(j.value,'$.id') "
+                "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j; "
+                "SELECT * FROM temp_posts"
             ]),
             (),
         )

--- a/tests/unit/test_sqlite_batch.py
+++ b/tests/unit/test_sqlite_batch.py
@@ -50,7 +50,11 @@ from api.agent.tools.sqlite_query_quality import (
     summarize_sqlite_tool_result_calls,
     summarize_sqlite_tool_result_sql,
 )
-from api.agent.tools.sqlite_state import reset_sqlite_db_path, set_sqlite_db_path
+from api.agent.tools.sqlite_state import (
+    get_sqlite_model_tables_with_identity,
+    reset_sqlite_db_path,
+    set_sqlite_db_path,
+)
 from api.models import BrowserUseAgent, PersistentAgent
 
 
@@ -1932,6 +1936,58 @@ class SqliteBatchQualityTests(SqliteBatchTestCase):
             source_derived_model_reconciled_paths([posts_import]),
             ("$.result.posts",),
         )
+        equivalent_source_forms = {
+            "cte payload alias": (
+                "WITH src AS (SELECT result_json AS payload FROM __tool_results) "
+                "INSERT INTO reddit_subreddit_posts_current(post_id) "
+                "SELECT json_extract(j.value,'$.id') FROM src,json_each(src.payload,'$.result.posts') j; "
+                "SELECT * FROM reddit_subreddit_posts_current LIMIT 50"
+            ),
+            "subselect payload": (
+                "INSERT INTO reddit_subreddit_posts_current(post_id) "
+                "SELECT json_extract(j.value,'$.id') FROM json_each("
+                "(SELECT result_json FROM __tool_results LIMIT 1),'$.result.posts') j; "
+                "SELECT * FROM reddit_subreddit_posts_current LIMIT 50"
+            ),
+            "nested json_extract": (
+                "INSERT INTO reddit_subreddit_posts_current(post_id) "
+                "SELECT json_extract(j.value,'$.id') FROM __tool_results t,"
+                "json_each(json_extract(t.result_json,'$.result')) j; "
+                "SELECT * FROM reddit_subreddit_posts_current LIMIT 50"
+            ),
+        }
+        for label, sql in equivalent_source_forms.items():
+            with self.subTest(label=label):
+                self.assertEqual(
+                    source_derived_model_reconciled_paths([sql]),
+                    ("$.result.posts",) if label != "nested json_extract" else ("$.result",),
+                )
+        self.assertEqual(
+            source_derived_model_reconciled_paths([
+                "INSERT INTO reddit_subreddit_posts_current(post_id) "
+                "SELECT json_extract(j.value,'$.id') FROM __tool_results t,json_each(t.result_json) j; "
+                "SELECT * FROM reddit_subreddit_posts_current LIMIT 50"
+            ]),
+            ("$",),
+        )
+        self.assertEqual(
+            source_derived_model_reconciled_paths([
+                "INSERT INTO reddit_subreddit_posts_current(post_id) "
+                "SELECT json_extract(j.value,'$.id') FROM __tool_results t,"
+                "json_each(t.result_json,'$.content.\"owner''s.items\"') j; "
+                "SELECT * FROM reddit_subreddit_posts_current LIMIT 50"
+            ]),
+            ('$.content."owner\'s.items"',),
+        )
+        self.assertEqual(
+            source_derived_model_reconciled_paths([
+                "INSERT INTO reddit_subreddit_posts_current(post_id,source_result_id) "
+                "SELECT json_extract(r.value,'$.id'),t.result_id FROM json_each(:rows,'$.result.posts') r "
+                "JOIN __tool_results t ON t.result_id=json_extract(r.value,'$.result_id'); "
+                "SELECT * FROM reddit_subreddit_posts_current LIMIT 50"
+            ]),
+            (),
+        )
         self.assertEqual(
             set(source_derived_model_reconciled_paths([
                 posts_import.rsplit(";", 1)[0] + "; "
@@ -1962,6 +2018,47 @@ class SqliteBatchQualityTests(SqliteBatchTestCase):
             ]),
             (),
         )
+
+    def test_new_model_identity_summary_excludes_ctas_temp_and_partial_indexes(self):
+        keyed = summarize_sqlite_tool_result_sql([
+            "CREATE TABLE durable_posts(post_id TEXT PRIMARY KEY); "
+            "INSERT INTO durable_posts SELECT json_extract(j.value,'$.id') "
+            "FROM __tool_results t,json_each(t.result_json,'$.result.posts') j"
+        ])
+        ctas = summarize_sqlite_tool_result_sql([
+            "CREATE TABLE copied_posts AS SELECT * FROM __tool_results"
+        ])
+        temporary = summarize_sqlite_tool_result_sql([
+            "CREATE TEMP TABLE temp_posts(post_id TEXT PRIMARY KEY)"
+        ])
+        partial = summarize_sqlite_tool_result_sql([
+            "CREATE TABLE partial_posts(post_id TEXT); "
+            "CREATE UNIQUE INDEX partial_posts_key ON partial_posts(post_id) WHERE post_id IS NOT NULL"
+        ])
+
+        self.assertEqual(keyed.keyed_explicit_table_names, ("durable_posts",))
+        self.assertEqual(ctas.keyed_explicit_table_names, ())
+        self.assertEqual(temporary.keyed_explicit_table_names, ())
+        self.assertEqual(partial.keyed_explicit_table_names, ())
+
+    def test_sqlite_model_identity_is_casefolded_and_rejects_partial_unique_indexes(self):
+        with self._with_temp_db() as (db_path, _token, _tmp):
+            with sqlite3.connect(db_path) as conn:
+                conn.executescript(
+                    "CREATE TABLE Reddit_Posts(post_id TEXT PRIMARY KEY);"
+                    "CREATE TABLE unique_posts(post_id TEXT);"
+                    "CREATE UNIQUE INDEX unique_posts_key ON unique_posts(post_id);"
+                    "CREATE TABLE partial_posts(post_id TEXT);"
+                    "CREATE UNIQUE INDEX partial_posts_key ON partial_posts(post_id) "
+                    "WHERE post_id IS NOT NULL;"
+                    "CREATE TABLE staging_posts(post_id TEXT PRIMARY KEY);"
+                    "CREATE TABLE unkeyed_posts(post_id TEXT);"
+                )
+
+            self.assertEqual(
+                get_sqlite_model_tables_with_identity(),
+                {"reddit_posts", "unique_posts"},
+            )
 
     def test_source_facts_copied_into_model_receive_advice(self):
         payload = (


### PR DESCRIPTION
## Summary

- reconcile source-derived SQLite mutations by imported JSON path instead of destination-table naming
- allow newly created durable keyed tables while continuing to reject staging tables, literal copies, failed writes, and mutations without bounded reads
- persist stable reconciliation directive hashes in existing SQLite tool-call metadata
- stop repeated focused loops after three total attempts or two successful-but-unverified attempts, then resume normal routing without `sqlite_batch` for one completion
- preserve the multi-array requirement that every keyed source entity must reconcile

## Root cause

Reconciliation inferred source identity from the destination table name. Valid imports into flexibly named durable tables could remain unverified, so the runtime repeatedly focused the agent on `sqlite_batch` across completions.

## Impact

A validated reconciliation immediately restores the full tool set. Repeated unverified or failed attempts are bounded and produce a persisted warning instead of trapping the agent in a SQLite loop. LLM provider routing, retries, failover, and timeout behavior are unchanged.

## Validation

```
uv run python manage.py test --settings=config.test_settings --parallel auto \
  --tag batch_event_processing \
  --tag batch_event_processing_credits \
  --tag batch_sqlite_quality
```

718 tests passed.