### PR TITLE
Migrate Apollo tooling and guard deprecated Pipedream providers

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -3922,6 +3922,7 @@ def _prepare_tool_batch(
             logger.info("Agent %s preparing tool %d/%d: %s", agent.id, idx, len(tool_calls), tool_name)
 
             preflight_entry: Optional[ToolCatalogEntry] = None
+            preflight_entry_resolved = False
             preflight_params: dict[str, Any] = {}
             try:
                 _, parsed_preflight_params = _parse_tool_call_params(
@@ -3940,6 +3941,7 @@ def _prepare_tool_batch(
             )
             if preflight_blocked_integration:
                 preflight_entry = resolve_tool_entry(agent, tool_name)
+                preflight_entry_resolved = True
                 if preflight_entry is not None:
                     preflight_blocked_integration = match_deprecated_pipedream_integration(
                         tool_name,
@@ -3972,7 +3974,8 @@ def _prepare_tool_batch(
                 and not is_credit_message_only_allowed_tool(tool_name)
             )
             if credit_message_only_restricted and not preflight_blocked_integration:
-                preflight_entry = resolve_tool_entry(agent, tool_name)
+                if not preflight_entry_resolved:
+                    preflight_entry = resolve_tool_entry(agent, tool_name)
                 preflight_blocked_integration = match_deprecated_pipedream_integration(
                     tool_name,
                     preflight_params,

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -87,8 +87,8 @@ from api.evals.credit_policy import is_eval_credit_exempt_context
 from api.evals.execution import get_current_eval_routing_profile
 from api.services.deprecated_provider_guard import (
     filter_deprecated_provider_blocked_tool,
+    get_blocked_deprecated_pipedream_integration,
     is_deprecated_provider_blocked_result,
-    is_pipedream_google_sheets_blocked_call,
 )
 from . import internal_reasoning
 from .daily_limit_mode import (
@@ -2437,7 +2437,7 @@ class _PreparedToolExecution:
     parallel_safe: bool
     parallel_ineligible_reason: Optional[str]
     resolved_entry: Optional[ToolCatalogEntry] = None
-    pipedream_google_sheets_blocked: bool = False
+    deprecated_provider_integration: Optional[str] = None
     display_metadata: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -3576,13 +3576,11 @@ def _refresh_tools_after_deprecated_provider_handoff(
     agent: PersistentAgent,
     result: Any,
     blocked_tool_name: str,
-    resolved_entry: Optional[ToolCatalogEntry],
-    blocked_provider_call: bool,
+    blocked_integration: Optional[str],
 ) -> Optional[List[dict]]:
     if not (
         is_deprecated_provider_blocked_result(result)
-        and resolved_entry is not None
-        and blocked_provider_call
+        and blocked_integration
     ):
         return None
     try:
@@ -3590,12 +3588,13 @@ def _refresh_tools_after_deprecated_provider_handoff(
             agent,
             get_agent_tools(agent),
             blocked_tool_name,
+            blocked_integration,
         )
     except Exception:
         # Tool refresh is secondary to returning the trusted block and its
         # recovery instructions; the next prompt build can retry the refresh.
         logger.exception(
-            "Agent %s: native Sheets handoff tool refresh failed; preserving the blocked result.",
+            "Agent %s: native integration handoff tool refresh failed; preserving the blocked result.",
             agent.id,
         )
         return None
@@ -3610,7 +3609,7 @@ def _execute_tool_call_runtime(
     eval_run_id: Optional[str],
     parallel_safe: bool = False,
     resolved_entry: Optional[ToolCatalogEntry] = None,
-    pipedream_google_sheets_blocked: Optional[bool] = None,
+    deprecated_provider_integration: Optional[str] = None,
 ) -> tuple[Any, Optional[List[dict]]]:
     updated_tools: Optional[List[dict]] = None
     try:
@@ -3621,13 +3620,14 @@ def _execute_tool_call_runtime(
     mock_result = _resolve_eval_mock_result(mock_config, tool_name, exec_params)
     if is_tool_blacklisted_for_agent(agent, tool_name):
         return tool_blacklist_error(tool_name), updated_tools
-    blocked_provider_call = pipedream_google_sheets_blocked
-    if blocked_provider_call is None and resolved_entry is not None:
-        blocked_provider_call = is_pipedream_google_sheets_blocked_call(
-            resolved_entry,
+    blocked_integration = deprecated_provider_integration
+    if blocked_integration is None:
+        blocked_integration = get_blocked_deprecated_pipedream_integration(
+            tool_name,
             exec_params,
+            entry=resolved_entry,
         )
-    if mock_result is not None and not blocked_provider_call:
+    if mock_result is not None and not blocked_integration:
         logger.info(
             "Agent %s: using mock for %s (eval_run_id=%s)",
             agent.id,
@@ -3643,14 +3643,13 @@ def _execute_tool_call_runtime(
             isolated_mcp=True,
             current_sqlite_db_path=get_sqlite_db_path(),
             resolved_entry=resolved_entry,
-            pipedream_google_sheets_blocked=blocked_provider_call,
+            deprecated_provider_integration=blocked_integration,
         )
         updated_tools = _refresh_tools_after_deprecated_provider_handoff(
             agent,
             result,
             tool_name,
-            resolved_entry,
-            bool(blocked_provider_call),
+            blocked_integration,
         )
         return result, updated_tools
     resolve_executor = _DIRECT_TOOL_EXECUTORS.get(tool_name)
@@ -3667,14 +3666,13 @@ def _execute_tool_call_runtime(
         exec_params,
         current_sqlite_db_path=get_sqlite_db_path(),
         resolved_entry=resolved_entry,
-        pipedream_google_sheets_blocked=blocked_provider_call,
+        deprecated_provider_integration=blocked_integration,
     )
     updated_tools = _refresh_tools_after_deprecated_provider_handoff(
         agent,
         result,
         tool_name,
-        resolved_entry,
-        bool(blocked_provider_call),
+        blocked_integration,
     )
     if (
         tool_name in {"meta_gobii_link_agents", "meta_gobii_unlink_agents"}
@@ -3776,7 +3774,7 @@ def _execute_prepared_tool_call(
                 eval_run_id=eval_run_id,
                 parallel_safe=parallel_safe,
                 resolved_entry=prepared.resolved_entry,
-                pipedream_google_sheets_blocked=prepared.pipedream_google_sheets_blocked,
+                deprecated_provider_integration=prepared.deprecated_provider_integration,
             )
             if _tool_result_is_success(result) and not parallel_safe:
                 refresh_skills_for_tool(agent, prepared.tool_name)
@@ -3966,7 +3964,30 @@ def _prepare_tool_batch(
             logger.info("Agent %s preparing tool %d/%d: %s", agent.id, idx, len(tool_calls), tool_name)
 
             preflight_entry: Optional[ToolCatalogEntry] = None
-            preflight_blocked_provider_call = False
+            preflight_params: dict[str, Any] = {}
+            try:
+                _, parsed_preflight_params = _parse_tool_call_params(
+                    _get_tool_call_arguments(call)
+                )
+                if isinstance(parsed_preflight_params, dict):
+                    preflight_params = parsed_preflight_params
+            except (TypeError, ValueError, json.JSONDecodeError):
+                # The normal argument-validation path below emits the model
+                # correction; preflight only needs valid parameters to detect
+                # generic Pipedream component calls before roster rejection.
+                pass
+            preflight_blocked_integration = get_blocked_deprecated_pipedream_integration(
+                tool_name,
+                preflight_params,
+            )
+            if preflight_blocked_integration:
+                preflight_entry = resolve_tool_entry(agent, tool_name)
+                if preflight_entry is not None:
+                    preflight_blocked_integration = get_blocked_deprecated_pipedream_integration(
+                        tool_name,
+                        preflight_params,
+                        entry=preflight_entry,
+                    )
             daily_state = None
             if isinstance(credit_snapshot, dict):
                 daily_state = credit_snapshot.get("daily_state")
@@ -3992,7 +4013,7 @@ def _prepare_tool_batch(
                 is_credit_message_only_mode(daily_state, task_credit_available)
                 and not is_credit_message_only_allowed_tool(tool_name)
             )
-            if credit_message_only_restricted:
+            if credit_message_only_restricted and not preflight_blocked_integration:
                 try:
                     _, preflight_params = _parse_tool_call_params(
                         _get_tool_call_arguments(call)
@@ -4001,15 +4022,13 @@ def _prepare_tool_batch(
                     preflight_params = None
                 if isinstance(preflight_params, dict):
                     preflight_entry = resolve_tool_entry(agent, tool_name)
-                    preflight_blocked_provider_call = bool(
-                        preflight_entry
-                        and is_pipedream_google_sheets_blocked_call(
-                            preflight_entry,
-                            preflight_params,
-                        )
+                    preflight_blocked_integration = get_blocked_deprecated_pipedream_integration(
+                        tool_name,
+                        preflight_params,
+                        entry=preflight_entry,
                     )
 
-            if credit_message_only_restricted and not preflight_blocked_provider_call:
+            if credit_message_only_restricted and not preflight_blocked_integration:
                 try:
                     step_kwargs = {
                         "agent": agent,
@@ -4034,7 +4053,11 @@ def _prepare_tool_batch(
                 followup_required = True
                 continue
 
-            if allowed_tool_names is not None and tool_name not in allowed_tool_names:
+            if (
+                allowed_tool_names is not None
+                and tool_name not in allowed_tool_names
+                and not preflight_blocked_integration
+            ):
                 if not unavailable_notice_recorded:
                     _record_policy_step(
                         agent,
@@ -4256,16 +4279,10 @@ def _prepare_tool_batch(
                 exec_params = dict(exec_params)
                 exec_params["_has_user_facing_message"] = has_user_facing_message
 
-            blocked_provider_call = (
-                preflight_blocked_provider_call
-                if preflight_entry is not None
-                else bool(
-                    resolved_entry
-                    and is_pipedream_google_sheets_blocked_call(
-                        resolved_entry,
-                        exec_params,
-                    )
-                )
+            blocked_integration = get_blocked_deprecated_pipedream_integration(
+                tool_name,
+                exec_params,
+                entry=resolved_entry,
             )
 
             if tool_name == "http_request":
@@ -4293,7 +4310,7 @@ def _prepare_tool_batch(
 
             parallel_ineligible_reason = get_parallel_safe_tool_rejection_reason(tool_name, tool_params)
 
-            if not blocked_provider_call and not _enforce_tool_rate_limit(
+            if not blocked_integration and not _enforce_tool_rate_limit(
                 agent,
                 tool_name,
                 span=tool_span,
@@ -4306,7 +4323,7 @@ def _prepare_tool_batch(
 
             credit_info = (
                 {"cost": None, "credit": None}
-                if blocked_provider_call
+                if blocked_integration
                 else _ensure_credit_for_tool(
                     agent,
                     tool_name,
@@ -4348,7 +4365,7 @@ def _prepare_tool_batch(
                     parallel_safe=parallel_ineligible_reason is None,
                     parallel_ineligible_reason=parallel_ineligible_reason,
                     resolved_entry=resolved_entry,
-                    pipedream_google_sheets_blocked=blocked_provider_call,
+                    deprecated_provider_integration=blocked_integration,
                 )
             )
 
@@ -4729,7 +4746,7 @@ def _finalize_tool_batch(
         if is_error_status:
             trusted_deprecated_provider_block = bool(
                 is_deprecated_provider_blocked_result(result)
-                and prepared.pipedream_google_sheets_blocked
+                and prepared.deprecated_provider_integration
             )
             _refund_tool_credit_on_error_if_configured(
                 agent=agent,

--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -86,9 +86,10 @@ from api.agent.events import publish_agent_event, AgentEventType
 from api.evals.credit_policy import is_eval_credit_exempt_context
 from api.evals.execution import get_current_eval_routing_profile
 from api.services.deprecated_provider_guard import (
-    filter_deprecated_provider_blocked_tool,
-    get_blocked_deprecated_pipedream_integration,
+    DeprecatedPipedreamIntegration,
     is_deprecated_provider_blocked_result,
+    match_deprecated_pipedream_integration,
+    refresh_tools_after_deprecated_provider_handoff,
 )
 from . import internal_reasoning
 from .daily_limit_mode import (
@@ -2437,7 +2438,7 @@ class _PreparedToolExecution:
     parallel_safe: bool
     parallel_ineligible_reason: Optional[str]
     resolved_entry: Optional[ToolCatalogEntry] = None
-    deprecated_provider_integration: Optional[str] = None
+    deprecated_provider_integration: Optional[DeprecatedPipedreamIntegration] = None
     display_metadata: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -3572,34 +3573,6 @@ _REFRESHING_TOOL_EXECUTORS: Dict[str, _ToolExecutorResolver] = {
 }
 
 
-def _refresh_tools_after_deprecated_provider_handoff(
-    agent: PersistentAgent,
-    result: Any,
-    blocked_tool_name: str,
-    blocked_integration: Optional[str],
-) -> Optional[List[dict]]:
-    if not (
-        is_deprecated_provider_blocked_result(result)
-        and blocked_integration
-    ):
-        return None
-    try:
-        return filter_deprecated_provider_blocked_tool(
-            agent,
-            get_agent_tools(agent),
-            blocked_tool_name,
-            blocked_integration,
-        )
-    except Exception:
-        # Tool refresh is secondary to returning the trusted block and its
-        # recovery instructions; the next prompt build can retry the refresh.
-        logger.exception(
-            "Agent %s: native integration handoff tool refresh failed; preserving the blocked result.",
-            agent.id,
-        )
-        return None
-
-
 def _execute_tool_call_runtime(
     agent: PersistentAgent,
     *,
@@ -3609,7 +3582,7 @@ def _execute_tool_call_runtime(
     eval_run_id: Optional[str],
     parallel_safe: bool = False,
     resolved_entry: Optional[ToolCatalogEntry] = None,
-    deprecated_provider_integration: Optional[str] = None,
+    deprecated_provider_integration: Optional[DeprecatedPipedreamIntegration] = None,
 ) -> tuple[Any, Optional[List[dict]]]:
     updated_tools: Optional[List[dict]] = None
     try:
@@ -3622,7 +3595,7 @@ def _execute_tool_call_runtime(
         return tool_blacklist_error(tool_name), updated_tools
     blocked_integration = deprecated_provider_integration
     if blocked_integration is None:
-        blocked_integration = get_blocked_deprecated_pipedream_integration(
+        blocked_integration = match_deprecated_pipedream_integration(
             tool_name,
             exec_params,
             entry=resolved_entry,
@@ -3635,47 +3608,32 @@ def _execute_tool_call_runtime(
             eval_run_id,
         )
         return mock_result, updated_tools
-    if parallel_safe:
-        result = execute_enabled_tool(
-            agent,
-            tool_name,
-            exec_params,
-            isolated_mcp=True,
-            current_sqlite_db_path=get_sqlite_db_path(),
-            resolved_entry=resolved_entry,
-            deprecated_provider_integration=blocked_integration,
-        )
-        updated_tools = _refresh_tools_after_deprecated_provider_handoff(
-            agent,
-            result,
-            tool_name,
-            blocked_integration,
-        )
-        return result, updated_tools
-    resolve_executor = _DIRECT_TOOL_EXECUTORS.get(tool_name)
-    if resolve_executor:
-        return resolve_executor()(agent, exec_params), updated_tools
-    resolve_refreshing_executor = _REFRESHING_TOOL_EXECUTORS.get(tool_name)
-    if resolve_refreshing_executor:
-        result = resolve_refreshing_executor()(agent, exec_params)
-        updated_tools = get_agent_tools(agent)
-        return result, updated_tools
+    if not parallel_safe:
+        resolve_executor = _DIRECT_TOOL_EXECUTORS.get(tool_name)
+        if resolve_executor:
+            return resolve_executor()(agent, exec_params), updated_tools
+        resolve_refreshing_executor = _REFRESHING_TOOL_EXECUTORS.get(tool_name)
+        if resolve_refreshing_executor:
+            return resolve_refreshing_executor()(agent, exec_params), get_agent_tools(agent)
     result = execute_enabled_tool(
         agent,
         tool_name,
         exec_params,
+        isolated_mcp=parallel_safe,
         current_sqlite_db_path=get_sqlite_db_path(),
         resolved_entry=resolved_entry,
         deprecated_provider_integration=blocked_integration,
     )
-    updated_tools = _refresh_tools_after_deprecated_provider_handoff(
+    updated_tools = refresh_tools_after_deprecated_provider_handoff(
         agent,
         result,
         tool_name,
         blocked_integration,
+        get_agent_tools,
     )
     if (
-        tool_name in {"meta_gobii_link_agents", "meta_gobii_unlink_agents"}
+        not parallel_safe
+        and tool_name in {"meta_gobii_link_agents", "meta_gobii_unlink_agents"}
         and isinstance(result, dict)
         and result.get("status") in {"ok", "unlinked"}
     ):
@@ -3976,14 +3934,14 @@ def _prepare_tool_batch(
                 # correction; preflight only needs valid parameters to detect
                 # generic Pipedream component calls before roster rejection.
                 pass
-            preflight_blocked_integration = get_blocked_deprecated_pipedream_integration(
+            preflight_blocked_integration = match_deprecated_pipedream_integration(
                 tool_name,
                 preflight_params,
             )
             if preflight_blocked_integration:
                 preflight_entry = resolve_tool_entry(agent, tool_name)
                 if preflight_entry is not None:
-                    preflight_blocked_integration = get_blocked_deprecated_pipedream_integration(
+                    preflight_blocked_integration = match_deprecated_pipedream_integration(
                         tool_name,
                         preflight_params,
                         entry=preflight_entry,
@@ -4014,19 +3972,12 @@ def _prepare_tool_batch(
                 and not is_credit_message_only_allowed_tool(tool_name)
             )
             if credit_message_only_restricted and not preflight_blocked_integration:
-                try:
-                    _, preflight_params = _parse_tool_call_params(
-                        _get_tool_call_arguments(call)
-                    )
-                except (TypeError, ValueError, json.JSONDecodeError):
-                    preflight_params = None
-                if isinstance(preflight_params, dict):
-                    preflight_entry = resolve_tool_entry(agent, tool_name)
-                    preflight_blocked_integration = get_blocked_deprecated_pipedream_integration(
-                        tool_name,
-                        preflight_params,
-                        entry=preflight_entry,
-                    )
+                preflight_entry = resolve_tool_entry(agent, tool_name)
+                preflight_blocked_integration = match_deprecated_pipedream_integration(
+                    tool_name,
+                    preflight_params,
+                    entry=preflight_entry,
+                )
 
             if credit_message_only_restricted and not preflight_blocked_integration:
                 try:
@@ -4279,7 +4230,7 @@ def _prepare_tool_batch(
                 exec_params = dict(exec_params)
                 exec_params["_has_user_facing_message"] = has_user_facing_message
 
-            blocked_integration = get_blocked_deprecated_pipedream_integration(
+            blocked_integration = match_deprecated_pipedream_integration(
                 tool_name,
                 exec_params,
                 entry=resolved_entry,

--- a/api/agent/system_skills/service.py
+++ b/api/agent/system_skills/service.py
@@ -117,6 +117,8 @@ def prepare_native_integration_handoff(agent: PersistentAgent, skill_key: str) -
     if not updated:
         return NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED
     return NATIVE_INTEGRATION_HANDOFF_READY
+
+
 def _system_skill_keys_for_tool(tool_name: str) -> list[str]:
     normalized_tool = str(tool_name or "").strip()
     if not normalized_tool:

--- a/api/agent/system_skills/service.py
+++ b/api/agent/system_skills/service.py
@@ -11,7 +11,6 @@ from api.services.pipedream_apps import enable_pipedream_apps_for_agent
 from .registry import SystemSkillDefinition, equivalent_system_skill_keys, get_system_skill_definition, normalize_system_skill_key
 from .defaults import (
     DEFAULT_SYSTEM_SKILL_DEFINITIONS,
-    GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
     WEBHOOKS_SYSTEM_SKILL_KEY,
 )
 
@@ -19,10 +18,6 @@ from .defaults import (
 NATIVE_INTEGRATION_HANDOFF_READY = "ready"
 NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED = "explicitly_disabled"
 NATIVE_INTEGRATION_HANDOFF_UNAVAILABLE = "unavailable"
-
-GOOGLE_SHEETS_HANDOFF_READY = NATIVE_INTEGRATION_HANDOFF_READY
-GOOGLE_SHEETS_HANDOFF_EXPLICITLY_DISABLED = NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED
-GOOGLE_SHEETS_HANDOFF_UNAVAILABLE = NATIVE_INTEGRATION_HANDOFF_UNAVAILABLE
 
 
 def default_enabled_system_skill_keys() -> tuple[str, ...]:
@@ -122,12 +117,6 @@ def prepare_native_integration_handoff(agent: PersistentAgent, skill_key: str) -
     if not updated:
         return NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED
     return NATIVE_INTEGRATION_HANDOFF_READY
-
-
-def prepare_google_sheets_native_handoff(agent: PersistentAgent) -> str:
-    return prepare_native_integration_handoff(agent, GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY)
-
-
 def _system_skill_keys_for_tool(tool_name: str) -> list[str]:
     normalized_tool = str(tool_name or "").strip()
     if not normalized_tool:

--- a/api/agent/system_skills/service.py
+++ b/api/agent/system_skills/service.py
@@ -16,9 +16,13 @@ from .defaults import (
 )
 
 
-GOOGLE_SHEETS_HANDOFF_READY = "ready"
-GOOGLE_SHEETS_HANDOFF_EXPLICITLY_DISABLED = "explicitly_disabled"
-GOOGLE_SHEETS_HANDOFF_UNAVAILABLE = "unavailable"
+NATIVE_INTEGRATION_HANDOFF_READY = "ready"
+NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED = "explicitly_disabled"
+NATIVE_INTEGRATION_HANDOFF_UNAVAILABLE = "unavailable"
+
+GOOGLE_SHEETS_HANDOFF_READY = NATIVE_INTEGRATION_HANDOFF_READY
+GOOGLE_SHEETS_HANDOFF_EXPLICITLY_DISABLED = NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED
+GOOGLE_SHEETS_HANDOFF_UNAVAILABLE = NATIVE_INTEGRATION_HANDOFF_UNAVAILABLE
 
 
 def default_enabled_system_skill_keys() -> tuple[str, ...]:
@@ -71,18 +75,18 @@ def get_enabled_system_skill_states(agent: PersistentAgent):
     return PersistentAgentSystemSkillState.objects.filter(agent=agent, is_enabled=True)
 
 
-def prepare_google_sheets_native_handoff(agent: PersistentAgent) -> str:
-    """Make the native Sheets path immediately usable unless it was explicitly disabled."""
+def prepare_native_integration_handoff(agent: PersistentAgent, skill_key: str) -> str:
+    """Make a native HTTP integration immediately usable unless explicitly disabled."""
     state = (
         PersistentAgentSystemSkillState.objects.filter(
             agent=agent,
-            skill_key=GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
+            skill_key=skill_key,
         )
         .only("id", "is_enabled")
         .first()
     )
     if state is not None and not state.is_enabled:
-        return GOOGLE_SHEETS_HANDOFF_EXPLICITLY_DISABLED
+        return NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED
 
     # Use the trusted built-in path so this handoff does not depend on MCP
     # discovery being healthy after the deprecated provider is rejected.
@@ -93,12 +97,12 @@ def prepare_google_sheets_native_handoff(agent: PersistentAgent) -> str:
 
     tool_result = mark_tool_enabled_without_discovery(agent, HTTP_REQUEST_TOOL_NAME)
     if tool_result.get("status") != "success":
-        return GOOGLE_SHEETS_HANDOFF_UNAVAILABLE
+        return NATIVE_INTEGRATION_HANDOFF_UNAVAILABLE
 
     used_at = timezone.now()
     state, created = PersistentAgentSystemSkillState.objects.get_or_create(
         agent=agent,
-        skill_key=GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
+        skill_key=skill_key,
         defaults={
             "is_enabled": True,
             "last_used_at": used_at,
@@ -106,7 +110,7 @@ def prepare_google_sheets_native_handoff(agent: PersistentAgent) -> str:
         },
     )
     if created:
-        return GOOGLE_SHEETS_HANDOFF_READY
+        return NATIVE_INTEGRATION_HANDOFF_READY
 
     updated = PersistentAgentSystemSkillState.objects.filter(
         id=state.id,
@@ -116,8 +120,12 @@ def prepare_google_sheets_native_handoff(agent: PersistentAgent) -> str:
         usage_count=F("usage_count") + 1,
     )
     if not updated:
-        return GOOGLE_SHEETS_HANDOFF_EXPLICITLY_DISABLED
-    return GOOGLE_SHEETS_HANDOFF_READY
+        return NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED
+    return NATIVE_INTEGRATION_HANDOFF_READY
+
+
+def prepare_google_sheets_native_handoff(agent: PersistentAgent) -> str:
+    return prepare_native_integration_handoff(agent, GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY)
 
 
 def _system_skill_keys_for_tool(tool_name: str) -> list[str]:

--- a/api/agent/tools/mcp_manager.py
+++ b/api/agent/tools/mcp_manager.py
@@ -93,7 +93,7 @@ from ...services.mcp_oauth import (
     ensure_mcp_oauth_credential,
 )
 from ...services.pipedream_apps import (
-    filter_guarded_pipedream_google_sheets_tools,
+    filter_guarded_pipedream_native_handoff_tools,
     get_effective_pipedream_app_slugs_for_agent,
     get_platform_pipedream_app_slugs,
     normalize_app_slug,
@@ -2513,7 +2513,7 @@ class MCPToolManager:
                 )
                 if tool.full_name not in seen_tool_names
             )
-        for tool_info in filter_guarded_pipedream_google_sheets_tools(agent, tools):
+        for tool_info in filter_guarded_pipedream_native_handoff_tools(agent, tools):
             if tool_info.full_name in enabled_set:
                 self._backfill_enabled_tool_metadata(
                     enabled_rows_by_name[tool_info.full_name],

--- a/api/agent/tools/tool_manager.py
+++ b/api/agent/tools/tool_manager.py
@@ -21,7 +21,7 @@ from util.text_sanitizer import decode_unicode_escapes
 
 from api.agent.eval_agents import is_eval_agent
 from api.services.agent_sqlite_coordination import AgentSQLiteBusy, agent_sqlite_busy_result
-from api.services.deprecated_provider_guard import pipedream_google_sheets_blocked_error
+from api.services.deprecated_provider_guard import deprecated_pipedream_blocked_error
 
 from ...models import PersistentAgent, PersistentAgentCustomTool, PersistentAgentEnabledTool, PersistentAgentSystemSkillState
 from ...services.sandbox_compute import SandboxComputeService, SandboxComputeUnavailable, sandbox_compute_enabled_for_agent, track_sandbox_unavailable
@@ -1489,23 +1489,23 @@ def execute_enabled_tool(
     isolated_mcp: bool = False,
     current_sqlite_db_path: Optional[str] = None,
     resolved_entry: Optional[ToolCatalogEntry] = None,
-    pipedream_google_sheets_blocked: Optional[bool] = None,
+    deprecated_provider_integration: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Execute an enabled tool, routing to the appropriate provider."""
     entry = resolved_entry or resolve_tool_entry(agent, tool_name)
+    blocked_error = deprecated_pipedream_blocked_error(
+        agent,
+        tool_name,
+        params,
+        entry=entry,
+        blocked_integration=deprecated_provider_integration,
+    )
+    if blocked_error is not None:
+        return blocked_error
     if not entry:
         return {"status": "error", "message": f"Tool '{tool_name}' is not available"}
 
     resolved_name = entry.full_name
-
-    blocked_error = pipedream_google_sheets_blocked_error(
-        agent,
-        entry,
-        params,
-        blocked_call=pipedream_google_sheets_blocked,
-    )
-    if blocked_error is not None:
-        return blocked_error
 
     params = _coerce_params_to_schema(params, entry.parameters)
 

--- a/api/agent/tools/tool_manager.py
+++ b/api/agent/tools/tool_manager.py
@@ -21,7 +21,10 @@ from util.text_sanitizer import decode_unicode_escapes
 
 from api.agent.eval_agents import is_eval_agent
 from api.services.agent_sqlite_coordination import AgentSQLiteBusy, agent_sqlite_busy_result
-from api.services.deprecated_provider_guard import deprecated_pipedream_blocked_error
+from api.services.deprecated_provider_guard import (
+    DeprecatedPipedreamIntegration,
+    deprecated_pipedream_blocked_error,
+)
 
 from ...models import PersistentAgent, PersistentAgentCustomTool, PersistentAgentEnabledTool, PersistentAgentSystemSkillState
 from ...services.sandbox_compute import SandboxComputeService, SandboxComputeUnavailable, sandbox_compute_enabled_for_agent, track_sandbox_unavailable
@@ -1489,7 +1492,7 @@ def execute_enabled_tool(
     isolated_mcp: bool = False,
     current_sqlite_db_path: Optional[str] = None,
     resolved_entry: Optional[ToolCatalogEntry] = None,
-    deprecated_provider_integration: Optional[str] = None,
+    deprecated_provider_integration: Optional[DeprecatedPipedreamIntegration] = None,
 ) -> Dict[str, Any]:
     """Execute an enabled tool, routing to the appropriate provider."""
     entry = resolved_entry or resolve_tool_entry(agent, tool_name)

--- a/api/agent/tools/tool_runtime.py
+++ b/api/agent/tools/tool_runtime.py
@@ -1,11 +1,10 @@
-import logging
 from typing import Any, Dict, Optional, cast
 
 from api.models import PersistentAgent
 from api.services.deprecated_provider_guard import (
-    filter_deprecated_provider_blocked_tool,
-    get_blocked_deprecated_pipedream_integration,
-    is_deprecated_provider_blocked_result,
+    DeprecatedPipedreamIntegration,
+    match_deprecated_pipedream_integration,
+    refresh_tools_after_deprecated_provider_handoff,
 )
 from api.services.tool_blacklist import is_tool_blacklisted_for_agent, tool_blacklist_error
 
@@ -28,8 +27,6 @@ from . import tool_manager as tool_manager_service
 from .tool_manager import ToolCatalogEntry, execute_enabled_tool
 from .web_chat_sender import execute_send_chat_message
 
-
-logger = logging.getLogger(__name__)
 _RESOLVED_ENTRY_UNSET = object()
 _CATALOG_FREE_RUNTIME_TOOL_NAMES = frozenset(
     {
@@ -62,34 +59,6 @@ def _refresh_agent_tools(agent: PersistentAgent) -> Optional[list[dict]]:
     return get_agent_tools(agent)
 
 
-def _refresh_agent_tools_after_deprecated_provider_handoff(
-    agent: PersistentAgent,
-    result: Any,
-    blocked_tool_name: str,
-    blocked_integration: Optional[str],
-) -> Optional[list[dict]]:
-    if not (
-        is_deprecated_provider_blocked_result(result)
-        and blocked_integration
-    ):
-        return None
-    try:
-        return filter_deprecated_provider_blocked_tool(
-            agent,
-            _refresh_agent_tools(agent),
-            blocked_tool_name,
-            blocked_integration,
-        )
-    except Exception:
-        # Preserve the actionable block if this best-effort roster refresh
-        # fails; the next prompt build can retry it from persisted state.
-        logger.exception(
-            "Agent %s: nested native integration handoff tool refresh failed; preserving the blocked result.",
-            agent.id,
-        )
-        return None
-
-
 def execute_runtime_tool_call(
     agent: PersistentAgent,
     *,
@@ -97,84 +66,51 @@ def execute_runtime_tool_call(
     exec_params: Dict[str, Any],
     isolated_mcp: bool = False,
     resolved_entry: Optional[ToolCatalogEntry] | object = _RESOLVED_ENTRY_UNSET,
-    deprecated_provider_integration: Optional[str] = None,
+    deprecated_provider_integration: Optional[DeprecatedPipedreamIntegration] = None,
 ) -> tuple[Any, Optional[list[dict]]]:
     updated_tools: Optional[list[dict]] = None
 
     if is_tool_blacklisted_for_agent(agent, tool_name):
         return tool_blacklist_error(tool_name), updated_tools
 
-    if isolated_mcp:
-        entry = (
-            tool_manager_service.resolve_tool_entry(agent, tool_name)
-            if resolved_entry is _RESOLVED_ENTRY_UNSET
-            else cast(Optional[ToolCatalogEntry], resolved_entry)
-        )
-        blocked_integration = deprecated_provider_integration or get_blocked_deprecated_pipedream_integration(
-            tool_name,
-            exec_params,
-            entry=entry,
-        )
-        if entry is None and not blocked_integration:
-            return {"status": "error", "message": f"Tool '{tool_name}' is not available"}, updated_tools
-        result = execute_enabled_tool(
-            agent,
-            tool_name,
-            exec_params,
-            isolated_mcp=True,
-            resolved_entry=entry,
-            deprecated_provider_integration=blocked_integration,
-        )
-        updated_tools = _refresh_agent_tools_after_deprecated_provider_handoff(
-            agent,
-            result,
-            tool_name,
-            blocked_integration,
-        )
-        return result, updated_tools
-    if tool_name == "spawn_web_task":
-        return execute_spawn_web_task(agent, exec_params), updated_tools
-    if tool_name == "send_email":
-        return execute_send_email(agent, exec_params), updated_tools
-    if tool_name == "send_sms":
-        return execute_send_sms(agent, exec_params), updated_tools
-    if tool_name == "send_chat_message":
-        return execute_send_chat_message(agent, exec_params), updated_tools
-    if tool_name == "send_mcp_message":
-        return execute_send_mcp_message(agent, exec_params), updated_tools
-    if tool_name == "send_agent_message":
-        return execute_send_agent_message(agent, exec_params), updated_tools
-    if tool_name == "update_schedule":
-        return execute_update_schedule(agent, exec_params), updated_tools
-    if tool_name == "update_charter":
-        return execute_update_charter(agent, exec_params), updated_tools
-    if tool_name == "secure_credentials_request":
-        return execute_secure_credentials_request(agent, exec_params), updated_tools
-    if tool_name == "request_contact_permission":
-        return execute_request_contact_permission(agent, exec_params), updated_tools
-    if tool_name == "request_human_input":
-        return execute_request_human_input(agent, exec_params), updated_tools
-    if tool_name == "search_tools":
-        result = execute_search_tools(agent, exec_params)
-        updated_tools = _refresh_agent_tools(agent)
-        return result, updated_tools
-    if tool_name == CREATE_CUSTOM_TOOL_NAME:
-        result = execute_create_custom_tool(agent, exec_params)
-        updated_tools = _refresh_agent_tools(agent)
-        return result, updated_tools
-    if tool_name == "apply_patch":
-        return execute_apply_patch(agent, exec_params), updated_tools
-    if tool_name == "end_planning":
-        result = execute_end_planning(agent, exec_params)
-        updated_tools = _refresh_agent_tools(agent)
-        return result, updated_tools
+    if not isolated_mcp:
+        if tool_name == "spawn_web_task":
+            return execute_spawn_web_task(agent, exec_params), updated_tools
+        if tool_name == "send_email":
+            return execute_send_email(agent, exec_params), updated_tools
+        if tool_name == "send_sms":
+            return execute_send_sms(agent, exec_params), updated_tools
+        if tool_name == "send_chat_message":
+            return execute_send_chat_message(agent, exec_params), updated_tools
+        if tool_name == "send_mcp_message":
+            return execute_send_mcp_message(agent, exec_params), updated_tools
+        if tool_name == "send_agent_message":
+            return execute_send_agent_message(agent, exec_params), updated_tools
+        if tool_name == "update_schedule":
+            return execute_update_schedule(agent, exec_params), updated_tools
+        if tool_name == "update_charter":
+            return execute_update_charter(agent, exec_params), updated_tools
+        if tool_name == "secure_credentials_request":
+            return execute_secure_credentials_request(agent, exec_params), updated_tools
+        if tool_name == "request_contact_permission":
+            return execute_request_contact_permission(agent, exec_params), updated_tools
+        if tool_name == "request_human_input":
+            return execute_request_human_input(agent, exec_params), updated_tools
+        if tool_name == "search_tools":
+            return execute_search_tools(agent, exec_params), _refresh_agent_tools(agent)
+        if tool_name == CREATE_CUSTOM_TOOL_NAME:
+            return execute_create_custom_tool(agent, exec_params), _refresh_agent_tools(agent)
+        if tool_name == "apply_patch":
+            return execute_apply_patch(agent, exec_params), updated_tools
+        if tool_name == "end_planning":
+            return execute_end_planning(agent, exec_params), _refresh_agent_tools(agent)
 
     entry = (
         tool_manager_service.resolve_tool_entry(agent, tool_name)
         if resolved_entry is _RESOLVED_ENTRY_UNSET
         else cast(Optional[ToolCatalogEntry], resolved_entry)
     )
-    blocked_integration = deprecated_provider_integration or get_blocked_deprecated_pipedream_integration(
+    blocked_integration = deprecated_provider_integration or match_deprecated_pipedream_integration(
         tool_name,
         exec_params,
         entry=entry,
@@ -185,13 +121,15 @@ def execute_runtime_tool_call(
         agent,
         tool_name,
         exec_params,
+        isolated_mcp=isolated_mcp,
         resolved_entry=entry,
         deprecated_provider_integration=blocked_integration,
     )
-    updated_tools = _refresh_agent_tools_after_deprecated_provider_handoff(
+    updated_tools = refresh_tools_after_deprecated_provider_handoff(
         agent,
         result,
         tool_name,
         blocked_integration,
+        _refresh_agent_tools,
     )
     return result, updated_tools

--- a/api/agent/tools/tool_runtime.py
+++ b/api/agent/tools/tool_runtime.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Optional, cast
 from api.models import PersistentAgent
 from api.services.deprecated_provider_guard import (
     filter_deprecated_provider_blocked_tool,
+    get_blocked_deprecated_pipedream_integration,
     is_deprecated_provider_blocked_result,
-    is_pipedream_google_sheets_blocked_call,
 )
 from api.services.tool_blacklist import is_tool_blacklisted_for_agent, tool_blacklist_error
 
@@ -66,13 +66,11 @@ def _refresh_agent_tools_after_deprecated_provider_handoff(
     agent: PersistentAgent,
     result: Any,
     blocked_tool_name: str,
-    resolved_entry: Optional[ToolCatalogEntry],
-    blocked_provider_call: bool,
+    blocked_integration: Optional[str],
 ) -> Optional[list[dict]]:
     if not (
         is_deprecated_provider_blocked_result(result)
-        and resolved_entry is not None
-        and blocked_provider_call
+        and blocked_integration
     ):
         return None
     try:
@@ -80,12 +78,13 @@ def _refresh_agent_tools_after_deprecated_provider_handoff(
             agent,
             _refresh_agent_tools(agent),
             blocked_tool_name,
+            blocked_integration,
         )
     except Exception:
         # Preserve the actionable block if this best-effort roster refresh
         # fails; the next prompt build can retry it from persisted state.
         logger.exception(
-            "Agent %s: nested native Sheets handoff tool refresh failed; preserving the blocked result.",
+            "Agent %s: nested native integration handoff tool refresh failed; preserving the blocked result.",
             agent.id,
         )
         return None
@@ -98,7 +97,7 @@ def execute_runtime_tool_call(
     exec_params: Dict[str, Any],
     isolated_mcp: bool = False,
     resolved_entry: Optional[ToolCatalogEntry] | object = _RESOLVED_ENTRY_UNSET,
-    pipedream_google_sheets_blocked: Optional[bool] = None,
+    deprecated_provider_integration: Optional[str] = None,
 ) -> tuple[Any, Optional[list[dict]]]:
     updated_tools: Optional[list[dict]] = None
 
@@ -111,27 +110,26 @@ def execute_runtime_tool_call(
             if resolved_entry is _RESOLVED_ENTRY_UNSET
             else cast(Optional[ToolCatalogEntry], resolved_entry)
         )
-        if entry is None:
-            return {"status": "error", "message": f"Tool '{tool_name}' is not available"}, updated_tools
-        blocked_provider_call = (
-            is_pipedream_google_sheets_blocked_call(entry, exec_params)
-            if pipedream_google_sheets_blocked is None
-            else pipedream_google_sheets_blocked
+        blocked_integration = deprecated_provider_integration or get_blocked_deprecated_pipedream_integration(
+            tool_name,
+            exec_params,
+            entry=entry,
         )
+        if entry is None and not blocked_integration:
+            return {"status": "error", "message": f"Tool '{tool_name}' is not available"}, updated_tools
         result = execute_enabled_tool(
             agent,
             tool_name,
             exec_params,
             isolated_mcp=True,
             resolved_entry=entry,
-            pipedream_google_sheets_blocked=blocked_provider_call,
+            deprecated_provider_integration=blocked_integration,
         )
         updated_tools = _refresh_agent_tools_after_deprecated_provider_handoff(
             agent,
             result,
             tool_name,
-            entry,
-            blocked_provider_call,
+            blocked_integration,
         )
         return result, updated_tools
     if tool_name == "spawn_web_task":
@@ -176,25 +174,24 @@ def execute_runtime_tool_call(
         if resolved_entry is _RESOLVED_ENTRY_UNSET
         else cast(Optional[ToolCatalogEntry], resolved_entry)
     )
-    if entry is None:
-        return {"status": "error", "message": f"Tool '{tool_name}' is not available"}, updated_tools
-    blocked_provider_call = (
-        is_pipedream_google_sheets_blocked_call(entry, exec_params)
-        if pipedream_google_sheets_blocked is None
-        else pipedream_google_sheets_blocked
+    blocked_integration = deprecated_provider_integration or get_blocked_deprecated_pipedream_integration(
+        tool_name,
+        exec_params,
+        entry=entry,
     )
+    if entry is None and not blocked_integration:
+        return {"status": "error", "message": f"Tool '{tool_name}' is not available"}, updated_tools
     result = execute_enabled_tool(
         agent,
         tool_name,
         exec_params,
         resolved_entry=entry,
-        pipedream_google_sheets_blocked=blocked_provider_call,
+        deprecated_provider_integration=blocked_integration,
     )
     updated_tools = _refresh_agent_tools_after_deprecated_provider_handoff(
         agent,
         result,
         tool_name,
-        entry,
-        blocked_provider_call,
+        blocked_integration,
     )
     return result, updated_tools

--- a/api/agent/tools/tracked_runtime.py
+++ b/api/agent/tools/tracked_runtime.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Optional
 from api.agent.comms.human_input_requests import attach_originating_step_from_result, track_human_input_request_created
 from api.models import PersistentAgent, PersistentAgentStep, PersistentAgentToolCall
 from api.services.deprecated_provider_guard import (
-    get_blocked_deprecated_pipedream_integration,
     is_deprecated_provider_blocked_result,
+    match_deprecated_pipedream_integration,
 )
 
 from .runtime_execution_context import tool_execution_context
@@ -73,7 +73,7 @@ def execute_tracked_runtime_tool_call(
         if runtime_tool_requires_catalog_entry(tool_name, isolated_mcp=isolated_mcp)
         else None
     )
-    blocked_integration = get_blocked_deprecated_pipedream_integration(
+    blocked_integration = match_deprecated_pipedream_integration(
         tool_name,
         exec_params,
         entry=resolved_entry,

--- a/api/agent/tools/tracked_runtime.py
+++ b/api/agent/tools/tracked_runtime.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Optional
 from api.agent.comms.human_input_requests import attach_originating_step_from_result, track_human_input_request_created
 from api.models import PersistentAgent, PersistentAgentStep, PersistentAgentToolCall
 from api.services.deprecated_provider_guard import (
+    get_blocked_deprecated_pipedream_integration,
     is_deprecated_provider_blocked_result,
-    is_pipedream_google_sheets_blocked_call,
 )
 
 from .runtime_execution_context import tool_execution_context
@@ -73,12 +73,13 @@ def execute_tracked_runtime_tool_call(
         if runtime_tool_requires_catalog_entry(tool_name, isolated_mcp=isolated_mcp)
         else None
     )
-    blocked_provider_call = bool(
-        resolved_entry
-        and is_pipedream_google_sheets_blocked_call(resolved_entry, exec_params)
+    blocked_integration = get_blocked_deprecated_pipedream_integration(
+        tool_name,
+        exec_params,
+        entry=resolved_entry,
     )
 
-    if not blocked_provider_call and not _enforce_tool_rate_limit(
+    if not blocked_integration and not _enforce_tool_rate_limit(
         agent,
         tool_name,
         attach_completion=attach_completion,
@@ -91,7 +92,7 @@ def execute_tracked_runtime_tool_call(
 
     credit_info = (
         {"cost": None, "credit": None}
-        if blocked_provider_call
+        if blocked_integration
         else _ensure_credit_for_tool(agent, tool_name)
     )
     if not credit_info:
@@ -133,7 +134,7 @@ def execute_tracked_runtime_tool_call(
                 exec_params=exec_params,
                 isolated_mcp=isolated_mcp,
                 resolved_entry=resolved_entry,
-                pipedream_google_sheets_blocked=blocked_provider_call,
+                deprecated_provider_integration=blocked_integration,
             )
         duration_ms = int(round((time.monotonic() - started_at) * 1000))
     except Exception as exc:
@@ -187,7 +188,7 @@ def execute_tracked_runtime_tool_call(
         attach_originating_step_from_result(step, result)
         track_human_input_request_created(step, result)
 
-    if blocked_provider_call and is_deprecated_provider_blocked_result(result):
+    if blocked_integration and is_deprecated_provider_blocked_result(result):
         _refund_tool_credit_on_error_if_configured(
             agent=agent,
             tool_name=tool_name,

--- a/api/migrations/0456_add_pipedream_apollo_guard_switch.py
+++ b/api/migrations/0456_add_pipedream_apollo_guard_switch.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+SWITCH_NAME = "pipedream_apollo_guard"
+
+
+def add_switch(apps, schema_editor):
+    Switch = apps.get_model("waffle", "Switch")
+    Switch.objects.get_or_create(
+        name=SWITCH_NAME,
+        defaults={"active": False},
+    )
+
+
+def remove_switch(apps, schema_editor):
+    Switch = apps.get_model("waffle", "Switch")
+    Switch.objects.filter(name=SWITCH_NAME).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0455_user_discord_identity"),
+        ("waffle", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_switch, remove_switch),
+    ]

--- a/api/services/deprecated_provider_guard.py
+++ b/api/services/deprecated_provider_guard.py
@@ -72,7 +72,7 @@ DEPRECATED_PIPEDREAM_INTEGRATIONS = {
 }
 
 
-def _guard_enabled(integration: DeprecatedPipedreamIntegration) -> bool:
+def deprecated_pipedream_guard_enabled(integration: DeprecatedPipedreamIntegration) -> bool:
     return is_waffle_switch_active(integration.switch_name, default=False)
 
 
@@ -129,7 +129,7 @@ def match_deprecated_pipedream_integration(
         if entry is not None
         else _integration_for_tool_name(tool_name, params)
     )
-    return integration if integration is not None and _guard_enabled(integration) else None
+    return integration if integration is not None and deprecated_pipedream_guard_enabled(integration) else None
 
 
 def _resolve_tool_entry(agent: PersistentAgent, tool_name: str) -> Any:
@@ -225,11 +225,7 @@ def filter_deprecated_provider_blocked_tool(
     blocked_tool_names = {blocked_tool_name}
     for tool_name in candidates - blocked_tool_names:
         entry = _resolve_tool_entry(agent, tool_name)
-        detected_integration = (
-            _integration_for_entry(entry, {})
-            if entry is not None
-            else _integration_for_tool_name(tool_name, {})
-        )
+        detected_integration = _integration_for_entry(entry, {}) if entry is not None else None
         if detected_integration == blocked_integration:
             blocked_tool_names.add(tool_name)
 
@@ -355,7 +351,7 @@ def deprecated_pipedream_blocked_error(
         return None
     # Callers that classify before billing pass the decision through so a
     # mid-call switch change cannot make execution and credit handling differ.
-    if blocked_integration is None and not _guard_enabled(integration):
+    if blocked_integration is None and not deprecated_pipedream_guard_enabled(integration):
         return None
 
     from api.agent.system_skills.service import (

--- a/api/services/deprecated_provider_guard.py
+++ b/api/services/deprecated_provider_guard.py
@@ -1,17 +1,24 @@
 import logging
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from django.db import DatabaseError
 
+from api.agent.system_skills.defaults import (
+    APOLLO_NATIVE_SYSTEM_SKILL_KEY,
+    GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
+)
 from api.agent.tools.runtime_execution_context import get_tool_execution_context
 from api.models import PersistentAgent, PersistentAgentEnabledTool, PersistentAgentToolCall
 from api.services.pipedream_apps import (
     PIPEDREAM_COMPONENT_OPTION_TOOLS,
     normalize_app_slug,
     pipedream_app_slug_for_tool_call,
-    pipedream_app_slug_for_tool_name,
 )
-from api.services.pipedream_feature_flags import pipedream_google_sheets_guard_enabled
+from api.services.pipedream_feature_flags import (
+    pipedream_apollo_guard_enabled,
+    pipedream_google_sheets_guard_enabled,
+)
 from util.analytics import Analytics, AnalyticsEvent, AnalyticsSource
 
 logger = logging.getLogger(__name__)
@@ -19,7 +26,48 @@ logger = logging.getLogger(__name__)
 DEPRECATED_PROVIDER_BLOCKED = "deprecated_provider_blocked"
 PIPEDREAM_PROVIDER = "pipedream"
 GOOGLE_SHEETS_INTEGRATION = "google_sheets"
-GOOGLE_SHEETS_REPLACEMENT = "google_sheets_native"
+APOLLO_INTEGRATION = "apollo"
+
+
+@dataclass(frozen=True)
+class DeprecatedPipedreamIntegration:
+    key: str
+    display_name: str
+    pipedream_app_slugs: frozenset[str]
+    native_skill_key: str
+    replacement: str
+    setup_url: str
+    analytics_event: AnalyticsEvent
+
+
+DEPRECATED_PIPEDREAM_INTEGRATIONS = {
+    GOOGLE_SHEETS_INTEGRATION: DeprecatedPipedreamIntegration(
+        key=GOOGLE_SHEETS_INTEGRATION,
+        display_name="Google Sheets",
+        pipedream_app_slugs=frozenset({"google_sheets"}),
+        native_skill_key=GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
+        replacement="google_sheets_native",
+        setup_url="/app/integrations",
+        analytics_event=AnalyticsEvent.PIPEDREAM_GOOGLE_SHEETS_EXECUTION_BLOCKED,
+    ),
+    APOLLO_INTEGRATION: DeprecatedPipedreamIntegration(
+        key=APOLLO_INTEGRATION,
+        display_name="Apollo",
+        pipedream_app_slugs=frozenset({"apollo_io", "apollo_io_oauth"}),
+        native_skill_key=APOLLO_NATIVE_SYSTEM_SKILL_KEY,
+        replacement="apollo_native",
+        setup_url="/app/integrations?provider=apollo",
+        analytics_event=AnalyticsEvent.PIPEDREAM_APOLLO_EXECUTION_BLOCKED,
+    ),
+}
+
+
+def _guard_enabled(integration_key: str) -> bool:
+    if integration_key == GOOGLE_SHEETS_INTEGRATION:
+        return pipedream_google_sheets_guard_enabled()
+    if integration_key == APOLLO_INTEGRATION:
+        return pipedream_apollo_guard_enabled()
+    return False
 
 
 def _provider_app_slug(entry: Any, params: Any) -> str:
@@ -37,12 +85,42 @@ def _provider_app_slug(entry: Any, params: Any) -> str:
     return pipedream_app_slug_for_tool_call(tool_name, params)
 
 
-def _entry_targets_pipedream_google_sheets(entry: Any, params: Any) -> bool:
-    return (
-        entry.provider == "mcp"
-        and str(entry.tool_server).strip().casefold() == PIPEDREAM_PROVIDER
-        and _provider_app_slug(entry, params) == GOOGLE_SHEETS_INTEGRATION
+def _integration_for_app_slug(app_slug: str) -> Optional[str]:
+    normalized_slug = normalize_app_slug(app_slug)
+    for integration in DEPRECATED_PIPEDREAM_INTEGRATIONS.values():
+        if normalized_slug in integration.pipedream_app_slugs:
+            return integration.key
+    return None
+
+
+def _integration_for_tool_name(tool_name: str, params: Any) -> Optional[str]:
+    return _integration_for_app_slug(pipedream_app_slug_for_tool_call(tool_name, params))
+
+
+def _integration_for_entry(entry: Any, params: Any) -> Optional[str]:
+    if (
+        entry.provider != "mcp"
+        or str(entry.tool_server).strip().casefold() != PIPEDREAM_PROVIDER
+    ):
+        return None
+    return _integration_for_app_slug(_provider_app_slug(entry, params))
+
+
+def get_blocked_deprecated_pipedream_integration(
+    tool_name: str,
+    params: Any,
+    *,
+    entry: Any = None,
+) -> Optional[str]:
+    integration_key = (
+        _integration_for_entry(entry, params)
+        if entry is not None
+        else _integration_for_tool_name(tool_name, params)
     )
+    if not integration_key:
+        return None
+    integration = DEPRECATED_PIPEDREAM_INTEGRATIONS[integration_key]
+    return integration_key if _guard_enabled(integration_key) else None
 
 
 def _resolve_tool_entry(agent: PersistentAgent, tool_name: str) -> Any:
@@ -53,44 +131,56 @@ def _resolve_tool_entry(agent: PersistentAgent, tool_name: str) -> Any:
     return resolve_tool_entry(agent, tool_name)
 
 
-def _blocked_error(handoff_status: str) -> dict[str, Any]:
+def _blocked_error(
+    integration: DeprecatedPipedreamIntegration,
+    handoff_status: str,
+) -> dict[str, Any]:
     from api.agent.system_skills.service import (
-        GOOGLE_SHEETS_HANDOFF_EXPLICITLY_DISABLED,
-        GOOGLE_SHEETS_HANDOFF_READY,
+        NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED,
+        NATIVE_INTEGRATION_HANDOFF_READY,
     )
 
-    if handoff_status == GOOGLE_SHEETS_HANDOFF_READY:
+    if handoff_status == NATIVE_INTEGRATION_HANDOFF_READY:
+        if integration.key == GOOGLE_SHEETS_INTEGRATION:
+            message = (
+                "Google Sheets through Pipedream is disabled. The native Google Sheets skill is enabled; continue "
+                "with it now. If Google Drive is disconnected, tell the requester to open /app/integrations, "
+                "connect Google Drive, and select the spreadsheets to use. Do not retry Pipedream."
+            )
+        else:
+            message = (
+                "Apollo through Pipedream is disabled. The native Apollo skill is enabled; continue with it now "
+                "using http_request. If Apollo is disconnected, tell the requester to open "
+                "/app/integrations?provider=apollo and connect Apollo. Do not retry Pipedream."
+            )
+        next_action = f"continue_with_native_{integration.key}"
+    elif handoff_status == NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED:
         message = (
-            "Google Sheets through Pipedream is disabled. The native Google Sheets skill is enabled; continue with "
-            "it now. If Google Drive is disconnected, tell the requester to open /app/integrations, connect Google "
-            "Drive, and select the spreadsheets to use. Do not retry Pipedream."
+            f"{integration.display_name} through Pipedream is disabled, and the native "
+            f"{integration.display_name} skill was explicitly disabled for this agent. Do not retry Pipedream; "
+            f"tell the requester the native {integration.display_name} skill must be re-enabled before this work "
+            "can continue."
         )
-        next_action = "continue_with_native_google_sheets"
-    elif handoff_status == GOOGLE_SHEETS_HANDOFF_EXPLICITLY_DISABLED:
-        message = (
-            "Google Sheets through Pipedream is disabled, and the native Google Sheets skill was explicitly disabled "
-            "for this agent. Do not retry Pipedream; tell the requester the native Google Sheets skill must be "
-            "re-enabled before this work can continue."
-        )
-        next_action = "ask_user_to_enable_native_google_sheets"
+        next_action = f"ask_user_to_enable_native_{integration.key}"
     else:
         message = (
-            "Google Sheets through Pipedream is disabled, and the native Google Sheets skill could not be prepared "
-            "automatically. Do not retry Pipedream; use search_tools to enable Google Sheets, or tell the requester "
-            "that native integration setup needs attention."
+            f"{integration.display_name} through Pipedream is disabled, and the native "
+            f"{integration.display_name} skill could not be prepared automatically. Do not retry Pipedream; use "
+            f"search_tools to enable {integration.display_name}, or tell the requester that native integration "
+            "setup needs attention."
         )
-        next_action = "enable_native_google_sheets"
+        next_action = f"enable_native_{integration.key}"
 
     return {
         "status": "error",
         "error_code": DEPRECATED_PROVIDER_BLOCKED,
         "message": message,
         "provider": PIPEDREAM_PROVIDER,
-        "integration": GOOGLE_SHEETS_INTEGRATION,
-        "replacement": GOOGLE_SHEETS_REPLACEMENT,
+        "integration": integration.key,
+        "replacement": integration.replacement,
         "handoff_status": handoff_status,
         "next_action": next_action,
-        "setup_url": "/app/integrations",
+        "setup_url": integration.setup_url,
         "retryable": False,
     }
 
@@ -107,10 +197,15 @@ def filter_deprecated_provider_blocked_tool(
     agent: PersistentAgent,
     tool_definitions: Optional[list[dict]],
     blocked_tool_name: str,
+    blocked_integration: str = GOOGLE_SHEETS_INTEGRATION,
 ) -> Optional[list[dict]]:
-    """Keep deprecated Sheets actions out of the same-turn roster refresh."""
+    """Keep deprecated provider actions out of the same-turn roster refresh."""
     if tool_definitions is None:
         return None
+
+    integration = DEPRECATED_PIPEDREAM_INTEGRATIONS.get(blocked_integration)
+    if integration is None:
+        return tool_definitions
 
     tool_names = {
         definition["function"]["name"]
@@ -131,12 +226,17 @@ def filter_deprecated_provider_blocked_tool(
     candidates = pipedream_tool_names | {
         tool_name
         for tool_name in tool_names
-        if pipedream_app_slug_for_tool_name(tool_name) == GOOGLE_SHEETS_INTEGRATION
+        if _integration_for_tool_name(tool_name, {}) == integration.key
     }
     blocked_tool_names = {blocked_tool_name}
     for tool_name in candidates - blocked_tool_names:
         entry = _resolve_tool_entry(agent, tool_name)
-        if entry is not None and _entry_targets_pipedream_google_sheets(entry, {}):
+        detected_integration = (
+            _integration_for_entry(entry, {})
+            if entry is not None
+            else _integration_for_tool_name(tool_name, {})
+        )
+        if detected_integration == integration.key:
             blocked_tool_names.add(tool_name)
 
     return [
@@ -181,6 +281,7 @@ def _invocation_log_context() -> tuple[str, str, str]:
 def _track_blocked_execution(
     agent: PersistentAgent,
     *,
+    integration: DeprecatedPipedreamIntegration,
     tool_name: str,
     app_slug: str,
     invocation_scope: str,
@@ -192,8 +293,8 @@ def _track_blocked_execution(
             "tool_name": tool_name,
             "provider": PIPEDREAM_PROVIDER,
             "app_slug": app_slug,
-            "integration": GOOGLE_SHEETS_INTEGRATION,
-            "replacement": GOOGLE_SHEETS_REPLACEMENT,
+            "integration": integration.key,
+            "replacement": integration.replacement,
             "invocation_scope": invocation_scope,
             "handoff_status": handoff_status,
             "error_code": DEPRECATED_PROVIDER_BLOCKED,
@@ -203,7 +304,7 @@ def _track_blocked_execution(
     try:
         Analytics.track_event(
             user_id=agent.user_id,
-            event=AnalyticsEvent.PIPEDREAM_GOOGLE_SHEETS_EXECUTION_BLOCKED,
+            event=integration.analytics_event,
             source=AnalyticsSource.AGENT,
             properties=properties,
         )
@@ -217,43 +318,61 @@ def _track_blocked_execution(
         )
 
 
-def pipedream_google_sheets_blocked_error(
+def deprecated_pipedream_blocked_error(
     agent: PersistentAgent,
-    entry: Any,
+    tool_name: str,
     params: Any,
     *,
-    blocked_call: Optional[bool] = None,
+    entry: Any = None,
+    blocked_integration: Optional[str] = None,
 ) -> Optional[dict[str, Any]]:
-    should_block = (
-        is_pipedream_google_sheets_blocked_call(entry, params)
-        if blocked_call is None
-        else blocked_call and is_pipedream_google_sheets_call(entry, params)
+    detected_integration = (
+        _integration_for_entry(entry, params)
+        if entry is not None
+        else _integration_for_tool_name(tool_name, params)
     )
-    if not should_block:
+    integration_key = blocked_integration or detected_integration
+    if not integration_key or detected_integration != integration_key:
+        return None
+
+    integration = DEPRECATED_PIPEDREAM_INTEGRATIONS.get(integration_key)
+    if integration is None:
+        return None
+    # Callers that classify before billing pass the decision through so a
+    # mid-call switch change cannot make execution and credit handling differ.
+    if blocked_integration is None and not _guard_enabled(integration_key):
         return None
 
     from api.agent.system_skills.service import (
-        GOOGLE_SHEETS_HANDOFF_UNAVAILABLE,
-        prepare_google_sheets_native_handoff,
+        NATIVE_INTEGRATION_HANDOFF_UNAVAILABLE,
+        prepare_native_integration_handoff,
     )
 
     try:
-        handoff_status = prepare_google_sheets_native_handoff(agent)
+        handoff_status = prepare_native_integration_handoff(
+            agent,
+            integration.native_skill_key,
+        )
     except DatabaseError:
-        handoff_status = GOOGLE_SHEETS_HANDOFF_UNAVAILABLE
+        handoff_status = NATIVE_INTEGRATION_HANDOFF_UNAVAILABLE
         logger.warning(
-            "Unable to prepare native Google Sheets handoff for agent %s.",
+            "Unable to prepare native %s handoff for agent %s.",
+            integration.display_name,
             agent.id,
             exc_info=True,
         )
 
-    app_slug = _provider_app_slug(entry, params)
+    app_slug = (
+        _provider_app_slug(entry, params)
+        if entry is not None
+        else pipedream_app_slug_for_tool_call(tool_name, params)
+    )
     invocation_scope, parent_tool_id, parent_tool_name = _invocation_log_context()
     logger.warning(
         "Blocked deprecated provider tool execution.",
         extra={
             "agent_id": str(agent.id),
-            "tool_name": entry.full_name,
+            "tool_name": tool_name,
             "resolved_provider": PIPEDREAM_PROVIDER,
             "app_slug": app_slug,
             "invocation_scope": invocation_scope,
@@ -265,20 +384,43 @@ def pipedream_google_sheets_blocked_error(
     )
     _track_blocked_execution(
         agent,
-        tool_name=entry.full_name,
+        integration=integration,
+        tool_name=tool_name,
         app_slug=app_slug,
         invocation_scope=invocation_scope,
         handoff_status=handoff_status,
     )
-    return _blocked_error(handoff_status)
+    return _blocked_error(integration, handoff_status)
+
+
+def pipedream_google_sheets_blocked_error(
+    agent: PersistentAgent,
+    entry: Any,
+    params: Any,
+    *,
+    blocked_call: Optional[bool] = None,
+) -> Optional[dict[str, Any]]:
+    if blocked_call is False:
+        return None
+    return deprecated_pipedream_blocked_error(
+        agent,
+        entry.full_name,
+        params,
+        entry=entry,
+        blocked_integration=GOOGLE_SHEETS_INTEGRATION if blocked_call else None,
+    )
 
 
 def is_pipedream_google_sheets_blocked_call(entry: Any, params: Any) -> bool:
     return (
-        is_pipedream_google_sheets_call(entry, params)
-        and pipedream_google_sheets_guard_enabled()
+        get_blocked_deprecated_pipedream_integration(
+            entry.full_name,
+            params,
+            entry=entry,
+        )
+        == GOOGLE_SHEETS_INTEGRATION
     )
 
 
 def is_pipedream_google_sheets_call(entry: Any, params: Any) -> bool:
-    return _entry_targets_pipedream_google_sheets(entry, params)
+    return _integration_for_entry(entry, params) == GOOGLE_SHEETS_INTEGRATION

--- a/api/services/deprecated_provider_guard.py
+++ b/api/services/deprecated_provider_guard.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -15,11 +16,9 @@ from api.services.pipedream_apps import (
     normalize_app_slug,
     pipedream_app_slug_for_tool_call,
 )
-from api.services.pipedream_feature_flags import (
-    pipedream_apollo_guard_enabled,
-    pipedream_google_sheets_guard_enabled,
-)
+from constants.feature_flags import PIPEDREAM_APOLLO_GUARD, PIPEDREAM_GOOGLE_SHEETS_GUARD
 from util.analytics import Analytics, AnalyticsEvent, AnalyticsSource
+from util.waffle_flags import is_waffle_switch_active
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +34,9 @@ class DeprecatedPipedreamIntegration:
     display_name: str
     pipedream_app_slugs: frozenset[str]
     native_skill_key: str
-    replacement: str
+    switch_name: str
     setup_url: str
+    ready_message: str
     analytics_event: AnalyticsEvent
 
 
@@ -46,8 +46,13 @@ DEPRECATED_PIPEDREAM_INTEGRATIONS = {
         display_name="Google Sheets",
         pipedream_app_slugs=frozenset({"google_sheets"}),
         native_skill_key=GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
-        replacement="google_sheets_native",
+        switch_name=PIPEDREAM_GOOGLE_SHEETS_GUARD,
         setup_url="/app/integrations",
+        ready_message=(
+            "Google Sheets through Pipedream is disabled. The native Google Sheets skill is enabled; continue "
+            "with it now. If Google Drive is disconnected, tell the requester to open /app/integrations, "
+            "connect Google Drive, and select the spreadsheets to use. Do not retry Pipedream."
+        ),
         analytics_event=AnalyticsEvent.PIPEDREAM_GOOGLE_SHEETS_EXECUTION_BLOCKED,
     ),
     APOLLO_INTEGRATION: DeprecatedPipedreamIntegration(
@@ -55,19 +60,20 @@ DEPRECATED_PIPEDREAM_INTEGRATIONS = {
         display_name="Apollo",
         pipedream_app_slugs=frozenset({"apollo_io", "apollo_io_oauth"}),
         native_skill_key=APOLLO_NATIVE_SYSTEM_SKILL_KEY,
-        replacement="apollo_native",
+        switch_name=PIPEDREAM_APOLLO_GUARD,
         setup_url="/app/integrations?provider=apollo",
+        ready_message=(
+            "Apollo through Pipedream is disabled. The native Apollo skill is enabled; continue with it now "
+            "using http_request. If Apollo is disconnected, tell the requester to open "
+            "/app/integrations?provider=apollo and connect Apollo. Do not retry Pipedream."
+        ),
         analytics_event=AnalyticsEvent.PIPEDREAM_APOLLO_EXECUTION_BLOCKED,
     ),
 }
 
 
-def _guard_enabled(integration_key: str) -> bool:
-    if integration_key == GOOGLE_SHEETS_INTEGRATION:
-        return pipedream_google_sheets_guard_enabled()
-    if integration_key == APOLLO_INTEGRATION:
-        return pipedream_apollo_guard_enabled()
-    return False
+def _guard_enabled(integration: DeprecatedPipedreamIntegration) -> bool:
+    return is_waffle_switch_active(integration.switch_name, default=False)
 
 
 def _provider_app_slug(entry: Any, params: Any) -> str:
@@ -85,19 +91,25 @@ def _provider_app_slug(entry: Any, params: Any) -> str:
     return pipedream_app_slug_for_tool_call(tool_name, params)
 
 
-def _integration_for_app_slug(app_slug: str) -> Optional[str]:
+def _integration_for_app_slug(app_slug: str) -> Optional[DeprecatedPipedreamIntegration]:
     normalized_slug = normalize_app_slug(app_slug)
     for integration in DEPRECATED_PIPEDREAM_INTEGRATIONS.values():
         if normalized_slug in integration.pipedream_app_slugs:
-            return integration.key
+            return integration
     return None
 
 
-def _integration_for_tool_name(tool_name: str, params: Any) -> Optional[str]:
+def _integration_for_tool_name(
+    tool_name: str,
+    params: Any,
+) -> Optional[DeprecatedPipedreamIntegration]:
     return _integration_for_app_slug(pipedream_app_slug_for_tool_call(tool_name, params))
 
 
-def _integration_for_entry(entry: Any, params: Any) -> Optional[str]:
+def _integration_for_entry(
+    entry: Any,
+    params: Any,
+) -> Optional[DeprecatedPipedreamIntegration]:
     if (
         entry.provider != "mcp"
         or str(entry.tool_server).strip().casefold() != PIPEDREAM_PROVIDER
@@ -106,21 +118,18 @@ def _integration_for_entry(entry: Any, params: Any) -> Optional[str]:
     return _integration_for_app_slug(_provider_app_slug(entry, params))
 
 
-def get_blocked_deprecated_pipedream_integration(
+def match_deprecated_pipedream_integration(
     tool_name: str,
     params: Any,
     *,
     entry: Any = None,
-) -> Optional[str]:
-    integration_key = (
+) -> Optional[DeprecatedPipedreamIntegration]:
+    integration = (
         _integration_for_entry(entry, params)
         if entry is not None
         else _integration_for_tool_name(tool_name, params)
     )
-    if not integration_key:
-        return None
-    integration = DEPRECATED_PIPEDREAM_INTEGRATIONS[integration_key]
-    return integration_key if _guard_enabled(integration_key) else None
+    return integration if integration is not None and _guard_enabled(integration) else None
 
 
 def _resolve_tool_entry(agent: PersistentAgent, tool_name: str) -> Any:
@@ -141,18 +150,7 @@ def _blocked_error(
     )
 
     if handoff_status == NATIVE_INTEGRATION_HANDOFF_READY:
-        if integration.key == GOOGLE_SHEETS_INTEGRATION:
-            message = (
-                "Google Sheets through Pipedream is disabled. The native Google Sheets skill is enabled; continue "
-                "with it now. If Google Drive is disconnected, tell the requester to open /app/integrations, "
-                "connect Google Drive, and select the spreadsheets to use. Do not retry Pipedream."
-            )
-        else:
-            message = (
-                "Apollo through Pipedream is disabled. The native Apollo skill is enabled; continue with it now "
-                "using http_request. If Apollo is disconnected, tell the requester to open "
-                "/app/integrations?provider=apollo and connect Apollo. Do not retry Pipedream."
-            )
+        message = integration.ready_message
         next_action = f"continue_with_native_{integration.key}"
     elif handoff_status == NATIVE_INTEGRATION_HANDOFF_EXPLICITLY_DISABLED:
         message = (
@@ -177,7 +175,7 @@ def _blocked_error(
         "message": message,
         "provider": PIPEDREAM_PROVIDER,
         "integration": integration.key,
-        "replacement": integration.replacement,
+        "replacement": integration.native_skill_key,
         "handoff_status": handoff_status,
         "next_action": next_action,
         "setup_url": integration.setup_url,
@@ -197,15 +195,11 @@ def filter_deprecated_provider_blocked_tool(
     agent: PersistentAgent,
     tool_definitions: Optional[list[dict]],
     blocked_tool_name: str,
-    blocked_integration: str = GOOGLE_SHEETS_INTEGRATION,
+    blocked_integration: DeprecatedPipedreamIntegration,
 ) -> Optional[list[dict]]:
     """Keep deprecated provider actions out of the same-turn roster refresh."""
     if tool_definitions is None:
         return None
-
-    integration = DEPRECATED_PIPEDREAM_INTEGRATIONS.get(blocked_integration)
-    if integration is None:
-        return tool_definitions
 
     tool_names = {
         definition["function"]["name"]
@@ -226,7 +220,7 @@ def filter_deprecated_provider_blocked_tool(
     candidates = pipedream_tool_names | {
         tool_name
         for tool_name in tool_names
-        if _integration_for_tool_name(tool_name, {}) == integration.key
+        if _integration_for_tool_name(tool_name, {}) == blocked_integration
     }
     blocked_tool_names = {blocked_tool_name}
     for tool_name in candidates - blocked_tool_names:
@@ -236,7 +230,7 @@ def filter_deprecated_provider_blocked_tool(
             if entry is not None
             else _integration_for_tool_name(tool_name, {})
         )
-        if detected_integration == integration.key:
+        if detected_integration == blocked_integration:
             blocked_tool_names.add(tool_name)
 
     return [
@@ -248,6 +242,31 @@ def filter_deprecated_provider_blocked_tool(
             and definition["function"].get("name") in blocked_tool_names
         )
     ]
+
+
+def refresh_tools_after_deprecated_provider_handoff(
+    agent: PersistentAgent,
+    result: Any,
+    blocked_tool_name: str,
+    blocked_integration: Optional[DeprecatedPipedreamIntegration],
+    refresh_tools: Callable[[PersistentAgent], Optional[list[dict]]],
+) -> Optional[list[dict]]:
+    if not (is_deprecated_provider_blocked_result(result) and blocked_integration):
+        return None
+    try:
+        return filter_deprecated_provider_blocked_tool(
+            agent,
+            refresh_tools(agent),
+            blocked_tool_name,
+            blocked_integration,
+        )
+    except Exception:
+        # The actionable block remains valid if this best-effort roster refresh fails.
+        logger.exception(
+            "Agent %s: native integration handoff tool refresh failed; preserving the blocked result.",
+            agent.id,
+        )
+        return None
 
 
 def _invocation_log_context() -> tuple[str, str, str]:
@@ -294,7 +313,7 @@ def _track_blocked_execution(
             "provider": PIPEDREAM_PROVIDER,
             "app_slug": app_slug,
             "integration": integration.key,
-            "replacement": integration.replacement,
+            "replacement": integration.native_skill_key,
             "invocation_scope": invocation_scope,
             "handoff_status": handoff_status,
             "error_code": DEPRECATED_PROVIDER_BLOCKED,
@@ -324,23 +343,19 @@ def deprecated_pipedream_blocked_error(
     params: Any,
     *,
     entry: Any = None,
-    blocked_integration: Optional[str] = None,
+    blocked_integration: Optional[DeprecatedPipedreamIntegration] = None,
 ) -> Optional[dict[str, Any]]:
     detected_integration = (
         _integration_for_entry(entry, params)
         if entry is not None
         else _integration_for_tool_name(tool_name, params)
     )
-    integration_key = blocked_integration or detected_integration
-    if not integration_key or detected_integration != integration_key:
-        return None
-
-    integration = DEPRECATED_PIPEDREAM_INTEGRATIONS.get(integration_key)
-    if integration is None:
+    integration = blocked_integration or detected_integration
+    if integration is None or detected_integration != integration:
         return None
     # Callers that classify before billing pass the decision through so a
     # mid-call switch change cannot make execution and credit handling differ.
-    if blocked_integration is None and not _guard_enabled(integration_key):
+    if blocked_integration is None and not _guard_enabled(integration):
         return None
 
     from api.agent.system_skills.service import (
@@ -391,36 +406,3 @@ def deprecated_pipedream_blocked_error(
         handoff_status=handoff_status,
     )
     return _blocked_error(integration, handoff_status)
-
-
-def pipedream_google_sheets_blocked_error(
-    agent: PersistentAgent,
-    entry: Any,
-    params: Any,
-    *,
-    blocked_call: Optional[bool] = None,
-) -> Optional[dict[str, Any]]:
-    if blocked_call is False:
-        return None
-    return deprecated_pipedream_blocked_error(
-        agent,
-        entry.full_name,
-        params,
-        entry=entry,
-        blocked_integration=GOOGLE_SHEETS_INTEGRATION if blocked_call else None,
-    )
-
-
-def is_pipedream_google_sheets_blocked_call(entry: Any, params: Any) -> bool:
-    return (
-        get_blocked_deprecated_pipedream_integration(
-            entry.full_name,
-            params,
-            entry=entry,
-        )
-        == GOOGLE_SHEETS_INTEGRATION
-    )
-
-
-def is_pipedream_google_sheets_call(entry: Any, params: Any) -> bool:
-    return _integration_for_entry(entry, params) == GOOGLE_SHEETS_INTEGRATION

--- a/api/services/native_integrations.py
+++ b/api/services/native_integrations.py
@@ -10,10 +10,11 @@ import httpx
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
-from api.models import GlobalSecret, MCPServerConfig, PersistentAgent, PersistentAgentEnabledTool
+from api.models import GlobalSecret, MCPServerConfig, PersistentAgent
 from api.services.pipedream_apps import disable_pipedream_apps_for_owner
 from api.services.persistent_agent_secrets import resolve_global_secret_owner_for_agent
 
@@ -621,6 +622,9 @@ NATIVE_INTEGRATION_PIPEDREAM_APP_SLUGS = {
 NATIVE_INTEGRATION_AGENT_WAKE_TOOL_NAMES = {
     META_ADS_PROVIDER.key: ("meta_ads",),
 }
+NATIVE_INTEGRATION_AGENT_WAKE_SYSTEM_SKILL_KEYS = {
+    APOLLO_PROVIDER.key: ("apollo_native",),
+}
 
 
 def list_native_integration_providers() -> list[NativeIntegrationProvider]:
@@ -719,19 +723,27 @@ def disable_overlapping_pipedream_tools_for_native_integration(
 def trigger_agents_for_native_integration_change(provider_key: str, owner_user, owner_org) -> int:
     provider = get_native_integration_provider(provider_key)
     tool_names = NATIVE_INTEGRATION_AGENT_WAKE_TOOL_NAMES.get(provider.key, ())
-    if not tool_names:
+    skill_keys = NATIVE_INTEGRATION_AGENT_WAKE_SYSTEM_SKILL_KEYS.get(provider.key, ())
+    if not tool_names and not skill_keys:
         return 0
 
-    enabled_qs = PersistentAgentEnabledTool.objects.filter(tool_full_name__in=tool_names)
+    wake_filter = Q()
+    if tool_names:
+        wake_filter |= Q(enabled_tools__tool_full_name__in=tool_names)
+    if skill_keys:
+        wake_filter |= Q(
+            system_skill_states__skill_key__in=skill_keys,
+            system_skill_states__is_enabled=True,
+        )
+
+    agents = PersistentAgent.objects.filter(wake_filter, is_deleted=False, is_active=True)
     if owner_org is not None:
-        enabled_qs = enabled_qs.filter(agent__organization=owner_org)
+        agents = agents.filter(organization=owner_org)
     else:
-        enabled_qs = enabled_qs.filter(agent__user=owner_user, agent__organization__isnull=True)
+        agents = agents.filter(user=owner_user, organization__isnull=True)
 
     agent_ids = list(
-        enabled_qs.filter(agent__is_deleted=False, agent__is_active=True)
-        .values_list("agent_id", flat=True)
-        .distinct()
+        agents.values_list("id", flat=True).distinct()
     )
     if not agent_ids:
         return 0

--- a/api/services/pipedream_apps.py
+++ b/api/services/pipedream_apps.py
@@ -239,10 +239,12 @@ def pipedream_app_slug_for_tool(tool: Any) -> str:
     )
 
 
-def _native_google_sheets_handoff_ready(agent: Optional[PersistentAgent]) -> bool:
+def _native_integration_handoff_ready(
+    agent: Optional[PersistentAgent],
+    skill_key: str,
+) -> bool:
     if agent is None or getattr(agent, "pk", None) is None:
         return False
-    from api.agent.system_skills.defaults import GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY
     from api.models import PersistentAgentSystemSkillState
     from api.services.tool_blacklist import is_tool_blacklisted_for_agent
 
@@ -253,7 +255,7 @@ def _native_google_sheets_handoff_ready(agent: Optional[PersistentAgent]) -> boo
             return False
         skill_enabled = PersistentAgentSystemSkillState.objects.filter(
             agent=agent,
-            skill_key=GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
+            skill_key=skill_key,
             is_enabled=True,
         ).exists()
         if not skill_enabled:
@@ -266,35 +268,51 @@ def _native_google_sheets_handoff_ready(agent: Optional[PersistentAgent]) -> boo
         ).exists()
     except DatabaseError:
         logger.warning(
-            "Unable to verify native Google Sheets handoff state for agent %s; preserving legacy tool visibility.",
+            "Unable to verify native integration handoff state for agent %s; preserving legacy tool visibility.",
             agent.pk,
             exc_info=True,
         )
         return False
 
 
-def filter_guarded_pipedream_google_sheets_tools(
+def filter_guarded_pipedream_native_handoff_tools(
     agent: Optional[PersistentAgent],
     tools: Iterable[Any],
 ) -> list[Any]:
     tool_list = list(tools)
-    has_legacy_sheets_tool = any(
-        getattr(tool, "server_name", "") == PIPEDREAM_RUNTIME_NAME
-        and pipedream_app_slug_for_tool(tool) == PIPEDREAM_GOOGLE_SHEETS_APP_SLUG
+    present_app_slugs = {
+        pipedream_app_slug_for_tool(tool)
         for tool in tool_list
-    )
-    if (
-        not has_legacy_sheets_tool
-        or not pipedream_google_sheets_guard_enabled()
-        or not _native_google_sheets_handoff_ready(agent)
-    ):
+        if getattr(tool, "server_name", "") == PIPEDREAM_RUNTIME_NAME
+    }
+    if not present_app_slugs:
         return tool_list
+
+    # Import lazily because the execution guard uses the app-slug helpers in
+    # this module while defining the shared provider specifications.
+    from api.services.deprecated_provider_guard import (
+        DEPRECATED_PIPEDREAM_INTEGRATIONS,
+        deprecated_pipedream_guard_enabled,
+    )
+
+    hidden_app_slugs = set()
+    for integration in DEPRECATED_PIPEDREAM_INTEGRATIONS.values():
+        if (
+            present_app_slugs.isdisjoint(integration.pipedream_app_slugs)
+            or not deprecated_pipedream_guard_enabled(integration)
+            or not _native_integration_handoff_ready(agent, integration.native_skill_key)
+        ):
+            continue
+        hidden_app_slugs.update(integration.pipedream_app_slugs)
+    if not hidden_app_slugs:
+        return tool_list
+
     return [
         tool
         for tool in tool_list
         if not (
             getattr(tool, "server_name", "") == PIPEDREAM_RUNTIME_NAME
-            and pipedream_app_slug_for_tool(tool) == PIPEDREAM_GOOGLE_SHEETS_APP_SLUG
+            and pipedream_app_slug_for_tool(tool) in hidden_app_slugs
         )
     ]
 
@@ -369,7 +387,7 @@ def filter_deprecated_pipedream_apps_without_agent(apps: Iterable[Any]) -> list[
 
 def filter_deprecated_pipedream_tools_for_agent(agent: PersistentAgent, tools: Iterable[Any]) -> list[Any]:
     visibility = get_pipedream_app_visibility_for_agent(agent)
-    return filter_guarded_pipedream_google_sheets_tools(agent, visibility.filter_tools(tools))
+    return filter_guarded_pipedream_native_handoff_tools(agent, visibility.filter_tools(tools))
 
 
 def get_owner_selected_app_slugs(owner_scope: str, owner_user=None, owner_org=None) -> list[str]:

--- a/api/services/pipedream_feature_flags.py
+++ b/api/services/pipedream_feature_flags.py
@@ -1,6 +1,10 @@
-from constants.feature_flags import PIPEDREAM_GOOGLE_SHEETS_GUARD
+from constants.feature_flags import PIPEDREAM_APOLLO_GUARD, PIPEDREAM_GOOGLE_SHEETS_GUARD
 from util.waffle_flags import is_waffle_switch_active
 
 
 def pipedream_google_sheets_guard_enabled() -> bool:
     return is_waffle_switch_active(PIPEDREAM_GOOGLE_SHEETS_GUARD, default=False)
+
+
+def pipedream_apollo_guard_enabled() -> bool:
+    return is_waffle_switch_active(PIPEDREAM_APOLLO_GUARD, default=False)

--- a/api/services/pipedream_feature_flags.py
+++ b/api/services/pipedream_feature_flags.py
@@ -1,10 +1,6 @@
-from constants.feature_flags import PIPEDREAM_APOLLO_GUARD, PIPEDREAM_GOOGLE_SHEETS_GUARD
+from constants.feature_flags import PIPEDREAM_GOOGLE_SHEETS_GUARD
 from util.waffle_flags import is_waffle_switch_active
 
 
 def pipedream_google_sheets_guard_enabled() -> bool:
     return is_waffle_switch_active(PIPEDREAM_GOOGLE_SHEETS_GUARD, default=False)
-
-
-def pipedream_apollo_guard_enabled() -> bool:
-    return is_waffle_switch_active(PIPEDREAM_APOLLO_GUARD, default=False)

--- a/console/native_integrations_api.py
+++ b/console/native_integrations_api.py
@@ -355,6 +355,7 @@ class NativeIntegrationCallbackAPIView(LoginRequiredMixin, View):
         with transaction.atomic():
             secret = save_native_integration_credentials(provider, owner_user, owner_org, credentials)
             disable_overlapping_pipedream_tools_for_native_integration(provider.key, owner_user, owner_org)
+            trigger_agents_for_native_integration_change(provider.key, owner_user, owner_org)
 
         return JsonResponse(
             {

--- a/constants/feature_flags.py
+++ b/constants/feature_flags.py
@@ -17,6 +17,9 @@ AGENT_CRON_THROTTLE = "agent_cron_throttle"
 # Emergency rollback for the universal legacy Google Sheets execution guard.
 PIPEDREAM_GOOGLE_SHEETS_GUARD = "pipedream_google_sheets_guard"
 
+# Emergency rollback for the universal legacy Apollo execution guard.
+PIPEDREAM_APOLLO_GUARD = "pipedream_apollo_guard"
+
 # Route /support form submissions to Intercom-style email intake.
 SUPPORT_INTERCOM = "support_intercom"
 

--- a/tests/unit/test_event_processing_parallel_tools.py
+++ b/tests/unit/test_event_processing_parallel_tools.py
@@ -297,12 +297,12 @@ class TestParallelToolCallsExecution(TestCase):
             isolated_mcp=False,
             current_sqlite_db_path=None,
             resolved_entry=None,
-            pipedream_google_sheets_blocked=False,
+            deprecated_provider_integration=None,
         ):
             nonlocal active, max_active
             self.assertTrue(isolated_mcp)
             self.assertIsNone(current_sqlite_db_path)
-            self.assertFalse(pipedream_google_sheets_blocked)
+            self.assertIsNone(deprecated_provider_integration)
             with lock:
                 active += 1
                 max_active = max(max_active, active)
@@ -361,9 +361,9 @@ class TestParallelToolCallsExecution(TestCase):
             isolated_mcp=False,
             current_sqlite_db_path=None,
             resolved_entry=None,
-            pipedream_google_sheets_blocked=False,
+            deprecated_provider_integration=None,
         ):
-            self.assertFalse(pipedream_google_sheets_blocked)
+            self.assertIsNone(deprecated_provider_integration)
             observed_states.append(statuses_by_tool())
             return {"status": "ok", "auto_sleep_ok": True}
 
@@ -972,12 +972,12 @@ class TestParallelToolCallsExecution(TestCase):
             isolated_mcp=False,
             current_sqlite_db_path=None,
             resolved_entry=None,
-            pipedream_google_sheets_blocked=False,
+            deprecated_provider_integration=None,
         ):
             nonlocal active, max_active, active_sources, max_active_sources
             self.assertTrue(isolated_mcp)
             self.assertIsNone(current_sqlite_db_path)
-            self.assertFalse(pipedream_google_sheets_blocked)
+            self.assertIsNone(deprecated_provider_integration)
             with lock:
                 active += 1
                 max_active = max(max_active, active)
@@ -1021,12 +1021,12 @@ class TestParallelToolCallsExecution(TestCase):
             isolated_mcp=False,
             current_sqlite_db_path=None,
             resolved_entry=None,
-            pipedream_google_sheets_blocked=False,
+            deprecated_provider_integration=None,
         ):
             nonlocal active, max_active, started
             self.assertTrue(isolated_mcp)
             self.assertIsNone(current_sqlite_db_path)
-            self.assertFalse(pipedream_google_sheets_blocked)
+            self.assertIsNone(deprecated_provider_integration)
             with lock:
                 started += 1
                 worker_number = started
@@ -1231,13 +1231,13 @@ class TestParallelToolCallsExecution(TestCase):
             isolated_mcp=False,
             current_sqlite_db_path=None,
             resolved_entry=None,
-            pipedream_google_sheets_blocked=False,
+            deprecated_provider_integration=None,
         ):
             from api.agent.tools.sqlite_state import get_sqlite_db_path
 
             self.assertTrue(isolated_mcp)
             self.assertEqual(current_sqlite_db_path, "/tmp/parallel-safe.sqlite")
-            self.assertFalse(pipedream_google_sheets_blocked)
+            self.assertIsNone(deprecated_provider_integration)
             captured_paths.append(get_sqlite_db_path())
             set_agent_variable("/shared", tool_name)
             return {"status": "ok", "auto_sleep_ok": True}

--- a/tests/unit/test_native_integrations.py
+++ b/tests/unit/test_native_integrations.py
@@ -972,6 +972,45 @@ class NativeIntegrationTests(TestCase):
                 self.assertEqual(mock_post.call_args.kwargs["data"]["client_id"], client_id)
                 self.assertEqual(mock_post.call_args.kwargs["data"]["client_secret"], client_secret)
 
+    @patch("api.agent.tasks.process_events.process_agent_events_task.delay")
+    @patch("api.services.native_integrations.httpx.post")
+    def test_apollo_oauth_callback_wakes_only_agents_with_native_skill(
+        self,
+        mock_post,
+        mock_delay,
+    ):
+        PersistentAgentSystemSkillState.objects.create(
+            agent=self.agent,
+            skill_key=APOLLO_NATIVE_SYSTEM_SKILL_KEY,
+            is_enabled=True,
+        )
+        unrelated_agent = PersistentAgent.objects.create(
+            user=self.user,
+            name="Unrelated HTTP Agent",
+            charter="Has HTTP but not the Apollo skill.",
+            browser_use_agent=BrowserUseAgent.objects.create(
+                user=self.user,
+                name="Unrelated HTTP Browser",
+            ),
+        )
+        PersistentAgentEnabledTool.objects.create(
+            agent=unrelated_agent,
+            tool_full_name="http_request",
+            tool_name="http_request",
+        )
+        state = self._start_oauth(provider_key="apollo")
+        mock_post.return_value = self._token_response(
+            access_token="apollo-access-token",
+            refresh_token="apollo-refresh-token",
+            provider=APOLLO_PROVIDER,
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._post_oauth_callback(state, provider_key="apollo")
+
+        self.assertEqual(response.status_code, 200, response.content)
+        mock_delay.assert_called_once_with(str(self.agent.id))
+
     @patch("api.services.native_integrations.httpx.post")
     def test_callback_stores_hubspot_scope_array(self, mock_post):
         state = self._start_oauth(provider_key="hubspot")

--- a/tests/unit/test_pipedream_apollo_guard.py
+++ b/tests/unit/test_pipedream_apollo_guard.py
@@ -10,7 +10,7 @@ from api.agent.core.event_processing import (
     _prepare_tool_batch,
 )
 from api.agent.system_skills.defaults import APOLLO_NATIVE_SYSTEM_SKILL_KEY
-from api.agent.tools.mcp_manager import MCPToolInfo
+from api.agent.tools.mcp_manager import MCPToolInfo, MCPToolManager
 from api.agent.tools.tool_manager import ToolCatalogEntry, execute_enabled_tool
 from api.agent.tools.tracked_runtime import execute_tracked_runtime_tool_call
 from api.models import (
@@ -298,11 +298,13 @@ class PipedreamApolloExecutionGuardTests(TestCase):
             "apollo_io-internal-lookup",
             server_name="internal_crm",
         )
+        unresolved_sibling = "apollo_io-stale-sibling"
         refreshed_tools = [
             {"type": "function", "function": {"name": candidate}}
             for candidate in (
                 entry.full_name,
                 sibling.full_name,
+                unresolved_sibling,
                 sheets.full_name,
                 internal.full_name,
                 "trello-create-card",
@@ -337,10 +339,84 @@ class PipedreamApolloExecutionGuardTests(TestCase):
         }
         self.assertNotIn(entry.full_name, updated_names)
         self.assertNotIn(sibling.full_name, updated_names)
+        self.assertIn(unresolved_sibling, updated_names)
         self.assertIn(sheets.full_name, updated_names)
         self.assertIn(internal.full_name, updated_names)
         self.assertIn("trello-create-card", updated_names)
         self.assertIn("http_request", updated_names)
+
+    def test_apollo_tools_hide_from_future_rosters_after_native_handoff(self):
+        apollo = self._mcp_entry("apollo_io-search-people")
+        apollo_oauth = self._mcp_entry("apollo_io_oauth-enrich-person")
+        sheets = self._mcp_entry("google_sheets-read-rows")
+        for entry in (apollo, apollo_oauth, sheets):
+            PersistentAgentEnabledTool.objects.create(
+                agent=self.agent,
+                tool_full_name=entry.full_name,
+                tool_server=entry.tool_server,
+                tool_name=entry.tool_name,
+            )
+
+        manager = MCPToolManager()
+        with patch.object(
+            manager,
+            "get_tools_for_agent",
+            return_value=[apollo.mcp_info, apollo_oauth.mcp_info, sheets.mcp_info],
+        ), patch.object(manager, "_backfill_enabled_tool_metadata"):
+            before_handoff = manager.get_enabled_tools_definitions(self.agent)
+            handoff = execute_enabled_tool(
+                self.agent,
+                apollo.full_name,
+                {},
+                resolved_entry=apollo,
+            )
+            after_handoff = manager.get_enabled_tools_definitions(self.agent)
+
+        before_names = {definition["function"]["name"] for definition in before_handoff}
+        after_names = {definition["function"]["name"] for definition in after_handoff}
+        self.assertEqual(handoff["handoff_status"], "ready")
+        self.assertEqual(
+            before_names,
+            {apollo.full_name, apollo_oauth.full_name, sheets.full_name},
+        )
+        self.assertNotIn(apollo.full_name, after_names)
+        self.assertNotIn(apollo_oauth.full_name, after_names)
+        self.assertIn(sheets.full_name, after_names)
+
+    def test_credit_preflight_does_not_resolve_spoofed_prefix_twice(self):
+        entry = self._mcp_entry(
+            "apollo_io-internal-lookup",
+            server_name="internal_crm",
+        )
+        tool_call = {
+            "id": "call-internal-apollo",
+            "function": {"name": entry.full_name, "arguments": "{}"},
+        }
+
+        with patch(
+            "api.agent.core.event_processing.is_credit_message_only_mode",
+            return_value=True,
+        ), patch(
+            "api.agent.core.event_processing.resolve_tool_entry",
+            return_value=entry,
+        ) as resolve:
+            prepared_batch = _prepare_tool_batch(
+                self.agent,
+                tool_calls=[tool_call],
+                budget_ctx=None,
+                eval_run_id=None,
+                heartbeat=None,
+                lock_extender=None,
+                credit_snapshot={"available": None, "daily_state": {}},
+                allow_inferred_message_continue=True,
+                has_non_sleep_calls=True,
+                has_user_facing_message=False,
+                attach_completion=lambda kwargs: None,
+                attach_prompt_archive=lambda step: None,
+            )
+
+        self.assertEqual(prepared_batch.prepared_calls, [])
+        resolve.assert_called_once_with(self.agent, entry.full_name)
 
     def test_eval_mock_cannot_bypass_apollo_guard(self):
         entry = self._mcp_entry("apollo_io-search-people")

--- a/tests/unit/test_pipedream_apollo_guard.py
+++ b/tests/unit/test_pipedream_apollo_guard.py
@@ -20,6 +20,11 @@ from api.models import (
     PersistentAgentSystemSkillState,
     PersistentAgentToolCall,
 )
+from api.services.native_integrations import (
+    APOLLO_PROVIDER,
+    native_integration_is_connected,
+    save_native_integration_credentials,
+)
 from constants.feature_flags import PIPEDREAM_APOLLO_GUARD
 from util.analytics import AnalyticsEvent, AnalyticsSource
 
@@ -71,15 +76,6 @@ class PipedreamApolloExecutionGuardTests(TestCase):
             mcp_info=tool_info,
         )
 
-    @staticmethod
-    def _enable(agent: PersistentAgent, entry: ToolCatalogEntry) -> None:
-        PersistentAgentEnabledTool.objects.create(
-            agent=agent,
-            tool_full_name=entry.full_name,
-            tool_server=entry.tool_server,
-            tool_name=entry.tool_name,
-        )
-
     def test_apollo_prefixes_metadata_and_generic_components_are_blocked(self):
         cases = (
             (self._mcp_entry("apollo_io-search-people"), {}),
@@ -119,6 +115,19 @@ class PipedreamApolloExecutionGuardTests(TestCase):
 
     def test_ready_handoff_enables_native_apollo_and_emits_analytics(self):
         entry = self._mcp_entry("apollo_io-search-people")
+        save_native_integration_credentials(
+            APOLLO_PROVIDER,
+            self.agent.user,
+            None,
+            {"provider_key": APOLLO_PROVIDER.key, "access_token": "apollo-access-token"},
+        )
+        self.assertTrue(
+            native_integration_is_connected(
+                APOLLO_PROVIDER.key,
+                self.agent.user,
+                None,
+            )
+        )
 
         with patch(
             "api.services.deprecated_provider_guard.Analytics.track_event"
@@ -276,7 +285,7 @@ class PipedreamApolloExecutionGuardTests(TestCase):
 
         self.assertEqual(len(prepared_batch.prepared_calls), 1)
         prepared = prepared_batch.prepared_calls[0]
-        self.assertEqual(prepared.deprecated_provider_integration, "apollo")
+        self.assertEqual(prepared.deprecated_provider_integration.key, "apollo")
         self.assertIsNone(prepared.resolved_entry)
         rate_limit.assert_not_called()
         credit_gate.assert_not_called()

--- a/tests/unit/test_pipedream_apollo_guard.py
+++ b/tests/unit/test_pipedream_apollo_guard.py
@@ -1,0 +1,434 @@
+import json
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, tag
+from waffle.testutils import override_switch
+
+from api.agent.core.event_processing import (
+    _execute_tool_call_runtime,
+    _prepare_tool_batch,
+)
+from api.agent.system_skills.defaults import APOLLO_NATIVE_SYSTEM_SKILL_KEY
+from api.agent.tools.mcp_manager import MCPToolInfo
+from api.agent.tools.tool_manager import ToolCatalogEntry, execute_enabled_tool
+from api.agent.tools.tracked_runtime import execute_tracked_runtime_tool_call
+from api.models import (
+    BrowserUseAgent,
+    PersistentAgent,
+    PersistentAgentEnabledTool,
+    PersistentAgentSystemSkillState,
+    PersistentAgentToolCall,
+)
+from constants.feature_flags import PIPEDREAM_APOLLO_GUARD
+from util.analytics import AnalyticsEvent, AnalyticsSource
+
+
+@tag("batch_mcp_tools")
+@override_switch(PIPEDREAM_APOLLO_GUARD, active=True)
+class PipedreamApolloExecutionGuardTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user = get_user_model().objects.create_user(
+            username="pipedream-apollo-guard@example.com",
+            email="pipedream-apollo-guard@example.com",
+            password="secret",
+        )
+        cls.agent = PersistentAgent.objects.create(
+            user=user,
+            name="Apollo Guard Agent",
+            charter="Test the Apollo provider guard.",
+            browser_use_agent=BrowserUseAgent.objects.create(
+                user=user,
+                name="Apollo Guard Browser",
+            ),
+        )
+
+    @staticmethod
+    def _mcp_entry(
+        tool_name: str,
+        *,
+        server_name: str = "pipedream",
+        app_slug: str = "",
+    ) -> ToolCatalogEntry:
+        tool_info = MCPToolInfo(
+            config_id=f"{server_name}-config",
+            full_name=tool_name,
+            server_name=server_name,
+            tool_name=tool_name,
+            description="Test MCP tool",
+            parameters={"type": "object", "properties": {}},
+            app_slug=app_slug,
+        )
+        return ToolCatalogEntry(
+            provider="mcp",
+            full_name=tool_name,
+            description=tool_info.description,
+            parameters=tool_info.parameters,
+            tool_server=server_name,
+            tool_name=tool_name,
+            server_config_id=tool_info.config_id,
+            mcp_info=tool_info,
+        )
+
+    @staticmethod
+    def _enable(agent: PersistentAgent, entry: ToolCatalogEntry) -> None:
+        PersistentAgentEnabledTool.objects.create(
+            agent=agent,
+            tool_full_name=entry.full_name,
+            tool_server=entry.tool_server,
+            tool_name=entry.tool_name,
+        )
+
+    def test_apollo_prefixes_metadata_and_generic_components_are_blocked(self):
+        cases = (
+            (self._mcp_entry("apollo_io-search-people"), {}),
+            (self._mcp_entry("apollo_io_oauth-search-people"), {}),
+            (self._mcp_entry("component-proxy", app_slug="apollo_io"), {}),
+            (self._mcp_entry("component-oauth-proxy", app_slug="apollo_io_oauth"), {}),
+            (
+                self._mcp_entry("retrieve_options"),
+                {"componentKey": "apollo_io-search-people"},
+            ),
+            (
+                self._mcp_entry("configure_component"),
+                {"component_key": "apollo_io_oauth-enrich-person"},
+            ),
+        )
+
+        for entry, params in cases:
+            with self.subTest(tool_name=entry.full_name, app_slug=entry.mcp_info.app_slug):
+                with patch("api.agent.tools.tool_manager.execute_mcp_tool") as shared, patch(
+                    "api.agent.tools.tool_manager.execute_mcp_tool_isolated"
+                ) as isolated:
+                    result = execute_enabled_tool(
+                        self.agent,
+                        entry.full_name,
+                        params,
+                        isolated_mcp=True,
+                        resolved_entry=entry,
+                    )
+
+                self.assertEqual(result["error_code"], "deprecated_provider_blocked")
+                self.assertEqual(result["integration"], "apollo")
+                self.assertEqual(result["replacement"], "apollo_native")
+                self.assertEqual(result["setup_url"], "/app/integrations?provider=apollo")
+                self.assertIs(result["retryable"], False)
+                shared.assert_not_called()
+                isolated.assert_not_called()
+
+    def test_ready_handoff_enables_native_apollo_and_emits_analytics(self):
+        entry = self._mcp_entry("apollo_io-search-people")
+
+        with patch(
+            "api.services.deprecated_provider_guard.Analytics.track_event"
+        ) as track_event:
+            result = execute_enabled_tool(
+                self.agent,
+                entry.full_name,
+                {},
+                resolved_entry=entry,
+            )
+
+        self.assertEqual(result["handoff_status"], "ready")
+        self.assertEqual(result["next_action"], "continue_with_native_apollo")
+        self.assertIn("using http_request", result["message"])
+        self.assertIn("Do not retry Pipedream", result["message"])
+        self.assertTrue(
+            PersistentAgentSystemSkillState.objects.filter(
+                agent=self.agent,
+                skill_key=APOLLO_NATIVE_SYSTEM_SKILL_KEY,
+                is_enabled=True,
+            ).exists()
+        )
+        self.assertTrue(
+            PersistentAgentEnabledTool.objects.filter(
+                agent=self.agent,
+                tool_full_name="http_request",
+            ).exists()
+        )
+        analytics_call = track_event.call_args.kwargs
+        self.assertEqual(
+            analytics_call["event"],
+            AnalyticsEvent.PIPEDREAM_APOLLO_EXECUTION_BLOCKED,
+        )
+        self.assertEqual(analytics_call["source"], AnalyticsSource.AGENT)
+        self.assertEqual(analytics_call["properties"]["tool_name"], entry.full_name)
+        self.assertEqual(analytics_call["properties"]["app_slug"], "apollo_io")
+        self.assertEqual(analytics_call["properties"]["invocation_scope"], "top_level")
+        self.assertEqual(analytics_call["properties"]["handoff_status"], "ready")
+        self.assertEqual(analytics_call["properties"]["agent_id"], str(self.agent.id))
+        self.assertIn("organization", analytics_call["properties"])
+
+    def test_explicitly_disabled_native_apollo_is_not_reactivated(self):
+        entry = self._mcp_entry("apollo_io-search-people")
+        state = PersistentAgentSystemSkillState.objects.create(
+            agent=self.agent,
+            skill_key=APOLLO_NATIVE_SYSTEM_SKILL_KEY,
+            is_enabled=False,
+        )
+
+        result = execute_enabled_tool(
+            self.agent,
+            entry.full_name,
+            {},
+            resolved_entry=entry,
+        )
+
+        state.refresh_from_db()
+        self.assertIs(state.is_enabled, False)
+        self.assertEqual(result["handoff_status"], "explicitly_disabled")
+        self.assertEqual(result["next_action"], "ask_user_to_enable_native_apollo")
+        self.assertFalse(
+            PersistentAgentEnabledTool.objects.filter(
+                agent=self.agent,
+                tool_full_name="http_request",
+            ).exists()
+        )
+
+    def test_unavailable_native_handoff_remains_typed_and_actionable(self):
+        entry = self._mcp_entry("apollo_io_oauth-enrich-person")
+
+        with patch(
+            "api.agent.tools.tool_manager.mark_tool_enabled_without_discovery",
+            return_value={"status": "error", "message": "unavailable"},
+        ):
+            result = execute_enabled_tool(
+                self.agent,
+                entry.full_name,
+                {},
+                resolved_entry=entry,
+            )
+
+        self.assertEqual(result["error_code"], "deprecated_provider_blocked")
+        self.assertEqual(result["handoff_status"], "unavailable")
+        self.assertEqual(result["next_action"], "enable_native_apollo")
+        self.assertIn("search_tools", result["message"])
+
+    def test_unresolved_stale_call_is_blocked_before_limits_and_persisted(self):
+        tool_name = "apollo_io-search-people"
+
+        with patch(
+            "api.agent.tools.tool_manager.resolve_tool_entry",
+            return_value=None,
+        ), patch(
+            "api.agent.core.event_processing._enforce_tool_rate_limit"
+        ) as rate_limit, patch(
+            "api.agent.core.event_processing._ensure_credit_for_tool"
+        ) as credit_gate, patch(
+            "api.agent.tools.tool_manager.execute_mcp_tool"
+        ) as executor, patch(
+            "api.agent.tools.tool_runtime._refresh_agent_tools",
+            return_value=[],
+        ):
+            result, _updated_tools = execute_tracked_runtime_tool_call(
+                self.agent,
+                tool_name=tool_name,
+                exec_params={"q_keywords": "founder"},
+            )
+
+        self.assertEqual(result["error_code"], "deprecated_provider_blocked")
+        self.assertNotIn("not available", result["message"])
+        persisted = PersistentAgentToolCall.objects.get(tool_name=tool_name)
+        persisted_result = json.loads(persisted.result)
+        self.assertEqual(persisted.status, PersistentAgentToolCall.Status.ERROR)
+        self.assertEqual(persisted_result["error_code"], "deprecated_provider_blocked")
+        self.assertEqual(persisted_result["integration"], "apollo")
+        self.assertEqual(persisted_result["status_code"], "deprecated_provider_blocked")
+        rate_limit.assert_not_called()
+        credit_gate.assert_not_called()
+        executor.assert_not_called()
+
+    def test_stale_generic_call_absent_from_latest_roster_reaches_guard(self):
+        tool_call = {
+            "id": "call-apollo",
+            "function": {
+                "name": "retrieve_options",
+                "arguments": json.dumps(
+                    {"componentKey": "apollo_io_oauth-search-people"}
+                ),
+            },
+        }
+
+        with patch(
+            "api.agent.core.event_processing.resolve_tool_entry",
+            return_value=None,
+        ), patch(
+            "api.agent.core.event_processing._enforce_tool_rate_limit"
+        ) as rate_limit, patch(
+            "api.agent.core.event_processing._ensure_credit_for_tool"
+        ) as credit_gate:
+            prepared_batch = _prepare_tool_batch(
+                self.agent,
+                tool_calls=[tool_call],
+                allowed_tool_names={"send_chat_message"},
+                budget_ctx=None,
+                eval_run_id=None,
+                heartbeat=None,
+                lock_extender=None,
+                credit_snapshot={"available": None, "daily_state": {}},
+                allow_inferred_message_continue=True,
+                has_non_sleep_calls=True,
+                has_user_facing_message=False,
+                attach_completion=lambda kwargs: None,
+                attach_prompt_archive=lambda step: None,
+            )
+
+        self.assertEqual(len(prepared_batch.prepared_calls), 1)
+        prepared = prepared_batch.prepared_calls[0]
+        self.assertEqual(prepared.deprecated_provider_integration, "apollo")
+        self.assertIsNone(prepared.resolved_entry)
+        rate_limit.assert_not_called()
+        credit_gate.assert_not_called()
+
+    def test_same_turn_refresh_removes_only_apollo_pipedream_tools(self):
+        entry = self._mcp_entry("apollo_io-search-people")
+        sibling = self._mcp_entry("apollo_io_oauth-enrich-person")
+        sheets = self._mcp_entry("google_sheets-read-rows")
+        internal = self._mcp_entry(
+            "apollo_io-internal-lookup",
+            server_name="internal_crm",
+        )
+        refreshed_tools = [
+            {"type": "function", "function": {"name": candidate}}
+            for candidate in (
+                entry.full_name,
+                sibling.full_name,
+                sheets.full_name,
+                internal.full_name,
+                "trello-create-card",
+                "http_request",
+            )
+        ]
+        resolved_entries = {
+            sibling.full_name: sibling,
+            sheets.full_name: sheets,
+            internal.full_name: internal,
+        }
+
+        with patch(
+            "api.agent.core.event_processing.get_agent_tools",
+            return_value=refreshed_tools,
+        ), patch(
+            "api.services.deprecated_provider_guard._resolve_tool_entry",
+            side_effect=lambda _agent, tool_name: resolved_entries.get(tool_name),
+        ):
+            result, updated_tools = _execute_tool_call_runtime(
+                self.agent,
+                tool_name=entry.full_name,
+                exec_params={},
+                budget_ctx=None,
+                eval_run_id=None,
+                resolved_entry=entry,
+            )
+
+        self.assertEqual(result["handoff_status"], "ready")
+        updated_names = {
+            definition["function"]["name"] for definition in updated_tools
+        }
+        self.assertNotIn(entry.full_name, updated_names)
+        self.assertNotIn(sibling.full_name, updated_names)
+        self.assertIn(sheets.full_name, updated_names)
+        self.assertIn(internal.full_name, updated_names)
+        self.assertIn("trello-create-card", updated_names)
+        self.assertIn("http_request", updated_names)
+
+    def test_eval_mock_cannot_bypass_apollo_guard(self):
+        entry = self._mcp_entry("apollo_io-search-people")
+
+        with patch(
+            "api.agent.core.event_processing._resolve_eval_mock_result",
+            return_value={"status": "ok", "people": [{"id": "mock"}]},
+        ), patch(
+            "api.agent.core.event_processing.get_agent_tools",
+            return_value=[],
+        ), patch(
+            "api.agent.tools.tool_manager.execute_mcp_tool",
+        ) as executor:
+            result, _updated_tools = _execute_tool_call_runtime(
+                self.agent,
+                tool_name=entry.full_name,
+                exec_params={},
+                budget_ctx=None,
+                eval_run_id="apollo-guard-eval",
+                resolved_entry=entry,
+            )
+
+        self.assertEqual(result["error_code"], "deprecated_provider_blocked")
+        executor.assert_not_called()
+
+    def test_parallel_executor_cannot_bypass_apollo_guard(self):
+        entry = self._mcp_entry("apollo_io_oauth-enrich-person")
+
+        with patch(
+            "api.agent.core.event_processing.get_agent_tools",
+            return_value=[],
+        ), patch(
+            "api.agent.tools.tool_manager.execute_mcp_tool",
+        ) as shared, patch(
+            "api.agent.tools.tool_manager.execute_mcp_tool_isolated",
+        ) as isolated:
+            result, _updated_tools = _execute_tool_call_runtime(
+                self.agent,
+                tool_name=entry.full_name,
+                exec_params={},
+                budget_ctx=None,
+                eval_run_id=None,
+                parallel_safe=True,
+                resolved_entry=entry,
+            )
+
+        self.assertEqual(result["error_code"], "deprecated_provider_blocked")
+        shared.assert_not_called()
+        isolated.assert_not_called()
+
+    def test_non_pipedream_prefix_match_remains_allowed(self):
+        entry = self._mcp_entry(
+            "apollo_io-internal-lookup",
+            server_name="internal_crm",
+        )
+
+        with patch(
+            "api.agent.tools.tool_manager.execute_mcp_tool",
+            return_value={"status": "ok", "person": {}},
+        ) as executor:
+            result = execute_enabled_tool(
+                self.agent,
+                entry.full_name,
+                {},
+                resolved_entry=entry,
+            )
+
+        self.assertEqual(result["status"], "ok")
+        executor.assert_called_once()
+
+    @override_switch(PIPEDREAM_APOLLO_GUARD, active=False)
+    def test_switch_off_restores_execution_and_unavailable_behavior(self):
+        entry = self._mcp_entry("apollo_io-search-people")
+
+        with patch(
+            "api.agent.tools.tool_manager.execute_mcp_tool",
+            return_value={"status": "ok", "people": []},
+        ) as executor:
+            resolved_result = execute_enabled_tool(
+                self.agent,
+                entry.full_name,
+                {},
+                resolved_entry=entry,
+            )
+        with patch(
+            "api.agent.tools.tool_manager.resolve_tool_entry",
+            return_value=None,
+        ):
+            unresolved_result, _updated_tools = _execute_tool_call_runtime(
+                self.agent,
+                tool_name="apollo_io-stale-tool",
+                exec_params={},
+                budget_ctx=None,
+                eval_run_id=None,
+                resolved_entry=None,
+            )
+
+        self.assertEqual(resolved_result["status"], "ok")
+        executor.assert_called_once()
+        self.assertIn("not available", unresolved_result["message"])

--- a/tests/unit/test_pipedream_google_sheets_guard.py
+++ b/tests/unit/test_pipedream_google_sheets_guard.py
@@ -15,7 +15,7 @@ from api.agent.core.event_processing import (
     _resolve_tool_for_execution,
 )
 from api.agent.system_skills.defaults import GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY
-from api.agent.system_skills.service import prepare_google_sheets_native_handoff
+from api.agent.system_skills.service import prepare_native_integration_handoff
 from api.agent.tools.mcp_manager import MCPToolInfo, MCPToolManager
 from api.agent.tools.sqlite_skills import format_recent_skills_for_prompt
 from api.agent.tools.tool_runtime import execute_runtime_tool_call
@@ -33,6 +33,7 @@ from api.models import (
     PersistentAgentSystemSkillState,
     PersistentAgentToolCall,
 )
+from api.services.deprecated_provider_guard import DEPRECATED_PIPEDREAM_INTEGRATIONS
 from constants.feature_flags import PIPEDREAM_GOOGLE_SHEETS_GUARD
 from util.analytics import AnalyticsEvent, AnalyticsSource
 
@@ -504,14 +505,20 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
             ],
         ), patch.object(manager, "_backfill_enabled_tool_metadata"):
             before_handoff = manager.get_enabled_tools_definitions(self.agent_a)
-            handoff_status = prepare_google_sheets_native_handoff(self.agent_a)
+            handoff_status = prepare_native_integration_handoff(
+                self.agent_a,
+                GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
+            )
             after_handoff = manager.get_enabled_tools_definitions(self.agent_a)
             PersistentAgentEnabledTool.objects.filter(
                 agent=self.agent_a,
                 tool_full_name="http_request",
             ).delete()
             after_native_tool_eviction = manager.get_enabled_tools_definitions(self.agent_a)
-            prepare_google_sheets_native_handoff(self.agent_a)
+            prepare_native_integration_handoff(
+                self.agent_a,
+                GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
+            )
             with patch(
                 "api.services.tool_blacklist.is_tool_blacklisted_for_agent",
                 return_value=True,
@@ -674,7 +681,7 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
         self.assertEqual(len(prepared_batch.prepared_calls), 1)
         prepared = prepared_batch.prepared_calls[0]
         self.assertEqual(
-            prepared.deprecated_provider_integration,
+            prepared.deprecated_provider_integration.key,
             "google_sheets",
         )
         self.assertIsNone(prepared.resolved_entry)
@@ -717,7 +724,7 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
         self._enable(self.agent_a, entry)
 
         with patch(
-            "api.services.deprecated_provider_guard.pipedream_google_sheets_guard_enabled",
+            "api.services.deprecated_provider_guard.is_waffle_switch_active",
             side_effect=[True, AssertionError("guard decision was evaluated twice")],
         ) as guard_enabled, patch(
             "api.agent.core.event_processing._enforce_tool_rate_limit",
@@ -739,7 +746,10 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
             )
 
         self.assertEqual(result["error_code"], "deprecated_provider_blocked")
-        guard_enabled.assert_called_once_with()
+        guard_enabled.assert_called_once_with(
+            PIPEDREAM_GOOGLE_SHEETS_GUARD,
+            default=False,
+        )
         rate_limit.assert_not_called()
         credit_gate.assert_not_called()
         executor.assert_not_called()
@@ -751,7 +761,13 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
             app_slug="google_sheets",
         )
         self._enable(self.agent_a, entry)
-        self.assertEqual(prepare_google_sheets_native_handoff(self.agent_a), "ready")
+        self.assertEqual(
+            prepare_native_integration_handoff(
+                self.agent_a,
+                GOOGLE_SHEETS_NATIVE_SYSTEM_SKILL_KEY,
+            ),
+            "ready",
+        )
         manager = MCPToolManager()
 
         with patch.object(
@@ -827,7 +843,7 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
             parallel_safe=False,
             parallel_ineligible_reason="test",
             resolved_entry=entry,
-            deprecated_provider_integration="google_sheets",
+            deprecated_provider_integration=DEPRECATED_PIPEDREAM_INTEGRATIONS["google_sheets"],
         )
         outcome = _ToolExecutionOutcome(
             prepared=prepared,

--- a/tests/unit/test_pipedream_google_sheets_guard.py
+++ b/tests/unit/test_pipedream_google_sheets_guard.py
@@ -619,6 +619,68 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
         resolve.assert_not_called()
         executor.assert_not_called()
 
+    def test_unresolved_stale_sheets_name_returns_native_handoff_error(self):
+        with patch(
+            "api.agent.tools.tool_runtime._refresh_agent_tools",
+            return_value=[],
+        ), patch(
+            "api.agent.tools.tool_manager.execute_mcp_tool",
+        ) as executor:
+            result, _updated_tools = execute_runtime_tool_call(
+                self.agent_a,
+                tool_name="google_sheets-stale-action",
+                exec_params={},
+                resolved_entry=None,
+            )
+
+        self.assertEqual(result["error_code"], "deprecated_provider_blocked")
+        self.assertEqual(result["integration"], "google_sheets")
+        self.assertNotIn("not available", result["message"])
+        executor.assert_not_called()
+
+    def test_stale_sheets_name_absent_from_latest_roster_reaches_guard(self):
+        tool_call = {
+            "id": "call-stale-sheets",
+            "function": {
+                "name": "google_sheets-stale-action",
+                "arguments": "{}",
+            },
+        }
+
+        with patch(
+            "api.agent.core.event_processing.resolve_tool_entry",
+            return_value=None,
+        ), patch(
+            "api.agent.core.event_processing._enforce_tool_rate_limit"
+        ) as rate_limit, patch(
+            "api.agent.core.event_processing._ensure_credit_for_tool"
+        ) as credit_gate:
+            prepared_batch = _prepare_tool_batch(
+                self.agent_a,
+                tool_calls=[tool_call],
+                allowed_tool_names={"send_chat_message"},
+                budget_ctx=None,
+                eval_run_id=None,
+                heartbeat=None,
+                lock_extender=None,
+                credit_snapshot={"available": None, "daily_state": {}},
+                allow_inferred_message_continue=True,
+                has_non_sleep_calls=True,
+                has_user_facing_message=False,
+                attach_completion=lambda kwargs: None,
+                attach_prompt_archive=lambda step: None,
+            )
+
+        self.assertEqual(len(prepared_batch.prepared_calls), 1)
+        prepared = prepared_batch.prepared_calls[0]
+        self.assertEqual(
+            prepared.deprecated_provider_integration,
+            "google_sheets",
+        )
+        self.assertIsNone(prepared.resolved_entry)
+        rate_limit.assert_not_called()
+        credit_gate.assert_not_called()
+
     def test_nested_direct_runtime_tool_skips_catalog_resolution(self):
         with patch(
             "api.agent.core.event_processing._enforce_tool_rate_limit",
@@ -647,7 +709,7 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
             exec_params={"to_address": "test@example.com", "body": "hello"},
             isolated_mcp=False,
             resolved_entry=None,
-            pipedream_google_sheets_blocked=False,
+            deprecated_provider_integration=None,
         )
 
     def test_nested_guard_decision_is_stable_for_execution_and_billing(self):
@@ -765,7 +827,7 @@ class PipedreamGoogleSheetsExecutionGuardTests(TestCase):
             parallel_safe=False,
             parallel_ineligible_reason="test",
             resolved_entry=entry,
-            pipedream_google_sheets_blocked=True,
+            deprecated_provider_integration="google_sheets",
         )
         outcome = _ToolExecutionOutcome(
             prepared=prepared,

--- a/util/analytics.py
+++ b/util/analytics.py
@@ -315,6 +315,7 @@ class AnalyticsEvent(StrEnum):
     # Pipedream Events
     PIPEDREAM_JIT_CONNECT_REDIRECT = 'Pipedream JIT Connect Redirect'
     PIPEDREAM_GOOGLE_SHEETS_EXECUTION_BLOCKED = 'Pipedream Google Sheets Execution Blocked'
+    PIPEDREAM_APOLLO_EXECUTION_BLOCKED = 'Pipedream Apollo Execution Blocked'
 
     # Email Events
     EMAIL_OPENED = 'Email Opened'


### PR DESCRIPTION
## Summary

- Add Apollo migration support across tool execution, runtime tracking, and system skills
- Introduce feature-flagged guards for deprecated Pipedream Apollo and Google Sheets providers
- Update event processing and analytics integrations
- Add unit coverage for parallel tool execution and provider guard behavior

## Testing

Not run (not requested)