### PR TITLE
Fix agent chat sidebar navigation and computer tool metadata

### DIFF
--- a/frontend/src/components/agentChat/AgentChatLayout.tsx
+++ b/frontend/src/components/agentChat/AgentChatLayout.tsx
@@ -465,8 +465,6 @@ export function AgentChatLayout({
   const {
     galleryShellPage = 'agents',
     showEmbeddedSettings = false,
-    onGalleryShellPageChange,
-    onBackFromEmbeddedSettings,
   } = chatSidebarProps
   const effectiveGalleryShellPage = galleryShellPage ?? 'agents'
   const currentContext = sidebarSettingsConfig?.context ?? null
@@ -637,20 +635,8 @@ export function AgentChatLayout({
   }, [agentId, highPriorityBannerDismissible, highPriorityBannerId])
 
   const handleSidebarModeChange = useCallback((mode: 'collapsed' | 'list' | 'gallery') => {
-    if (showGalleryShellPanel && mode !== 'gallery') {
-      preEmbeddedSidebarModeRef.current = null
-      setSidebarMode(mode)
-      onGalleryShellPageChange?.('agents')
-      return
-    }
-    if (showEmbeddedSettings && mode !== 'gallery') {
-      preEmbeddedSidebarModeRef.current = null
-      setSidebarMode(mode)
-      onBackFromEmbeddedSettings?.()
-      return
-    }
     setSidebarMode(mode)
-  }, [onBackFromEmbeddedSettings, onGalleryShellPageChange, setSidebarMode, showEmbeddedSettings, showGalleryShellPanel])
+  }, [setSidebarMode])
 
   const handleSettingsOpen = useCallback(() => {
     setSettingsOpen(true)

--- a/frontend/src/components/agentChat/ChatSidebar.tsx
+++ b/frontend/src/components/agentChat/ChatSidebar.tsx
@@ -817,12 +817,19 @@ export const ChatSidebar = memo(function ChatSidebar({
           ) : null}
 
           {showSettingsView ? (
-            <div className={`min-h-0 flex-1 overflow-y-auto${showDesktopSettingsView ? '' : ' hidden'}`}>
+            <div
+              className="min-h-0 flex-1 overflow-y-auto"
+              style={showDesktopSettingsView ? undefined : { display: 'none' }}
+            >
               {embeddedSettingsPanel}
             </div>
           ) : null}
           {!showSettingsView && showCustomGalleryShellPanel ? (
-            <div className={`agent-gallery-scroll${showDesktopGalleryShellPanel ? '' : ' hidden'}`} data-variant="sidebar">
+            <div
+              className="agent-gallery-scroll"
+              data-variant="sidebar"
+              style={showDesktopGalleryShellPanel ? undefined : { display: 'none' }}
+            >
               {galleryShellPanel}
             </div>
           ) : null}

--- a/frontend/src/components/agentChat/ChatSidebar.tsx
+++ b/frontend/src/components/agentChat/ChatSidebar.tsx
@@ -140,8 +140,10 @@ export const ChatSidebar = memo(function ChatSidebar({
   const showSettingsView = showEmbeddedSettings && Boolean(embeddedSettingsPanel)
   const showGalleryShellSwitcher = Boolean(onGalleryShellPageChange)
   const showCustomGalleryShellPanel = galleryShellPage !== 'agents' && Boolean(galleryShellPanel)
-  const collapsed = desktopMode === 'collapsed' && !showSettingsView
-  const galleryMode = desktopMode === 'gallery' || showSettingsView
+  const collapsed = desktopMode === 'collapsed'
+  const galleryMode = desktopMode === 'gallery'
+  const showDesktopSettingsView = galleryMode && showSettingsView
+  const showDesktopGalleryShellPanel = galleryMode && !showSettingsView && showCustomGalleryShellPanel
   const favoriteAgentIdSet = useMemo(() => new Set(favoriteAgentIds), [favoriteAgentIds])
   const mutedAgentIdSet = useMemo(() => new Set(mutedAgentIds), [mutedAgentIds])
   const hasFavoritesInRoster = useMemo(
@@ -197,19 +199,12 @@ export const ChatSidebar = memo(function ChatSidebar({
   }, [isMobile, showCustomGalleryShellPanel, galleryShellPage])
 
   const handleStepLeft = useCallback(() => {
-    if (showSettingsView) {
-      onDesktopModeChange?.('list')
-      return
-    }
     onDesktopModeChange?.(getPreviousAgentChatSidebarMode(desktopMode))
-  }, [desktopMode, onDesktopModeChange, showSettingsView])
+  }, [desktopMode, onDesktopModeChange])
 
   const handleStepRight = useCallback(() => {
-    if (showSettingsView) {
-      return
-    }
     onDesktopModeChange?.(getNextAgentChatSidebarMode(desktopMode))
-  }, [desktopMode, onDesktopModeChange, showSettingsView])
+  }, [desktopMode, onDesktopModeChange])
 
   const openMessageSearch = useCallback(() => {
     if (isMobile) {
@@ -770,7 +765,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                 <PanelLeftClose className="h-4 w-4" />
               </button>
             ) : null}
-            {!messageSearchOpen && !galleryMode && !showSettingsView ? (
+            {!messageSearchOpen && !galleryMode ? (
               <button
                 type="button"
                 className="chat-sidebar-toggle"
@@ -784,12 +779,13 @@ export const ChatSidebar = memo(function ChatSidebar({
           </div>
         </div>
 
-        {messageSearchOpen ? messageSearchPanel : <div className="chat-sidebar-section">
-          {showSettingsView ? (
+        {messageSearchOpen ? messageSearchPanel : null}
+        <div className={messageSearchOpen ? 'hidden' : 'chat-sidebar-section'}>
+          {showDesktopSettingsView ? (
             <div className="chat-sidebar-section-header">
               <span className="chat-sidebar-section-title">{embeddedSettingsTitle}</span>
             </div>
-          ) : showCustomGalleryShellPanel ? null : (
+          ) : showDesktopGalleryShellPanel ? null : (
             <div className="chat-sidebar-section-header">
               <span className="chat-sidebar-section-title">Agents</span>
               {!collapsed && hasAgents && !loading ? (
@@ -798,7 +794,7 @@ export const ChatSidebar = memo(function ChatSidebar({
             </div>
           )}
 
-          {!collapsed && !showSettingsView && !showCustomGalleryShellPanel ? (
+          {!collapsed && !showDesktopSettingsView && !showDesktopGalleryShellPanel ? (
             <div
               className="chat-sidebar-controls"
               data-gallery={galleryMode ? 'true' : 'false'}
@@ -821,41 +817,43 @@ export const ChatSidebar = memo(function ChatSidebar({
           ) : null}
 
           {showSettingsView ? (
-            <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className={`min-h-0 flex-1 overflow-y-auto${showDesktopSettingsView ? '' : ' hidden'}`}>
               {embeddedSettingsPanel}
             </div>
-          ) : showCustomGalleryShellPanel ? (
-            <div className="agent-gallery-scroll" data-variant="sidebar">
+          ) : null}
+          {!showSettingsView && showCustomGalleryShellPanel ? (
+            <div className={`agent-gallery-scroll${showDesktopGalleryShellPanel ? '' : ' hidden'}`} data-variant="sidebar">
               {galleryShellPanel}
             </div>
-          ) : galleryMode ? (
-            <ChatSidebarGallery
-              variant="sidebar"
-              agents={agents}
-              favoriteAgentIds={favoriteAgentIds}
-              activeAgentId={activeAgentId}
-              switchingAgentId={switchingAgentId}
-              hasAgents={hasAgents}
-              loading={loading}
-              errorMessage={errorMessage}
-              searchQuery=""
-              onSelectAgent={handleAgentSelect}
-              onConfigureAgent={onConfigureAgent}
-              onToggleAgentFavorite={onToggleAgentFavorite}
-              onCreateAgent={onCreateAgent ? handleCreateAgent : undefined}
-              createAgentButtonDisabled={createAgentButtonDisabled}
-              createAgentDisabled={createAgentDisabled}
-              createAgentDisabledReason={createAgentDisabledReason}
-              teamTemplateMenu={teamTemplateMenu}
-              scrollToAgentId={scrollToAgentId}
-              onScrolledToAgent={onScrolledToAgent}
-            />
-          ) : (
-            renderListContent('sidebar', collapsed)
-          )}
-        </div>}
+          ) : null}
+          {!showDesktopSettingsView && !showDesktopGalleryShellPanel ? (
+            galleryMode ? (
+              <ChatSidebarGallery
+                variant="sidebar"
+                agents={agents}
+                favoriteAgentIds={favoriteAgentIds}
+                activeAgentId={activeAgentId}
+                switchingAgentId={switchingAgentId}
+                hasAgents={hasAgents}
+                loading={loading}
+                errorMessage={errorMessage}
+                searchQuery=""
+                onSelectAgent={handleAgentSelect}
+                onConfigureAgent={onConfigureAgent}
+                onToggleAgentFavorite={onToggleAgentFavorite}
+                onCreateAgent={onCreateAgent ? handleCreateAgent : undefined}
+                createAgentButtonDisabled={createAgentButtonDisabled}
+                createAgentDisabled={createAgentDisabled}
+                createAgentDisabledReason={createAgentDisabledReason}
+                teamTemplateMenu={teamTemplateMenu}
+                scrollToAgentId={scrollToAgentId}
+                onScrolledToAgent={onScrolledToAgent}
+              />
+            ) : renderListContent('sidebar', collapsed)
+          ) : null}
+        </div>
 
-        {!messageSearchOpen && !showSettingsView && settings ? (
+        {!messageSearchOpen && !showDesktopSettingsView && settings ? (
           <SidebarSettingsMenu
             {...settings}
             variant="sidebar"

--- a/frontend/src/components/agentChat/tooling/toolRegistry.ts
+++ b/frontend/src/components/agentChat/tooling/toolRegistry.ts
@@ -31,7 +31,7 @@ function compareEntryOrder(left: ToolEntryDisplay, right: ToolEntryDisplay): num
 
 function toTitleCase(value: string): string {
   return value
-    .split(/[\s_\-]+/)
+    .split(/[\s_-]+/)
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ')
@@ -105,6 +105,9 @@ function deriveMcpInfo(toolName: string | null | undefined, rawResult: unknown):
 
 function descriptorFor(toolName: string | null | undefined): ToolDescriptor {
   const normalized = (toolName ?? '').toLowerCase()
+  if (normalized.startsWith('mcp_computer_')) {
+    return TOOL_DESCRIPTORS.get('mcp_computer')!
+  }
   return TOOL_DESCRIPTORS.get(normalized) || TOOL_DESCRIPTORS.get('default')!
 }
 

--- a/frontend/src/components/tooling/toolMetadata.ts
+++ b/frontend/src/components/tooling/toolMetadata.ts
@@ -28,6 +28,7 @@ import {
   BarChart3,
   Image as ImageIcon,
   Video,
+  Monitor,
   type LucideIcon,
 } from 'lucide-react'
 import { summarizeSchedule } from '../../util/schedule'
@@ -502,6 +503,23 @@ function deriveDiscordReaction(
 }
 
 export const TOOL_METADATA_CONFIGS: ToolMetadataConfig[] = [
+  {
+    name: 'mcp_computer',
+    label: 'Computer',
+    icon: Monitor,
+    iconBgClass: 'bg-indigo-100',
+    iconColorClass: 'text-indigo-700',
+    detailKind: 'default',
+    derive(entry) {
+      const action = (entry.toolName ?? '')
+        .replace(/^mcp_computer_/i, '')
+        .replace(/^[0-9a-f]{8}_/i, '')
+      return {
+        label: action ? titleCase(action) : 'Computer',
+        caption: 'Computer',
+      }
+    },
+  },
   {
     name: 'run_command',
     label: 'Run command',

--- a/frontend/src/hooks/useImmersiveShellBridge.ts
+++ b/frontend/src/hooks/useImmersiveShellBridge.ts
@@ -67,16 +67,14 @@ export function useImmersiveShellBridge({
       return
     }
     if (selectionPage !== 'agents') {
-      if (selectionSidebarMode !== 'gallery') {
-        dispatch(immersiveShellActions.setSidebarMode('gallery'))
-      }
+      dispatch(immersiveShellActions.setSidebarMode('gallery'))
       return
     }
     const storedSelectionMode = readSelectionSidebarModePreference()
-    if (storedSelectionMode && storedSelectionMode !== selectionSidebarMode) {
+    if (storedSelectionMode) {
       dispatch(immersiveShellActions.setSidebarMode(storedSelectionMode))
     }
-  }, [agentId, dispatch, selectionPage, selectionSidebarMode])
+  }, [agentId, dispatch, selectionPage])
 
   useEffect(() => {
     if (typeof window === 'undefined') {

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -2706,8 +2706,12 @@ export function AgentChatPage({
     trackSignupPreviewActionBlocked('collaborate', location)
   }, [trackSignupPreviewActionBlocked])
 
-  const navigateShellPath = useCallback((nextPath: string, nextAgentId?: string | null) => {
-    const nextUrl = `${nextPath}${window.location.search}${window.location.hash}`
+  const navigateShellPath = useCallback((
+    nextPath: string,
+    nextAgentId?: string | null,
+    nextSearch = window.location.search,
+  ) => {
+    const nextUrl = `${nextPath}${nextSearch}${window.location.hash}`
     setShellPathname(nextPath)
     if (typeof nextAgentId !== 'undefined' && nextAgentId !== activeAgentIdRef.current) {
       setSwitchingAgentId(null)
@@ -2727,7 +2731,11 @@ export function AgentChatPage({
       dispatch(immersiveShellActions.setSidebarMode('gallery'))
     }
     const nextPath = buildAgentChatShellPath(window.location.pathname, resolvedAgentId, subview)
-    navigateShellPath(nextPath, resolvedAgentId)
+    const nextSearchParams = new URLSearchParams(window.location.search)
+    nextSearchParams.delete('shell')
+    const nextSearchValue = nextSearchParams.toString()
+    const nextSearch = nextSearchValue ? `?${nextSearchValue}` : ''
+    navigateShellPath(nextPath, resolvedAgentId, nextSearch)
   }, [dispatch, navigateShellPath])
 
   const handleConfigureAgent = useCallback((agent: AgentRosterEntry) => {

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -1021,6 +1021,13 @@ export function AgentChatPage({
     setSwitchingAgentId,
     shellPathname,
   })
+  useEffect(() => {
+    if (shellSubview === 'chat') {
+      return
+    }
+    setMessageSearchState((current) => current.open ? { ...current, open: false } : current)
+    dispatch(immersiveShellActions.setSidebarMode('gallery'))
+  }, [dispatch, shellSubview])
   const [createOrganizationOpen, setCreateOrganizationOpen] = useState(false)
   const [createOrganizationName, setCreateOrganizationName] = useState('')
   const [createOrganizationBusy, setCreateOrganizationBusy] = useState(false)

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -2715,6 +2715,9 @@ export function AgentChatPage({
     if (!resolvedAgentId) {
       return
     }
+    if (subview !== 'chat') {
+      setMessageSearchState((current) => current.open ? { ...current, open: false } : current)
+    }
     dispatch(immersiveShellActions.setSidebarMode('gallery'))
     const nextPath = buildAgentChatShellPath(window.location.pathname, resolvedAgentId, subview)
     navigateShellPath(nextPath, resolvedAgentId)

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -4441,7 +4441,7 @@ export function AgentChatPage({
         </div>,
       )
     }
-    if (selectionPage !== 'agents') {
+    if (selectionPage !== 'agents' && selectionSidebarMode === 'gallery') {
       return renderSelectionLayout(
         selectionMainPanel ? (
           <div className="flex min-h-full w-full flex-1 md:hidden">

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -3559,11 +3559,8 @@ export function AgentChatPage({
     viewerEmail,
   ])
   const handleSelectionSidebarModeChange = useCallback((mode: 'collapsed' | 'list' | 'gallery') => {
-    if (selectionPage !== 'agents' && mode !== 'gallery' && onSelectionPageChange) {
-      onSelectionPageChange('agents')
-    }
     dispatch(immersiveShellActions.setSidebarMode(mode))
-  }, [dispatch, onSelectionPageChange, selectionPage])
+  }, [dispatch])
   const selectionSidebarProps: SelectionSidebarProps = {
     agents: sidebarAgents,
     agentInvites: rosterQuery.data?.agentInvites ?? [],

--- a/frontend/src/screens/AgentChatPage.tsx
+++ b/frontend/src/screens/AgentChatPage.tsx
@@ -2717,8 +2717,8 @@ export function AgentChatPage({
     }
     if (subview !== 'chat') {
       setMessageSearchState((current) => current.open ? { ...current, open: false } : current)
+      dispatch(immersiveShellActions.setSidebarMode('gallery'))
     }
-    dispatch(immersiveShellActions.setSidebarMode('gallery'))
     const nextPath = buildAgentChatShellPath(window.location.pathname, resolvedAgentId, subview)
     navigateShellPath(nextPath, resolvedAgentId)
   }, [dispatch, navigateShellPath])

--- a/frontend/src/styles/agentChatLegacy.css
+++ b/frontend/src/styles/agentChatLegacy.css
@@ -5614,7 +5614,7 @@
 }
 .chat-sidebar-header[data-has-center='true'] {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    grid-template-columns: auto minmax(0, 1fr) auto;
     column-gap: 0.75rem;
 }
 .chat-sidebar-header[data-collapsed='true'] {
@@ -6313,11 +6313,13 @@
     position: relative;
     display: flex;
     align-items: center;
+    min-width: 0;
 }
 .chat-context-switcher__trigger {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
+    min-width: 0;
     max-width: 11rem;
     padding: 0.35rem 0.55rem;
     border-radius: 0.65rem;
@@ -6348,8 +6350,10 @@
 .chat-context-switcher__chevron {
     width: 0.95rem;
     height: 0.95rem;
+    flex-shrink: 0;
 }
 .chat-context-switcher__label {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
## Summary

- Keep embedded settings and custom gallery panels scoped to gallery mode.
- Preserve sidebar navigation when switching between shell views.
- Add metadata support and action labels for computer MCP tools.
- Improve sidebar header and context-switcher sizing and truncation.

## Testing

Not run (not requested).