### PR TITLE
Preserve compute tools and successful batches after runtime errors

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -151,6 +151,8 @@ from ..tools.request_human_input import execute_request_human_input
 from ..tools.search_tools import execute_search_tools
 from ..tools.tool_manager import (
     BUILTIN_TOOL_REGISTRY,
+    PYTHON_EXEC_TOOL_NAME,
+    RUN_COMMAND_TOOL_NAME,
     ToolCatalogEntry,
     auto_enable_heuristic_tools,
     execute_enabled_tool,
@@ -237,6 +239,7 @@ def _coerce_loop_iteration_limit(value: int | None) -> int:
 TOOL_ERROR_TYPE_MAX_BYTES = 120
 PREFERRED_PROVIDER_MAX_AGE = timedelta(hours=1)
 MESSAGE_TOOL_NAMES = set(CREDIT_MESSAGE_TOOL_NAMES) | {"send_discord_message"}
+NON_FILTERABLE_TOOL_NAMES = frozenset({PYTHON_EXEC_TOOL_NAME, RUN_COMMAND_TOOL_NAME})
 MESSAGE_SUCCESS_STATUSES = {"ok", "queued", "sent", "success"}
 MESSAGE_TOOL_BODY_KEYS = {
     "send_email": "mobile_first_html",
@@ -1723,12 +1726,18 @@ def _filter_tools_after_non_retryable_result(
         return tools
 
     if payload.get(TERMINAL_ERROR_FLAG) is True:
-        allowed = MESSAGE_TOOL_NAMES | {"request_human_input", "sleep_until_next_trigger"}
+        allowed = MESSAGE_TOOL_NAMES | {
+            "request_human_input",
+            "sleep_until_next_trigger",
+            *NON_FILTERABLE_TOOL_NAMES,
+        }
         return [
             tool
             for tool in tools
             if tool.get("function", {}).get("name") in allowed
         ]
+    if tool_name in NON_FILTERABLE_TOOL_NAMES:
+        return tools
     return [
         tool
         for tool in tools

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -644,6 +644,21 @@ def _tool_result_status_is_ok(result: object) -> bool:
     return isinstance(payload, dict) and str(payload.get("status") or "").casefold() == "ok"
 
 
+def _tool_result_completed_successfully(tool_status: object, result: object) -> bool:
+    if str(tool_status or "").strip().casefold() != PersistentAgentToolCall.Status.COMPLETE:
+        return False
+    try:
+        payload = result if isinstance(result, dict) else json.loads(str(result or ""))
+    except (TypeError, ValueError):
+        return True
+    if not isinstance(payload, dict):
+        return True
+    result_status = str(payload.get("status") or "").strip().casefold()
+    if not result_status:
+        return True
+    return result_status in {"ok", "success", "complete", "completed"}
+
+
 def _source_url_from_tool_params(
     agent: PersistentAgent,
     tool_name: str,
@@ -749,6 +764,7 @@ def _build_browser_task_tool_result_record(
         result_text=json.dumps(normalized_payload, ensure_ascii=False),
         result_id=str(task.id),
         source_batch_id=str(task.id),
+        succeeded=task.status == BrowserUseAgentTask.StatusChoices.COMPLETED,
     )
 
 
@@ -772,6 +788,7 @@ def _build_mcp_task_tool_result_record(task: PersistentAgentMCPTask) -> ToolCall
         result_text=json.dumps(payload, ensure_ascii=False),
         result_id=str(task.id),
         source_batch_id=str(task.id),
+        succeeded=task.status == PersistentAgentMCPTask.Status.COMPLETED,
     )
 
 
@@ -5209,6 +5226,10 @@ def _get_unified_history_prompt(
                         else None
                     ),
                     source_bearing=source_bearing,
+                    succeeded=_tool_result_completed_successfully(
+                        row.get("status"),
+                        result_text,
+                    ),
                 )
             )
         missing_parent_ids = set(tool_call_parent_ids.values()) - {record.step_id for record in tool_call_records}
@@ -5261,6 +5282,10 @@ def _get_unified_history_prompt(
                             else None
                         ),
                         source_bearing=source_bearing,
+                        succeeded=_tool_result_completed_successfully(
+                            row.get("status"),
+                            result_text,
+                        ),
                     )
                 )
         if tool_call_records:

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -5242,6 +5242,7 @@ def _get_unified_history_prompt(
                     "result",
                     "tool_name",
                     "tool_params",
+                    "status",
                     "step__created_at",
                     "step__completion_id",
                 )

--- a/api/agent/core/tests/test_event_processing.py
+++ b/api/agent/core/tests/test_event_processing.py
@@ -88,6 +88,8 @@ class NonRetryableToolAvailabilityTests(SimpleTestCase):
     tools = [
         {"type": "function", "function": {"name": "mcp_vendor_search"}},
         {"type": "function", "function": {"name": "http_request"}},
+        {"type": "function", "function": {"name": "run_command"}},
+        {"type": "function", "function": {"name": "python_exec"}},
         {"type": "function", "function": {"name": "send_chat_message"}},
         {"type": "function", "function": {"name": "sleep_until_next_trigger"}},
     ]
@@ -101,8 +103,25 @@ class NonRetryableToolAvailabilityTests(SimpleTestCase):
 
         self.assertEqual(
             _tool_names(filtered),
-            {"http_request", "send_chat_message", "sleep_until_next_trigger"},
+            {
+                "http_request",
+                "run_command",
+                "python_exec",
+                "send_chat_message",
+                "sleep_until_next_trigger",
+            },
         )
+
+    def test_non_retryable_result_keeps_compute_tools_available(self):
+        for tool_name in ("run_command", "python_exec"):
+            with self.subTest(tool_name=tool_name):
+                filtered = _filter_tools_after_non_retryable_result(
+                    self.tools,
+                    tool_name,
+                    {"status": "error", "retryable": False},
+                )
+
+                self.assertEqual(filtered, self.tools)
 
     def test_terminal_result_leaves_only_delivery_and_stop_tools(self):
         filtered = _filter_tools_after_non_retryable_result(
@@ -113,8 +132,36 @@ class NonRetryableToolAvailabilityTests(SimpleTestCase):
 
         self.assertEqual(
             _tool_names(filtered),
-            {"send_chat_message", "sleep_until_next_trigger"},
+            {
+                "run_command",
+                "python_exec",
+                "send_chat_message",
+                "sleep_until_next_trigger",
+            },
         )
+
+    def test_terminal_compute_result_keeps_compute_tools_available(self):
+        for tool_name in ("run_command", "python_exec"):
+            with self.subTest(tool_name=tool_name):
+                filtered = _filter_tools_after_non_retryable_result(
+                    self.tools,
+                    tool_name,
+                    {
+                        "status": "error",
+                        "retryable": False,
+                        "terminal_error": True,
+                    },
+                )
+
+                self.assertEqual(
+                    _tool_names(filtered),
+                    {
+                        "run_command",
+                        "python_exec",
+                        "send_chat_message",
+                        "sleep_until_next_trigger",
+                    },
+                )
 
     def test_success_result_with_irrelevant_retryable_field_keeps_tools(self):
         filtered = _filter_tools_after_non_retryable_result(
@@ -333,8 +380,105 @@ class NonRetryableToolAvailabilityTests(SimpleTestCase):
                 )
                 self.assertEqual(
                     _tool_names(executed.tools),
-                    {"send_chat_message", "sleep_until_next_trigger"},
+                    {
+                        "run_command",
+                        "python_exec",
+                        "send_chat_message",
+                        "sleep_until_next_trigger",
+                    },
                 )
+
+    def test_same_batch_terminal_result_allows_pending_compute_siblings(self):
+        def prepared(idx, tool_name):
+            return _PreparedToolExecution(
+                idx=idx,
+                tool_name=tool_name,
+                tool_params={},
+                exec_params={},
+                pending_step=None,
+                credits_consumed=None,
+                consumed_credit=None,
+                call_id=f"call_{idx}",
+                explicit_continue=None,
+                inferred_continue=False,
+                parallel_safe=False,
+                parallel_ineligible_reason="unsafe",
+            )
+
+        source = prepared(1, "mcp_vendor_search")
+        command = prepared(2, "run_command")
+        python = prepared(3, "python_exec")
+        outcomes = [
+            _ToolExecutionOutcome(
+                prepared=source,
+                result={
+                    "status": "error",
+                    "retryable": False,
+                    "terminal_error": True,
+                },
+                duration_ms=1,
+                updated_tools=None,
+                variable_map={},
+            ),
+            _ToolExecutionOutcome(
+                prepared=command,
+                result={"status": "ok"},
+                duration_ms=1,
+                updated_tools=None,
+                variable_map={},
+            ),
+            _ToolExecutionOutcome(
+                prepared=python,
+                result={"status": "ok"},
+                duration_ms=1,
+                updated_tools=None,
+                variable_map={},
+            ),
+        ]
+        batch = _PreparedToolBatch(
+            prepared_calls=[source, command, python],
+            followup_required=False,
+            all_calls_sleep=False,
+            abort_after_execution=False,
+            parallel_ineligible_reason="unsafe",
+        )
+        agent = SimpleNamespace(id=uuid4(), refresh_from_db=lambda **_kwargs: None)
+
+        with (
+            patch(
+                "api.agent.core.event_processing._execute_prepared_tool_call",
+                side_effect=outcomes,
+            ) as execute,
+            patch("api.agent.core.event_processing._persist_tool_execution_outcome"),
+            patch("api.agent.core.event_processing._mark_prepared_tool_started"),
+            patch(
+                "api.agent.core.event_processing._should_abort_processing",
+                return_value=False,
+            ),
+        ):
+            executed = _execute_prepared_tool_batch_inner(
+                agent,
+                batch,
+                budget_ctx=None,
+                eval_run_id=None,
+                tools=self.tools,
+                heartbeat=None,
+                lock_extender=None,
+            )
+
+        self.assertEqual(
+            [call.args[1].tool_name for call in execute.call_args_list],
+            ["mcp_vendor_search", "run_command", "python_exec"],
+        )
+        self.assertEqual(
+            _tool_names(executed.tools),
+            {
+                "run_command",
+                "python_exec",
+                "send_chat_message",
+                "sleep_until_next_trigger",
+            },
+        )
 
 
 @tag('batch_event_processing')

--- a/api/agent/core/tests/test_link_references.py
+++ b/api/agent/core/tests/test_link_references.py
@@ -745,6 +745,30 @@ class LinkReferenceTests(TestCase):
         self.assertIn("do not call this tool again", prompt_info.meta)
         self.assertIn('"retryable":false', prompt_info.preview_text)
 
+    def test_non_retryable_compute_error_omits_terminal_result_contract(self):
+        for tool_name in ("run_command", "python_exec"):
+            with self.subTest(tool_name=tool_name):
+                record = ToolCallResultRecord(
+                    step_id=f"{tool_name}-failure",
+                    tool_name=tool_name,
+                    created_at=datetime.now(timezone.utc),
+                    result_text=json.dumps({
+                        "status": "error",
+                        "message": "The submitted code failed.",
+                        "retryable": False,
+                    }),
+                    succeeded=False,
+                )
+
+                prompt_info = prepare_tool_results_for_prompt(
+                    [record],
+                    recency_positions={record.step_id: 0},
+                    fresh_tool_call_step_ids={record.step_id},
+                )[record.step_id]
+
+                self.assertNotIn("TERMINAL RESULT (`retryable=false`)", prompt_info.meta)
+                self.assertNotIn("do not call this tool again", prompt_info.meta)
+
     def test_source_result_preview_pairs_raw_url_with_reference_without_mutating_result(self):
         url = "https://profiles.example.test/avery?view=full#bio"
         raw_result = f'{{"results":[{{"name":"Avery Chen","profile_url":"{url}"}}]}}'

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -516,7 +516,10 @@ def prepare_tool_results_for_prompt(
         is_current_source_batch = (
             current_source_batch_id is not None
             and record.succeeded
-            and source_batch_id == current_source_batch_id
+            and (
+                record.source_batch_id is None
+                or source_batch_id == current_source_batch_id
+            )
         )
 
         context_hint = None

--- a/api/agent/core/tool_results.py
+++ b/api/agent/core/tool_results.py
@@ -8,7 +8,7 @@ from typing import Callable, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 from ..tools.context_hints import URL_FIELD_PRIORITY, extract_context_hint, hint_from_unstructured_text
 from ..tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
 from ..tools.sqlite_state import TOOL_RESULTS_TABLE, get_sqlite_db_path
-from ..tools.tool_manager import SQLITE_TOOL_NAME
+from ..tools.tool_manager import PYTHON_EXEC_TOOL_NAME, RUN_COMMAND_TOOL_NAME, SQLITE_TOOL_NAME
 from .link_references import is_source_bearing_tool
 from .result_analysis import ResultAnalysis, analyze_result, analysis_to_dict, _get_json_type, _safe_json_path
 
@@ -46,6 +46,7 @@ MAX_TOOL_RESULT_BYTES = 5_000_000
 MAX_TOP_KEYS = 20
 
 EXCLUDED_TOOL_NAMES = {SQLITE_TOOL_NAME, "sqlite_query"}
+COMPUTE_SOURCE_TOOL_NAMES = frozenset({PYTHON_EXEC_TOOL_NAME, RUN_COMMAND_TOOL_NAME})
 SPAWN_WEB_TASK_RESULT_TOOL_NAME = "spawn_web_task_result"
 
 SCHEMA_ELIGIBLE_TOOL_PREFIXES = ("http_request", "mcp_")
@@ -174,6 +175,7 @@ class ToolCallResultRecord:
     source_url: Optional[str] = None
     will_continue_work: Optional[bool] = None
     source_bearing: Optional[bool] = None
+    succeeded: bool = True
 
 
 @dataclass(frozen=True)
@@ -188,6 +190,10 @@ class ToolResultPromptInfo:
 
 def _record_is_source_bearing(record: ToolCallResultRecord) -> bool:
     return is_source_bearing_tool(record.tool_name) and record.source_bearing is not False
+
+
+def _record_is_batch_eligible(record: ToolCallResultRecord) -> bool:
+    return _record_is_source_bearing(record) or record.tool_name in COMPUTE_SOURCE_TOOL_NAMES
 
 
 def entity_name_stem(value: str) -> str:
@@ -451,7 +457,7 @@ def prepare_tool_results_for_prompt(
     source_records = [
         record
         for record in records
-        if _record_is_source_bearing(record)
+        if _record_is_batch_eligible(record) and record.succeeded
     ]
     current_source_record = (
         max(source_records, key=lambda record: record.created_at)
@@ -471,6 +477,7 @@ def prepare_tool_results_for_prompt(
         if (
             not record.result_text
             or not _record_is_source_bearing(record)
+            or not record.succeeded
             or (
                 record.source_batch_id is not None
                 and record.tool_name == current_source_tool_name
@@ -507,8 +514,9 @@ def prepare_tool_results_for_prompt(
         recency_position = recency_positions.get(record.step_id)
         is_fresh_tool_call = record.step_id in fresh_step_ids
         is_current_source_batch = (
-            record.source_batch_id is None
-            or source_batch_id == current_source_batch_id
+            current_source_batch_id is not None
+            and record.succeeded
+            and source_batch_id == current_source_batch_id
         )
 
         context_hint = None
@@ -743,7 +751,7 @@ def prepare_tool_results_for_prompt(
             allow_fallback_query_hints=not is_scrape_markdown and not is_historical_same_tool_source,
             include_result_id=not hide_literal_result_id and not is_historical_same_tool_source,
         )
-        terminal_directive = _terminal_result_directive(result_text)
+        terminal_directive = _terminal_result_directive(result_text, record.tool_name)
         if terminal_directive:
             meta_text += f"\n{terminal_directive}"
         if record.tool_name == "sqlite_batch" and sqlite_result_has_query_result(result_text):
@@ -1367,7 +1375,9 @@ def sqlite_result_has_query_result(result_text: str) -> bool:
     )
 
 
-def _terminal_result_directive(result_text: str) -> str:
+def _terminal_result_directive(result_text: str, tool_name: str) -> str:
+    if tool_name in COMPUTE_SOURCE_TOOL_NAMES:
+        return ""
     try:
         payload = json.loads(result_text)
     except (json.JSONDecodeError, TypeError):

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2808,6 +2808,59 @@ class PromptContextBuilderTests(TestCase):
             ],
         )
 
+    def test_failed_python_result_preserves_latest_successful_compute_batch(self):
+        sqlite_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(sqlite_tmp.cleanup)
+        db_path = f"{sqlite_tmp.name}/state.db"
+        token = set_sqlite_db_path(db_path)
+        self.addCleanup(reset_sqlite_db_path, token)
+
+        successful_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="successful analytics query",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=successful_step,
+            tool_name="python_exec",
+            tool_params={"code": "rows = query_analytics()"},
+            result=json.dumps({
+                "status": "success",
+                "rows": [{"account_id": "acct-1", "revenue": 125}],
+            }),
+            status=PersistentAgentToolCall.Status.COMPLETE,
+        )
+
+        failed_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="failed analytics query",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=failed_step,
+            tool_name="python_exec",
+            tool_params={"code": "rows = query_missing_column()"},
+            result=json.dumps({
+                "status": "error",
+                "message": "column does not exist",
+            }),
+            status=PersistentAgentToolCall.Status.COMPLETE,
+        )
+
+        with patch("api.agent.core.prompt_context.enqueue_history_compaction"):
+            build_prompt_context(self.agent)
+
+        with sqlite3.connect(db_path) as conn:
+            current_batches = conn.execute(
+                "SELECT result_id, is_current_batch FROM __tool_results "
+                "WHERE tool_name = 'python_exec' ORDER BY created_at"
+            ).fetchall()
+        self.assertEqual(
+            current_batches,
+            [
+                (str(successful_step.id)[:6], 1),
+                (str(failed_step.id)[:6], 0),
+            ],
+        )
+
     def test_tool_call_history_includes_cost_component(self):
         """Tool-call unified history should include a dedicated <cost> component."""
         with patch(

--- a/tests/unit/test_event_processing.py
+++ b/tests/unit/test_event_processing.py
@@ -2929,6 +2929,56 @@ class PromptContextBuilderTests(TestCase):
         )
         self.assertNotIn(f"<parent_result_id>{parent_tool_call.pk}</parent_result_id>", content)
 
+    def test_backfilled_parent_tool_call_uses_persisted_success_status(self):
+        sqlite_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(sqlite_tmp.cleanup)
+        db_path = f"{sqlite_tmp.name}/state.db"
+        token = set_sqlite_db_path(db_path)
+        self.addCleanup(reset_sqlite_db_path, token)
+
+        parent_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="successful parent compute call",
+        )
+        parent_tool_call = PersistentAgentToolCall.objects.create(
+            step=parent_step,
+            tool_name="python_exec",
+            tool_params={"code": "load_accounts()"},
+            result=json.dumps({
+                "status": "success",
+                "rows": [{"account_id": "acct-1"}],
+            }),
+            status=PersistentAgentToolCall.Status.COMPLETE,
+        )
+        child_step = PersistentAgentStep.objects.create(
+            agent=self.agent,
+            description="child delivery call",
+        )
+        PersistentAgentToolCall.objects.create(
+            step=child_step,
+            parent_tool_call=parent_tool_call,
+            tool_name="send_email",
+            tool_params={"to": "person@example.com"},
+            result=json.dumps({"status": "sent"}),
+            status=PersistentAgentToolCall.Status.COMPLETE,
+        )
+
+        with (
+            patch(
+                "api.agent.core.prompt_context._get_recent_prompt_history_steps",
+                return_value=[child_step],
+            ),
+            patch("api.agent.core.prompt_context.enqueue_history_compaction"),
+        ):
+            build_prompt_context(self.agent)
+
+        with sqlite3.connect(db_path) as conn:
+            parent_batch = conn.execute(
+                "SELECT result_id, is_current_batch FROM __tool_results "
+                "WHERE tool_name = 'python_exec'"
+            ).fetchone()
+        self.assertEqual(parent_batch, (str(parent_step.id)[:6], 1))
+
     def test_tool_result_lookup_components_are_non_shrinkable_in_promptree(self):
         from api.agent.core import promptree
 

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -21,6 +21,46 @@ from api.models import (
 
 @tag("batch_promptree")
 class PromptContextSqliteGuidanceTests(SimpleTestCase):
+    def test_tool_result_success_requires_completed_call_and_successful_payload(self):
+        successful_payloads = (
+            '{"status": "ok"}',
+            '{"status": "success"}',
+            '{"status": "complete"}',
+            '{"status": "completed"}',
+            '{"legacy": true}',
+            "legacy plain text",
+        )
+        for payload in successful_payloads:
+            with self.subTest(payload=payload):
+                self.assertTrue(
+                    prompt_context._tool_result_completed_successfully(
+                        "complete",
+                        payload,
+                    )
+                )
+
+        unsuccessful_payloads = (
+            '{"status": "error"}',
+            '{"status": "failed"}',
+            '{"status": "blocked"}',
+            '{"status": "action_required"}',
+        )
+        for payload in unsuccessful_payloads:
+            with self.subTest(payload=payload):
+                self.assertFalse(
+                    prompt_context._tool_result_completed_successfully(
+                        "complete",
+                        payload,
+                    )
+                )
+
+        self.assertFalse(
+            prompt_context._tool_result_completed_successfully(
+                "error",
+                '{"status": "ok"}',
+            )
+        )
+
     def test_successful_terminal_sqlite_result_suppresses_immediate_model_guidance(self):
         started_at = datetime(2026, 8, 3, 1, 0, tzinfo=timezone.utc)
         inbound = SimpleNamespace(timestamp=started_at)

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -67,6 +67,175 @@ class ToolResultSchemaTests(SimpleTestCase):
             ),
         )
 
+    def test_failed_result_does_not_replace_last_successful_compute_batch(self):
+        records = [
+            tool_results.ToolCallResultRecord(
+                step_id="python-success",
+                tool_name="python_exec",
+                created_at=datetime(2026, 8, 11, 0, 5, tzinfo=timezone.utc),
+                result_text=json.dumps({"status": "ok", "stdout": [{"screened": 219}]}),
+                source_batch_id="successful-scan",
+                succeeded=True,
+            ),
+            tool_results.ToolCallResultRecord(
+                step_id="python-failure",
+                tool_name="python_exec",
+                created_at=datetime(2026, 8, 11, 0, 6, tzinfo=timezone.utc),
+                result_text=json.dumps({
+                    "status": "error",
+                    "message": "HTTP Error 400",
+                    "retryable": False,
+                }),
+                source_batch_id="failed-detail-query",
+                succeeded=False,
+            ),
+            tool_results.ToolCallResultRecord(
+                step_id="http-action-required",
+                tool_name="http_request",
+                created_at=datetime(2026, 8, 11, 0, 7, tzinfo=timezone.utc),
+                result_text=json.dumps({
+                    "status": "action_required",
+                    "message": "Authorization required",
+                }),
+                source_batch_id="blocked-connector",
+                succeeded=False,
+            ),
+            tool_results.ToolCallResultRecord(
+                step_id="http-failure",
+                tool_name="http_request",
+                created_at=datetime(2026, 8, 11, 0, 8, tzinfo=timezone.utc),
+                result_text=json.dumps({
+                    "status": "error",
+                    "message": "upstream request failed",
+                }),
+                source_batch_id="failed-http",
+                succeeded=False,
+            ),
+            tool_results.ToolCallResultRecord(
+                step_id="mcp-failure",
+                tool_name="mcp_vendor_search",
+                created_at=datetime(2026, 8, 11, 0, 9, tzinfo=timezone.utc),
+                result_text=json.dumps({
+                    "status": "failed",
+                    "message": "remote task failed",
+                }),
+                source_batch_id="failed-mcp",
+                succeeded=False,
+            ),
+        ]
+
+        with tempfile.NamedTemporaryFile(suffix=".sqlite3") as db_file:
+            token = set_sqlite_db_path(db_file.name)
+            try:
+                tool_results.prepare_tool_results_for_prompt(
+                    records,
+                    recency_positions={},
+                )
+            finally:
+                reset_sqlite_db_path(token)
+
+            with sqlite3.connect(db_file.name) as conn:
+                current_batches = conn.execute(
+                    "SELECT result_id, is_current_batch FROM __tool_results ORDER BY created_at"
+                ).fetchall()
+
+        self.assertEqual(
+            current_batches,
+            [
+                ("python-success", 1),
+                ("python-failure", 0),
+                ("http-action-required", 0),
+                ("http-failure", 0),
+                ("mcp-failure", 0),
+            ],
+        )
+
+    def test_new_successful_batch_replaces_previous_batch_and_keeps_siblings(self):
+        records = [
+            tool_results.ToolCallResultRecord(
+                step_id="old-source",
+                tool_name="http_request",
+                created_at=datetime(2026, 8, 11, 0, 1, tzinfo=timezone.utc),
+                result_text=json.dumps({"status": "ok", "result": [{"id": "old"}]}),
+                source_batch_id="old-batch",
+            ),
+            tool_results.ToolCallResultRecord(
+                step_id="new-source-a",
+                tool_name="http_request",
+                created_at=datetime(2026, 8, 11, 0, 2, tzinfo=timezone.utc),
+                result_text=json.dumps({"status": "success", "result": [{"id": "a"}]}),
+                source_batch_id="new-batch",
+            ),
+            tool_results.ToolCallResultRecord(
+                step_id="new-source-b",
+                tool_name="mcp_vendor_search",
+                created_at=datetime(2026, 8, 11, 0, 3, tzinfo=timezone.utc),
+                result_text=json.dumps({"status": "complete", "result": [{"id": "b"}]}),
+                source_batch_id="new-batch",
+            ),
+        ]
+
+        with tempfile.NamedTemporaryFile(suffix=".sqlite3") as db_file:
+            token = set_sqlite_db_path(db_file.name)
+            try:
+                tool_results.prepare_tool_results_for_prompt(
+                    records,
+                    recency_positions={},
+                )
+            finally:
+                reset_sqlite_db_path(token)
+
+            with sqlite3.connect(db_file.name) as conn:
+                current_batches = conn.execute(
+                    "SELECT result_id, is_current_batch FROM __tool_results ORDER BY created_at"
+                ).fetchall()
+
+        self.assertEqual(
+            current_batches,
+            [
+                ("old-source", 0),
+                ("new-source-a", 1),
+                ("new-source-b", 1),
+            ],
+        )
+
+    def test_no_current_batch_when_every_eligible_result_failed(self):
+        records = [
+            tool_results.ToolCallResultRecord(
+                step_id="failed-command",
+                tool_name="run_command",
+                created_at=datetime(2026, 8, 11, 0, 1, tzinfo=timezone.utc),
+                result_text=json.dumps({"status": "error"}),
+                source_batch_id="failed-command-batch",
+                succeeded=False,
+            ),
+            tool_results.ToolCallResultRecord(
+                step_id="failed-source",
+                tool_name="mcp_vendor_search",
+                created_at=datetime(2026, 8, 11, 0, 2, tzinfo=timezone.utc),
+                result_text=json.dumps({"status": "failed"}),
+                source_batch_id="failed-source-batch",
+                succeeded=False,
+            ),
+        ]
+
+        with tempfile.NamedTemporaryFile(suffix=".sqlite3") as db_file:
+            token = set_sqlite_db_path(db_file.name)
+            try:
+                tool_results.prepare_tool_results_for_prompt(
+                    records,
+                    recency_positions={},
+                )
+            finally:
+                reset_sqlite_db_path(token)
+
+            with sqlite3.connect(db_file.name) as conn:
+                current_count = conn.execute(
+                    "SELECT COUNT(*) FROM __tool_results WHERE is_current_batch=1"
+                ).fetchone()[0]
+
+        self.assertEqual(current_count, 0)
+
     def test_analyzes_array_result(self):
         payload = [{"id": 1, "name": "Alpha"}, {"id": 2, "name": "Beta"}]
 

--- a/tests/unit/test_tool_results_schema.py
+++ b/tests/unit/test_tool_results_schema.py
@@ -812,6 +812,10 @@ class ToolResultSchemaTests(SimpleTestCase):
             1,
         )
         self.assertIn("do not import from memory or previews alone", combined_meta)
+        for index, record in enumerate(records):
+            preview = info[record.step_id].preview_text or ""
+            self.assertIn(f"# Interview {index}", preview)
+            self.assertIn(f"Company: Example {index}", preview)
 
     def test_http_prose_siblings_get_one_bound_row_work_set(self):
         records = [


### PR DESCRIPTION
## Summary

- Keep `run_command` and `python_exec` available after non-retryable and terminal tool errors.
- Track tool-result success explicitly when building prompt history.
- Prevent failed compute results from replacing the latest successful source batch or adding terminal guidance.
- Add regression coverage for filtering, batch selection, and success detection.

## Testing

- Added and updated focused unit tests covering event processing, prompt context, link references, and tool-result schemas.
- Not run (not requested).