### PR TITLE
Keep active work running despite future schedules

### DIFF
--- a/api/agent/core/event_processing.py
+++ b/api/agent/core/event_processing.py
@@ -7541,8 +7541,6 @@ def _run_agent_loop(
                 try:
                     prompt_context_result = build_prompt_context(
                         agent,
-                        current_iteration=i + 1,
-                        max_iterations=effective_max_loop_iterations,
                         reasoning_only_streak=reasoning_only_streak,
                         is_first_run=is_first_run,
                         daily_credit_state=daily_state,

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -4219,11 +4219,9 @@ def _get_system_instruction(
     )
     stop_continue_examples = (
         "## Stop/continue\n\n"
-        "Set will_continue_work=true only while this active request has unsent results, unverified constraints, needed tool "
-        "results, immediately executable work, or its own plan cleanup. Completing delivery or config does not finish a "
-        "separate actionable clause in the same request. Set false only when the current request is complete or blocked. "
-        "Future schedules, queued conversations, and their plan items do not by themselves keep a completed turn open; "
-        "they do not justify deferring executable current work.\n"
+        "Set will_continue_work=true while this request has unsent/unverified results, needed tool results, executable "
+        "work, or plan cleanup. Delivery/config does not finish other work. Set false only when complete or blocked; "
+        "schedules neither complete nor defer current work.\n"
         f"{text_only_guidance}"
         "Before final delivery, mark its delivery step done and leave unrelated steps in todo. Never send a "
         "complete answer with true for cleanup: update_plan "

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -3143,16 +3143,6 @@ def add_budget_awareness_sections(
             return f"{seconds // 3600}h"
         return f"{seconds // 86400}d"
 
-    if max_iterations and max_iterations > 0:
-        iteration_text = (
-            f"Iteration progress: {current_iteration}/{max_iterations} in this processing cycle."
-        )
-    else:
-        iteration_text = (
-            f"Iteration progress: {current_iteration} with no maximum iterations specified for this cycle."
-        )
-    sections.append(("iteration_progress", iteration_text, 3, True))
-
     try:
         ctx = get_budget_context()
         if ctx is not None:
@@ -3440,21 +3430,6 @@ def add_budget_awareness_sections(
         ))
     except Exception:
         logger.debug("Failed to append tool cost overview to budget awareness.", exc_info=True)
-
-    if max_iterations and max_iterations > 0:
-        try:
-            if (current_iteration / max_iterations) > 0.8:
-                sections.append(
-                    (
-                        "iteration_warning",
-                        "Low iterations: never false-complete; carry unfinished scope into the next cycle.",
-                        2,
-                        True,
-                    )
-                )
-        except Exception:
-            # Non-fatal; omit iteration warning on any arithmetic error
-            pass
 
     if not sections:
         return False
@@ -4244,9 +4219,11 @@ def _get_system_instruction(
     )
     stop_continue_examples = (
         "## Stop/continue\n\n"
-        "Set will_continue_work=true only while this active request has unsent results, unverified constraints, needed "
-        "tool results, or its own plan cleanup. Set false after delivery/config; future schedules, queued conversations, "
-        "and their plan items do not keep this turn open.\n"
+        "Set will_continue_work=true only while this active request has unsent results, unverified constraints, needed tool "
+        "results, immediately executable work, or its own plan cleanup. Completing delivery or config does not finish a "
+        "separate actionable clause in the same request. Set false only when the current request is complete or blocked. "
+        "Future schedules, queued conversations, and their plan items do not by themselves keep a completed turn open; "
+        "they do not justify deferring executable current work.\n"
         f"{text_only_guidance}"
         "Before final delivery, mark its delivery step done and leave unrelated steps in todo. Never send a "
         "complete answer with true for cleanup: update_plan "

--- a/api/agent/core/prompt_context.py
+++ b/api/agent/core/prompt_context.py
@@ -156,7 +156,6 @@ from util.urls import build_agent_daily_limit_action_links
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer("gobii.utils")
 
-DEFAULT_MAX_AGENT_LOOP_ITERATIONS = 100
 # Keep internal reasoning previews short in unified history; shrink with HMT instead of dropping early context.
 INTERNAL_REASONING_DISPLAY_LIMIT_BYTES = 3000
 SIGNED_FILES_URL_RE = re.compile(
@@ -1168,25 +1167,6 @@ def _get_prompt_snapshot(
     return snapshot
 
 
-def _resolve_max_iterations(max_iterations: Optional[int]) -> int:
-    """Derive the iteration ceiling, falling back to event_processing defaults."""
-
-    if max_iterations is not None:
-        return max_iterations
-
-    try:
-        # Imported lazily to avoid circular imports when event_processing loads us.
-        from api.agent.core import event_processing as event_processing_module  # noqa: WPS433
-
-        return getattr(
-            event_processing_module,
-            "MAX_AGENT_LOOP_ITERATIONS",
-            DEFAULT_MAX_AGENT_LOOP_ITERATIONS,
-        )
-    except Exception:
-        return DEFAULT_MAX_AGENT_LOOP_ITERATIONS
-
-
 # --------------------------------------------------------------------------- #
 #  Prompt‑building helpers
 # --------------------------------------------------------------------------- #
@@ -1562,8 +1542,6 @@ def _append_agent_owner_custom_instructions(system_prompt: str, agent: Persisten
 
 def _render_prompt_context_once(
     agent: PersistentAgent,
-    current_iteration: int = 1,
-    max_iterations: Optional[int] = None,
     reasoning_only_streak: int = 0,
     is_first_run: bool = False,
     daily_credit_state: Optional[dict] = None,
@@ -1575,7 +1553,6 @@ def _render_prompt_context_once(
     run_cache: PromptRunCache | None = None,
     prompt_message_transform: Callable[[List[dict]], List[dict]] | None = None,
 ) -> PromptRenderResult:
-    max_iterations = _resolve_max_iterations(max_iterations)
     span = trace.get_current_span()
 
     model, prompt_allows_implied_send = _prompt_render_settings_from_failover_configs(
@@ -1916,8 +1893,6 @@ def _render_prompt_context_once(
             daily_credit_state = get_agent_daily_credit_state(agent)
         add_budget_awareness_sections(
             critical_group,
-            current_iteration=current_iteration,
-            max_iterations=max_iterations,
             daily_credit_state=daily_credit_state,
             task_credit_available=task_credit_available,
             agent=agent,
@@ -2248,8 +2223,6 @@ def _stabilize_prompt_render(
 @tracer.start_as_current_span("Build Prompt Context")
 def build_prompt_context(
     agent: PersistentAgent,
-    current_iteration: int = 1,
-    max_iterations: Optional[int] = None,
     reasoning_only_streak: int = 0,
     is_first_run: bool = False,
     daily_credit_state: Optional[dict] = None,
@@ -2268,8 +2241,6 @@ def build_prompt_context(
 
     Args:
         agent: Persistent agent being processed.
-        current_iteration: 1-based iteration counter inside the loop.
-        max_iterations: Maximum iterations allowed for this processing cycle.
         reasoning_only_streak: Number of consecutive iterations without tool calls.
         is_first_run: Whether this is the very first processing cycle for the agent.
         daily_credit_state: Pre-computed daily credit state (optional).
@@ -2303,8 +2274,6 @@ def build_prompt_context(
         prefer_low_latency=prefer_low_latency,
         preview=False,
         render_kwargs=dict(
-            current_iteration=current_iteration,
-            max_iterations=max_iterations,
             reasoning_only_streak=reasoning_only_streak,
             is_first_run=is_first_run,
             daily_credit_state=daily_credit_state,
@@ -2347,8 +2316,6 @@ def build_prompt_context(
 
 def build_prompt_context_preview(
     agent: PersistentAgent,
-    current_iteration: int = 1,
-    max_iterations: Optional[int] = None,
     reasoning_only_streak: int = 0,
     is_first_run: bool = False,
     daily_credit_state: Optional[dict] = None,
@@ -2371,8 +2338,6 @@ def build_prompt_context_preview(
         prefer_low_latency=prefer_low_latency,
         preview=True,
         render_kwargs=dict(
-            current_iteration=current_iteration,
-            max_iterations=max_iterations,
             reasoning_only_streak=reasoning_only_streak,
             is_first_run=is_first_run,
             daily_credit_state=daily_credit_state,
@@ -3123,8 +3088,6 @@ def _get_sandbox_prompt_summary(agent: PersistentAgent) -> str:
 def add_budget_awareness_sections(
     critical_group,
     *,
-    current_iteration: int,
-    max_iterations: int,
     daily_credit_state: dict | None = None,
     task_credit_available=None,
     agent: PersistentAgent | None = None,

--- a/api/evals/scenarios/effort_calibration.py
+++ b/api/evals/scenarios/effort_calibration.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from typing import Iterable
 
 from django.db.models import Sum
+from django.test import override_settings
 
 from api.agent.tools.eval_synthetic_tools import EVAL_SYNTHETIC_TOOL_SERVER
 from api.agent.tools.sqlite_guardrails import clear_guarded_connection, open_guarded_sqlite_connection
@@ -51,6 +52,7 @@ EFFORT_UNSCHEDULED_REMAINING_WORK_SETS_RESUME = "effort_unscheduled_remaining_wo
 EFFORT_PARTIAL_SOURCE_BLOCK_REPORTS_AND_RESUMES = "effort_partial_source_block_reports_and_resumes"
 EFFORT_TOOL_WAIT_NEXT_SCHEDULE_REQUIRES_SCHEDULE = "effort_tool_wait_next_schedule_requires_schedule"
 EFFORT_AUTOMATIC_FUTURE_EVENTS_STAY_OFF_PLAN = "effort_automatic_future_events_stay_off_plan"
+EFFORT_ACTIVE_WORK_IGNORES_FUTURE_SCHEDULE = "effort_active_work_ignores_future_schedule"
 DEEP_WORK_CORRECTION_STEP_PREFIX = "Deep-work communication correction:"
 
 EFFORT_CALIBRATION_SCENARIO_SLUGS = [
@@ -68,6 +70,7 @@ EFFORT_CALIBRATION_SCENARIO_SLUGS = [
     EFFORT_PARTIAL_SOURCE_BLOCK_REPORTS_AND_RESUMES,
     EFFORT_TOOL_WAIT_NEXT_SCHEDULE_REQUIRES_SCHEDULE,
     EFFORT_AUTOMATIC_FUTURE_EVENTS_STAY_OFF_PLAN,
+    EFFORT_ACTIVE_WORK_IGNORES_FUTURE_SCHEDULE,
 ]
 
 MESSAGE_TOOL_NAMES = {
@@ -2419,6 +2422,170 @@ class EffortToolWaitNextScheduleRequiresScheduleScenario(EffortCalibrationScenar
             forbidden_tool_names=EFFORT_OVERWORK_TOOL_NAMES | ARTIFACT_TOOL_NAMES | RESEARCH_TOOL_NAMES,
         )
         self._record_orchestrator_budget(run_id, task_name="verify_turn_budget", max_completions=5)
+
+
+@register_scenario
+class EffortActiveWorkIgnoresFutureScheduleScenario(EffortCalibrationScenario):
+    slug = EFFORT_ACTIVE_WORK_IGNORES_FUTURE_SCHEDULE
+    description = (
+        "An hourly fallback schedule should not make an agent stop while its active request still has immediately "
+        "actionable bounded work."
+    )
+    tags = (*EffortCalibrationScenario.tags, "continuation", "scheduling", "real_harness")
+    tasks = [
+        ScenarioTask(name="inject_prompt", assertion_type="agent_processing"),
+        ScenarioTask(name="verify_active_work_continued", assertion_type="tool_call"),
+        ScenarioTask(name="verify_turn_budget", assertion_type="tool_call"),
+    ]
+
+    @staticmethod
+    def active_work_continued(
+        calls: Iterable[PersistentAgentToolCall],
+        *,
+        minimum_batches: int = 8,
+        explicitly_slept: bool = False,
+    ) -> tuple[bool, str]:
+        work_calls = []
+        for call in calls:
+            if call.tool_name == "eval_prepare_next_batch":
+                if call.status != PersistentAgentToolCall.Status.COMPLETE:
+                    continue
+                work_calls.append(call)
+                continue
+            if call.tool_name == "sleep_until_next_trigger":
+                return False, f"The agent slept after only {len(work_calls)} bounded batch(es)."
+            if call.tool_name in MESSAGE_TOOL_NAMES and resolved_tool_param(call, "will_continue_work") is False:
+                return False, f"The agent sent a terminal update after only {len(work_calls)} bounded batch(es)."
+
+        if explicitly_slept:
+            return False, f"The agent explicitly slept with active work after {len(work_calls)} bounded batch(es)."
+        if len(work_calls) >= minimum_batches:
+            return True, f"The agent kept active work moving across {len(work_calls)} bounded batches."
+        return False, f"The agent processed only {len(work_calls)} bounded batch(es)."
+
+    def run(self, run_id: str, agent_id: str) -> None:
+        self._ready_agent(
+            agent_id,
+            charter=(
+                "Work through the owner's active analysis backlog with the configured batch-preparation workflow. "
+                "Preserve durable checkpoints so scheduled wakes can recover from an interruption."
+            ),
+            schedule=None,
+        )
+        self._enable_eval_synthetic_tools(agent_id, ["eval_prepare_next_batch"])
+        self._seed_prior_trajectory_tool_call(
+            agent_id,
+            tool_name="eval_prepare_next_batch",
+            tool_params={"batch_size": 4, "query": "analysis-offset-0"},
+            result={
+                "status": "ok",
+                "prepared_count": 4,
+                "remaining_work": 996,
+                "next_cursor": "analysis-offset-4",
+                "next_action": "Continue bounded work now with query='analysis-offset-4'.",
+            },
+        )
+
+        def batch_result(next_offset: int) -> dict:
+            remaining = 1000 - next_offset
+            return {
+                "status": "ok",
+                "prepared_count": 4,
+                "remaining_work": remaining,
+                "next_cursor": f"analysis-offset-{next_offset}",
+                "next_action": f"Continue bounded work now with query='analysis-offset-{next_offset}'.",
+                "verification": "This receipt is authoritative; more bounded batches are immediately available.",
+            }
+
+        mock_config = {
+            "eval_prepare_next_batch": {
+                "rules": [
+                    {
+                        "param_contains": {"query": f"analysis-offset-{offset}"},
+                        "result": batch_result(offset + 4),
+                    }
+                    for offset in range(4, 84, 4)
+                ],
+                "default": {
+                    "status": "error",
+                    "message": "Pass the latest next_cursor in query to advance the active batch.",
+                    "retryable": True,
+                },
+            }
+        }
+
+        self.record_task_result(run_id, None, EvalRunTask.Status.RUNNING, task_name="inject_prompt")
+        with override_settings(AGENT_INTERACTIVE_MAX_LOOP_ITERATIONS=5), self.wait_for_agent_idle(
+            agent_id,
+            timeout=180,
+        ):
+            inbound = self.inject_message(
+                agent_id,
+                (
+                    "Set the analysis schedule to run every hour. In fact, do not stop until the active backlog is "
+                    "finished."
+                ),
+                trigger_processing=True,
+                eval_run_id=run_id,
+                mock_config=mock_config,
+                eval_stop_policy={
+                    "stop_on_unexpected_relevant_tool": True,
+                    "allowed_tool_names": ["eval_prepare_next_batch", "sqlite_batch"],
+                    "ignored_tool_names": list(MESSAGE_TOOL_NAMES | STOP_TOOL_NAMES),
+                    "ignore_sqlite_agent_config_mutations": False,
+                    "max_relevant_tool_calls": 8,
+                },
+            )
+        self.record_task_result(
+            run_id,
+            None,
+            EvalRunTask.Status.PASSED,
+            task_name="inject_prompt",
+            observed_summary="Active work request completed through the real agent harness.",
+            artifacts={"message": inbound},
+        )
+
+        calls = _tool_calls_for_run(run_id, after=inbound.timestamp)
+        agent = PersistentAgent.objects.get(id=agent_id)
+        has_hourly_schedule = (agent.schedule or "").strip() in {
+            "0 * * * *",
+            "@every 1h",
+        } or agent.additional_schedules.filter(
+            enabled=True,
+            kind="recurring",
+            expression__in=("0 * * * *", "@every 1h"),
+        ).exists()
+        explicitly_slept = PersistentAgentStep.objects.filter(
+            agent_id=agent_id,
+            created_at__gte=inbound.timestamp,
+            description="Decided to sleep until next trigger.",
+        ).exists()
+        continued, summary = self.active_work_continued(
+            calls,
+            minimum_batches=1,
+            explicitly_slept=explicitly_slept,
+        )
+        passed = has_hourly_schedule and continued
+        if not has_hourly_schedule:
+            summary = f"The hourly schedule was not configured. {summary}"
+        work_calls = [
+            call
+            for call in calls
+            if call.tool_name == "eval_prepare_next_batch"
+            and call.status == PersistentAgentToolCall.Status.COMPLETE
+        ]
+        self.record_task_result(
+            run_id,
+            work_calls[-1].step if work_calls else None,
+            EvalRunTask.Status.PASSED if passed else EvalRunTask.Status.FAILED,
+            task_name="verify_active_work_continued",
+            expected_summary=(
+                "The agent should configure the requested hourly fallback and then perform current actionable work "
+                "before any terminal update or voluntary sleep."
+            ),
+            observed_summary=summary,
+        )
+        self._record_orchestrator_budget(run_id, task_name="verify_turn_budget", max_completions=10)
 
 
 @register_scenario

--- a/api/evals/scenarios/effort_calibration.py
+++ b/api/evals/scenarios/effort_calibration.py
@@ -2562,7 +2562,7 @@ class EffortActiveWorkIgnoresFutureScheduleScenario(EffortCalibrationScenario):
         ).exists()
         continued, summary = self.active_work_continued(
             calls,
-            minimum_batches=1,
+            minimum_batches=2,
             explicitly_slept=explicitly_slept,
         )
         passed = has_hourly_schedule and continued

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -2713,8 +2713,8 @@ class FirstRunPromptCalibrationTests(TestCase):
         )
         self.assertIn("Feedback addressed to someone else is not yours", system_prompt)
         self.assertIn("Trust only agent_config_update for whether config changed", system_prompt)
-        self.assertIn("Completing delivery or config does not finish a separate actionable clause", system_prompt)
-        self.assertIn("they do not justify deferring executable current work", system_prompt)
+        self.assertIn("Delivery/config does not finish other work", system_prompt)
+        self.assertIn("schedules neither complete nor defer current work", system_prompt)
         self.assertNotIn("Iteration progress:", system_prompt)
         self.assertNotIn("Low iterations:", system_prompt)
         self.assertIn(

--- a/api/evals/tests/test_effort_calibration.py
+++ b/api/evals/tests/test_effort_calibration.py
@@ -23,6 +23,7 @@ from api.agent.tools.request_human_input import execute_request_human_input, get
 from api.agent.tools.web_chat_sender import execute_send_chat_message
 from api.evals.scenarios.effort_calibration import (
     ARTIFACT_TOOL_NAMES,
+    EFFORT_ACTIVE_WORK_IGNORES_FUTURE_SCHEDULE,
     EFFORT_CALIBRATION_SCENARIO_SLUGS,
     EFFORT_EXPLICIT_DEEP_RESEARCH_REMAINS_CAPABLE,
     EFFORT_ORDINARY_CONTINUATION_AVOIDS_CORRECTIVE_CHURN,
@@ -33,6 +34,7 @@ from api.evals.scenarios.effort_calibration import (
     EFFORT_SIMPLE_CURRENT_YC_BATCH_REPORT,
     EFFORT_TOOL_WAIT_NEXT_SCHEDULE_REQUIRES_SCHEDULE,
     EFFORT_UNSCHEDULED_REMAINING_WORK_SETS_RESUME,
+    EffortActiveWorkIgnoresFutureScheduleScenario,
     EffortCalibrationScenario,
     EffortOrdinaryContinuationAvoidsCorrectiveChurnScenario,
     EffortSimpleCurrentCompanyReportScenario,
@@ -177,6 +179,34 @@ class EffortCalibrationSuiteTests(SimpleTestCase):
         self.assertIn(EFFORT_UNSCHEDULED_REMAINING_WORK_SETS_RESUME, suite.scenario_slugs)
         self.assertIn(EFFORT_PARTIAL_SOURCE_BLOCK_REPORTS_AND_RESUMES, suite.scenario_slugs)
         self.assertIn(EFFORT_TOOL_WAIT_NEXT_SCHEDULE_REQUIRES_SCHEDULE, suite.scenario_slugs)
+        self.assertIn(EFFORT_ACTIVE_WORK_IGNORES_FUTURE_SCHEDULE, suite.scenario_slugs)
+
+    def test_active_work_continuation_requires_two_batches_before_stopping(self):
+        work_call = _eval_tool_call("eval_prepare_next_batch")
+        second_work_call = _eval_tool_call("eval_prepare_next_batch")
+        terminal = _eval_tool_call(
+            "send_chat_message",
+            {"body": "I'll resume on the hour.", "will_continue_work": False},
+        )
+        sleep = _eval_tool_call("sleep_until_next_trigger")
+
+        passed, _summary = EffortActiveWorkIgnoresFutureScheduleScenario.active_work_continued(
+            [work_call, second_work_call], minimum_batches=2
+        )
+        terminal_passed, terminal_summary = (
+            EffortActiveWorkIgnoresFutureScheduleScenario.active_work_continued(
+                [work_call, terminal], minimum_batches=2
+            )
+        )
+        sleep_passed, sleep_summary = EffortActiveWorkIgnoresFutureScheduleScenario.active_work_continued(
+            [work_call, sleep], minimum_batches=2
+        )
+
+        self.assertTrue(passed)
+        self.assertFalse(terminal_passed)
+        self.assertIn("terminal update", terminal_summary)
+        self.assertFalse(sleep_passed)
+        self.assertIn("slept", sleep_summary)
 
     def test_sqlite_tool_results_suite_contains_item_link_report(self):
         suite = SuiteRegistry.get(SQLITE_TOOL_RESULT_SUITE_SLUG)
@@ -2683,7 +2713,10 @@ class FirstRunPromptCalibrationTests(TestCase):
         )
         self.assertIn("Feedback addressed to someone else is not yours", system_prompt)
         self.assertIn("Trust only agent_config_update for whether config changed", system_prompt)
-        self.assertIn("Set false after delivery/config; future schedules, queued conversations", system_prompt)
+        self.assertIn("Completing delivery or config does not finish a separate actionable clause", system_prompt)
+        self.assertIn("they do not justify deferring executable current work", system_prompt)
+        self.assertNotIn("Iteration progress:", system_prompt)
+        self.assertNotIn("Low iterations:", system_prompt)
         self.assertIn(
             "Explicit or clearly implied ongoing work, reminders, and future triggers may be scheduled",
             system_prompt,

--- a/tests/unit/test_agent_event_processing_credits.py
+++ b/tests/unit/test_agent_event_processing_credits.py
@@ -1177,8 +1177,6 @@ class PersistentAgentToolCreditTests(TestCase):
         }
         result = add_budget_awareness_sections(
             critical_group,
-            current_iteration=2,
-            max_iterations=4,
             daily_credit_state=state,
         )
         self.assertTrue(result)
@@ -1213,8 +1211,6 @@ class PersistentAgentToolCreditTests(TestCase):
         with patch("api.agent.core.event_processing.Analytics.track_event") as track_mock:
             add_budget_awareness_sections(
                 critical_group,
-                current_iteration=1,
-                max_iterations=2,
                 daily_credit_state=state,
                 agent=self.agent,
             )
@@ -1234,8 +1230,6 @@ class PersistentAgentToolCreditTests(TestCase):
         }
         result = add_budget_awareness_sections(
             critical_group,
-            current_iteration=1,
-            max_iterations=0,
             daily_credit_state=state,
         )
         self.assertTrue(result)
@@ -1274,8 +1268,6 @@ class PersistentAgentToolCreditTests(TestCase):
 
         result = add_budget_awareness_sections(
             critical_group,
-            current_iteration=1,
-            max_iterations=5,
             daily_credit_state=None,
             agent=self.agent,
         )

--- a/tests/unit/test_prompt_context_sqlite_guidance.py
+++ b/tests/unit/test_prompt_context_sqlite_guidance.py
@@ -318,29 +318,6 @@ class PromptContextSqliteGuidanceTests(SimpleTestCase):
         self.assertIn("group_concat(DISTINCT x)", guidance)
         self.assertNotIn("Copy names/paths/values/URLs", guidance)
 
-    def test_low_iteration_warning_keeps_unfinished_work_active(self):
-        collector = _NestedPromptSectionCollector()
-        with (
-            patch("api.agent.core.prompt_context.get_budget_context", return_value=None),
-            patch("api.agent.core.prompt_context.get_browser_daily_task_limit", return_value=None),
-            patch(
-                "api.agent.core.prompt_context.get_tool_cost_overview",
-                return_value=(Decimal("1"), {}),
-            ),
-        ):
-            added = prompt_context.add_budget_awareness_sections(
-                collector,
-                current_iteration=9,
-                max_iterations=10,
-            )
-
-        warning = collector.sections["iteration_warning"]
-        self.assertTrue(added)
-        self.assertIn("never false-complete", warning)
-        self.assertIn("unfinished scope", warning)
-        self.assertIn("next cycle", warning)
-        self.assertNotIn("set a schedule", warning)
-
     def test_sqlite_retry_warning_flags_repeated_empty_probes(self):
         warning = prompt_context._build_sqlite_retry_warning(
             [


### PR DESCRIPTION
## Summary

- remove iteration progress and low-iteration warnings from agent prompts so the runtime owns processing boundaries
- clarify that configuring a future schedule does not complete separate, executable work in the active request
- add a real-harness regression eval for continuing active work after an hourly fallback schedule is configured
- add prompt/scorer coverage and make the synthetic batch fixture advance through explicit cursors

## Root cause

The agent saw its iteration counter and treated proximity to the processing limit as a reason to voluntarily sleep, even though the runtime automatically schedules continuation at that boundary. It could also treat creating an hourly schedule as a substitute for work that was still executable in the current request.

## Impact

Agents should continue bounded active work until the runtime pauses them, while still sleeping normally when scheduled or one-off work is genuinely complete. Schedule creation and timing behavior remain intact.

## Validation

- active-work regression before fix: failed 3/3
- active-work regression after final prompt cleanup: passed 3/3 (9/9 tasks)
- focused unit tests: 108 passed
- finished/idle counter-evals: 17/17 tasks passed
- primary recurring-schedule creation: 3/3 runs passed
- multiple recurring schedules: 3/3 runs passed
- durable rule plus multiple schedules: 3/3 reruns passed
- full agent scheduling suite: 31/33 tasks passed; direct creation, exact timer, update, cancel, listing, and guardrail cases passed. The two misses were an ancillary charter persistence case (passed on rerun) and an optional weekly-automation offer that does not create a schedule.
- `git diff --check`
