### PR TITLE
Limit burn-rate judge suggestions to one run per UTC day

### DIFF
--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -152,13 +152,8 @@ def maybe_run_agent_judge(
             BURN_RATE_TIER_STEP_DOWN_REASON in trigger.reasons
             and not _claim_burn_rate_judge_daily_slot(agent)
         ):
-            trigger = build_judge_trigger(
-                agent,
-                tools=tools,
-                extra_trigger_reasons=extra_trigger_reasons,
-                trigger_context=trigger_context,
-            )
-            if trigger is None:
+            trigger.reasons.remove(BURN_RATE_TIER_STEP_DOWN_REASON)
+            if not trigger.reasons:
                 return
         _run_judge(agent, trigger, routing_profile=routing_profile)
     except Exception:
@@ -306,7 +301,7 @@ def build_judge_trigger(
         _trigger_reasons(recent_messages, recent_tool_calls),
         extra_trigger_reasons or [],
     )
-    if BURN_RATE_TIER_STEP_DOWN_REASON in reasons and _has_burn_rate_judge_daily_slot(agent):
+    if BURN_RATE_TIER_STEP_DOWN_REASON in reasons and _burn_rate_judge_daily_slot_claimed(agent):
         reasons.remove(BURN_RATE_TIER_STEP_DOWN_REASON)
     if not reasons:
         return None
@@ -1467,7 +1462,7 @@ def _burn_rate_judge_daily_cache_timeout(now=None) -> int:
     return max(1, int((next_day - current_time).total_seconds()))
 
 
-def _has_burn_rate_judge_daily_slot(agent: PersistentAgent) -> bool:
+def _burn_rate_judge_daily_slot_claimed(agent: PersistentAgent) -> bool:
     try:
         return bool(get_redis_client().get(_burn_rate_judge_daily_cache_key(agent)))
     except redis.RedisError:

--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -49,6 +49,7 @@ JUDGE_RUN_CACHE_TTL_SECONDS = 60 * 60 * 12
 JUDGE_MIN_STEP_GAP = 10
 JUDGE_RUN_COOLDOWN_SECONDS = 60 * 45
 JUDGE_DAILY_RUN_LIMIT = 6
+BURN_RATE_TIER_STEP_DOWN_REASON = "burn_rate_tier_step_down"
 REPORT_TOOL_NAME = "report_judge_suggestion"
 NO_ACTION = "no_action"
 JUDGE_FAILED_TOOL_TRIGGER_IGNORED_TOOL_NAMES = frozenset({"send_chat_message"})
@@ -144,6 +145,18 @@ def maybe_run_agent_judge(
         )
         if trigger is None:
             return
+        if (
+            BURN_RATE_TIER_STEP_DOWN_REASON in trigger.reasons
+            and not _claim_burn_rate_judge_daily_slot(agent)
+        ):
+            trigger = build_judge_trigger(
+                agent,
+                tools=tools,
+                extra_trigger_reasons=extra_trigger_reasons,
+                trigger_context=trigger_context,
+            )
+            if trigger is None:
+                return
         _run_judge(agent, trigger, routing_profile=routing_profile)
     except Exception:
         # The judge is advisory. A failure here must never interrupt agent work.
@@ -290,6 +303,8 @@ def build_judge_trigger(
         _trigger_reasons(recent_messages, recent_tool_calls),
         extra_trigger_reasons or [],
     )
+    if BURN_RATE_TIER_STEP_DOWN_REASON in reasons and _has_burn_rate_judge_daily_slot(agent):
+        reasons.remove(BURN_RATE_TIER_STEP_DOWN_REASON)
     if not reasons:
         return None
 
@@ -1431,6 +1446,34 @@ def _hash_payload(payload: dict[str, Any]) -> str:
 
 def _judge_run_cache_key(agent: PersistentAgent, evidence_hash: str) -> str:
     return f"agent-judge:run:{agent.id}:{evidence_hash}"
+
+
+def _burn_rate_judge_daily_cache_key(agent: PersistentAgent, now=None) -> str:
+    current_time = now or timezone.now()
+    return f"agent-judge:burn-rate:{agent.id}:{current_time.date().isoformat()}"
+
+
+def _burn_rate_judge_daily_cache_timeout(now=None) -> int:
+    current_time = now or timezone.now()
+    next_day = (current_time + timedelta(days=1)).replace(
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
+    )
+    return max(1, int((next_day - current_time).total_seconds()))
+
+
+def _has_burn_rate_judge_daily_slot(agent: PersistentAgent) -> bool:
+    return bool(cache.get(_burn_rate_judge_daily_cache_key(agent)))
+
+
+def _claim_burn_rate_judge_daily_slot(agent: PersistentAgent) -> bool:
+    return cache.add(
+        _burn_rate_judge_daily_cache_key(agent),
+        True,
+        timeout=_burn_rate_judge_daily_cache_timeout(),
+    )
 
 
 def approve_judge_suggestion(suggestion: PersistentAgentJudgeSuggestion) -> None:

--- a/api/agent/core/agent_judge.py
+++ b/api/agent/core/agent_judge.py
@@ -8,9 +8,12 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
+import redis
 from django.core.cache import cache
 from django.db import DatabaseError, IntegrityError, transaction
 from django.utils import timezone
+
+from config.redis_client import get_redis_client
 
 from api.agent.core.llm_config import INPUT_TOKEN_HEADROOM, LLMNotConfiguredError, get_agent_judge_llm_config, get_agent_llm_tier
 from api.agent.core.llm_utils import run_completion
@@ -1465,15 +1468,34 @@ def _burn_rate_judge_daily_cache_timeout(now=None) -> int:
 
 
 def _has_burn_rate_judge_daily_slot(agent: PersistentAgent) -> bool:
-    return bool(cache.get(_burn_rate_judge_daily_cache_key(agent)))
+    try:
+        return bool(get_redis_client().get(_burn_rate_judge_daily_cache_key(agent)))
+    except redis.RedisError:
+        logger.warning(
+            "Failed to read burn-rate judge daily marker for agent %s; allowing the judge to run.",
+            agent.id,
+            exc_info=True,
+        )
+        return False
 
 
 def _claim_burn_rate_judge_daily_slot(agent: PersistentAgent) -> bool:
-    return cache.add(
-        _burn_rate_judge_daily_cache_key(agent),
-        True,
-        timeout=_burn_rate_judge_daily_cache_timeout(),
-    )
+    try:
+        return bool(
+            get_redis_client().set(
+                _burn_rate_judge_daily_cache_key(agent),
+                "1",
+                ex=_burn_rate_judge_daily_cache_timeout(),
+                nx=True,
+            )
+        )
+    except redis.RedisError:
+        logger.warning(
+            "Failed to claim burn-rate judge daily marker for agent %s; allowing the judge to run.",
+            agent.id,
+            exc_info=True,
+        )
+        return True
 
 
 def approve_judge_suggestion(suggestion: PersistentAgentJudgeSuggestion) -> None:

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -337,8 +337,8 @@ class AgentJudgeTests(TestCase):
     def test_burn_rate_cap_preserves_independent_automatic_trigger(self):
         self._add_steps(1)
         redis_client = MagicMock()
-        redis_client.get.side_effect = [None, "1"]
-        redis_client.set.return_value = True
+        redis_client.get.side_effect = [None, None]
+        redis_client.set.side_effect = [True, False]
         response = _judge_response(
             {
                 "suggestion_type": NO_ACTION,
@@ -357,7 +357,13 @@ class AgentJudgeTests(TestCase):
         ) as analytics_mock, patch(
             "api.agent.core.agent_judge.get_redis_client",
             return_value=redis_client,
-        ), patch("api.agent.core.agent_judge.JUDGE_RUN_COOLDOWN_SECONDS", 0):
+        ), patch(
+            "api.agent.core.agent_judge.build_judge_trigger",
+            wraps=build_judge_trigger,
+        ) as build_trigger_mock, patch(
+            "api.agent.core.agent_judge.JUDGE_RUN_COOLDOWN_SECONDS",
+            0,
+        ):
             maybe_run_agent_judge(
                 self.agent,
                 tools=[],
@@ -372,6 +378,7 @@ class AgentJudgeTests(TestCase):
             )
 
         self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(build_trigger_mock.call_count, 2)
         triggered_properties = [
             call.kwargs["properties"]
             for call in analytics_mock.call_args_list

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -4,16 +4,19 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.db import DatabaseError
 from django.test import TestCase, tag
 from django.utils import timezone
 
 from api.agent.core.agent_judge import (
+    BURN_RATE_TIER_STEP_DOWN_REASON,
     JUDGE_DAILY_RUN_LIMIT,
     JudgePromptLimits,
     NO_ACTION,
     REPORT_TOOL_NAME,
     _build_judge_messages,
+    _burn_rate_judge_daily_cache_key,
     _judge_tool_definition,
     _judge_prompt_limits,
     approve_judge_suggestion,
@@ -293,6 +296,94 @@ class AgentJudgeTests(TestCase):
 
         self.assertIsNotNone(trigger)
         self.assertEqual(trigger.reasons, ["burn_rate_throttled"])
+
+    def test_burn_rate_trigger_runs_judge_once_per_utc_day(self):
+        self._add_steps(1)
+        response = _judge_response(
+            {
+                "suggestion_type": NO_ACTION,
+                "message": "No action needed.",
+            }
+        )
+
+        with patch(
+            "api.agent.core.agent_judge.get_agent_judge_llm_config",
+            return_value=("test-provider", "test-model", {}),
+        ), patch(
+            "api.agent.core.agent_judge.run_completion",
+            return_value=response,
+        ) as run_mock, patch("api.agent.core.agent_judge.JUDGE_RUN_COOLDOWN_SECONDS", 0):
+            maybe_run_agent_judge(
+                self.agent,
+                tools=[],
+                extra_trigger_reasons=[BURN_RATE_TIER_STEP_DOWN_REASON],
+            )
+            self._add_steps(10)
+            maybe_run_agent_judge(
+                self.agent,
+                tools=[],
+                extra_trigger_reasons=[BURN_RATE_TIER_STEP_DOWN_REASON],
+            )
+
+        run_mock.assert_called_once()
+
+    def test_burn_rate_cap_preserves_independent_automatic_trigger(self):
+        self._add_steps(1)
+        response = _judge_response(
+            {
+                "suggestion_type": NO_ACTION,
+                "message": "No action needed.",
+            }
+        )
+
+        with patch(
+            "api.agent.core.agent_judge.get_agent_judge_llm_config",
+            return_value=("test-provider", "test-model", {}),
+        ), patch(
+            "api.agent.core.agent_judge.run_completion",
+            return_value=response,
+        ) as run_mock, patch(
+            "api.agent.core.agent_judge.Analytics.track_event",
+        ) as analytics_mock, patch("api.agent.core.agent_judge.JUDGE_RUN_COOLDOWN_SECONDS", 0):
+            maybe_run_agent_judge(
+                self.agent,
+                tools=[],
+                extra_trigger_reasons=[BURN_RATE_TIER_STEP_DOWN_REASON],
+            )
+            self._add_steps(10)
+            self._add_message(1, body="This is still broken.")
+            maybe_run_agent_judge(
+                self.agent,
+                tools=[],
+                extra_trigger_reasons=[BURN_RATE_TIER_STEP_DOWN_REASON],
+            )
+
+        self.assertEqual(run_mock.call_count, 2)
+        triggered_properties = [
+            call.kwargs["properties"]
+            for call in analytics_mock.call_args_list
+            if call.kwargs["event"] == AnalyticsEvent.PERSISTENT_AGENT_LLM_JUDGE_TRIGGERED
+        ]
+        self.assertEqual(triggered_properties[1]["trigger_reasons"], ["negative_user_language"])
+
+    def test_burn_rate_cap_resets_with_the_utc_date(self):
+        self._add_steps(1)
+        current_time = timezone.now()
+        today_key = _burn_rate_judge_daily_cache_key(self.agent, current_time)
+        cache.set(today_key, True, timeout=60)
+
+        with patch(
+            "api.agent.core.agent_judge.timezone.now",
+            return_value=current_time + timedelta(days=1),
+        ):
+            trigger = build_judge_trigger(
+                self.agent,
+                tools=[],
+                extra_trigger_reasons=[BURN_RATE_TIER_STEP_DOWN_REASON],
+            )
+
+        self.assertIsNotNone(trigger)
+        self.assertIn(BURN_RATE_TIER_STEP_DOWN_REASON, trigger.reasons)
 
     def test_custom_tool_failure_trigger_context_reaches_judge_prompt(self):
         self._add_steps(1)

--- a/tests/unit/test_agent_llm_judge.py
+++ b/tests/unit/test_agent_llm_judge.py
@@ -1,10 +1,9 @@
 import json
 from datetime import timedelta
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.db import DatabaseError
 from django.test import TestCase, tag
 from django.utils import timezone
@@ -299,6 +298,9 @@ class AgentJudgeTests(TestCase):
 
     def test_burn_rate_trigger_runs_judge_once_per_utc_day(self):
         self._add_steps(1)
+        redis_client = MagicMock()
+        redis_client.get.side_effect = [None, "1"]
+        redis_client.set.return_value = True
         response = _judge_response(
             {
                 "suggestion_type": NO_ACTION,
@@ -312,7 +314,10 @@ class AgentJudgeTests(TestCase):
         ), patch(
             "api.agent.core.agent_judge.run_completion",
             return_value=response,
-        ) as run_mock, patch("api.agent.core.agent_judge.JUDGE_RUN_COOLDOWN_SECONDS", 0):
+        ) as run_mock, patch(
+            "api.agent.core.agent_judge.get_redis_client",
+            return_value=redis_client,
+        ), patch("api.agent.core.agent_judge.JUDGE_RUN_COOLDOWN_SECONDS", 0):
             maybe_run_agent_judge(
                 self.agent,
                 tools=[],
@@ -326,9 +331,14 @@ class AgentJudgeTests(TestCase):
             )
 
         run_mock.assert_called_once()
+        redis_client.set.assert_called_once()
+        self.assertTrue(redis_client.set.call_args.kwargs["nx"])
 
     def test_burn_rate_cap_preserves_independent_automatic_trigger(self):
         self._add_steps(1)
+        redis_client = MagicMock()
+        redis_client.get.side_effect = [None, "1"]
+        redis_client.set.return_value = True
         response = _judge_response(
             {
                 "suggestion_type": NO_ACTION,
@@ -344,7 +354,10 @@ class AgentJudgeTests(TestCase):
             return_value=response,
         ) as run_mock, patch(
             "api.agent.core.agent_judge.Analytics.track_event",
-        ) as analytics_mock, patch("api.agent.core.agent_judge.JUDGE_RUN_COOLDOWN_SECONDS", 0):
+        ) as analytics_mock, patch(
+            "api.agent.core.agent_judge.get_redis_client",
+            return_value=redis_client,
+        ), patch("api.agent.core.agent_judge.JUDGE_RUN_COOLDOWN_SECONDS", 0):
             maybe_run_agent_judge(
                 self.agent,
                 tools=[],
@@ -369,12 +382,16 @@ class AgentJudgeTests(TestCase):
     def test_burn_rate_cap_resets_with_the_utc_date(self):
         self._add_steps(1)
         current_time = timezone.now()
-        today_key = _burn_rate_judge_daily_cache_key(self.agent, current_time)
-        cache.set(today_key, True, timeout=60)
+        redis_client = MagicMock()
+        redis_client.get.return_value = None
+        tomorrow = current_time + timedelta(days=1)
 
         with patch(
             "api.agent.core.agent_judge.timezone.now",
-            return_value=current_time + timedelta(days=1),
+            return_value=tomorrow,
+        ), patch(
+            "api.agent.core.agent_judge.get_redis_client",
+            return_value=redis_client,
         ):
             trigger = build_judge_trigger(
                 self.agent,
@@ -384,6 +401,7 @@ class AgentJudgeTests(TestCase):
 
         self.assertIsNotNone(trigger)
         self.assertIn(BURN_RATE_TIER_STEP_DOWN_REASON, trigger.reasons)
+        redis_client.get.assert_called_once_with(_burn_rate_judge_daily_cache_key(self.agent, tomorrow))
 
     def test_custom_tool_failure_trigger_context_reaches_judge_prompt(self):
         self._add_steps(1)


### PR DESCRIPTION
## Summary

- Add a per-agent daily cache-backed limit for burn-rate tier step-down judge runs.
- Preserve independent automatic judge triggers when the burn-rate limit is reached.
- Add coverage for daily limiting and UTC-date reset behavior.

## Testing

- Added unit tests covering the daily cap, independent triggers, and date-based reset.