### PR TITLE
Improve mobile performance across chat and homepage experiences

### DIFF
--- a/frontend/src/components/agentChat/AgentComposer.tsx
+++ b/frontend/src/components/agentChat/AgentComposer.tsx
@@ -51,6 +51,7 @@ import { sanitizeHtml } from '../../util/sanitize'
 import { clearAgentChatMessageDraft, readAgentChatMessageDraft, writeAgentChatMessageDraft } from '../../util/agentChatDraftStorage'
 import type { LlmIntelligenceConfig } from '../../types/llmIntelligence'
 import { useModal } from '../../hooks/useModal'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import { AgentChatMenuItem } from './uiPrimitives'
 
 // Detect if user is on macOS
@@ -774,6 +775,7 @@ export const AgentComposer = memo(function AgentComposer({
   const [pendingQuestionsForceExpanded, setPendingQuestionsForceExpanded] = useState(hasPendingQuestions)
   const { isProprietaryMode } = useAppSelector(selectSubscriptionState)
   const [appsModal, showAppsModal] = useModal()
+  const isMobile = useIsMobile()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const composedShellRef = useCallback((node: HTMLDivElement | null) => {
     if (typeof externalShellRef === 'function') {
@@ -1171,8 +1173,7 @@ export const AgentComposer = memo(function AgentComposer({
       setCountdownProgress(progress)
     }
 
-    // Update every 100ms for smooth animation
-    countdownIntervalRef.current = setInterval(updateProgress, 100)
+    countdownIntervalRef.current = setInterval(updateProgress, isMobile ? 250 : 100)
     updateProgress()
 
     return () => {
@@ -1181,7 +1182,7 @@ export const AgentComposer = memo(function AgentComposer({
         countdownIntervalRef.current = null
       }
     }
-  }, [hasMultipleInsights, isInsightsPaused, isProcessing])
+  }, [hasMultipleInsights, isInsightsPaused, isMobile, isProcessing])
 
   useEffect(() => {
     if (!hasMultipleInsights || isInsightsPaused || !isProcessing) {

--- a/frontend/src/components/agentChat/StreamingReplyCard.tsx
+++ b/frontend/src/components/agentChat/StreamingReplyCard.tsx
@@ -4,6 +4,7 @@ import { MarkdownViewer } from '../common/MarkdownViewer'
 import { AgentAvatarBadge } from '../common/AgentAvatarBadge'
 import { looksLikeHtml, sanitizeHtml, stripBlockquoteQuotes } from '../../util/sanitize'
 import { useTypewriter } from '../../hooks/useTypewriter'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import { chatActions } from '../../store/chatSlice'
 import { useAppDispatch } from '../../store/hooks'
 import { repairIncompleteMarkdown, splitMarkdownBlocks } from './streamingMarkdownBlocks'
@@ -45,17 +46,19 @@ export function StreamingReplyCard({
   onLinkClick,
 }: StreamingReplyCardProps) {
   const dispatch = useAppDispatch()
+  const isMobile = useIsMobile()
 
   // One reveal path for every arrival pattern: providers may stream the body
   // incrementally or burst it whole at the end (tool-call arguments often arrive as one
   // chunk) — the typewriter decouples what the user sees from how the network delivered
   // it, and accelerates to finish once the stream is done.
-  // ~40fps reveal: every frame feeds the markdown renderer directly (no plain-text
+  // The reveal feeds the markdown renderer directly (no plain-text
   // tail — the in-flight text must LOOK like markdown), and block memoization bounds the
-  // per-frame parse to just the growing tail block.
+  // per-frame parse to just the growing tail block. Phones update less often but reveal
+  // more characters per pass to preserve throughput without reparsing at desktop cadence.
   const { displayedContent, isWaiting } = useTypewriter(content, isStreaming && !done, {
-    charsPerFrame: 6,
-    frameIntervalMs: 24,
+    charsPerFrame: isMobile ? 24 : 6,
+    frameIntervalMs: isMobile ? 100 : 24,
     waitingThresholdMs: 200,
     finishBoost: 4,
   })

--- a/frontend/src/components/agentChat/StreamingThinkingCard.tsx
+++ b/frontend/src/components/agentChat/StreamingThinkingCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useTypewriter } from '../../hooks/useTypewriter'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import { buildThinkingCluster } from './activityEntryUtils'
 import { ToolClusterCard } from './ToolClusterCard'
 
@@ -10,9 +11,10 @@ type StreamingThinkingCardProps = {
 }
 
 export function StreamingThinkingCard({ cursor, reasoning, isStreaming }: StreamingThinkingCardProps) {
+  const isMobile = useIsMobile()
   const { displayedContent } = useTypewriter(reasoning, isStreaming, {
-    charsPerFrame: 1,
-    frameIntervalMs: 18,
+    charsPerFrame: isMobile ? 6 : 1,
+    frameIntervalMs: isMobile ? 100 : 18,
     waitingThresholdMs: 120,
   })
   const cluster = useMemo(

--- a/frontend/src/screens/ImmersiveApp.tsx
+++ b/frontend/src/screens/ImmersiveApp.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Plus, Zap } from 'lucide-react'
 import type { ConsoleContext } from '../api/context'
 import { jsonFetch } from '../api/http'
 import { SubscriptionUpgradeModal } from '../components/common/SubscriptionUpgradeModal'
+import { ImmersivePageFrame } from '../components/common/ImmersivePageFrame'
 import type { SelectionShellPage } from '../components/agentChat/SelectionShellPageSwitcher'
 import { AnalyticsEvent } from '../constants/analyticsEvents'
 import { useAgentRoster } from '../hooks/useAgentRoster'
@@ -10,13 +11,11 @@ import { AgentChatPage } from './AgentChatPage'
 import { AgentCollaboratorInviteResponsePage } from './agentCollaborators/AgentCollaboratorInviteResponsePage'
 import { ImmersiveApiKeysPage } from './apiKeys/ImmersiveApiKeysPage'
 import { ImmersiveBillingPage } from './billing/ImmersiveBillingPage'
-import { ImmersiveMcpServersPage } from './integrations/ImmersiveMcpServersPage'
 import { ImmersiveOrganizationPage } from './organization/ImmersiveOrganizationPage'
 import { ImmersiveOutboxPage } from './outbox/ImmersiveOutboxPage'
 import { OrganizationInviteAcceptPage } from './organization/OrganizationInviteAcceptPage'
 import { ImmersiveProfilePage } from './profile/ImmersiveProfilePage'
 import { ImmersiveSecretsPage } from './secrets/ImmersiveSecretsPage'
-import { ImmersiveUsagePage } from './usage/ImmersiveUsagePage'
 import { ImmersivePetLayer } from '../components/pets/ImmersivePetLayer'
 import { ensureAuthenticated, selectSubscriptionState, subscriptionActions, type PlanTier } from '../store/subscriptionSlice'
 import { useAppDispatch, useAppSelector } from '../store/hooks'
@@ -31,6 +30,13 @@ const APP_BASE = '/app'
 const RETURN_TO_STORAGE_KEY = 'gobii:immersive:return_to'
 const DEFAULT_CLOSE_PATH = '/app/agents'
 const UPGRADE_MODAL_QUERY_PARAM = 'upgrade'
+
+const ImmersiveUsagePage = lazy(() => import('./usage/ImmersiveUsagePage').then((module) => ({
+  default: module.ImmersiveUsagePage,
+})))
+const ImmersiveMcpServersPage = lazy(() => import('./integrations/ImmersiveMcpServersPage').then((module) => ({
+  default: module.ImmersiveMcpServersPage,
+})))
 
 type AppRoute =
   | { kind: 'command-center' }
@@ -85,6 +91,20 @@ type AgentShellPageConfig = {
   render: (context: AgentShellPageRenderContext) => ReactNode
 }
 
+function LazyShellPage({ layout, children }: { layout: AgentShellLayout; children: ReactNode }) {
+  return (
+    <Suspense fallback={(
+      <ImmersivePageFrame layout={layout}>
+        <div className="flex min-h-[60vh] items-center justify-center">
+          <p className="text-sm font-medium text-slate-500">Loading workspace…</p>
+        </div>
+      </ImmersivePageFrame>
+    )}>
+      {children}
+    </Suspense>
+  )
+}
+
 const AGENT_SHELL_PRESERVED_QUERY_KEYS = [
   'embed',
   'return_to',
@@ -115,18 +135,24 @@ const AGENT_SHELL_PAGE_CONFIG: Record<AgentShellPage, AgentShellPageConfig> = {
   },
   usage: {
     path: '/app/usage',
-    render: ({ layout, refreshKey }) => <ImmersiveUsagePage layout={layout} refreshKey={refreshKey} />,
+    render: ({ layout, refreshKey }) => (
+      <LazyShellPage layout={layout}>
+        <ImmersiveUsagePage layout={layout} refreshKey={refreshKey} />
+      </LazyShellPage>
+    ),
   },
   integrations: {
     path: '/app/integrations',
     render: ({ layout, refreshKey, pipedreamAppsSettingsUrl, pipedreamAppSearchUrl, nativeIntegrationsUrl }) => (
-      <ImmersiveMcpServersPage
-        layout={layout}
-        refreshKey={refreshKey}
-        nativeIntegrationsUrl={nativeIntegrationsUrl}
-        pipedreamAppsUrl={pipedreamAppsSettingsUrl}
-        pipedreamAppSearchUrl={pipedreamAppSearchUrl}
-      />
+      <LazyShellPage layout={layout}>
+        <ImmersiveMcpServersPage
+          layout={layout}
+          refreshKey={refreshKey}
+          nativeIntegrationsUrl={nativeIntegrationsUrl}
+          pipedreamAppsUrl={pipedreamAppsSettingsUrl}
+          pipedreamAppSearchUrl={pipedreamAppSearchUrl}
+        />
+      </LazyShellPage>
     ),
   },
   'api-keys': {

--- a/pages/templates/home/_k_always_on.html
+++ b/pages/templates/home/_k_always_on.html
@@ -281,9 +281,9 @@
       if (!hub || !cards.length) return;
 
       function motionReduced() {
-        if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return true;
         var perf = window.GobiiHomePerf;
-        return false; /* phones animate too; genuine prefers-reduced-motion handled above */
+        if (perf && typeof perf.shouldReduceHomepageMotion === 'function' && perf.shouldReduceHomepageMotion()) return true;
+        return Boolean(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
       }
 
       /* restart .gkw-row arrivals inside `el`, staggered */

--- a/pages/templates/home/_k_night.html
+++ b/pages/templates/home/_k_night.html
@@ -416,12 +416,10 @@
     var ticks = [].slice.call(sec.querySelectorAll('.gk-nt-tick'));
     var tallies = [].slice.call(end.querySelectorAll('b[data-n]'));
 
-    /* These sections animate on phones too. GobiiHomePerf.shouldReduceHomepageMotion()
-       treats any coarse pointer or narrow screen as reduced motion, which predates this
-       redesign and would silently kill the story animations on every phone. They are
-       IntersectionObserver-gated, pause off-screen, and animate only opacity/transform,
-       so the cost is bounded. Genuine prefers-reduced-motion is still honoured. */
-    var reduced = (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) ||
+    var perf = window.GobiiHomePerf;
+    var reduced = (perf && typeof perf.shouldReduceHomepageMotion === 'function' &&
+                   perf.shouldReduceHomepageMotion()) ||
+                  (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) ||
                   /* the cinema layout stacks via display:contents; anything that can't do that
                      gets the static timeline, which is plain block flow. */
                   !(window.CSS && CSS.supports && CSS.supports('display', 'contents'));
@@ -585,10 +583,14 @@
       });
     }
 
+    if (reduced) {
+      staticFinish();
+      return;
+    }
+
     var booted = false;
     function boot() {
       booted = true;
-      if (reduced) { staticFinish(); return; }
       [].forEach.call(sec.querySelectorAll('b[data-n]'), function (el) { el.textContent = '0'; });
       show(0);
       start();

--- a/pages/templates/home/_k_platform.html
+++ b/pages/templates/home/_k_platform.html
@@ -36,8 +36,8 @@
                  background: linear-gradient(180deg, rgba(16,10,32,.95) 0%, rgba(16,10,32,.82) 58%,
                                              rgba(16,10,32,0) 100%); }
   .gk-pf-vhead b { color: #fff; font-size: clamp(12px,1.3vw,13.5px); font-weight: 600; }
-  .gk-pf-pulse { width: 7px; height: 7px; border-radius: 50%; background: #34d399; flex-shrink: 0;
-                 animation: gk-pf-pl 1.8s infinite; }
+  .gk-pf-pulse { width: 7px; height: 7px; border-radius: 50%; background: #34d399; flex-shrink: 0; }
+  .gk-pf-motion .gk-pf-pulse { animation: gk-pf-pl 1.8s infinite; }
   @keyframes gk-pf-pl { 50% { opacity: .28; } }
   .gk-pf-eg { font-size: 9.5px; font-weight: 700; letter-spacing: 1px; padding: 3px 9px; }
   .gk-pf-cnt { margin-left: auto; font-variant-numeric: tabular-nums; color: #fff; font-weight: 600;
@@ -50,16 +50,18 @@
                                                       rgba(76,29,149,.24) 100%); }
   .gk-pf-surf { position: absolute; left: 0; right: 0; top: -11px; height: 12px; overflow: hidden; }
   .gk-pf-surf svg { position: absolute; top: 0; left: 0; width: 200%; height: 100%; }
-  .gk-pf-surf .gk-pf-w1 { fill: rgba(167,139,250,.55); animation: gk-pf-drift 7s linear infinite; }
-  .gk-pf-surf .gk-pf-w2 { fill: rgba(196,181,253,.32); animation: gk-pf-drift 11s linear infinite reverse; }
+  .gk-pf-surf .gk-pf-w1 { fill: rgba(167,139,250,.55); }
+  .gk-pf-surf .gk-pf-w2 { fill: rgba(196,181,253,.32); }
+  .gk-pf-motion .gk-pf-surf .gk-pf-w1 { animation: gk-pf-drift 7s linear infinite; }
+  .gk-pf-motion .gk-pf-surf .gk-pf-w2 { animation: gk-pf-drift 11s linear infinite reverse; }
   @keyframes gk-pf-drift { to { transform: translateX(-50%); } }
   .gk-pf-meniscus { position: absolute; left: 0; right: 0; top: -1px; height: 2px;
                     background: linear-gradient(90deg, rgba(196,181,253,0), #c4b5fd 22%, #f0abfc 78%,
                                                 rgba(240,171,252,0));
                     box-shadow: 0 0 20px rgba(240,171,252,.75); }
   .gk-pf-bubbles { position: absolute; inset: 0; overflow: hidden; }
-  .gk-pf-bubbles i { position: absolute; bottom: -8px; border-radius: 50%; background: rgba(224,213,255,.34);
-                     animation: gk-pf-rise linear infinite; }
+  .gk-pf-bubbles i { position: absolute; bottom: -8px; border-radius: 50%; background: rgba(224,213,255,.34); }
+  .gk-pf-motion .gk-pf-bubbles i { animation: gk-pf-rise linear infinite; }
   @keyframes gk-pf-rise { 0% { transform: translateY(0) scale(.7); opacity: 0; }
                           12% { opacity: .8; } 100% { transform: translateY(-320px) scale(1.1); opacity: 0; } }
 
@@ -423,8 +425,9 @@
       rate.addEventListener('input', paintRoi);
 
       var perf = window.GobiiHomePerf;
-      var reduced = (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) ||
-                    false; /* see note above: phones animate too */
+      var reduced = (perf && typeof perf.shouldReduceHomepageMotion === 'function' &&
+                     perf.shouldReduceHomepageMotion()) ||
+                    (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
       if (reduced || typeof window.IntersectionObserver !== 'function' ||
           typeof window.requestAnimationFrame !== 'function') {
@@ -432,6 +435,7 @@
         return;
       }
 
+      vessel.classList.add('gk-pf-motion');
       paint(0); paintRoi();
 
       var running = false;

--- a/templates/includes/_unified_header_nav.html
+++ b/templates/includes/_unified_header_nav.html
@@ -52,6 +52,7 @@
             background: rgba(18,12,32,.97); border: 1px solid rgba(255,255,255,.12); border-radius: 16px;
             padding: 10px; box-shadow: 0 24px 60px rgba(0,0,0,.6); max-height: calc(100vh - 96px);
             overflow-y: auto; }
+  .gk-mobile-panel[hidden] { display: none; }
   .gk-mobile-panel a, .gk-mobile-panel button.gk-mm-link { display: block; width: 100%; text-align: left;
             color: rgba(255,255,255,.85); text-decoration: none; font-size: 14.5px; padding: 12px 14px;
             border-radius: 10px; background: none; border: 0; font-family: inherit; cursor: pointer; }
@@ -228,10 +229,10 @@
           </div>
         </div>
       {% endif %}
-      <button type="button" class="gk-burger"
-              x-data="{}"
-              @click="$dispatch('toggle-mobile-nav')"
-              aria-label="Toggle navigation">☰</button>
+      <button type="button" class="gk-burger" id="gk-mobile-nav-toggle"
+              aria-label="Toggle navigation"
+              aria-controls="gk-mobile-nav-panel"
+              aria-expanded="false">☰</button>
     </nav>
   </div>
 </header>
@@ -274,27 +275,8 @@
 </script>
 
 <!-- Mobile Navigation Panel -->
-<div x-data="{ showMobileNav: false }"
-     @toggle-mobile-nav.window="showMobileNav = !showMobileNav"
-     @keydown.escape.window="showMobileNav = false"
-     @pagehide.window="showMobileNav = false"
-     @htmx:before-history-save.window="showMobileNav = false"
-     @htmx:before-request.window="showMobileNav = false"
-     @pageshow.window="if (event.persisted) { showMobileNav = false }"
-     @visibilitychange.window="if (document.visibilityState === 'hidden') { showMobileNav = false }"
-     @freeze.window="showMobileNav = false"
-     @close-mobile-nav.window="showMobileNav = false"
-     class="relative z-50">
-  <div x-show="showMobileNav"
-       x-transition:enter="ease-out duration-200"
-       x-transition:enter-start="opacity-0 -translate-y-2"
-       x-transition:enter-end="opacity-100 translate-y-0"
-       x-transition:leave="ease-in duration-150"
-       x-transition:leave-start="opacity-100 translate-y-0"
-       x-transition:leave-end="opacity-0 -translate-y-2"
-       @click.outside="showMobileNav = false"
-       class="gk-mobile-panel"
-       x-cloak>
+<div class="relative z-50">
+  <div class="gk-mobile-panel" id="gk-mobile-nav-panel" hidden>
     {% if settings.GOBII_PROPRIETARY_MODE %}
       <a href="{% url 'pages:library' %}">Agent library</a>
       <a class="gk-mm-sub" href="{% url 'pages:solution' slug='recruiting' %}">Recruiting</a>
@@ -326,3 +308,34 @@
     {% endif %}
   </div>
 </div>
+
+<script>
+(function(){
+  var toggle = document.getElementById('gk-mobile-nav-toggle');
+  var panel = document.getElementById('gk-mobile-nav-panel');
+  if (!toggle || !panel) return;
+
+  function isOpen(){ return !panel.hidden; }
+  function setOpen(open){
+    panel.hidden = !open;
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  }
+  function close(){ setOpen(false); }
+
+  toggle.addEventListener('click', function(){ setOpen(!isOpen()); });
+  panel.addEventListener('click', function(event){
+    if (event.target instanceof Element && event.target.closest('a, button')) close();
+  });
+  document.addEventListener('click', function(event){
+    if (isOpen() && !panel.contains(event.target) && !toggle.contains(event.target)) close();
+  });
+  document.addEventListener('keydown', function(event){
+    if (event.key === 'Escape' && isOpen()) {
+      close();
+      toggle.focus();
+    }
+  });
+  document.addEventListener('close-mobile-nav', close);
+  window.addEventListener('pageshow', function(event){ if (event.persisted) close(); });
+})();
+</script>

--- a/tests/unit/test_pages.py
+++ b/tests/unit/test_pages.py
@@ -709,6 +709,35 @@ class HomePageTests(TestCase):
         self.assertIn("initScrollAnimations();", content)
         self.assertIn("@media (pointer: coarse), (max-width: 767px)", content)
 
+    @override_settings(GOBII_PROPRIETARY_MODE=True)
+    def test_modern_homepage_story_sections_use_perf_motion_reduction(self):
+        with override_switch("homepage_perf_motion_reduction", active=True):
+            response = self.client.get("/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["home_use_k"])
+        content = response.content.decode("utf-8")
+        self.assertGreaterEqual(content.count("perf.shouldReduceHomepageMotion()"), 3)
+        self.assertIn("vessel.classList.add('gk-pf-motion')", content)
+        self.assertIn("root.classList.add('gk-ao-static')", content)
+
+    def test_home_page_mobile_navigation_uses_native_controller(self):
+        response = self.client.get("/")
+
+        self.assertEqual(response.status_code, 200)
+        soup = BeautifulSoup(response.content, "html.parser")
+        toggle = soup.find(id="gk-mobile-nav-toggle")
+        panel = soup.find(id="gk-mobile-nav-panel")
+        self.assertIsNotNone(toggle)
+        self.assertIsNotNone(panel)
+        self.assertEqual(toggle.get("aria-controls"), "gk-mobile-nav-panel")
+        self.assertEqual(toggle.get("aria-expanded"), "false")
+        self.assertTrue(panel.has_attr("hidden"))
+
+        content = response.content.decode("utf-8")
+        self.assertNotIn("toggle-mobile-nav", content)
+        self.assertIn("document.addEventListener('close-mobile-nav', close)", content)
+
     def test_home_page_omits_perf_motion_reduction_when_switch_is_off(self):
         with override_switch("homepage_perf_motion_reduction", active=False):
             response = self.client.get("/")


### PR DESCRIPTION
## Summary

- Reduce mobile rendering and timer frequency for streaming chat replies, thinking cards, and insight countdowns.
- Lazy-load usage and integrations pages to reduce the initial immersive app bundle.
- Make homepage motion reduction performance-aware while preserving accessibility preferences.
- Replace Alpine-powered mobile navigation with a lightweight native controller and add accessibility state attributes.
- Add homepage tests covering motion reduction and mobile navigation behavior.

## Testing

- Added and updated Django unit tests for homepage motion handling and mobile navigation markup/controller behavior.
- Not run (not requested)