### PR TITLE
Replace deprecated Stripe prorate= with proration_behavior

### DIFF
--- a/api/services/direct_trial_promos.py
+++ b/api/services/direct_trial_promos.py
@@ -728,7 +728,7 @@ def _cancel_partial_subscription(
     try:
         stripe.Subscription.delete(
             subscription_id,
-            prorate=False,
+            proration_behavior='none',
             api_key=stripe.api_key,
         )
     except stripe.error.StripeError:

--- a/util/subscription_helper.py
+++ b/util/subscription_helper.py
@@ -422,7 +422,7 @@ def ensure_single_individual_subscription(
                 dup_id,
                 customer_id,
             )
-            stripe.Subscription.delete(dup_id, prorate=True)  # type: ignore[attr-defined]
+            stripe.Subscription.delete(dup_id, proration_behavior='create_prorations')  # type: ignore[attr-defined]
         except Exception:
             logger.warning(
                 "Failed to cancel duplicate subscription %s for customer %s",


### PR DESCRIPTION
## What

Stripe deprecated `prorate=` on Subscription (2020-08-27). Two mechanical one-token changes, surrounding code unchanged:

- `prorate=False` → `proration_behavior='none'`
- `prorate=True` → `proration_behavior='create_prorations'`

Generated by watch-api. No auto-merge. Tests in this repo were not run.

Changelog: https://docs.stripe.com/changelog/2020-08-27/deprecates-prorate-parameters-subscriptions